### PR TITLE
Start enabling evaluation of info inside of a function name, before checking if something is a function.

### DIFF
--- a/SharpMUSH.Tests/Commands/GeneralCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/GeneralCommandTests.cs
@@ -203,10 +203,15 @@ public class GeneralCommandTests : BaseUnitTest
 	public async ValueTask SpicyFunctionCall()
 	{
 		await Parser.CommandListParse(MModule.single("&foo me=ucstr; think [get(me/foo)](bar)"));
+		await Parser.CommandListParse(MModule.single("&foo me=ucstr; think [[get(me/foo)](foobar)]"));
 
 		await Parser.NotifyService
 			.Received(Quantity.Exactly(1))
 			.Notify(Arg.Any<DBRef>(), "BAR");
+		
+		await Parser.NotifyService
+			.Received(Quantity.Exactly(1))
+			.Notify(Arg.Any<DBRef>(), "FOOBAR");
 	}
 
 	[Test, Skip("Not Implemented")]

--- a/SharpMUSH.Tests/Commands/GeneralCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/GeneralCommandTests.cs
@@ -202,8 +202,9 @@ public class GeneralCommandTests : BaseUnitTest
 	[Test]
 	public async ValueTask SpicyFunctionCall()
 	{
-		await Parser.CommandListParse(MModule.single("&foo me=ucstr; think [get(me/foo)](bar)"));
-		await Parser.CommandListParse(MModule.single("&foo me=ucstr; think [[get(me/foo)](foobar)]"));
+		await Parser.CommandParse("1", MModule.single("&foo me=ucstr"));
+		await Parser.CommandParse("1", MModule.single("think [get(me/foo)](bar)"));
+		await Parser.CommandParse("1", MModule.single("think [[get(me/foo)](foobar)]"));
 
 		await Parser.NotifyService
 			.Received(Quantity.Exactly(1))

--- a/SharpMUSH.Tests/Commands/GeneralCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/GeneralCommandTests.cs
@@ -199,7 +199,7 @@ public class GeneralCommandTests : BaseUnitTest
 			.Notify(Arg.Any<DBRef>(), "Linked exit #8 to #0");
 	}
 	
-	[Test, Skip("Not yet implemented")]
+	[Test]
 	public async ValueTask SpicyFunctionCall()
 	{
 		await Parser.CommandListParse(MModule.single("&foo me=ucstr; think [get(me/foo)](bar)"));

--- a/SharpMUSH.Tests/Commands/GeneralCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/GeneralCommandTests.cs
@@ -214,6 +214,21 @@ public class GeneralCommandTests : BaseUnitTest
 			.Received(Quantity.Exactly(1))
 			.Notify(Arg.Any<DBRef>(), "FOOBAR");
 	}
+	
+	[Test]
+	public async ValueTask SpicyFunctionCall2()
+	{
+		await Parser.CommandListParse(MModule.single("think setq(1,ucstr); think %q<1>(bar)"));
+		await Parser.CommandListParse(MModule.single("think setq(1,ucstr); think [%q<1>(foobar)]"));
+
+		await Parser.NotifyService
+			.Received(Quantity.Exactly(1))
+			.Notify(Arg.Any<DBRef>(), "BAR");
+		
+		await Parser.NotifyService
+			.Received(Quantity.Exactly(1))
+			.Notify(Arg.Any<DBRef>(), "FOOBAR");
+	}
 
 	[Test, Skip("Not Implemented")]
 	public async ValueTask DoFlagSet()

--- a/SharpMUSH.Tests/Commands/GeneralCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/GeneralCommandTests.cs
@@ -203,31 +203,41 @@ public class GeneralCommandTests : BaseUnitTest
 	public async ValueTask SpicyFunctionCall()
 	{
 		await Parser.CommandParse("1", MModule.single("&foo me=ucstr"));
-		await Parser.CommandParse("1", MModule.single("think [get(me/foo)](bar)"));
-		await Parser.CommandParse("1", MModule.single("think [[get(me/foo)](foobar)]"));
+		await Parser.CommandParse("1", MModule.single("think [get(me/foo)](bar1)"));
+		await Parser.CommandParse("1", MModule.single("think [[get(me/foo)](foobar2)]"));
 
 		await Parser.NotifyService
 			.Received(Quantity.Exactly(1))
-			.Notify(Arg.Any<DBRef>(), "BAR");
+			.Notify(Arg.Any<DBRef>(), "BAR1");
 		
 		await Parser.NotifyService
 			.Received(Quantity.Exactly(1))
-			.Notify(Arg.Any<DBRef>(), "FOOBAR");
+			.Notify(Arg.Any<DBRef>(), "FOOBAR2");
 	}
 	
 	[Test]
 	public async ValueTask SpicyFunctionCall2()
 	{
-		await Parser.CommandListParse(MModule.single("think setq(1,ucstr); think %q<1>(bar)"));
-		await Parser.CommandListParse(MModule.single("think setq(1,ucstr); think [%q<1>(foobar)]"));
+		await Parser.CommandListParse(MModule.single("think setq(1,ucstr); think %q<1>(bar3)"));
+		await Parser.CommandListParse(MModule.single("think setq(1,ucstr); think [%q<1>(foobar4)]"));
 
 		await Parser.NotifyService
 			.Received(Quantity.Exactly(1))
-			.Notify(Arg.Any<DBRef>(), "BAR");
+			.Notify(Arg.Any<DBRef>(), "BAR3");
 		
 		await Parser.NotifyService
 			.Received(Quantity.Exactly(1))
-			.Notify(Arg.Any<DBRef>(), "FOOBAR");
+			.Notify(Arg.Any<DBRef>(), "FOOBAR4");
+	}
+
+	[Test]
+	public async ValueTask SpicyCommandCall()
+	{
+		await Parser.CommandListParse(MModule.single("think setq(cmd,think); %q<cmd> FOOBAR5"));
+
+		await Parser.NotifyService
+			.Received(Quantity.Exactly(1))
+			.Notify(Arg.Any<DBRef>(), "FOOBAR5");
 	}
 
 	[Test, Skip("Not Implemented")]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Re-enabled a test that validates command parsing and notification behavior, ensuring it now executes as part of the test suite.
	- Added new command parsing scenarios and verification for notification service messages, including multiple variations.
	- Introduced new test methods for additional command parsing and notification checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->