### PR TITLE
Perf: reduce allocations in parser hot path and cache immutable singl…

### DIFF
--- a/SharpMUSH.Implementation/BooleanExpressionParser.cs
+++ b/SharpMUSH.Implementation/BooleanExpressionParser.cs
@@ -9,6 +9,8 @@ namespace SharpMUSH.Implementation;
 
 public class BooleanExpressionParser(IMediator mediator) : IBooleanExpressionParser
 {
+	private const int MaxCompiledExpressionCacheEntries = 4096;
+
 	/// <summary>
 	/// Cache of compiled lock expressions keyed by their text representation.
 	/// Lock expressions are static text stored on objects that change only when a player
@@ -18,11 +20,19 @@ public class BooleanExpressionParser(IMediator mediator) : IBooleanExpressionPar
 	/// 
 	/// Uses Lazy&lt;T&gt; to ensure only one thread performs the expensive compilation
 	/// for a given key, even under concurrent access.
+	/// 
+	/// The cache is bounded to avoid unbounded memory growth from arbitrary player-provided
+	/// lock text. When the cap is reached and a new key is introduced, entries are cleared.
 	/// </summary>
 	private static readonly ConcurrentDictionary<string, Lazy<Func<AnySharpObject, AnySharpObject, bool>>> _compiledCache = new();
 
 	public Func<AnySharpObject, AnySharpObject, bool> Compile(string text)
 	{
+		if (!_compiledCache.ContainsKey(text) && _compiledCache.Count >= MaxCompiledExpressionCacheEntries)
+		{
+			_compiledCache.Clear();
+		}
+
 		var lazy = _compiledCache.GetOrAdd(
 			text,
 			key => new Lazy<Func<AnySharpObject, AnySharpObject, bool>>(

--- a/SharpMUSH.Implementation/BooleanExpressionParser.cs
+++ b/SharpMUSH.Implementation/BooleanExpressionParser.cs
@@ -10,6 +10,9 @@ namespace SharpMUSH.Implementation;
 public class BooleanExpressionParser(IMediator mediator) : IBooleanExpressionParser
 {
 	private const int MaxCompiledExpressionCacheEntries = 4096;
+	private const int CacheEvictionBatchSize = MaxCompiledExpressionCacheEntries / 4;
+	private static readonly object _cacheTrimLock = new();
+	private static readonly Queue<string> _cacheInsertionOrder = new();
 
 	/// <summary>
 	/// Cache of compiled lock expressions keyed by their text representation.
@@ -22,21 +25,28 @@ public class BooleanExpressionParser(IMediator mediator) : IBooleanExpressionPar
 	/// for a given key, even under concurrent access.
 	/// 
 	/// The cache is bounded to avoid unbounded memory growth from arbitrary player-provided
-	/// lock text. When the cap is reached and a new key is introduced, entries are cleared.
+	/// lock text. When the cap is reached and a new key is introduced, the oldest keys
+	/// are evicted in batches to keep hot entries resident and avoid full-cache flushes.
 	/// </summary>
 	private static readonly ConcurrentDictionary<string, Lazy<Func<AnySharpObject, AnySharpObject, bool>>> _compiledCache = new();
 
 	public Func<AnySharpObject, AnySharpObject, bool> Compile(string text)
 	{
-		if (!_compiledCache.ContainsKey(text) && _compiledCache.Count >= MaxCompiledExpressionCacheEntries)
+		if (!_compiledCache.TryGetValue(text, out var lazy))
 		{
-			_compiledCache.Clear();
-		}
+			var candidate = new Lazy<Func<AnySharpObject, AnySharpObject, bool>>(
+				() => CompileInternal(text), LazyThreadSafetyMode.ExecutionAndPublication);
 
-		var lazy = _compiledCache.GetOrAdd(
-			text,
-			key => new Lazy<Func<AnySharpObject, AnySharpObject, bool>>(
-				() => CompileInternal(key), LazyThreadSafetyMode.ExecutionAndPublication));
+			if (_compiledCache.TryAdd(text, candidate))
+			{
+				TrackCacheKeyAndTrimIfNeeded(text);
+				lazy = candidate;
+			}
+			else
+			{
+				lazy = _compiledCache[text];
+			}
+		}
 
 		try
 		{
@@ -47,6 +57,24 @@ public class BooleanExpressionParser(IMediator mediator) : IBooleanExpressionPar
 			// Remove poisoned entry so subsequent attempts can retry
 			_compiledCache.TryRemove(text, out _);
 			throw;
+		}
+	}
+
+	private static void TrackCacheKeyAndTrimIfNeeded(string key)
+	{
+		lock (_cacheTrimLock)
+		{
+			_cacheInsertionOrder.Enqueue(key);
+			if (_compiledCache.Count <= MaxCompiledExpressionCacheEntries)
+			{
+				return;
+			}
+
+			for (var i = 0; i < CacheEvictionBatchSize && _compiledCache.Count > MaxCompiledExpressionCacheEntries && _cacheInsertionOrder.Count > 0; i++)
+			{
+				var removeKey = _cacheInsertionOrder.Dequeue();
+				_compiledCache.TryRemove(removeKey, out _);
+			}
 		}
 	}
 

--- a/SharpMUSH.Implementation/BooleanExpressionParser.cs
+++ b/SharpMUSH.Implementation/BooleanExpressionParser.cs
@@ -1,4 +1,5 @@
 using Mediator;
+using Microsoft.Extensions.DependencyInjection;
 using SharpMUSH.Implementation.Visitors;
 using SharpMUSH.Library.DiscriminatedUnions;
 using SharpMUSH.Library.ParserInterfaces;
@@ -7,19 +8,32 @@ using ZiggyCreatures.Caching.Fusion;
 
 namespace SharpMUSH.Implementation;
 
-public class BooleanExpressionParser(IMediator mediator, IFusionCache cache) : IBooleanExpressionParser
+public class BooleanExpressionParser(
+	IMediator mediator,
+	[FromKeyedServices("compiled-expressions")] IFusionCache cache) : IBooleanExpressionParser
 {
+	// Keep in sync with the registration constant in Startup.cs (CompiledExpressionsCacheName).
+	private const string CompiledExpressionsCacheName = "compiled-expressions";
 	private const string CompiledExpressionsTag = "compiled-lock-expressions";
 	private const string CacheKeyPrefix = "compiled-lock-expr:";
 
 	/// <summary>
 	/// Per-entry cache options for compiled lock expressions.
-	/// The 1-hour Duration provides automatic expiry, naturally bounding memory usage
-	/// without requiring manual eviction bookkeeping.
+	/// <list type="bullet">
+	///   <item><description><b>Duration 1 h</b> – absolute ceiling before eviction.</description></item>
+	///   <item><description><b>EagerRefreshThreshold 0.9</b> – when an entry reaches 90 % of its TTL
+	///     and is accessed, FusionCache silently recompiles it in the background so hot entries never
+	///     suffer a cold-start compile stall. This effectively favours frequently-accessed lock
+	///     expressions over rarely-called ones.</description></item>
+	///   <item><description><b>Size 1</b> – each entry counts as one unit against the dedicated
+	///     MemoryCache SizeLimit (1 024), capping the total number of cached expressions.</description></item>
+	/// </list>
 	/// </summary>
 	private static readonly FusionCacheEntryOptions CompiledExpressionEntryOptions = new()
 	{
 		Duration = TimeSpan.FromHours(1),
+		EagerRefreshThreshold = 0.9f,
+		Size = 1,
 	};
 
 	/// <summary>

--- a/SharpMUSH.Implementation/BooleanExpressionParser.cs
+++ b/SharpMUSH.Implementation/BooleanExpressionParser.cs
@@ -2,145 +2,51 @@ using Mediator;
 using SharpMUSH.Implementation.Visitors;
 using SharpMUSH.Library.DiscriminatedUnions;
 using SharpMUSH.Library.ParserInterfaces;
-using System.Collections.Concurrent;
 using System.Linq.Expressions;
+using ZiggyCreatures.Caching.Fusion;
 
 namespace SharpMUSH.Implementation;
 
-public class BooleanExpressionParser(IMediator mediator) : IBooleanExpressionParser
+public class BooleanExpressionParser(IMediator mediator, IFusionCache cache) : IBooleanExpressionParser
 {
-	private const int MaxCompiledExpressionCacheEntries = 4096;
-	private const int CacheEvictionBatchSize = MaxCompiledExpressionCacheEntries / 4;
-	private readonly object _cacheTrimLock = new();
-	private readonly Queue<string> _cacheInsertionOrder = new();
+	private const string CompiledExpressionsTag = "compiled-lock-expressions";
+	private const string CacheKeyPrefix = "compiled-lock-expr:";
 
 	/// <summary>
-	/// Cache of compiled lock expressions keyed by their text representation.
-	/// Lock expressions are static text stored on objects that change only when a player
-	/// explicitly sets a lock (via @lock). Since compilation involves a full ANTLR
-	/// lex-parse-visit cycle plus Expression.Lambda.Compile() (JIT compilation),
-	/// caching provides significant savings on the frequent lock-check hot path.
-	/// 
-	/// Uses Lazy&lt;T&gt; to ensure only one thread performs the expensive compilation
-	/// for a given key, even under concurrent access.
-	/// 
-	/// The cache is bounded to avoid unbounded memory growth from arbitrary player-provided
-	/// lock text. When the cap is reached and a new key is introduced, the oldest keys
-	/// are evicted in batches to keep hot entries resident and avoid full-cache flushes.
+	/// Per-entry cache options for compiled lock expressions.
+	/// The 1-hour Duration provides automatic expiry, naturally bounding memory usage
+	/// without requiring manual eviction bookkeeping.
 	/// </summary>
-	private readonly ConcurrentDictionary<string, Lazy<Func<AnySharpObject, AnySharpObject, bool>>> _compiledCache = new();
+	private static readonly FusionCacheEntryOptions CompiledExpressionEntryOptions = new()
+	{
+		Duration = TimeSpan.FromHours(1),
+	};
 
+	/// <summary>
+	/// Returns a compiled delegate for the given lock expression text, using FusionCache to avoid
+	/// repeated ANTLR lex-parse-visit + Expression.Lambda.Compile() work on the hot path.
+	/// Entries are tagged so the entire compiled-expression set can be flushed at once.
+	/// </summary>
 	public Func<AnySharpObject, AnySharpObject, bool> Compile(string text)
-	{
-		while (true)
-		{
-			if (_compiledCache.TryGetValue(text, out var existing))
-			{
-				try
-				{
-					return existing.Value;
-				}
-				catch
-				{
-					TryRemoveIfCurrent(text, existing);
-					throw;
-				}
-			}
-
-			var candidate = new Lazy<Func<AnySharpObject, AnySharpObject, bool>>(
-				() => CompileInternal(text), LazyThreadSafetyMode.ExecutionAndPublication);
-			if (!_compiledCache.TryAdd(text, candidate))
-			{
-				continue;
-			}
-
-			TrackCacheKeyAndTrimIfNeeded(text);
-			try
-			{
-				return candidate.Value;
-			}
-			catch
-			{
-				// Candidate failed compilation. Remove poisoned entry and retry.
-				TryRemoveIfCurrent(text, candidate);
-				continue;
-			}
-		}
-	}
-
-	private bool TryRemoveIfCurrent(string text, Lazy<Func<AnySharpObject, AnySharpObject, bool>> lazy)
-	{
-		if (_compiledCache.TryGetValue(text, out var current) && ReferenceEquals(current, lazy))
-		{
-			return _compiledCache.TryRemove(new KeyValuePair<string, Lazy<Func<AnySharpObject, AnySharpObject, bool>>>(text, lazy));
-		}
-
-		return false;
-	}
-
-	private void TrackCacheKeyAndTrimIfNeeded(string key)
-	{
-		lock (_cacheTrimLock)
-		{
-			_cacheInsertionOrder.Enqueue(key);
-			if (_compiledCache.Count <= MaxCompiledExpressionCacheEntries)
-			{
-				return;
-			}
-
-			for (var i = 0; i < CacheEvictionBatchSize && _compiledCache.Count > MaxCompiledExpressionCacheEntries && _cacheInsertionOrder.Count > 0; i++)
-			{
-				var removeKey = _cacheInsertionOrder.Dequeue();
-				_compiledCache.TryRemove(removeKey, out _);
-			}
-		}
-	}
-
-	/// <summary>
-	/// Removes all occurrences of a key from insertion order.
-	/// Call only while holding _cacheTrimLock.
-	/// </summary>
-	private void RemoveFromCacheInsertionOrder(string key)
-	{
-		if (_cacheInsertionOrder.Count == 0)
-		{
-			return;
-		}
-
-		var retained = new Queue<string>(_cacheInsertionOrder.Count);
-		while (_cacheInsertionOrder.Count > 0)
-		{
-			var existing = _cacheInsertionOrder.Dequeue();
-			if (!string.Equals(existing, key, StringComparison.Ordinal))
-			{
-				retained.Enqueue(existing);
-			}
-		}
-
-		while (retained.Count > 0)
-		{
-			_cacheInsertionOrder.Enqueue(retained.Dequeue());
-		}
-	}
+		=> cache.GetOrSet(
+			$"{CacheKeyPrefix}{text}",
+			_ => CompileInternal(text),
+			CompiledExpressionEntryOptions,
+			tags: [CompiledExpressionsTag])!;
 
 	/// <summary>
 	/// Invalidate a cached compiled expression. Call this when a lock expression changes
-	/// (e.g., via @lock or @unlock). If text is null, clears the entire cache.
+	/// (e.g., via @lock or @unlock). If text is null, clears all compiled expressions.
 	/// </summary>
 	public void InvalidateCache(string? text = null)
 	{
-		lock (_cacheTrimLock)
+		if (text is null)
 		{
-			if (text is null)
-			{
-				_compiledCache.Clear();
-				_cacheInsertionOrder.Clear();
-				return;
-			}
-
-			_compiledCache.TryRemove(text, out _);
-			RemoveFromCacheInsertionOrder(text);
+			cache.RemoveByTag(CompiledExpressionsTag);
+			return;
 		}
+
+		cache.Remove($"{CacheKeyPrefix}{text}");
 	}
 
 	private Func<AnySharpObject, AnySharpObject, bool> CompileInternal(string text)

--- a/SharpMUSH.Implementation/BooleanExpressionParser.cs
+++ b/SharpMUSH.Implementation/BooleanExpressionParser.cs
@@ -2,18 +2,40 @@
 using SharpMUSH.Implementation.Visitors;
 using SharpMUSH.Library.DiscriminatedUnions;
 using SharpMUSH.Library.ParserInterfaces;
+using System.Collections.Concurrent;
 using System.Linq.Expressions;
 
 namespace SharpMUSH.Implementation;
 
 public class BooleanExpressionParser(IMediator mediator) : IBooleanExpressionParser
 {
-	// Future optimization: Cache invalidation system for when objects/flags change
-	// The compiled expression could be cached and invalidated when:
-	// - A character stops existing
-	// - A flag gets removed
-	// - Other rare structural changes occur
+	/// <summary>
+	/// Cache of compiled lock expressions keyed by their text representation.
+	/// Lock expressions are static text stored on objects that change only when a player
+	/// explicitly sets a lock (via @lock). Since compilation involves a full ANTLR
+	/// lex-parse-visit cycle plus Expression.Lambda.Compile() (JIT compilation),
+	/// caching provides significant savings on the frequent lock-check hot path.
+	/// </summary>
+	private static readonly ConcurrentDictionary<string, Func<AnySharpObject, AnySharpObject, bool>> _compiledCache = new();
+
 	public Func<AnySharpObject, AnySharpObject, bool> Compile(string text)
+	{
+		return _compiledCache.GetOrAdd(text, CompileInternal);
+	}
+
+	/// <summary>
+	/// Invalidate a cached compiled expression. Call this when a lock expression changes
+	/// (e.g., via @lock). If text is null, clears the entire cache.
+	/// </summary>
+	public static void InvalidateCache(string? text = null)
+	{
+		if (text is null)
+			_compiledCache.Clear();
+		else
+			_compiledCache.TryRemove(text, out _);
+	}
+
+	private Func<AnySharpObject, AnySharpObject, bool> CompileInternal(string text)
 	{
 		AntlrInputStreamSpan inputStream = new(text.AsMemory(), nameof(Compile));
 		SharpMUSHBoolExpLexer sharpLexer = new(inputStream);

--- a/SharpMUSH.Implementation/BooleanExpressionParser.cs
+++ b/SharpMUSH.Implementation/BooleanExpressionParser.cs
@@ -34,36 +34,48 @@ public class BooleanExpressionParser(IMediator mediator) : IBooleanExpressionPar
 	{
 		while (true)
 		{
-			var candidate = new Lazy<Func<AnySharpObject, AnySharpObject, bool>>(
-				() => CompileInternal(text), LazyThreadSafetyMode.ExecutionAndPublication);
-			var lazy = _compiledCache.GetOrAdd(text, candidate);
-
-			if (ReferenceEquals(lazy, candidate))
+			if (_compiledCache.TryGetValue(text, out var existing))
 			{
-				TrackCacheKeyAndTrimIfNeeded(text);
+				try
+				{
+					return existing.Value;
+				}
+				catch
+				{
+					TryRemoveIfCurrent(text, existing);
+					throw;
+				}
 			}
 
+			var candidate = new Lazy<Func<AnySharpObject, AnySharpObject, bool>>(
+				() => CompileInternal(text), LazyThreadSafetyMode.ExecutionAndPublication);
+			if (!_compiledCache.TryAdd(text, candidate))
+			{
+				continue;
+			}
+
+			TrackCacheKeyAndTrimIfNeeded(text);
 			try
 			{
-				return lazy.Value;
+				return candidate.Value;
 			}
 			catch
 			{
-				// Remove poisoned entry so subsequent attempts can retry.
-				// Only remove if this exact lazy is still the current mapping.
-				if (_compiledCache.TryGetValue(text, out var current) && ReferenceEquals(current, lazy))
-				{
-					_compiledCache.TryRemove(new KeyValuePair<string, Lazy<Func<AnySharpObject, AnySharpObject, bool>>>(text, lazy));
-				}
-
-				if (ReferenceEquals(lazy, candidate))
-				{
-					continue;
-				}
-
-				throw;
+				// Candidate failed compilation. Remove poisoned entry and retry.
+				TryRemoveIfCurrent(text, candidate);
+				continue;
 			}
 		}
+	}
+
+	private bool TryRemoveIfCurrent(string text, Lazy<Func<AnySharpObject, AnySharpObject, bool>> lazy)
+	{
+		if (_compiledCache.TryGetValue(text, out var current) && ReferenceEquals(current, lazy))
+		{
+			return _compiledCache.TryRemove(new KeyValuePair<string, Lazy<Func<AnySharpObject, AnySharpObject, bool>>>(text, lazy));
+		}
+
+		return false;
 	}
 
 	private void TrackCacheKeyAndTrimIfNeeded(string key)
@@ -84,6 +96,10 @@ public class BooleanExpressionParser(IMediator mediator) : IBooleanExpressionPar
 		}
 	}
 
+	/// <summary>
+	/// Removes all occurrences of a key from insertion order.
+	/// Call only while holding _cacheTrimLock.
+	/// </summary>
 	private void RemoveFromCacheInsertionOrder(string key)
 	{
 		if (_cacheInsertionOrder.Count == 0)

--- a/SharpMUSH.Implementation/BooleanExpressionParser.cs
+++ b/SharpMUSH.Implementation/BooleanExpressionParser.cs
@@ -1,4 +1,4 @@
-﻿using Mediator;
+using Mediator;
 using SharpMUSH.Implementation.Visitors;
 using SharpMUSH.Library.DiscriminatedUnions;
 using SharpMUSH.Library.ParserInterfaces;
@@ -15,17 +15,34 @@ public class BooleanExpressionParser(IMediator mediator) : IBooleanExpressionPar
 	/// explicitly sets a lock (via @lock). Since compilation involves a full ANTLR
 	/// lex-parse-visit cycle plus Expression.Lambda.Compile() (JIT compilation),
 	/// caching provides significant savings on the frequent lock-check hot path.
+	/// 
+	/// Uses Lazy&lt;T&gt; to ensure only one thread performs the expensive compilation
+	/// for a given key, even under concurrent access.
 	/// </summary>
-	private static readonly ConcurrentDictionary<string, Func<AnySharpObject, AnySharpObject, bool>> _compiledCache = new();
+	private static readonly ConcurrentDictionary<string, Lazy<Func<AnySharpObject, AnySharpObject, bool>>> _compiledCache = new();
 
 	public Func<AnySharpObject, AnySharpObject, bool> Compile(string text)
 	{
-		return _compiledCache.GetOrAdd(text, CompileInternal);
+		var lazy = _compiledCache.GetOrAdd(
+			text,
+			key => new Lazy<Func<AnySharpObject, AnySharpObject, bool>>(
+				() => CompileInternal(key), LazyThreadSafetyMode.ExecutionAndPublication));
+
+		try
+		{
+			return lazy.Value;
+		}
+		catch
+		{
+			// Remove poisoned entry so subsequent attempts can retry
+			_compiledCache.TryRemove(text, out _);
+			throw;
+		}
 	}
 
 	/// <summary>
 	/// Invalidate a cached compiled expression. Call this when a lock expression changes
-	/// (e.g., via @lock). If text is null, clears the entire cache.
+	/// (e.g., via @lock or @unlock). If text is null, clears the entire cache.
 	/// </summary>
 	public static void InvalidateCache(string? text = null)
 	{

--- a/SharpMUSH.Implementation/BooleanExpressionParser.cs
+++ b/SharpMUSH.Implementation/BooleanExpressionParser.cs
@@ -11,8 +11,8 @@ public class BooleanExpressionParser(IMediator mediator) : IBooleanExpressionPar
 {
 	private const int MaxCompiledExpressionCacheEntries = 4096;
 	private const int CacheEvictionBatchSize = MaxCompiledExpressionCacheEntries / 4;
-	private static readonly object _cacheTrimLock = new();
-	private static readonly Queue<string> _cacheInsertionOrder = new();
+	private readonly object _cacheTrimLock = new();
+	private readonly Queue<string> _cacheInsertionOrder = new();
 
 	/// <summary>
 	/// Cache of compiled lock expressions keyed by their text representation.
@@ -28,39 +28,45 @@ public class BooleanExpressionParser(IMediator mediator) : IBooleanExpressionPar
 	/// lock text. When the cap is reached and a new key is introduced, the oldest keys
 	/// are evicted in batches to keep hot entries resident and avoid full-cache flushes.
 	/// </summary>
-	private static readonly ConcurrentDictionary<string, Lazy<Func<AnySharpObject, AnySharpObject, bool>>> _compiledCache = new();
+	private readonly ConcurrentDictionary<string, Lazy<Func<AnySharpObject, AnySharpObject, bool>>> _compiledCache = new();
 
 	public Func<AnySharpObject, AnySharpObject, bool> Compile(string text)
 	{
-		if (!_compiledCache.TryGetValue(text, out var lazy))
+		while (true)
 		{
 			var candidate = new Lazy<Func<AnySharpObject, AnySharpObject, bool>>(
 				() => CompileInternal(text), LazyThreadSafetyMode.ExecutionAndPublication);
+			var lazy = _compiledCache.GetOrAdd(text, candidate);
 
-			if (_compiledCache.TryAdd(text, candidate))
+			if (ReferenceEquals(lazy, candidate))
 			{
 				TrackCacheKeyAndTrimIfNeeded(text);
-				lazy = candidate;
 			}
-			else
-			{
-				lazy = _compiledCache[text];
-			}
-		}
 
-		try
-		{
-			return lazy.Value;
-		}
-		catch
-		{
-			// Remove poisoned entry so subsequent attempts can retry
-			_compiledCache.TryRemove(text, out _);
-			throw;
+			try
+			{
+				return lazy.Value;
+			}
+			catch
+			{
+				// Remove poisoned entry so subsequent attempts can retry.
+				// Only remove if this exact lazy is still the current mapping.
+				if (_compiledCache.TryGetValue(text, out var current) && ReferenceEquals(current, lazy))
+				{
+					_compiledCache.TryRemove(new KeyValuePair<string, Lazy<Func<AnySharpObject, AnySharpObject, bool>>>(text, lazy));
+				}
+
+				if (ReferenceEquals(lazy, candidate))
+				{
+					continue;
+				}
+
+				throw;
+			}
 		}
 	}
 
-	private static void TrackCacheKeyAndTrimIfNeeded(string key)
+	private void TrackCacheKeyAndTrimIfNeeded(string key)
 	{
 		lock (_cacheTrimLock)
 		{
@@ -78,16 +84,47 @@ public class BooleanExpressionParser(IMediator mediator) : IBooleanExpressionPar
 		}
 	}
 
+	private void RemoveFromCacheInsertionOrder(string key)
+	{
+		if (_cacheInsertionOrder.Count == 0)
+		{
+			return;
+		}
+
+		var retained = new Queue<string>(_cacheInsertionOrder.Count);
+		while (_cacheInsertionOrder.Count > 0)
+		{
+			var existing = _cacheInsertionOrder.Dequeue();
+			if (!string.Equals(existing, key, StringComparison.Ordinal))
+			{
+				retained.Enqueue(existing);
+			}
+		}
+
+		while (retained.Count > 0)
+		{
+			_cacheInsertionOrder.Enqueue(retained.Dequeue());
+		}
+	}
+
 	/// <summary>
 	/// Invalidate a cached compiled expression. Call this when a lock expression changes
 	/// (e.g., via @lock or @unlock). If text is null, clears the entire cache.
 	/// </summary>
-	public static void InvalidateCache(string? text = null)
+	public void InvalidateCache(string? text = null)
 	{
-		if (text is null)
-			_compiledCache.Clear();
-		else
+		lock (_cacheTrimLock)
+		{
+			if (text is null)
+			{
+				_compiledCache.Clear();
+				_cacheInsertionOrder.Clear();
+				return;
+			}
+
 			_compiledCache.TryRemove(text, out _);
+			RemoveFromCacheInsertionOrder(text);
+		}
 	}
 
 	private Func<AnySharpObject, AnySharpObject, bool> CompileInternal(string text)

--- a/SharpMUSH.Implementation/Commands/MoreCommands.cs
+++ b/SharpMUSH.Implementation/Commands/MoreCommands.cs
@@ -2518,7 +2518,7 @@ public partial class Commands
 		var executorName = MModule.single(executor.Object().Name);
 		var poseMessage = isNoSpace
 			? MModule.concat(executorName, MModule.trim(message, " ", global::MarkupString.TrimType.TrimStart))
-			: MModule.concat(MModule.concat(executorName, MModule.single(" ")), message);
+			: MModule.ConcatMany([executorName, MModule.Space(), message]);
 
 		await CommunicationService!.SendToRoomAsync(executor, executorLocation,
 			_ => poseMessage,

--- a/SharpMUSH.Implementation/Functions/StringFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/StringFunctions.cs
@@ -1,4 +1,4 @@
-﻿using ANSILibrary;
+using ANSILibrary;
 using DotNext.Collections.Generic;
 using Humanizer;
 using MarkupString;
@@ -132,24 +132,26 @@ public partial class Functions
 		}
 
 		// If not Emit, use Speakername.
-
-		var concat = MModule.single(string.Empty);
+		// Build the prefix using ConcatMany to avoid O(N²) sequential concat
+		var parts = new List<MString>(4);
 
 		if (messageType is not INotifyService.NotificationType.Emit)
 		{
-			concat = MModule.concat(concat, speakerName);
+			parts.Add(speakerName);
 		}
 
 		if (messageType is INotifyService.NotificationType.Pose or INotifyService.NotificationType.Say)
 		{
-			concat = MModule.concat(concat, MModule.single(" "));
+			parts.Add(MModule.Space());
 		}
 
 		if (messageType is INotifyService.NotificationType.Say)
 		{
-			concat = MModule.concat(concat, sayString);
-			concat = MModule.concat(concat, open);
+			parts.Add(sayString);
+			parts.Add(open);
 		}
+
+		var concat = parts.Count > 0 ? MModule.ConcatMany(parts) : MModule.empty();
 
 		/*
 		  If <transform> is specified (an object/attribute pair or attribute, as with map() and similar functions),
@@ -340,9 +342,9 @@ public partial class Functions
 
 	[SharpFunction(Name = "strcat", Flags = FunctionFlags.Regular, ParameterNames = ["string..."])]
 	public static ValueTask<CallState> Concat(IMUSHCodeParser parser, SharpFunctionAttribute _2)
-		=> ValueTask.FromResult<CallState>(parser.CurrentState.ArgumentsOrdered
-			.Select(x => x.Value.Message)
-			.Aggregate((x, y) => MModule.concat(x, y)));
+		=> ValueTask.FromResult<CallState>(MModule.ConcatMany(
+			parser.CurrentState.ArgumentsOrdered
+				.Select(x => x.Value.Message ?? MModule.empty())));
 
 	[SharpFunction(Name = "cat", Flags = FunctionFlags.Regular, ParameterNames = ["string..."])]
 	public static ValueTask<CallState> Cat(IMUSHCodeParser parser, SharpFunctionAttribute _2)

--- a/SharpMUSH.Implementation/Functions/StringFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/StringFunctions.cs
@@ -132,26 +132,30 @@ public partial class Functions
 		}
 
 		// If not Emit, use Speakername.
-		// Build the prefix using ConcatMany to avoid O(N²) sequential concat
-		var parts = new List<MString>(4);
+		// Build the prefix using ConcatMany to avoid O(N²) sequential concat.
+		// List is allocated lazily to avoid an allocation for the Emit case (no prefix).
+		List<MString>? parts = null;
 
 		if (messageType is not INotifyService.NotificationType.Emit)
 		{
+			parts ??= new List<MString>(4);
 			parts.Add(speakerName);
 		}
 
 		if (messageType is INotifyService.NotificationType.Pose or INotifyService.NotificationType.Say)
 		{
+			parts ??= new List<MString>(4);
 			parts.Add(MModule.Space());
 		}
 
 		if (messageType is INotifyService.NotificationType.Say)
 		{
+			parts ??= new List<MString>(4);
 			parts.Add(sayString);
 			parts.Add(open);
 		}
 
-		var concat = parts.Count > 0 ? MModule.ConcatMany(parts) : MModule.empty();
+		var concat = parts is { Count: > 0 } ? MModule.ConcatMany(parts) : MModule.Empty();
 
 		/*
 		  If <transform> is specified (an object/attribute pair or attribute, as with map() and similar functions),
@@ -344,7 +348,7 @@ public partial class Functions
 	public static ValueTask<CallState> Concat(IMUSHCodeParser parser, SharpFunctionAttribute _2)
 		=> ValueTask.FromResult<CallState>(MModule.ConcatMany(
 			parser.CurrentState.ArgumentsOrdered
-				.Select(x => x.Value.Message ?? MModule.empty())));
+				.Select(x => x.Value.Message ?? MModule.Empty())));
 
 	[SharpFunction(Name = "cat", Flags = FunctionFlags.Regular, ParameterNames = ["string..."])]
 	public static ValueTask<CallState> Cat(IMUSHCodeParser parser, SharpFunctionAttribute _2)

--- a/SharpMUSH.Implementation/Handlers/Database/SetLockCommandHandler.cs
+++ b/SharpMUSH.Implementation/Handlers/Database/SetLockCommandHandler.cs
@@ -10,6 +10,14 @@ public class SetLockCommandHandler(ISharpDatabase database, IBooleanExpressionPa
 {
 	public async ValueTask<Unit> Handle(SetLockCommand request, CancellationToken cancellationToken)
 	{
+		// Invalidate any previously compiled expression for the old lock on this object+lockName.
+		// The old lock text comes from the in-memory object (no extra DB round-trip).
+		if (request.Target.Locks.TryGetValue(request.LockName, out var oldLock)
+			&& oldLock.LockString is not "#TRUE" and not null)
+		{
+			BooleanExpressionParser.InvalidateCache(oldLock.LockString);
+		}
+
 		// Normalize the lock string by converting bare dbrefs to objids
 		// This ensures locks won't match recycled dbrefs after objects are destroyed
 		var normalizedLockString = booleanParser.Normalize(request.LockString);
@@ -28,6 +36,13 @@ public class UnsetLockCommandHandler(ISharpDatabase database) : ICommandHandler<
 {
 	public async ValueTask<Unit> Handle(UnsetLockCommand request, CancellationToken cancellationToken)
 	{
+		// Invalidate the compiled expression for the lock being removed
+		if (request.Target.Locks.TryGetValue(request.LockName, out var oldLock)
+			&& oldLock.LockString is not "#TRUE" and not null)
+		{
+			BooleanExpressionParser.InvalidateCache(oldLock.LockString);
+		}
+
 		await database.UnsetLockAsync(request.Target, request.LockName, cancellationToken);
 		return new Unit();
 	}

--- a/SharpMUSH.Implementation/Handlers/Database/SetLockCommandHandler.cs
+++ b/SharpMUSH.Implementation/Handlers/Database/SetLockCommandHandler.cs
@@ -10,7 +10,7 @@ public class SetLockCommandHandler(ISharpDatabase database, IBooleanExpressionPa
 {
 	public async ValueTask<Unit> Handle(SetLockCommand request, CancellationToken cancellationToken)
 	{
-		// Invalidate any previously compiled expression for the old lock on this object+lockName.
+		// Invalidate any previously compiled expression for the old lock text.
 		// The old lock text comes from the in-memory object (no extra DB round-trip).
 		if (request.Target.Locks.TryGetValue(request.LockName, out var oldLock)
 			&& oldLock.LockString is not "#TRUE" and not null)

--- a/SharpMUSH.Implementation/Handlers/Database/SetLockCommandHandler.cs
+++ b/SharpMUSH.Implementation/Handlers/Database/SetLockCommandHandler.cs
@@ -15,7 +15,7 @@ public class SetLockCommandHandler(ISharpDatabase database, IBooleanExpressionPa
 		if (request.Target.Locks.TryGetValue(request.LockName, out var oldLock)
 			&& oldLock.LockString is not "#TRUE" and not null)
 		{
-			BooleanExpressionParser.InvalidateCache(oldLock.LockString);
+			booleanParser.InvalidateCache(oldLock.LockString);
 		}
 
 		// Normalize the lock string by converting bare dbrefs to objids
@@ -32,7 +32,7 @@ public class SetLockCommandHandler(ISharpDatabase database, IBooleanExpressionPa
 		return new Unit();
 	}
 }
-public class UnsetLockCommandHandler(ISharpDatabase database) : ICommandHandler<UnsetLockCommand>
+public class UnsetLockCommandHandler(ISharpDatabase database, IBooleanExpressionParser booleanParser) : ICommandHandler<UnsetLockCommand>
 {
 	public async ValueTask<Unit> Handle(UnsetLockCommand request, CancellationToken cancellationToken)
 	{
@@ -40,7 +40,7 @@ public class UnsetLockCommandHandler(ISharpDatabase database) : ICommandHandler<
 		if (request.Target.Locks.TryGetValue(request.LockName, out var oldLock)
 			&& oldLock.LockString is not "#TRUE" and not null)
 		{
-			BooleanExpressionParser.InvalidateCache(oldLock.LockString);
+			booleanParser.InvalidateCache(oldLock.LockString);
 		}
 
 		await database.UnsetLockAsync(request.Target, request.LockName, cancellationToken);

--- a/SharpMUSH.Implementation/SharpMUSH.Implementation.csproj
+++ b/SharpMUSH.Implementation/SharpMUSH.Implementation.csproj
@@ -27,6 +27,7 @@
 		<PackageReference Include="morelinq" Version="4.4.0" />
 		<PackageReference Include="OneOf" Version="3.0.271" />
 		<PackageReference Include="Serilog" Version="4.3.1" />
+		<PackageReference Include="ZiggyCreatures.FusionCache" Version="2.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
+++ b/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
@@ -144,7 +144,7 @@ public class SharpMUSHParserVisitor(
 		// Collect non-null child results to batch-merge at the end
 		var results = new List<CallState>(childCount);
 
-		foreach (var i in Enumerable.Range(0, childCount))
+		for (var i = 0; i < childCount; i++)
 		{
 			var child = node.GetChild(i);
 			var childResult = child is null ? null : await child.Accept(this);
@@ -200,23 +200,34 @@ public class SharpMUSHParserVisitor(
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static CallState BatchMergeResults(List<CallState> results)
 	{
-		// Check if any result has Arguments — if so, use arguments merge path
-		var argumentSource = results.FirstOrDefault(r => r.Arguments is not null);
+		// Single pass: find the first result with Arguments
+		CallState? argumentSource = null;
+		for (var i = 0; i < results.Count; i++)
+		{
+			if (results[i].Arguments is not null)
+			{
+				argumentSource = results[i];
+				break;
+			}
+		}
 
 		if (argumentSource is not null)
 		{
-			// Batch merge arguments: count total first, then copy once
+			// Batch merge arguments: count total first, then copy once — no LINQ
 			var totalArgs = 0;
-			foreach (var r in results)
-				totalArgs += r.Arguments?.Length ?? 0;
+			for (var i = 0; i < results.Count; i++)
+				totalArgs += results[i].Arguments?.Length ?? 0;
 
 			var merged = new MString[totalArgs];
 			var offset = 0;
-			foreach (var r in results.Where(r => r.Arguments is { Length: > 0 }))
+			for (var i = 0; i < results.Count; i++)
 			{
-				var args = r.Arguments!;
-				args.CopyTo(merged, offset);
-				offset += args.Length;
+				var args = results[i].Arguments;
+				if (args is { Length: > 0 })
+				{
+					args.CopyTo(merged, offset);
+					offset += args.Length;
+				}
 			}
 
 			return argumentSource with { Arguments = merged };

--- a/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
+++ b/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
@@ -130,16 +130,29 @@ public class SharpMUSHParserVisitor(
 	{
 		if (node is null) return null;
 
-		var result = await DefaultResult;
+		var childCount = node.ChildCount;
+		if (childCount == 0) return null;
 
-		await foreach (var child in Enumerable
-							 .Range(0, node.ChildCount)
-							 .ToAsyncEnumerable()
-							 .Select(node.GetChild))
+		// Fast path for single child — no aggregation needed
+		if (childCount == 1)
 		{
-			result = child is null
-				? AggregateResult(result, null)
-				: AggregateResult(result, await child.Accept(this));
+			var only = node.GetChild(0);
+			return only is null ? null : await only.Accept(this);
+		}
+
+		// Collect non-null child results to batch-merge at the end
+		List<CallState>? results = null;
+
+		for (var i = 0; i < childCount; i++)
+		{
+			var child = node.GetChild(i);
+			var childResult = child is null ? null : await child.Accept(this);
+
+			if (childResult is not null)
+			{
+				results ??= new List<CallState>(childCount);
+				results.Add(childResult);
+			}
 
 			// Halt evaluation if a limit has been exceeded
 			if (parser.CurrentState.LimitExceeded?.IsExceeded == true)
@@ -148,43 +161,84 @@ public class SharpMUSHParserVisitor(
 			}
 		}
 
-		return result;
+		if (results is null || results.Count == 0)
+			return null;
+
+		if (results.Count == 1)
+			return results[0];
+
+		return BatchMergeResults(results);
 	}
 
 	public async ValueTask<CallState?> VisitChildrenOrBreak(IRuleNode node, Func<bool> haltPredicate)
 	{
-		var result = await DefaultResult;
+		var childCount = node.ChildCount;
+		List<CallState>? results = null;
 
-		await foreach (var child in Enumerable
-								 .Range(0, node.ChildCount)
-								 .Select(node.GetChild)
-								 .ToAsyncEnumerable()
-								 .TakeWhile(_ => !haltPredicate()))
+		for (var i = 0; i < childCount; i++)
 		{
-			result = AggregateResult(result, await child.Accept(this));
+			if (haltPredicate()) break;
+			var child = node.GetChild(i);
+			if (child is not null)
+			{
+				var childResult = await child.Accept(this);
+				if (childResult is not null)
+				{
+					results ??= new List<CallState>(childCount);
+					results.Add(childResult);
+				}
+			}
 		}
 
-		return result;
+		if (results is null || results.Count == 0)
+			return null;
+
+		if (results.Count == 1)
+			return results[0];
+
+		return BatchMergeResults(results);
 	}
 
-	[MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-	private static CallState? AggregateResult(CallState? aggregate,
-		CallState? nextResult)
-		=> (aggregate, nextResult) switch
+	/// <summary>
+	/// Merges a list of child CallState results in O(N) instead of the previous
+	/// pairwise AggregateResult approach which was O(N²) for Message concatenation.
+	/// Uses ConcatMany for messages (single StringBuilder pass) and batched array
+	/// construction for arguments.
+	/// </summary>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private static CallState BatchMergeResults(List<CallState> results)
+	{
+		// Check if any result has Arguments — if so, use arguments merge path
+		if (results[0].Arguments is not null)
 		{
-			(null, null)
-				=> null,
-			({ Arguments: not null } agg, { Arguments: not null } next)
-				=> agg with { Arguments = [.. agg.Arguments, .. next.Arguments] },
-			({ Message: not null } agg, { Message: not null } next)
-				=> agg with {
-					Message = MModule.concat(agg.Message, next.Message), 
-					ParsedMessage = () => ValueTask.FromResult<MString?>(MModule.concat(agg.Message, next.Message))
-				},
-				// => new CallState(MModule.concat(agg.Message, next.Message), agg.Depth),
-			var (agg, next)
-				=> agg ?? next
-		};
+			// Batch merge arguments: count total first, then copy once
+			var totalArgs = 0;
+			foreach (var r in results)
+				totalArgs += r.Arguments?.Length ?? 0;
+
+			var merged = new MString[totalArgs];
+			var offset = 0;
+			foreach (var r in results)
+			{
+				if (r.Arguments is { Length: > 0 } args)
+				{
+					args.CopyTo(merged, offset);
+					offset += args.Length;
+				}
+			}
+
+			return results[0] with { Arguments = merged };
+		}
+
+		// Message merge path: use ConcatMany for O(N) instead of O(N²)
+		var messages = new MString[results.Count];
+		for (var i = 0; i < results.Count; i++)
+			messages[i] = results[i].Message ?? MModule.empty();
+
+		var combined = MModule.ConcatMany(messages);
+		return new CallState(combined, results[0].Depth, null,
+			() => ValueTask.FromResult<MString?>(combined));
+	}
 
 	/// <summary>
 	/// Extracts text from a parser context using the source string.

--- a/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
+++ b/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
@@ -209,7 +209,17 @@ public class SharpMUSHParserVisitor(
 	private static CallState BatchMergeResults(List<CallState> results)
 	{
 		// Check if any result has Arguments — if so, use arguments merge path
-		if (results[0].Arguments is not null)
+		CallState? argumentSource = null;
+		foreach (var r in results)
+		{
+			if (r.Arguments is not null)
+			{
+				argumentSource = r;
+				break;
+			}
+		}
+
+		if (argumentSource is not null)
 		{
 			// Batch merge arguments: count total first, then copy once
 			var totalArgs = 0;
@@ -227,13 +237,13 @@ public class SharpMUSHParserVisitor(
 				}
 			}
 
-			return results[0] with { Arguments = merged };
+			return argumentSource with { Arguments = merged };
 		}
 
 		// Message merge path: use ConcatMany for O(N) instead of O(N²)
 		var messages = new MString[results.Count];
 		for (var i = 0; i < results.Count; i++)
-			messages[i] = results[i].Message ?? MModule.empty();
+			messages[i] = results[i].Message ?? MModule.Empty();
 
 		var combined = MModule.ConcatMany(messages);
 		return new CallState(combined, results[0].Depth, null,

--- a/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
+++ b/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
@@ -16,6 +16,7 @@ using SharpMUSH.Library.ParserInterfaces;
 using SharpMUSH.Library.Queries.Database;
 using SharpMUSH.Library.Services.Interfaces;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using static SharpMUSHParser;
 
@@ -200,15 +201,7 @@ public class SharpMUSHParserVisitor(
 	private static CallState BatchMergeResults(List<CallState> results)
 	{
 		// Check if any result has Arguments — if so, use arguments merge path
-		CallState? argumentSource = null;
-		foreach (var r in results)
-		{
-			if (r.Arguments is not null)
-			{
-				argumentSource = r;
-				break;
-			}
-		}
+		var argumentSource = results.FirstOrDefault(r => r.Arguments is not null);
 
 		if (argumentSource is not null)
 		{
@@ -219,13 +212,11 @@ public class SharpMUSHParserVisitor(
 
 			var merged = new MString[totalArgs];
 			var offset = 0;
-			foreach (var r in results)
+			foreach (var r in results.Where(r => r.Arguments is { Length: > 0 }))
 			{
-				if (r.Arguments is { Length: > 0 } args)
-				{
-					args.CopyTo(merged, offset);
-					offset += args.Length;
-				}
+				var args = r.Arguments!;
+				args.CopyTo(merged, offset);
+				offset += args.Length;
 			}
 
 			return argumentSource with { Arguments = merged };

--- a/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
+++ b/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
@@ -141,33 +141,24 @@ public class SharpMUSHParserVisitor(
 		}
 
 		// Collect non-null child results to batch-merge at the end
-		List<CallState>? results = null;
+		var results = new List<CallState>(childCount);
 
-		for (var i = 0; i < childCount; i++)
+		foreach (var i in Enumerable.Range(0, childCount))
 		{
 			var child = node.GetChild(i);
 			var childResult = child is null ? null : await child.Accept(this);
-
-			if (childResult is not null)
-			{
-				results ??= new List<CallState>(childCount);
-				results.Add(childResult);
-			}
+			if (childResult is not null) results.Add(childResult);
 
 			// Halt evaluation if a limit has been exceeded
-			if (parser.CurrentState.LimitExceeded?.IsExceeded == true)
-			{
-				break;
-			}
+			if (parser.CurrentState.LimitExceeded?.IsExceeded == true) break;
 		}
 
-		if (results is null || results.Count == 0)
-			return null;
-
-		if (results.Count == 1)
-			return results[0];
-
-		return BatchMergeResults(results);
+		return results.Count switch
+		{
+			0 => null,
+			1 => results[0],
+			_ => BatchMergeResults(results)
+		};
 	}
 
 	public async ValueTask<CallState?> VisitChildrenOrBreak(IRuleNode node, Func<bool> haltPredicate)

--- a/SharpMUSH.Library/Commands/Database/SetLockCommand.cs
+++ b/SharpMUSH.Library/Commands/Database/SetLockCommand.cs
@@ -6,12 +6,12 @@ namespace SharpMUSH.Library.Commands.Database;
 
 public record SetLockCommand(SharpObject Target, string LockName, string LockString) : ICommand, ICacheInvalidating
 {
-	public string[] CacheKeys => [$"object:{Target.DBRef}"];
+	public string[] CacheKeys => [$"object:{Target.DBRef}", $"lock:{Target.DBRef}:{LockName}"];
 	public string[] CacheTags => [];
 }
 
 public record UnsetLockCommand(SharpObject Target, string LockName) : ICommand, ICacheInvalidating
 {
-	public string[] CacheKeys => [$"object:{Target.DBRef}"];
+	public string[] CacheKeys => [$"object:{Target.DBRef}", $"lock:{Target.DBRef}:{LockName}"];
 	public string[] CacheTags => [];
 }

--- a/SharpMUSH.Library/ParserInterfaces/CallState.cs
+++ b/SharpMUSH.Library/ParserInterfaces/CallState.cs
@@ -1,4 +1,4 @@
-﻿using OneOf.Types;
+using OneOf.Types;
 using SharpMUSH.Library.DiscriminatedUnions;
 using SharpMUSH.Library.Extensions;
 using SharpMUSH.Library.Models;
@@ -65,6 +65,9 @@ public record CallState(MString? Message, int Depth, MString[]? Arguments, Func<
 	{
 	}
 
-	public static readonly CallState EmptyArgument = new(MModule.empty(), 0, [], () => ValueTask.FromResult(MModule.empty())!);
-	public static readonly CallState Empty = new(MModule.empty(), 0, null, () => ValueTask.FromResult(MModule.empty())!);
+	private static readonly MString _emptyMString = MModule.empty();
+	private static readonly Func<ValueTask<MString?>> _emptyParsedMessage = () => ValueTask.FromResult<MString?>(_emptyMString);
+
+	public static readonly CallState EmptyArgument = new(_emptyMString, 0, [], _emptyParsedMessage);
+	public static readonly CallState Empty = new(_emptyMString, 0, null, _emptyParsedMessage);
 }

--- a/SharpMUSH.Library/ParserInterfaces/IBooleanExpressionParser.cs
+++ b/SharpMUSH.Library/ParserInterfaces/IBooleanExpressionParser.cs
@@ -6,6 +6,7 @@ public interface IBooleanExpressionParser
 {
 	Func<AnySharpObject, AnySharpObject, bool> Compile(string text);
 	bool Validate(string text, AnySharpObject lockee);
+	void InvalidateCache(string? text = null);
 
 	/// <summary>
 	/// Normalizes a lock expression by converting bare dbrefs to objids.

--- a/SharpMUSH.MarkupString/MarkupStringModule.cs
+++ b/SharpMUSH.MarkupString/MarkupStringModule.cs
@@ -289,22 +289,47 @@ public static partial class MarkupStringModule
         return Math.Max(0, insertionPoint - 1);
     }
 
-    // ── Construction ──────────────────────────────────────────────────────────
+    // ── Cached singletons ────────────────────────────────────────────────────
+    // MarkupString is immutable, so frequently-used identical instances can be shared.
 
-    public static MarkupString Single(string str)
+    private static readonly MarkupString _empty = new(string.Empty, ImmutableArray<AttributeRun>.Empty);
+    private static readonly MarkupString _space = NewPlain(" ");
+    private static readonly MarkupString _comma = NewPlain(",");
+    private static readonly MarkupString _zero = NewPlain("0");
+    private static readonly MarkupString _one = NewPlain("1");
+    private static readonly MarkupString _negOne = NewPlain("#-1");
+    private static readonly MarkupString _newline = NewPlain("\n");
+
+    /// <summary>Creates a new plain (no-markup) MarkupString. Used for singleton initialization.</summary>
+    private static MarkupString NewPlain(string str) =>
+        new(str, ImmutableArray.Create(new AttributeRun(0, str.Length, ImmutableArray<IMarkup>.Empty)));
+
+    /// <summary>
+    /// Returns a cached singleton for commonly used plain-text strings,
+    /// avoiding repeated allocations for values like " ", ",", "0", "1", "#-1", "\n".
+    /// Falls through to a new allocation only for uncached strings.
+    /// </summary>
+    public static MarkupString Single(string str) => str switch
     {
-        if (str.Length == 0)
-            return new MarkupString(string.Empty, ImmutableArray<AttributeRun>.Empty);
-        return new MarkupString(str,
-            ImmutableArray.Create(new AttributeRun(0, str.Length, ImmutableArray<IMarkup>.Empty)));
-    }
+        "" => _empty,
+        " " => _space,
+        "," => _comma,
+        "0" => _zero,
+        "1" => _one,
+        "#-1" => _negOne,
+        "\n" => _newline,
+        _ => new MarkupString(str,
+            ImmutableArray.Create(new AttributeRun(0, str.Length, ImmutableArray<IMarkup>.Empty)))
+    };
 
     // F#-style lowercase alias kept for callers that use `single`
-    public static MarkupString single(string? str) => str is null ? Empty() : Single(str);
+    public static MarkupString single(string? str) => str is null ? _empty : Single(str);
 
-    public static MarkupString Empty() =>
-        new(string.Empty, ImmutableArray<AttributeRun>.Empty);
-    public static MarkupString empty() => Empty();
+    public static MarkupString Empty() => _empty;
+    public static MarkupString empty() => _empty;
+
+    /// <summary>Returns the cached space singleton (" "). Avoids allocations at 77+ call sites.</summary>
+    public static MarkupString Space() => _space;
 
     public static MarkupString MarkupSingle(IMarkup markup, string str)
     {
@@ -341,7 +366,7 @@ public static partial class MarkupStringModule
             builder.Add(new AttributeRun(run.Start + offset, run.Length, run.Markups));
         return new MarkupString(combinedText, builder.ToImmutable());
     }
-    public static MarkupString concat(MarkupString? a, MarkupString? b) => Concat(a ?? Empty(), b ?? Empty());
+    public static MarkupString concat(MarkupString? a, MarkupString? b) => Concat(a ?? _empty, b ?? _empty);
 
     public static MarkupString ConcatMany(IEnumerable<MarkupString> items)
     {

--- a/SharpMUSH.Server/Startup.cs
+++ b/SharpMUSH.Server/Startup.cs
@@ -27,6 +27,7 @@ using SharpMUSH.Library.Services;
 using SharpMUSH.Library.Services.DatabaseConversion;
 using SharpMUSH.Library.Services.Interfaces;
 using SharpMUSH.Messaging.NATS;
+using Microsoft.Extensions.Caching.Memory;
 using ZiggyCreatures.Caching.Fusion;
 using TaskScheduler = SharpMUSH.Library.Services.TaskScheduler;
 
@@ -39,6 +40,9 @@ string natsUrl,
 DatabaseProvider databaseProvider = DatabaseProvider.ArangoDB,
 string? memgraphUri = null)
 {
+// Cache name for the dedicated compiled boolean-lock expression cache.
+// Must match the [FromKeyedServices] key used in BooleanExpressionParser.
+public const string CompiledExpressionsCacheName = "compiled-expressions";
 // This method gets called by the runtime. Use this method to add services to the container.
 // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
 public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
@@ -216,6 +220,17 @@ x.AddConsumer<Consumers.ConnectionClosedConsumer>();
 });
 
 services.AddFusionCache().TryWithAutoSetup();
+
+// Dedicated cache for compiled boolean-lock expressions.
+// Uses a size-limited memory cache (max 1024 entries, 25% compaction) so rarely-used
+// entries are evicted first under memory pressure while hot entries stay resident.
+services.AddFusionCache(CompiledExpressionsCacheName)
+	.WithMemoryCache(_ => new MemoryCache(new MemoryCacheOptions
+	{
+		SizeLimit = 1024,
+		CompactionPercentage = 0.25,
+	}))
+	.AsKeyedServiceByCacheName();
 services.AddQuartz(x =>
 {
 x.UseInMemoryStore();

--- a/SharpMUSH.Tests/Parser/BooleanExpressionUnitTests.cs
+++ b/SharpMUSH.Tests/Parser/BooleanExpressionUnitTests.cs
@@ -3,6 +3,7 @@ using SharpMUSH.Library;
 using SharpMUSH.Library.Extensions;
 using SharpMUSH.Library.Models;
 using SharpMUSH.Library.ParserInterfaces;
+using System.Collections.Concurrent;
 
 namespace SharpMUSH.Tests.Parser;
 
@@ -151,5 +152,75 @@ public class BooleanExpressionUnitTests
 		var dbn = (await Database.GetObjectNodeAsync(new DBRef(1))).Known();
 
 		await Assert.That(bep.Validate(input, dbn)).IsEqualTo(expected);
+	}
+
+	[Test]
+	public async Task InvalidateCache_SpecificExpression_AllowsRecompile()
+	{
+		var bep = BooleanParser;
+		var player = (await Database.GetObjectNodeAsync(new DBRef(1))).Known();
+		var input = "type^Player";
+
+		await Assert.That(bep.Compile(input)(player, player)).IsTrue();
+		bep.InvalidateCache(input);
+		await Assert.That(bep.Compile(input)(player, player)).IsTrue();
+	}
+
+	[Test]
+	public async Task InvalidateCache_AllExpressions_AllowsRecompile()
+	{
+		var bep = BooleanParser;
+		var player = (await Database.GetObjectNodeAsync(new DBRef(1))).Known();
+
+		await Assert.That(bep.Compile("#TRUE")(player, player)).IsTrue();
+		await Assert.That(bep.Compile("type^Thing")(player, player)).IsFalse();
+
+		bep.InvalidateCache();
+
+		await Assert.That(bep.Compile("#TRUE")(player, player)).IsTrue();
+		await Assert.That(bep.Compile("type^Thing")(player, player)).IsFalse();
+	}
+
+	[Test]
+	public async Task CompileAndInvalidateCache_Concurrently_DoesNotThrow()
+	{
+		var bep = BooleanParser;
+		var player = (await Database.GetObjectNodeAsync(new DBRef(1))).Known();
+		var input = "type^Player";
+		var errors = new ConcurrentQueue<Exception>();
+
+		var compileTask = Task.Run(() =>
+		{
+			for (var i = 0; i < 200; i++)
+			{
+				try
+				{
+					var compiled = bep.Compile(input);
+					_ = compiled(player, player);
+				}
+				catch (Exception ex)
+				{
+					errors.Enqueue(ex);
+				}
+			}
+		});
+
+		var invalidateTask = Task.Run(() =>
+		{
+			for (var i = 0; i < 200; i++)
+			{
+				try
+				{
+					bep.InvalidateCache(input);
+				}
+				catch (Exception ex)
+				{
+					errors.Enqueue(ex);
+				}
+			}
+		});
+
+		await Task.WhenAll(compileTask, invalidateTask);
+		await Assert.That(errors).IsEmpty();
 	}
 }

--- a/SharpMUSH.Tests/Parser/BooleanExpressionUnitTests.cs
+++ b/SharpMUSH.Tests/Parser/BooleanExpressionUnitTests.cs
@@ -184,6 +184,7 @@ public class BooleanExpressionUnitTests
 	[Test]
 	public async Task CompileAndInvalidateCache_Concurrently_DoesNotThrow()
 	{
+		const int iterationCount = 1000;
 		var bep = BooleanParser;
 		var player = (await Database.GetObjectNodeAsync(new DBRef(1))).Known();
 		var input = "type^Player";
@@ -191,7 +192,7 @@ public class BooleanExpressionUnitTests
 
 		var compileTask = Task.Run(() =>
 		{
-			for (var i = 0; i < 200; i++)
+			for (var i = 0; i < iterationCount; i++)
 			{
 				try
 				{
@@ -207,7 +208,7 @@ public class BooleanExpressionUnitTests
 
 		var invalidateTask = Task.Run(() =>
 		{
-			for (var i = 0; i < 200; i++)
+			for (var i = 0; i < iterationCount; i++)
 			{
 				try
 				{


### PR DESCRIPTION
…etons

- Cache MModule.Empty() and common singletons (space, comma, 0, 1, #-1, newline) as static readonly fields, eliminating ~6 heap allocations per call at 77+ sites
- Replace VisitChildren async enumerable chain with plain for-loop, removing Enumerable.Range().ToAsyncEnumerable().Select() adapter allocations per tree node
- Replace O(N²) AggregateResult pairwise concat with BatchMergeResults using ConcatMany (single StringBuilder pass) for O(N) message concatenation
- Add ConcurrentDictionary cache for compiled boolean lock expressions, avoiding repeated ANTLR lex-parse-visit + Expression.Lambda.Compile() per check
- Replace sequential MModule.concat chains with ConcatMany in Speak, strcat, pose
- Share cached empty MString and delegate in CallState.Empty/EmptyArgument

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Space() accessor and public InvalidateCache(string? text = null) to the boolean-expression API.
  * Set/Unset lock handling now invalidates related compiled-expression cache entries.

* **Refactor**
  * Optimized string/markup concatenation and reuse to reduce allocations.
  * Streamlined parser child-result aggregation for more efficient batched merges.

* **Bug Fixes**
  * Made expression compilation caching bounded, thread-safe, and resilient to failures.
  * Adjusted pose/speech message composition for consistent output.

* **Tests**
  * Added tests for cache invalidation and concurrent use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->