### PR TITLE
perf: add comprehensive BenchmarkDotNet benchmarks and nightly CI wor…

### DIFF
--- a/.github/workflows/benchmark-nightly.yml
+++ b/.github/workflows/benchmark-nightly.yml
@@ -1,0 +1,68 @@
+name: Nightly Benchmarks
+
+on:
+  schedule:
+    # 02:00 UTC every night
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: BenchmarkDotNet (Job.Default)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java (required for ANTLR parser generation)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.x
+          cache: true
+          cache-dependency-path: '**/*.csproj'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build (Release)
+        run: dotnet build --no-restore --configuration Release
+
+      # SHARPMUSH_CI_BENCHMARK is intentionally NOT set here so that
+      # AdaptiveBenchmarkConfig selects Job.Default (full nightly run).
+      - name: Run Benchmarks
+        run: >
+          dotnet run
+          --project SharpMUSH.Benchmarks
+          --configuration Release
+          --no-build
+          -- --all
+
+      - name: Publish Results to Step Summary
+        if: always()
+        run: |
+          echo "## Benchmark Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          for f in BenchmarkDotNet.Artifacts/results/*.md; do
+            if [ -f "$f" ]; then
+              echo "### $(basename "$f" .md)" >> "$GITHUB_STEP_SUMMARY"
+              cat "$f" >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
+      - name: Upload Benchmark Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-${{ github.run_id }}
+          path: BenchmarkDotNet.Artifacts/
+          if-no-files-found: warn

--- a/.github/workflows/benchmark-nightly.yml
+++ b/.github/workflows/benchmark-nightly.yml
@@ -51,13 +51,23 @@ jobs:
         run: |
           echo "## Benchmark Results" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Full BenchmarkDotNet reports are available in the uploaded artifact \`benchmark-results-${{ github.run_id }}\`." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          found_any=false
           for f in BenchmarkDotNet.Artifacts/results/*.md; do
             if [ -f "$f" ]; then
-              echo "### $(basename "$f" .md)" >> "$GITHUB_STEP_SUMMARY"
-              cat "$f" >> "$GITHUB_STEP_SUMMARY"
-              echo "" >> "$GITHUB_STEP_SUMMARY"
+              if [ "$found_any" = false ]; then
+                echo "### Result files" >> "$GITHUB_STEP_SUMMARY"
+                found_any=true
+              fi
+              echo "- \`$(basename "$f")\`" >> "$GITHUB_STEP_SUMMARY"
             fi
           done
+
+          if [ "$found_any" = false ]; then
+            echo "_No markdown benchmark result files were found in \`BenchmarkDotNet.Artifacts/results\`._" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Upload Benchmark Artifacts
         if: always()

--- a/SharpMUSH.Benchmarks/AdaptiveBenchmarkConfig.cs
+++ b/SharpMUSH.Benchmarks/AdaptiveBenchmarkConfig.cs
@@ -1,0 +1,40 @@
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Validators;
+
+namespace SharpMUSH.Benchmarks;
+
+/// <summary>
+/// CI-aware BenchmarkDotNet configuration.
+/// Uses <see cref="Job.ShortRun"/> when the CI environment variable is set (GitHub Actions / SHARPMUSH_CI_BENCHMARK),
+/// and <see cref="Job.Default"/> for nightly / local runs.
+/// </summary>
+public class AdaptiveBenchmarkConfig : ManualConfig
+{
+	/// <summary>Returns true when running inside a CI environment.</summary>
+	public static bool IsCi() =>
+		string.Equals(Environment.GetEnvironmentVariable("SHARPMUSH_CI_BENCHMARK"), "true", StringComparison.OrdinalIgnoreCase);
+
+	public AdaptiveBenchmarkConfig()
+	{
+		AddJob(IsCi()
+			? Job.ShortRun.WithId("CI")
+			: Job.Default.WithId("Nightly"));
+
+		AddDiagnoser(MemoryDiagnoser.Default);
+		AddDiagnoser(ThreadingDiagnoser.Default);
+		AddDiagnoser(ExceptionDiagnoser.Default);
+
+		AddLogger(ConsoleLogger.Default);
+		AddColumnProvider(DefaultColumnProviders.Instance);
+		AddExporter(MarkdownExporter.GitHub);
+
+		AddValidator(JitOptimizationsValidator.FailOnError);
+		AddValidator(RunModeValidator.FailOnError);
+		AddValidator(GenericBenchmarksValidator.DontFailOnError);
+	}
+}

--- a/SharpMUSH.Benchmarks/BaseBenchmark.cs
+++ b/SharpMUSH.Benchmarks/BaseBenchmark.cs
@@ -2,21 +2,10 @@ using Core.Arango;
 using Core.Arango.Serialization.Json;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
-using Mediator;
 using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
-using OneOf.Types;
 using Serilog;
 using SharpMUSH.Library;
-using SharpMUSH.Library.DiscriminatedUnions;
-using SharpMUSH.Library.Extensions;
-using SharpMUSH.Library.Models;
-using SharpMUSH.Library.ParserInterfaces;
-using SharpMUSH.Library.Services;
-using System.Collections.Concurrent;
-using System.Text;
 using Testcontainers.ArangoDb;
-using BenchmarkDotNet.Attributes;
 
 namespace SharpMUSH.Benchmarks;
 
@@ -40,7 +29,7 @@ public class BaseBenchmark
 	private IContainer? _natsContainer;
 
 	[GlobalSetup]
-	public async ValueTask Setup()
+	public virtual async ValueTask Setup()
 	{
 		_arangoContainer = new ArangoDbBuilder("arangodb:latest")
 			.WithPassword("password")
@@ -73,6 +62,9 @@ public class BaseBenchmark
 
 		if (_arangoContainer is not null)
 			await _arangoContainer.DisposeAsync().ConfigureAwait(false);
+
+		_server?.Dispose();
+		Environment.SetEnvironmentVariable("NATS_URL", null);
 	}
 
 	protected async Task<IMUSHCodeParser?> TestParser() =>

--- a/SharpMUSH.Benchmarks/BenchmarkHelpers.cs
+++ b/SharpMUSH.Benchmarks/BenchmarkHelpers.cs
@@ -1,0 +1,80 @@
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using OneOf.Types;
+using SharpMUSH.Library;
+using SharpMUSH.Library.Extensions;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Services;
+using System.Collections.Concurrent;
+using System.Text;
+
+namespace SharpMUSH.Benchmarks;
+
+/// <summary>
+/// Shared helpers used by both <see cref="BaseBenchmark"/> and <see cref="MemgraphBaseBenchmark"/>.
+/// </summary>
+internal static class BenchmarkHelpers
+{
+	private static readonly byte[] NatsConfig =
+		"max_payload: 6291456\njetstream: true\n"u8.ToArray();
+
+	/// <summary>Starts a NATS 2 container with JetStream enabled on a random host port.</summary>
+	public static async Task<IContainer> StartNatsContainerAsync()
+	{
+		var container = new ContainerBuilder("nats:2-alpine")
+			.WithPortBinding(4222, true)
+			.WithResourceMapping(NatsConfig, "/etc/nats/nats.conf")
+			.WithCommand("-c", "/etc/nats/nats.conf")
+			.WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Server is ready"))
+			.WithReuse(false)
+			.Build();
+
+		await container.StartAsync().ConfigureAwait(false);
+		return container;
+	}
+
+	/// <summary>
+	/// Creates a fully configured <see cref="IMUSHCodeParser"/> bound to connection handle 1 (#1).
+	/// </summary>
+	public static async Task<IMUSHCodeParser?> CreateTestParser(
+		ISharpDatabase database,
+		IServiceProvider services)
+	{
+		var realOne = await database.GetObjectNodeAsync(new DBRef(1)).ConfigureAwait(false);
+		var one = realOne.Object()!.DBRef;
+
+		var mockPublisher = Substitute.For<IPublisher>();
+		var simpleConnectionService = new ConnectionService(mockPublisher);
+		await simpleConnectionService.Register(
+			1, "localhost", "localhost", "test",
+			_ => ValueTask.CompletedTask,
+			_ => ValueTask.CompletedTask,
+			() => Encoding.UTF8).ConfigureAwait(false);
+		await simpleConnectionService.Bind(1, one).ConfigureAwait(false);
+
+		var parser = services.GetRequiredService<IMUSHCodeParser>();
+		return parser.FromState(new ParserState(
+			Registers: new ConcurrentStack<Dictionary<string, MString>>([[]]),
+			IterationRegisters: new ConcurrentStack<IterationWrapper<MString>>(),
+			RegexRegisters: new ConcurrentStack<Dictionary<string, MString>>(),
+			SwitchStack: new ConcurrentStack<MString>(),
+			ExecutionStack: new ConcurrentStack<Execution>(),
+			EnvironmentRegisters: [],
+			CurrentEvaluation: null,
+			ParserFunctionDepth: 0,
+			Function: null,
+			Command: "think",
+			CommandInvoker: _ => ValueTask.FromResult(new Option<CallState>(new None())),
+			Switches: [],
+			Arguments: [],
+			Executor: one,
+			Enactor: one,
+			Caller: one,
+			Handle: 1
+		));
+	}
+}

--- a/SharpMUSH.Benchmarks/BenchmarkHelpers.cs
+++ b/SharpMUSH.Benchmarks/BenchmarkHelpers.cs
@@ -1,16 +1,10 @@
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
-using Mediator;
 using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
 using OneOf.Types;
 using SharpMUSH.Library;
 using SharpMUSH.Library.Extensions;
-using SharpMUSH.Library.Models;
-using SharpMUSH.Library.ParserInterfaces;
-using SharpMUSH.Library.Services;
 using System.Collections.Concurrent;
-using System.Text;
 
 namespace SharpMUSH.Benchmarks;
 
@@ -46,15 +40,6 @@ internal static class BenchmarkHelpers
 	{
 		var realOne = await database.GetObjectNodeAsync(new DBRef(1)).ConfigureAwait(false);
 		var one = realOne.Object()!.DBRef;
-
-		var mockPublisher = Substitute.For<IPublisher>();
-		var simpleConnectionService = new ConnectionService(mockPublisher);
-		await simpleConnectionService.Register(
-			1, "localhost", "localhost", "test",
-			_ => ValueTask.CompletedTask,
-			_ => ValueTask.CompletedTask,
-			() => Encoding.UTF8).ConfigureAwait(false);
-		await simpleConnectionService.Bind(1, one).ConfigureAwait(false);
 
 		var parser = services.GetRequiredService<IMUSHCodeParser>();
 		return parser.FromState(new ParserState(

--- a/SharpMUSH.Benchmarks/CommandParseBenchmarks.cs
+++ b/SharpMUSH.Benchmarks/CommandParseBenchmarks.cs
@@ -16,10 +16,11 @@ public class CommandParseBenchmarks : BaseBenchmark
 	private static readonly MString PemitSelfInput = MModule.single("@pemit me=Hello World");
 	private static readonly MString SetAttrInput = MModule.single("@set me=SAFE");
 
-	public CommandParseBenchmarks()
+	[GlobalSetup]
+	public override async ValueTask Setup()
 	{
-		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
-		_parser = TestParser().ConfigureAwait(false).GetAwaiter().GetResult();
+		await base.Setup().ConfigureAwait(false);
+		_parser = await TestParser().ConfigureAwait(false);
 	}
 
 	[Benchmark(Description = "think with literal text")]

--- a/SharpMUSH.Benchmarks/CommandParseBenchmarks.cs
+++ b/SharpMUSH.Benchmarks/CommandParseBenchmarks.cs
@@ -1,0 +1,44 @@
+namespace SharpMUSH.Benchmarks;
+
+/// <summary>
+/// Benchmarks for MUSH command dispatch via <see cref="IMUSHCodeParser.CommandParse(MString)"/>.
+/// Covers the hot path from raw input → ANTLR4 parse → command lookup (trie) → command execution.
+/// </summary>
+[BenchmarkCategory("Command Dispatch")]
+public class CommandParseBenchmarks : BaseBenchmark
+{
+	private IMUSHCodeParser? _parser;
+
+	// Pre-computed inputs to eliminate per-iteration allocation overhead.
+	private static readonly MString ThinkSimpleInput = MModule.single("think Hello World");
+	private static readonly MString ThinkSubstInput = MModule.single("think %#");
+	private static readonly MString ThinkNameSubstInput = MModule.single("think %N");
+	private static readonly MString PemitSelfInput = MModule.single("@pemit me=Hello World");
+	private static readonly MString SetAttrInput = MModule.single("@set me=SAFE");
+
+	public CommandParseBenchmarks()
+	{
+		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
+		_parser = TestParser().ConfigureAwait(false).GetAwaiter().GetResult();
+	}
+
+	[Benchmark(Description = "think with literal text")]
+	public async Task ThinkSimple() =>
+		await _parser!.CommandParse(ThinkSimpleInput);
+
+	[Benchmark(Description = "think with %# (executor dbref)")]
+	public async Task ThinkWithDbRefSubstitution() =>
+		await _parser!.CommandParse(ThinkSubstInput);
+
+	[Benchmark(Description = "think with %N (executor name)")]
+	public async Task ThinkWithNameSubstitution() =>
+		await _parser!.CommandParse(ThinkNameSubstInput);
+
+	[Benchmark(Description = "@pemit me=Hello World")]
+	public async Task PemitSelf() =>
+		await _parser!.CommandParse(PemitSelfInput);
+
+	[Benchmark(Description = "@set me=SAFE (flag toggle)")]
+	public async Task SetFlag() =>
+		await _parser!.CommandParse(SetAttrInput);
+}

--- a/SharpMUSH.Benchmarks/DatabaseBenchmarks.cs
+++ b/SharpMUSH.Benchmarks/DatabaseBenchmarks.cs
@@ -1,0 +1,85 @@
+using SharpMUSH.Library.Models;
+
+namespace SharpMUSH.Benchmarks;
+
+/// <summary>
+/// Database read benchmarks backed by <b>ArangoDB</b>.
+/// Measures the raw persistence layer: object lookups, graph traversals, and attribute reads.
+/// </summary>
+[BenchmarkCategory("Database Read", "ArangoDB")]
+public class ArangoDBReadBenchmarks : BaseBenchmark
+{
+	private AnySharpContainer? _masterRoom;
+
+	public ArangoDBReadBenchmarks()
+	{
+		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
+		_masterRoom = _database!.GetObjectNodeAsync(new DBRef(2))
+			.ConfigureAwait(false).GetAwaiter().GetResult()
+			.Known.AsContainer;
+	}
+
+	[Benchmark(Description = "GetObjectNodeAsync(#1) — God player")]
+	public async ValueTask<AnyOptionalSharpObject> GetGodPlayerNode() =>
+		await _database!.GetObjectNodeAsync(new DBRef(1));
+
+	[Benchmark(Description = "GetObjectNodeAsync(#2) — Master Room")]
+	public async ValueTask<AnyOptionalSharpObject> GetMasterRoomNode() =>
+		await _database!.GetObjectNodeAsync(new DBRef(2));
+
+	[Benchmark(Description = "GetContentsAsync(Master Room)")]
+	public async Task GetRoomContents()
+	{
+		await foreach (var _ in _database!.GetContentsAsync(_masterRoom!))
+		{ /* enumerate */ }
+	}
+
+	[Benchmark(Description = "GetLocationAsync(#1) — 1-hop traversal")]
+	public async ValueTask<AnyOptionalSharpContainer> GetLocation() =>
+		await _database!.GetLocationAsync(new DBRef(1));
+
+	[Benchmark(Description = "GetAttributeAsync(#1, AADESC)")]
+	public async Task GetAttribute()
+	{
+		await foreach (var _ in _database!.GetAttributeAsync(new DBRef(1), ["AADESC"]))
+		{ /* enumerate */ }
+	}
+}
+
+/// <summary>
+/// Database write benchmarks backed by <b>ArangoDB</b>.
+/// Each iteration uses a unique name to avoid key collisions.
+/// </summary>
+[BenchmarkCategory("Database Write", "ArangoDB")]
+public class ArangoDBWriteBenchmarks : BaseBenchmark
+{
+	private SharpPlayer? _godPlayer;
+	private AnySharpContainer? _masterRoom;
+	private int _counter;
+
+	public ArangoDBWriteBenchmarks()
+	{
+		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
+		_godPlayer = _database!.GetObjectNodeAsync(new DBRef(1))
+			.ConfigureAwait(false).GetAwaiter().GetResult()
+			.AsPlayer;
+		_masterRoom = _database!.GetObjectNodeAsync(new DBRef(2))
+			.ConfigureAwait(false).GetAwaiter().GetResult()
+			.Known.AsContainer;
+	}
+
+	[Benchmark(Description = "CreateThingAsync — unique name each call")]
+	public async ValueTask<DBRef> CreateThing()
+	{
+		var name = $"bench_{Interlocked.Increment(ref _counter):X8}";
+		return await _database!.CreateThingAsync(name, _masterRoom!, _godPlayer!, _masterRoom!);
+	}
+
+	[Benchmark(Description = "SetAttributeAsync on #1")]
+	public async ValueTask<bool> SetAttribute() =>
+		await _database!.SetAttributeAsync(
+			new DBRef(1),
+			["BENCH_ATTR"],
+			MModule.single($"v{Interlocked.Increment(ref _counter)}"),
+			_godPlayer!);
+}

--- a/SharpMUSH.Benchmarks/DatabaseBenchmarks.cs
+++ b/SharpMUSH.Benchmarks/DatabaseBenchmarks.cs
@@ -1,5 +1,3 @@
-using SharpMUSH.Library.Models;
-
 namespace SharpMUSH.Benchmarks;
 
 /// <summary>
@@ -11,12 +9,11 @@ public class ArangoDBReadBenchmarks : BaseBenchmark
 {
 	private AnySharpContainer? _masterRoom;
 
-	public ArangoDBReadBenchmarks()
+	[GlobalSetup]
+	public override async ValueTask Setup()
 	{
-		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
-		_masterRoom = _database!.GetObjectNodeAsync(new DBRef(2))
-			.ConfigureAwait(false).GetAwaiter().GetResult()
-			.Known.AsContainer;
+		await base.Setup().ConfigureAwait(false);
+		_masterRoom = (await _database!.GetObjectNodeAsync(new DBRef(2)).ConfigureAwait(false)).Known.AsContainer;
 	}
 
 	[Benchmark(Description = "GetObjectNodeAsync(#1) — God player")]
@@ -57,15 +54,12 @@ public class ArangoDBWriteBenchmarks : BaseBenchmark
 	private AnySharpContainer? _masterRoom;
 	private int _counter;
 
-	public ArangoDBWriteBenchmarks()
+	[GlobalSetup]
+	public override async ValueTask Setup()
 	{
-		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
-		_godPlayer = _database!.GetObjectNodeAsync(new DBRef(1))
-			.ConfigureAwait(false).GetAwaiter().GetResult()
-			.AsPlayer;
-		_masterRoom = _database!.GetObjectNodeAsync(new DBRef(2))
-			.ConfigureAwait(false).GetAwaiter().GetResult()
-			.Known.AsContainer;
+		await base.Setup().ConfigureAwait(false);
+		_godPlayer = (await _database!.GetObjectNodeAsync(new DBRef(1)).ConfigureAwait(false)).AsPlayer;
+		_masterRoom = (await _database!.GetObjectNodeAsync(new DBRef(2)).ConfigureAwait(false)).Known.AsContainer;
 	}
 
 	[Benchmark(Description = "CreateThingAsync — unique name each call")]

--- a/SharpMUSH.Benchmarks/GlobalUsings.cs
+++ b/SharpMUSH.Benchmarks/GlobalUsings.cs
@@ -1,2 +1,6 @@
 global using MModule = global::MarkupString.MarkupStringModule;
 global using MString = global::MarkupString.MarkupString;
+global using BenchmarkDotNet.Attributes;
+global using SharpMUSH.Library.Models;
+global using SharpMUSH.Library.DiscriminatedUnions;
+global using SharpMUSH.Library.ParserInterfaces;

--- a/SharpMUSH.Benchmarks/ListFunctionBenchmarks.cs
+++ b/SharpMUSH.Benchmarks/ListFunctionBenchmarks.cs
@@ -36,10 +36,11 @@ public class ListFunctionBenchmarks : BaseBenchmark
 	private static readonly MString MapInput10 = MModule.single("map(upcase,lnum(10))");
 	private static readonly MString MapInput100 = MModule.single("map(upcase,lnum(100))");
 
-	public ListFunctionBenchmarks()
+	[GlobalSetup]
+	public override async ValueTask Setup()
 	{
-		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
-		_parser = TestParser().ConfigureAwait(false).GetAwaiter().GetResult();
+		await base.Setup().ConfigureAwait(false);
+		_parser = await TestParser().ConfigureAwait(false);
 	}
 
 	[Benchmark(Description = "lnum(N) — generate N-element list")]

--- a/SharpMUSH.Benchmarks/ListFunctionBenchmarks.cs
+++ b/SharpMUSH.Benchmarks/ListFunctionBenchmarks.cs
@@ -1,0 +1,100 @@
+namespace SharpMUSH.Benchmarks;
+
+/// <summary>
+/// Benchmarks for the built-in MUSH list and iteration function category.
+/// Covers <c>lnum()</c>, <c>iter()</c>, <c>words()</c>, <c>member()</c>, <c>sort()</c>, and <c>map()</c>.
+/// </summary>
+[BenchmarkCategory("List Functions")]
+public class ListFunctionBenchmarks : BaseBenchmark
+{
+	private IMUSHCodeParser? _parser;
+
+	private static readonly MString Lnum10 = MModule.single("lnum(10)");
+	private static readonly MString Lnum100 = MModule.single("lnum(100)");
+	private static readonly MString Lnum1000 = MModule.single("lnum(1000)");
+
+	private static readonly MString Iter10 = MModule.single("iter(lnum(10),%i0)");
+	private static readonly MString Iter100 = MModule.single("iter(lnum(100),%i0)");
+	private static readonly MString Iter1000 = MModule.single("iter(lnum(1000),%i0)");
+
+	private static readonly MString Words10 = MModule.single(
+		$"words({string.Join(" ", Enumerable.Range(1, 10))})");
+	private static readonly MString Words100 = MModule.single(
+		$"words({string.Join(" ", Enumerable.Range(1, 100))})");
+
+	private static readonly MString Member10 = MModule.single(
+		$"member({string.Join(" ", Enumerable.Range(1, 10))},5)");
+	private static readonly MString Member100 = MModule.single(
+		$"member({string.Join(" ", Enumerable.Range(1, 100))},50)");
+
+	// Reversed order to stress sort
+	private static readonly MString Sort10 = MModule.single(
+		$"sort({string.Join(" ", Enumerable.Range(1, 10).Select(i => (11 - i).ToString()))})");
+	private static readonly MString Sort100 = MModule.single(
+		$"sort({string.Join(" ", Enumerable.Range(1, 100).Select(i => (101 - i).ToString()))})");
+
+	private static readonly MString MapInput10 = MModule.single("map(upcase,lnum(10))");
+	private static readonly MString MapInput100 = MModule.single("map(upcase,lnum(100))");
+
+	public ListFunctionBenchmarks()
+	{
+		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
+		_parser = TestParser().ConfigureAwait(false).GetAwaiter().GetResult();
+	}
+
+	[Benchmark(Description = "lnum(N) — generate N-element list")]
+	[Arguments(10)]
+	[Arguments(100)]
+	[Arguments(1000)]
+	public async Task Lnum(int count)
+	{
+		var input = count switch { 10 => Lnum10, 100 => Lnum100, _ => Lnum1000 };
+		await _parser!.FunctionParse(input);
+	}
+
+	[Benchmark(Description = "iter(lnum(N),%i0) — iterate N items")]
+	[Arguments(10)]
+	[Arguments(100)]
+	[Arguments(1000)]
+	public async Task Iter(int count)
+	{
+		var input = count switch { 10 => Iter10, 100 => Iter100, _ => Iter1000 };
+		await _parser!.FunctionParse(input);
+	}
+
+	[Benchmark(Description = "words(N-element list)")]
+	[Arguments(10)]
+	[Arguments(100)]
+	public async Task Words(int count)
+	{
+		var input = count == 10 ? Words10 : Words100;
+		await _parser!.FunctionParse(input);
+	}
+
+	[Benchmark(Description = "member(list,value) — linear scan")]
+	[Arguments(10)]
+	[Arguments(100)]
+	public async Task Member(int count)
+	{
+		var input = count == 10 ? Member10 : Member100;
+		await _parser!.FunctionParse(input);
+	}
+
+	[Benchmark(Description = "sort(reversed-list) — stress sort")]
+	[Arguments(10)]
+	[Arguments(100)]
+	public async Task Sort(int count)
+	{
+		var input = count == 10 ? Sort10 : Sort100;
+		await _parser!.FunctionParse(input);
+	}
+
+	[Benchmark(Description = "map(upcase,lnum(N)) — function applied per element")]
+	[Arguments(10)]
+	[Arguments(100)]
+	public async Task Map(int count)
+	{
+		var input = count == 10 ? MapInput10 : MapInput100;
+		await _parser!.FunctionParse(input);
+	}
+}

--- a/SharpMUSH.Benchmarks/LockEvaluationBenchmarks.cs
+++ b/SharpMUSH.Benchmarks/LockEvaluationBenchmarks.cs
@@ -1,0 +1,83 @@
+using Microsoft.Extensions.DependencyInjection;
+using SharpMUSH.Library.ParserInterfaces;
+
+namespace SharpMUSH.Benchmarks;
+
+/// <summary>
+/// Benchmarks for the MUSH lock / boolean-expression subsystem.
+/// Separates <em>compile</em> (lex → parse → LINQ expression tree → delegate)
+/// from <em>evaluate</em> (call pre-compiled delegate) costs.
+/// </summary>
+[BenchmarkCategory("Lock/Boolean Expression")]
+public class LockEvaluationBenchmarks : BaseBenchmark
+{
+	private IBooleanExpressionParser? _lockParser;
+	private AnySharpObject? _godPlayer;
+
+	// Pre-compiled locks — used for the evaluate-only benchmarks
+	private Func<AnySharpObject, AnySharpObject, bool>? _simpleLock;
+	private Func<AnySharpObject, AnySharpObject, bool>? _andLock;
+	private Func<AnySharpObject, AnySharpObject, bool>? _orLock;
+	private Func<AnySharpObject, AnySharpObject, bool>? _nestedLock;
+	private Func<AnySharpObject, AnySharpObject, bool>? _complexLock;
+
+	public LockEvaluationBenchmarks()
+	{
+		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
+
+		_lockParser = _server!.Services.GetRequiredService<IBooleanExpressionParser>();
+		_godPlayer = _database!.GetObjectNodeAsync(new DBRef(1))
+			.ConfigureAwait(false).GetAwaiter().GetResult()
+			.Known;
+
+		_simpleLock = _lockParser.Compile("#1");
+		_andLock = _lockParser.Compile("#1&#1&#1");
+		_orLock = _lockParser.Compile("#1|#2");
+		_nestedLock = _lockParser.Compile("(#1|#2)&!(#2)");
+		_complexLock = _lockParser.Compile("(#1|#2)&!(#3|#4)&(#1|#1)&!(#2|#2)");
+	}
+
+	// ── Compile benchmarks ────────────────────────────────────────────────────
+
+	[Benchmark(Description = "Compile: #1 (trivial object match)")]
+	public Func<AnySharpObject, AnySharpObject, bool> CompileSimple() =>
+		_lockParser!.Compile("#1");
+
+	[Benchmark(Description = "Compile: #1&#1&#1 (3-way AND)")]
+	public Func<AnySharpObject, AnySharpObject, bool> CompileAndLock() =>
+		_lockParser!.Compile("#1&#1&#1");
+
+	[Benchmark(Description = "Compile: #1|#2 (OR)")]
+	public Func<AnySharpObject, AnySharpObject, bool> CompileOrLock() =>
+		_lockParser!.Compile("#1|#2");
+
+	[Benchmark(Description = "Compile: (A|B)&!B (nested NOT)")]
+	public Func<AnySharpObject, AnySharpObject, bool> CompileNestedLock() =>
+		_lockParser!.Compile("(#1|#2)&!(#2)");
+
+	[Benchmark(Description = "Compile: 8-term complex lock")]
+	public Func<AnySharpObject, AnySharpObject, bool> CompileComplexLock() =>
+		_lockParser!.Compile("(#1|#2)&!(#3|#4)&(#1|#1)&!(#2|#2)");
+
+	// ── Evaluate benchmarks (pre-compiled delegate, no parsing overhead) ──────
+
+	[Benchmark(Description = "Evaluate: simple #1 lock")]
+	public bool EvaluateSimple() =>
+		_simpleLock!(_godPlayer!, _godPlayer!);
+
+	[Benchmark(Description = "Evaluate: AND lock (#1&#1&#1)")]
+	public bool EvaluateAndLock() =>
+		_andLock!(_godPlayer!, _godPlayer!);
+
+	[Benchmark(Description = "Evaluate: OR lock (#1|#2)")]
+	public bool EvaluateOrLock() =>
+		_orLock!(_godPlayer!, _godPlayer!);
+
+	[Benchmark(Description = "Evaluate: nested lock (A|B)&!B")]
+	public bool EvaluateNestedLock() =>
+		_nestedLock!(_godPlayer!, _godPlayer!);
+
+	[Benchmark(Description = "Evaluate: complex 8-term lock")]
+	public bool EvaluateComplexLock() =>
+		_complexLock!(_godPlayer!, _godPlayer!);
+}

--- a/SharpMUSH.Benchmarks/LockEvaluationBenchmarks.cs
+++ b/SharpMUSH.Benchmarks/LockEvaluationBenchmarks.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using SharpMUSH.Library.ParserInterfaces;
 
 namespace SharpMUSH.Benchmarks;
 
@@ -21,14 +20,13 @@ public class LockEvaluationBenchmarks : BaseBenchmark
 	private Func<AnySharpObject, AnySharpObject, bool>? _nestedLock;
 	private Func<AnySharpObject, AnySharpObject, bool>? _complexLock;
 
-	public LockEvaluationBenchmarks()
+	[GlobalSetup]
+	public override async ValueTask Setup()
 	{
-		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
+		await base.Setup().ConfigureAwait(false);
 
 		_lockParser = _server!.Services.GetRequiredService<IBooleanExpressionParser>();
-		_godPlayer = _database!.GetObjectNodeAsync(new DBRef(1))
-			.ConfigureAwait(false).GetAwaiter().GetResult()
-			.Known;
+		_godPlayer = (await _database!.GetObjectNodeAsync(new DBRef(1)).ConfigureAwait(false)).Known;
 
 		_simpleLock = _lockParser.Compile("#1");
 		_andLock = _lockParser.Compile("#1&#1&#1");

--- a/SharpMUSH.Benchmarks/MStringBenchmarks.cs
+++ b/SharpMUSH.Benchmarks/MStringBenchmarks.cs
@@ -1,0 +1,92 @@
+using SharpMUSH.MarkupString.TextAlignerModule;
+
+namespace SharpMUSH.Benchmarks;
+
+/// <summary>
+/// Pure CPU benchmarks for the F#-backed <c>MString</c> / <c>MModule</c> markup-string library.
+/// No database or DI container is required — these are allocation and throughput measurements.
+/// </summary>
+[Config(typeof(AdaptiveBenchmarkConfig))]
+[BenchmarkCategory("Markup String")]
+public class MStringBenchmarks
+{
+	// ── Pre-computed plain strings ─────────────────────────────────────────────
+	private static readonly string Plain10 = new string('x', 10);
+	private static readonly string Plain100 = new string('x', 100);
+	private static readonly string Plain1000 = new string('x', 1000);
+
+	// A string with embedded ANSI escape codes (green text, reset)
+	private static readonly string AnsiStr50 =
+		$"\x1b[32m{new string('g', 25)}\x1b[0m{new string('w', 25)}";
+
+	// ── Pre-computed MStrings ──────────────────────────────────────────────────
+	private static readonly MString Ms10 = MModule.single(Plain10);
+	private static readonly MString Ms100 = MModule.single(Plain100);
+	private static readonly MString Ms1000 = MModule.single(Plain1000);
+	private static readonly MString MsAnsi = MModule.single(AnsiStr50);
+
+	// Pre-computed column-alignment inputs
+	private static readonly MString ColA = MModule.single("Name");
+	private static readonly MString ColB = MModule.single("Score");
+	private static readonly MString ColC = MModule.single("Rank");
+	private static readonly MString Filler = MModule.single(" ");
+	private static readonly MString ColSep = MModule.single(" ");
+	private static readonly MString RowSep = MModule.single("\n");
+
+	// ── single() — baseline construction ──────────────────────────────────────
+
+	[Benchmark(Description = "MModule.single — 10 chars")]
+	[Arguments(10)]
+	[Arguments(100)]
+	[Arguments(1000)]
+	public MString CreateFromPlain(int length)
+	{
+		var str = length switch { 10 => Plain10, 100 => Plain100, _ => Plain1000 };
+		return MModule.single(str);
+	}
+
+	[Benchmark(Description = "MModule.single — ANSI escape string (50 chars)")]
+	public MString CreateFromAnsi() => MModule.single(AnsiStr50);
+
+	// ── concat() ───────────────────────────────────────────────────────────────
+
+	[Benchmark(Description = "MModule.concat — two 100-char plain strings")]
+	public MString ConcatTwoStrings() => MModule.concat(Ms100, Ms100);
+
+	[Benchmark(Description = "MModule.concatAttach — two strings (preserves ANSI)")]
+	public MString ConcatAttach() => MModule.concatAttach(MsAnsi, Ms100);
+
+	// ── getLength() ────────────────────────────────────────────────────────────
+
+	[Benchmark(Description = "MModule.getLength — 100-char plain")]
+	public int GetLengthPlain() => MModule.getLength(Ms100);
+
+	[Benchmark(Description = "MModule.getLength — ANSI string (logical width)")]
+	public int GetLengthAnsi() => MModule.getLength(MsAnsi);
+
+	// ── substring() ───────────────────────────────────────────────────────────
+
+	[Benchmark(Description = "MModule.substring — mid-section of 1000-char string")]
+	public MString Substring() => MModule.substring(100, 50, Ms1000);
+
+	// ── TextAlignerModule.align() ──────────────────────────────────────────────
+
+	[Benchmark(Description = "TextAlignerModule.align — 3 columns 20/20/20")]
+	public MString Align3Columns() =>
+		TextAlignerModule.align("20 20 20", [ColA, ColB, ColC], Filler, ColSep, RowSep);
+
+	[Benchmark(Description = "TextAlignerModule.align — 3 columns with multi-line content")]
+	public MString AlignMultiLine()
+	{
+		var content = MModule.single("line1\nline2\nline3");
+		return TextAlignerModule.align("30", [content], Filler, ColSep, RowSep);
+	}
+
+	// ── ToPlainText (rendering) ────────────────────────────────────────────────
+
+	[Benchmark(Description = "MString.ToPlainText — plain 1000-char string")]
+	public string ToPlainTextPlain() => Ms1000.ToPlainText();
+
+	[Benchmark(Description = "MString.ToPlainText — ANSI string (strip escapes)")]
+	public string ToPlainTextAnsi() => MsAnsi.ToPlainText();
+}

--- a/SharpMUSH.Benchmarks/MemgraphBaseBenchmark.cs
+++ b/SharpMUSH.Benchmarks/MemgraphBaseBenchmark.cs
@@ -1,34 +1,23 @@
-using Core.Arango;
-using Core.Arango.Serialization.Json;
+using BenchmarkDotNet.Attributes;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
-using Mediator;
 using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
-using OneOf.Types;
 using Serilog;
 using SharpMUSH.Library;
-using SharpMUSH.Library.DiscriminatedUnions;
-using SharpMUSH.Library.Extensions;
-using SharpMUSH.Library.Models;
+using SharpMUSH.Library.Definitions;
 using SharpMUSH.Library.ParserInterfaces;
-using SharpMUSH.Library.Services;
-using System.Collections.Concurrent;
-using System.Text;
-using Testcontainers.ArangoDb;
-using BenchmarkDotNet.Attributes;
 
 namespace SharpMUSH.Benchmarks;
 
 /// <summary>
-/// Base class for all ArangoDB-backed benchmarks.
-/// Spins up ArangoDB and NATS Testcontainers, wires up the full DI stack,
+/// Base class for all Memgraph-backed benchmarks.
+/// Spins up Memgraph and NATS Testcontainers, wires up the full DI stack,
 /// and provides a ready-to-use <see cref="IMUSHCodeParser"/>.
 /// </summary>
 [Config(typeof(AdaptiveBenchmarkConfig))]
-public class BaseBenchmark
+public class MemgraphBaseBenchmark
 {
-	public BaseBenchmark() =>
+	public MemgraphBaseBenchmark() =>
 		Log.Logger = new LoggerConfiguration()
 			.WriteTo.Console()
 			.MinimumLevel.Information()
@@ -36,23 +25,26 @@ public class BaseBenchmark
 
 	protected TestWebApplicationBuilderFactory<Server.Program>? _server;
 	protected ISharpDatabase? _database;
-	private ArangoDbContainer? _arangoContainer;
+	private IContainer? _memgraphContainer;
 	private IContainer? _natsContainer;
 
 	[GlobalSetup]
 	public async ValueTask Setup()
 	{
-		_arangoContainer = new ArangoDbBuilder("arangodb:latest")
-			.WithPassword("password")
+		_memgraphContainer = new ContainerBuilder("memgraph/memgraph:3.8.1")
+			.WithPortBinding(7687, true)
+			.WithCommand(
+				"--bolt-num-workers=4",
+				"--storage-mode=IN_MEMORY_TRANSACTIONAL",
+				"--memory-limit=1024",
+				"--log-level=WARNING")
+			.WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("You are running Memgraph"))
+			.WithReuse(false)
 			.Build();
 
-		await _arangoContainer.StartAsync().ConfigureAwait(false);
+		await _memgraphContainer.StartAsync().ConfigureAwait(false);
 
-		var config = new ArangoConfiguration
-		{
-			ConnectionString = $"Server={_arangoContainer.GetTransportAddress()};User=root;Realm=;Password=password;",
-			Serializer = new ArangoJsonSerializer(new ArangoJsonDefaultPolicy())
-		};
+		var memgraphUri = $"bolt://localhost:{_memgraphContainer.GetMappedPublicPort(7687)}";
 
 		_natsContainer = await BenchmarkHelpers.StartNatsContainerAsync().ConfigureAwait(false);
 		Environment.SetEnvironmentVariable("NATS_URL",
@@ -61,7 +53,13 @@ public class BaseBenchmark
 		var configFile = Path.Combine(AppContext.BaseDirectory, "mushcnf.dst");
 		var colorFile = Path.Combine(AppContext.BaseDirectory, "colors.json");
 
-		_server = new TestWebApplicationBuilderFactory<Server.Program>(config, configFile, colorFile);
+		_server = new TestWebApplicationBuilderFactory<Server.Program>(
+			acnf: null,
+			configFile: configFile,
+			colorFile: colorFile,
+			databaseProvider: DatabaseProvider.Memgraph,
+			memgraphUri: memgraphUri);
+
 		_database = _server!.Services.GetRequiredService<ISharpDatabase>();
 	}
 
@@ -71,8 +69,8 @@ public class BaseBenchmark
 		if (_natsContainer is not null)
 			await _natsContainer.DisposeAsync().ConfigureAwait(false);
 
-		if (_arangoContainer is not null)
-			await _arangoContainer.DisposeAsync().ConfigureAwait(false);
+		if (_memgraphContainer is not null)
+			await _memgraphContainer.DisposeAsync().ConfigureAwait(false);
 	}
 
 	protected async Task<IMUSHCodeParser?> TestParser() =>

--- a/SharpMUSH.Benchmarks/MemgraphBaseBenchmark.cs
+++ b/SharpMUSH.Benchmarks/MemgraphBaseBenchmark.cs
@@ -1,11 +1,9 @@
-using BenchmarkDotNet.Attributes;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 using SharpMUSH.Library;
 using SharpMUSH.Library.Definitions;
-using SharpMUSH.Library.ParserInterfaces;
 
 namespace SharpMUSH.Benchmarks;
 
@@ -29,7 +27,7 @@ public class MemgraphBaseBenchmark
 	private IContainer? _natsContainer;
 
 	[GlobalSetup]
-	public async ValueTask Setup()
+	public virtual async ValueTask Setup()
 	{
 		_memgraphContainer = new ContainerBuilder("memgraph/memgraph:3.8.1")
 			.WithPortBinding(7687, true)
@@ -71,6 +69,9 @@ public class MemgraphBaseBenchmark
 
 		if (_memgraphContainer is not null)
 			await _memgraphContainer.DisposeAsync().ConfigureAwait(false);
+
+		_server?.Dispose();
+		Environment.SetEnvironmentVariable("NATS_URL", null);
 	}
 
 	protected async Task<IMUSHCodeParser?> TestParser() =>

--- a/SharpMUSH.Benchmarks/MemgraphDatabaseBenchmarks.cs
+++ b/SharpMUSH.Benchmarks/MemgraphDatabaseBenchmarks.cs
@@ -1,0 +1,85 @@
+using SharpMUSH.Library.Models;
+
+namespace SharpMUSH.Benchmarks;
+
+/// <summary>
+/// Database read benchmarks backed by <b>Memgraph</b>.
+/// Mirrors <see cref="ArangoDBReadBenchmarks"/> — compare results to quantify backend differences.
+/// </summary>
+[BenchmarkCategory("Database Read", "Memgraph")]
+public class MemgraphReadBenchmarks : MemgraphBaseBenchmark
+{
+	private AnySharpContainer? _masterRoom;
+
+	public MemgraphReadBenchmarks()
+	{
+		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
+		_masterRoom = _database!.GetObjectNodeAsync(new DBRef(2))
+			.ConfigureAwait(false).GetAwaiter().GetResult()
+			.Known.AsContainer;
+	}
+
+	[Benchmark(Description = "GetObjectNodeAsync(#1) — God player")]
+	public async ValueTask<AnyOptionalSharpObject> GetGodPlayerNode() =>
+		await _database!.GetObjectNodeAsync(new DBRef(1));
+
+	[Benchmark(Description = "GetObjectNodeAsync(#2) — Master Room")]
+	public async ValueTask<AnyOptionalSharpObject> GetMasterRoomNode() =>
+		await _database!.GetObjectNodeAsync(new DBRef(2));
+
+	[Benchmark(Description = "GetContentsAsync(Master Room)")]
+	public async Task GetRoomContents()
+	{
+		await foreach (var _ in _database!.GetContentsAsync(_masterRoom!))
+		{ /* enumerate */ }
+	}
+
+	[Benchmark(Description = "GetLocationAsync(#1) — 1-hop traversal")]
+	public async ValueTask<AnyOptionalSharpContainer> GetLocation() =>
+		await _database!.GetLocationAsync(new DBRef(1));
+
+	[Benchmark(Description = "GetAttributeAsync(#1, AADESC)")]
+	public async Task GetAttribute()
+	{
+		await foreach (var _ in _database!.GetAttributeAsync(new DBRef(1), ["AADESC"]))
+		{ /* enumerate */ }
+	}
+}
+
+/// <summary>
+/// Database write benchmarks backed by <b>Memgraph</b>.
+/// Mirrors <see cref="ArangoDBWriteBenchmarks"/> — compare results to quantify backend differences.
+/// </summary>
+[BenchmarkCategory("Database Write", "Memgraph")]
+public class MemgraphWriteBenchmarks : MemgraphBaseBenchmark
+{
+	private SharpPlayer? _godPlayer;
+	private AnySharpContainer? _masterRoom;
+	private int _counter;
+
+	public MemgraphWriteBenchmarks()
+	{
+		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
+		_godPlayer = _database!.GetObjectNodeAsync(new DBRef(1))
+			.ConfigureAwait(false).GetAwaiter().GetResult()
+			.AsPlayer;
+		_masterRoom = _database!.GetObjectNodeAsync(new DBRef(2))
+			.ConfigureAwait(false).GetAwaiter().GetResult()
+			.Known.AsContainer;
+	}
+
+	[Benchmark(Description = "CreateThingAsync — unique name each call")]
+	public async ValueTask<DBRef> CreateThing()
+	{
+		var name = $"bench_{Interlocked.Increment(ref _counter):X8}";
+		return await _database!.CreateThingAsync(name, _masterRoom!, _godPlayer!, _masterRoom!);
+	}
+
+	[Benchmark(Description = "SetAttributeAsync on #1")]
+	public async ValueTask<bool> SetAttribute() =>
+		await _database!.SetAttributeAsync(
+			new DBRef(1),
+			["BENCH_ATTR"],
+			MModule.single($"v{Interlocked.Increment(ref _counter)}"),
+			_godPlayer!);
+}

--- a/SharpMUSH.Benchmarks/MemgraphDatabaseBenchmarks.cs
+++ b/SharpMUSH.Benchmarks/MemgraphDatabaseBenchmarks.cs
@@ -1,5 +1,3 @@
-using SharpMUSH.Library.Models;
-
 namespace SharpMUSH.Benchmarks;
 
 /// <summary>
@@ -11,12 +9,11 @@ public class MemgraphReadBenchmarks : MemgraphBaseBenchmark
 {
 	private AnySharpContainer? _masterRoom;
 
-	public MemgraphReadBenchmarks()
+	[GlobalSetup]
+	public override async ValueTask Setup()
 	{
-		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
-		_masterRoom = _database!.GetObjectNodeAsync(new DBRef(2))
-			.ConfigureAwait(false).GetAwaiter().GetResult()
-			.Known.AsContainer;
+		await base.Setup().ConfigureAwait(false);
+		_masterRoom = (await _database!.GetObjectNodeAsync(new DBRef(2)).ConfigureAwait(false)).Known.AsContainer;
 	}
 
 	[Benchmark(Description = "GetObjectNodeAsync(#1) — God player")]
@@ -57,15 +54,12 @@ public class MemgraphWriteBenchmarks : MemgraphBaseBenchmark
 	private AnySharpContainer? _masterRoom;
 	private int _counter;
 
-	public MemgraphWriteBenchmarks()
+	[GlobalSetup]
+	public override async ValueTask Setup()
 	{
-		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
-		_godPlayer = _database!.GetObjectNodeAsync(new DBRef(1))
-			.ConfigureAwait(false).GetAwaiter().GetResult()
-			.AsPlayer;
-		_masterRoom = _database!.GetObjectNodeAsync(new DBRef(2))
-			.ConfigureAwait(false).GetAwaiter().GetResult()
-			.Known.AsContainer;
+		await base.Setup().ConfigureAwait(false);
+		_godPlayer = (await _database!.GetObjectNodeAsync(new DBRef(1)).ConfigureAwait(false)).AsPlayer;
+		_masterRoom = (await _database!.GetObjectNodeAsync(new DBRef(2)).ConfigureAwait(false)).Known.AsContainer;
 	}
 
 	[Benchmark(Description = "CreateThingAsync — unique name each call")]

--- a/SharpMUSH.Benchmarks/NotifyPipelineBenchmarks.cs
+++ b/SharpMUSH.Benchmarks/NotifyPipelineBenchmarks.cs
@@ -19,11 +19,12 @@ public class NotifyPipelineBenchmarks : BaseBenchmark
 	private static readonly MString ThinkCmd = MModule.single("think Hello World");
 	private static readonly MString PemitCmd = MModule.single("@pemit me=Hello World");
 
-	public NotifyPipelineBenchmarks()
+	[GlobalSetup]
+	public override async ValueTask Setup()
 	{
-		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
+		await base.Setup().ConfigureAwait(false);
 		_notifyService = _server!.Services.GetRequiredService<INotifyService>();
-		_parser = TestParser().ConfigureAwait(false).GetAwaiter().GetResult();
+		_parser = await TestParser().ConfigureAwait(false);
 	}
 
 	// ── Direct notify calls (no parsing) ──────────────────────────────────────

--- a/SharpMUSH.Benchmarks/NotifyPipelineBenchmarks.cs
+++ b/SharpMUSH.Benchmarks/NotifyPipelineBenchmarks.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.DependencyInjection;
+using SharpMUSH.Library.Services.Interfaces;
+
+namespace SharpMUSH.Benchmarks;
+
+/// <summary>
+/// Benchmarks for the output pipeline: <c>INotifyService.Notify</c> throughput.
+/// Uses a real NATS JetStream container (spun up in <c>BaseBenchmark.Setup</c>) to
+/// measure end-to-end message-bus latency from notify call to publish acknowledgement.
+/// </summary>
+[BenchmarkCategory("Output Pipeline")]
+public class NotifyPipelineBenchmarks : BaseBenchmark
+{
+	private INotifyService? _notifyService;
+	private IMUSHCodeParser? _parser;
+
+	private static readonly MString ShortMsg = MModule.single("Hello World");
+	private static readonly MString LongMsg = MModule.single(new string('x', 1000));
+	private static readonly MString ThinkCmd = MModule.single("think Hello World");
+	private static readonly MString PemitCmd = MModule.single("@pemit me=Hello World");
+
+	public NotifyPipelineBenchmarks()
+	{
+		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
+		_notifyService = _server!.Services.GetRequiredService<INotifyService>();
+		_parser = TestParser().ConfigureAwait(false).GetAwaiter().GetResult();
+	}
+
+	// ── Direct notify calls (no parsing) ──────────────────────────────────────
+
+	[Benchmark(Description = "INotifyService.Notify — single short message")]
+	public async Task NotifyShortMessage() =>
+		await _notifyService!.Notify(1L, ShortMsg, null);
+
+	[Benchmark(Description = "INotifyService.Notify — single long message (1 KB)")]
+	public async Task NotifyLongMessage() =>
+		await _notifyService!.Notify(1L, LongMsg, null);
+
+	[Benchmark(Description = "INotifyService.Notify — 10 sequential messages")]
+	public async Task Notify10Sequential()
+	{
+		for (var i = 0; i < 10; i++)
+			await _notifyService!.Notify(1L, ShortMsg, null);
+	}
+
+	[Benchmark(Description = "INotifyService.Notify — 100 sequential messages")]
+	public async Task Notify100Sequential()
+	{
+		for (var i = 0; i < 100; i++)
+			await _notifyService!.Notify(1L, ShortMsg, null);
+	}
+
+	// ── End-to-end command path (includes parsing + notify) ───────────────────
+
+	[Benchmark(Description = "CommandParse think — full output path")]
+	public async Task ThinkThroughPipeline() =>
+		await _parser!.CommandParse(ThinkCmd);
+
+	[Benchmark(Description = "CommandParse @pemit — full output path")]
+	public async Task PemitThroughPipeline() =>
+		await _parser!.CommandParse(PemitCmd);
+}

--- a/SharpMUSH.Benchmarks/Program.cs
+++ b/SharpMUSH.Benchmarks/Program.cs
@@ -4,10 +4,6 @@ namespace SharpMUSH.Benchmarks;
 
 public class Program
 {
-	public static void Main(string[] args)
-	{
-		var summary = BenchmarkRunner.Run<SimpleFunctionCalls>();
-		// var sfc = new SimpleFunctionCalls();
-		// sfc.Depth().ConfigureAwait(false).GetAwaiter().GetResult();
-	}
+	public static void Main(string[] args) =>
+		BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
 }

--- a/SharpMUSH.Benchmarks/SharpMUSH.Benchmarks.csproj
+++ b/SharpMUSH.Benchmarks/SharpMUSH.Benchmarks.csproj
@@ -18,6 +18,7 @@
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 		<PackageReference Include="Testcontainers" Version="4.10.0" />
+		<PackageReference Include="Testcontainers.ArangoDb" Version="4.10.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/SharpMUSH.Benchmarks/SharpMUSH.Benchmarks.csproj
+++ b/SharpMUSH.Benchmarks/SharpMUSH.Benchmarks.csproj
@@ -15,10 +15,13 @@
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
 		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+		<PackageReference Include="Testcontainers" Version="4.10.0" />
 	</ItemGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\SharpMUSH.Database.Memgraph\SharpMUSH.Database.Memgraph.csproj" />
 		<ProjectReference Include="..\SharpMUSH.Implementation\SharpMUSH.Implementation.csproj" />
 		<ProjectReference Include="..\SharpMUSH.Server\SharpMUSH.Server.csproj" />
 	</ItemGroup>

--- a/SharpMUSH.Benchmarks/SimpleFunctionCalls.cs
+++ b/SharpMUSH.Benchmarks/SimpleFunctionCalls.cs
@@ -1,5 +1,3 @@
-using BenchmarkDotNet.Attributes;
-using SharpMUSH.Library.ParserInterfaces;
 using System.Text;
 
 namespace SharpMUSH.Benchmarks;
@@ -7,12 +5,13 @@ namespace SharpMUSH.Benchmarks;
 [BenchmarkCategory("Non-DB Function Evaluation")]
 public class SimpleFunctionCalls : BaseBenchmark
 {
-	private readonly IMUSHCodeParser? _parser;
+	private IMUSHCodeParser? _parser;
 
-	public SimpleFunctionCalls()
+	[GlobalSetup]
+	public override async ValueTask Setup()
 	{
-		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
-		_parser = TestParser().ConfigureAwait(false).GetAwaiter().GetResult();
+		await base.Setup().ConfigureAwait(false);
+		_parser = await TestParser().ConfigureAwait(false);
 	}
 
 	[Benchmark]

--- a/SharpMUSH.Benchmarks/SimpleFunctionCalls.cs
+++ b/SharpMUSH.Benchmarks/SimpleFunctionCalls.cs
@@ -1,11 +1,9 @@
-﻿using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Attributes;
 using SharpMUSH.Library.ParserInterfaces;
 using System.Text;
 
 namespace SharpMUSH.Benchmarks;
 
-[SimpleJob(RuntimeMoniker.Net90)]
 [BenchmarkCategory("Non-DB Function Evaluation")]
 public class SimpleFunctionCalls : BaseBenchmark
 {
@@ -27,16 +25,11 @@ public class SimpleFunctionCalls : BaseBenchmark
 	{
 		var sb = new StringBuilder();
 		foreach (var _ in Enumerable.Range(0, depth))
-		{
 			sb.Append("[add(1,");
-		}
 		sb.Append('1');
 		foreach (var _ in Enumerable.Range(0, depth))
-		{
 			sb.Append(")]");
-		}
-		var str = sb.ToString();
 
-		await _parser!.FunctionParse(MModule.single(str));
+		await _parser!.FunctionParse(MModule.single(sb.ToString()));
 	}
 }

--- a/SharpMUSH.Benchmarks/StringFunctionBenchmarks.cs
+++ b/SharpMUSH.Benchmarks/StringFunctionBenchmarks.cs
@@ -29,10 +29,11 @@ public class StringFunctionBenchmarks : BaseBenchmark
 	private static readonly MString Cat26 = MModule.single(
 		$"cat({string.Join(",", Enumerable.Range('a', 26).Select(c => ((char)c).ToString()))})");
 
-	public StringFunctionBenchmarks()
+	[GlobalSetup]
+	public override async ValueTask Setup()
 	{
-		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
-		_parser = TestParser().ConfigureAwait(false).GetAwaiter().GetResult();
+		await base.Setup().ConfigureAwait(false);
+		_parser = await TestParser().ConfigureAwait(false);
 	}
 
 	[Benchmark(Description = "mid(abcdefghij,2,5)")]

--- a/SharpMUSH.Benchmarks/StringFunctionBenchmarks.cs
+++ b/SharpMUSH.Benchmarks/StringFunctionBenchmarks.cs
@@ -1,0 +1,86 @@
+namespace SharpMUSH.Benchmarks;
+
+/// <summary>
+/// Benchmarks for the built-in MUSH string function category.
+/// Exercises <see cref="IMUSHCodeParser.FunctionParse(MString)"/> with common string operations.
+/// </summary>
+[BenchmarkCategory("String Functions")]
+public class StringFunctionBenchmarks : BaseBenchmark
+{
+	private IMUSHCodeParser? _parser;
+
+	// Fixed inputs
+	private static readonly MString MidInput = MModule.single("mid(abcdefghij,2,5)");
+	private static readonly MString LjustInput = MModule.single("ljust(hello,20)");
+	private static readonly MString RjustInput = MModule.single("rjust(hello,20)");
+	private static readonly MString TrimInput = MModule.single("trim(  hello world  )");
+	private static readonly MString CenterInput = MModule.single("center(hi,20)");
+
+	// Parameterized by length — pre-computed to avoid per-iteration string allocation
+	private static readonly MString Left10 = MModule.single($"left({new string('x', 10)},5)");
+	private static readonly MString Left100 = MModule.single($"left({new string('x', 100)},5)");
+	private static readonly MString Left1000 = MModule.single($"left({new string('x', 1000)},5)");
+
+	private static readonly MString Strlen10 = MModule.single($"strlen({new string('x', 10)})");
+	private static readonly MString Strlen100 = MModule.single($"strlen({new string('x', 100)})");
+	private static readonly MString Strlen1000 = MModule.single($"strlen({new string('x', 1000)})");
+
+	private static readonly MString Cat5 = MModule.single("cat(a,b,c,d,e)");
+	private static readonly MString Cat26 = MModule.single(
+		$"cat({string.Join(",", Enumerable.Range('a', 26).Select(c => ((char)c).ToString()))})");
+
+	public StringFunctionBenchmarks()
+	{
+		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
+		_parser = TestParser().ConfigureAwait(false).GetAwaiter().GetResult();
+	}
+
+	[Benchmark(Description = "mid(abcdefghij,2,5)")]
+	public async Task Mid() =>
+		await _parser!.FunctionParse(MidInput);
+
+	[Benchmark(Description = "left(Nx,5) — vary input length")]
+	[Arguments(10)]
+	[Arguments(100)]
+	[Arguments(1000)]
+	public async Task Left(int length)
+	{
+		var input = length switch { 10 => Left10, 100 => Left100, _ => Left1000 };
+		await _parser!.FunctionParse(input);
+	}
+
+	[Benchmark(Description = "strlen(Nx) — vary input length")]
+	[Arguments(10)]
+	[Arguments(100)]
+	[Arguments(1000)]
+	public async Task Strlen(int length)
+	{
+		var input = length switch { 10 => Strlen10, 100 => Strlen100, _ => Strlen1000 };
+		await _parser!.FunctionParse(input);
+	}
+
+	[Benchmark(Description = "ljust(hello,20)")]
+	public async Task Ljust() =>
+		await _parser!.FunctionParse(LjustInput);
+
+	[Benchmark(Description = "rjust(hello,20)")]
+	public async Task Rjust() =>
+		await _parser!.FunctionParse(RjustInput);
+
+	[Benchmark(Description = "center(hi,20)")]
+	public async Task Center() =>
+		await _parser!.FunctionParse(CenterInput);
+
+	[Benchmark(Description = "trim(  hello world  )")]
+	public async Task Trim() =>
+		await _parser!.FunctionParse(TrimInput);
+
+	[Benchmark(Description = "cat(N args) — vary arg count")]
+	[Arguments(5)]
+	[Arguments(26)]
+	public async Task Cat(int count)
+	{
+		var input = count == 5 ? Cat5 : Cat26;
+		await _parser!.FunctionParse(input);
+	}
+}

--- a/SharpMUSH.Benchmarks/SubstitutionBenchmarks.cs
+++ b/SharpMUSH.Benchmarks/SubstitutionBenchmarks.cs
@@ -32,10 +32,11 @@ public class SubstitutionBenchmarks : BaseBenchmark
 	private static readonly MString Add5Subst = MModule.single(
 		"[add(%#,[add(%#,[add(%#,[add(%#,%#)])])])]");
 
-	public SubstitutionBenchmarks()
+	[GlobalSetup]
+	public override async ValueTask Setup()
 	{
-		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
-		_parser = TestParser().ConfigureAwait(false).GetAwaiter().GetResult();
+		await base.Setup().ConfigureAwait(false);
+		_parser = await TestParser().ConfigureAwait(false);
 	}
 
 	[Benchmark(Description = "think %# — executor dbref command subst")]

--- a/SharpMUSH.Benchmarks/SubstitutionBenchmarks.cs
+++ b/SharpMUSH.Benchmarks/SubstitutionBenchmarks.cs
@@ -1,0 +1,76 @@
+namespace SharpMUSH.Benchmarks;
+
+/// <summary>
+/// Benchmarks for the MUSH substitution and register system.
+/// Tests the <c>%#</c>, <c>%N</c>, <c>%q</c>, and <c>%i</c> expansion hot paths
+/// inside both <see cref="IMUSHCodeParser.FunctionParse(MString)"/> and
+/// <see cref="IMUSHCodeParser.CommandParse(MString)"/>.
+/// </summary>
+[BenchmarkCategory("Substitution & Registers")]
+public class SubstitutionBenchmarks : BaseBenchmark
+{
+	private IMUSHCodeParser? _parser;
+
+	// %# / %N — always available, no register setup required
+	private static readonly MString ExecDbRefCmd = MModule.single("think %#");
+	private static readonly MString ExecNameCmd = MModule.single("think %N");
+
+	// cat() with multiple %# to stress repeated substitution expansion
+	private static readonly MString Cat3Subst = MModule.single("[cat(%#,%#,%#)]");
+	private static readonly MString Cat10Subst = MModule.single(
+		$"[cat({string.Join(",", Enumerable.Repeat("%#", 10))})]");
+
+	// setq + read — exercises the q-register write+read path
+	private static readonly MString SetQRead = MModule.single("[setq(0,hello)]%q0");
+
+	// iter — exercises iteration register (%i0) population and access
+	private static readonly MString IterReg5 = MModule.single("iter(lnum(5),%i0)");
+	private static readonly MString IterReg50 = MModule.single("iter(lnum(50),%i0)");
+
+	// Nested substitutions: add() with %# embedded at various recursion depths
+	private static readonly MString Add1Subst = MModule.single("[add(0,%#)]");
+	private static readonly MString Add5Subst = MModule.single(
+		"[add(%#,[add(%#,[add(%#,[add(%#,%#)])])])]");
+
+	public SubstitutionBenchmarks()
+	{
+		Setup().ConfigureAwait(false).GetAwaiter().GetResult();
+		_parser = TestParser().ConfigureAwait(false).GetAwaiter().GetResult();
+	}
+
+	[Benchmark(Description = "think %# — executor dbref command subst")]
+	public async Task ThinkDbRef() =>
+		await _parser!.CommandParse(ExecDbRefCmd);
+
+	[Benchmark(Description = "think %N — executor name command subst")]
+	public async Task ThinkName() =>
+		await _parser!.CommandParse(ExecNameCmd);
+
+	[Benchmark(Description = "[cat(%#,…)] — 3 substitutions in function")]
+	public async Task Cat3Substitutions() =>
+		await _parser!.FunctionParse(Cat3Subst);
+
+	[Benchmark(Description = "[cat(%#,…)] — 10 substitutions in function")]
+	public async Task Cat10Substitutions() =>
+		await _parser!.FunctionParse(Cat10Subst);
+
+	[Benchmark(Description = "[setq(0,hello)]%q0 — q-register set+read")]
+	public async Task SetQRegisterAndRead() =>
+		await _parser!.FunctionParse(SetQRead);
+
+	[Benchmark(Description = "iter(lnum(5),%i0) — iteration register access")]
+	public async Task IterRegisterSmall() =>
+		await _parser!.FunctionParse(IterReg5);
+
+	[Benchmark(Description = "iter(lnum(50),%i0) — iteration register access at scale")]
+	public async Task IterRegisterMedium() =>
+		await _parser!.FunctionParse(IterReg50);
+
+	[Benchmark(Description = "[add(0,%#)] — single nested substitution in function")]
+	public async Task AddSingleSubstitution() =>
+		await _parser!.FunctionParse(Add1Subst);
+
+	[Benchmark(Description = "nested add(%#,…) x5 — 5-deep nested substitution")]
+	public async Task AddDeepSubstitution() =>
+		await _parser!.FunctionParse(Add5Subst);
+}

--- a/SharpMUSH.Benchmarks/TestWebApplicationBuilderFactory.cs
+++ b/SharpMUSH.Benchmarks/TestWebApplicationBuilderFactory.cs
@@ -10,15 +10,18 @@ using Serilog;
 using Serilog.Sinks.SystemConsole.Themes;
 using SharpMUSH.Configuration;
 using SharpMUSH.Configuration.Options;
+using SharpMUSH.Library.Definitions;
 using SharpMUSH.Library.Services.Interfaces;
 using SharpMUSH.Server;
 
 namespace SharpMUSH.Benchmarks;
 
 public class TestWebApplicationBuilderFactory<TProgram>(
-		ArangoConfiguration acnf,
+		ArangoConfiguration? acnf,
 		string configFile,
-		string colorFile) :
+		string colorFile,
+		DatabaseProvider databaseProvider = DatabaseProvider.ArangoDB,
+		string? memgraphUri = null) :
 	WebApplicationFactory<TProgram> where TProgram : class
 {
 	protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -32,14 +35,13 @@ public class TestWebApplicationBuilderFactory<TProgram>(
 		Log.Logger = log;
 
 		var natsUrl = Environment.GetEnvironmentVariable("NATS_URL") ?? "nats://localhost:4222";
-		var startup = new Startup(acnf, colorFile, natsUrl);
+		var startup = new Startup(acnf, colorFile, natsUrl, databaseProvider, memgraphUri);
 
 		var substitute = Substitute.For<IOptionsWrapper<SharpMUSHOptions>>();
 		substitute.CurrentValue.Returns(ReadPennMushConfig.Create(configFile));
 
 		builder.ConfigureServices(services =>
 		{
-			// Build a minimal configuration for Serilog to read from
 			var configuration = new ConfigurationBuilder()
 				.SetBasePath(AppContext.BaseDirectory)
 				.AddJsonFile("appsettings.json", optional: true)
@@ -47,10 +49,9 @@ public class TestWebApplicationBuilderFactory<TProgram>(
 			startup.ConfigureServices(services, configuration);
 		});
 		builder.ConfigureTestServices(sc =>
-			{
-				sc.RemoveAll<IOptionsWrapper<SharpMUSHOptions>>();
-				sc.AddSingleton(x => substitute);
-			}
-		);
+		{
+			sc.RemoveAll<IOptionsWrapper<SharpMUSHOptions>>();
+			sc.AddSingleton(x => substitute);
+		});
 	}
 }

--- a/SharpMUSH.Benchmarks/TestWebApplicationBuilderFactory.cs
+++ b/SharpMUSH.Benchmarks/TestWebApplicationBuilderFactory.cs
@@ -26,6 +26,9 @@ public class TestWebApplicationBuilderFactory<TProgram>(
 {
 	protected override void ConfigureWebHost(IWebHostBuilder builder)
 	{
+		if (databaseProvider == DatabaseProvider.ArangoDB && acnf is null)
+			throw new ArgumentNullException(nameof(acnf), "Arango configuration is required for ArangoDB benchmarks.");
+
 		var log = new LoggerConfiguration()
 			.Enrich.FromLogContext()
 			.WriteTo.Console(theme: AnsiConsoleTheme.Code)

--- a/SharpMUSH.Configuration.Generated/SharpMUSH.Configuration.Generated.csproj
+++ b/SharpMUSH.Configuration.Generated/SharpMUSH.Configuration.Generated.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.0.0" PrivateAssets="all" />
   </ItemGroup>
 	
 </Project>

--- a/SharpMUSH.Implementation.Generated/SharpMUSH.Implementation.Generated.csproj
+++ b/SharpMUSH.Implementation.Generated/SharpMUSH.Implementation.Generated.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.0.0" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/SharpMUSH.Tests/Performance/DatabaseLatencyTests.cs
+++ b/SharpMUSH.Tests/Performance/DatabaseLatencyTests.cs
@@ -1,0 +1,127 @@
+using Microsoft.Extensions.DependencyInjection;
+using SharpMUSH.Library;
+using SharpMUSH.Library.DiscriminatedUnions;
+using SharpMUSH.Library.Models;
+using System.Diagnostics;
+
+namespace SharpMUSH.Tests.Performance;
+
+/// <summary>
+/// Observational latency diagnostics for the database layer.
+/// Reports mean and P50/P95/P99 latency percentiles per operation to the console.
+/// Always runs (not Explicit) to provide warm-path diagnostics; contains no assertions.
+/// </summary>
+public class DatabaseLatencyTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactory { get; init; }
+
+	private ISharpDatabase Database => WebAppFactory.Services.GetRequiredService<ISharpDatabase>();
+
+	[Test]
+	public async Task ReportObjectNodeLookupLatency()
+	{
+		const int iterations = 100;
+		const int warmup = 10;
+
+		// Warm up
+		for (var i = 0; i < warmup; i++)
+			await Database.GetObjectNodeAsync(new DBRef(1));
+
+		var timings = new long[iterations];
+		for (var i = 0; i < iterations; i++)
+		{
+			var sw = Stopwatch.StartNew();
+			await Database.GetObjectNodeAsync(new DBRef(1));
+			timings[i] = sw.ElapsedTicks;
+		}
+
+		PrintReport("GetObjectNodeAsync(#1)", timings, iterations);
+	}
+
+	[Test]
+	public async Task ReportAttributeReadLatency()
+	{
+		const int iterations = 100;
+		const int warmup = 10;
+
+		for (var i = 0; i < warmup; i++)
+			await ConsumeAsync(Database.GetAttributeAsync(new DBRef(1), ["AADESC"]));
+
+		var timings = new long[iterations];
+		for (var i = 0; i < iterations; i++)
+		{
+			var sw = Stopwatch.StartNew();
+			await ConsumeAsync(Database.GetAttributeAsync(new DBRef(1), ["AADESC"]));
+			timings[i] = sw.ElapsedTicks;
+		}
+
+		PrintReport("GetAttributeAsync(#1, AADESC)", timings, iterations);
+	}
+
+	[Test]
+	public async Task ReportContentsEnumerationLatency()
+	{
+		const int iterations = 100;
+		const int warmup = 10;
+
+		var masterRoom = (await Database.GetObjectNodeAsync(new DBRef(2))).Known.AsContainer;
+
+		for (var i = 0; i < warmup; i++)
+			await ConsumeAsync(Database.GetContentsAsync(masterRoom));
+
+		var timings = new long[iterations];
+		for (var i = 0; i < iterations; i++)
+		{
+			var sw = Stopwatch.StartNew();
+			await ConsumeAsync(Database.GetContentsAsync(masterRoom));
+			timings[i] = sw.ElapsedTicks;
+		}
+
+		PrintReport("GetContentsAsync(MasterRoom)", timings, iterations);
+	}
+
+	[Test]
+	public async Task ReportLocationTraversalLatency()
+	{
+		const int iterations = 100;
+		const int warmup = 10;
+
+		for (var i = 0; i < warmup; i++)
+			await Database.GetLocationAsync(new DBRef(1));
+
+		var timings = new long[iterations];
+		for (var i = 0; i < iterations; i++)
+		{
+			var sw = Stopwatch.StartNew();
+			await Database.GetLocationAsync(new DBRef(1));
+			timings[i] = sw.ElapsedTicks;
+		}
+
+		PrintReport("GetLocationAsync(#1)", timings, iterations);
+	}
+
+	private static async Task ConsumeAsync<T>(IAsyncEnumerable<T> source)
+	{
+		await foreach (var _ in source)
+		{ /* enumerate */ }
+	}
+
+	private static void PrintReport(string label, long[] timings, int iterations)
+	{
+		Array.Sort(timings);
+		var ticksPerMs = (double)Stopwatch.Frequency / 1000.0;
+
+		var meanMs = timings.Average() / ticksPerMs;
+		var p50Ms = timings[iterations / 2] / ticksPerMs;
+		var p95Ms = timings[(int)(iterations * 0.95)] / ticksPerMs;
+		var p99Ms = timings[(int)(iterations * 0.99)] / ticksPerMs;
+
+		Console.WriteLine($"\n[{label}]");
+		Console.WriteLine($"  Iterations : {iterations}");
+		Console.WriteLine($"  Mean       : {meanMs,8:F3} ms");
+		Console.WriteLine($"  P50        : {p50Ms,8:F3} ms");
+		Console.WriteLine($"  P95        : {p95Ms,8:F3} ms");
+		Console.WriteLine($"  P99        : {p99Ms,8:F3} ms");
+	}
+}

--- a/SharpMUSH.Tests/Performance/DatabaseLatencyTests.cs
+++ b/SharpMUSH.Tests/Performance/DatabaseLatencyTests.cs
@@ -109,13 +109,17 @@ public class DatabaseLatencyTests
 
 	private static void PrintReport(string label, long[] timings, int iterations)
 	{
+		if (timings.Length == 0)
+			throw new ArgumentException("Timings collection must not be empty.", nameof(timings));
+
 		Array.Sort(timings);
 		var ticksPerMs = (double)Stopwatch.Frequency / 1000.0;
+		var sampleCount = timings.Length;
 
 		var meanMs = timings.Average() / ticksPerMs;
-		var p50Ms = timings[iterations / 2] / ticksPerMs;
-		var p95Ms = timings[(int)(iterations * 0.95)] / ticksPerMs;
-		var p99Ms = timings[(int)(iterations * 0.99)] / ticksPerMs;
+		var p50Ms = timings[GetPercentileIndex(sampleCount, 0.50)] / ticksPerMs;
+		var p95Ms = timings[GetPercentileIndex(sampleCount, 0.95)] / ticksPerMs;
+		var p99Ms = timings[GetPercentileIndex(sampleCount, 0.99)] / ticksPerMs;
 
 		Console.WriteLine($"\n[{label}]");
 		Console.WriteLine($"  Iterations : {iterations}");
@@ -123,5 +127,11 @@ public class DatabaseLatencyTests
 		Console.WriteLine($"  P50        : {p50Ms,8:F3} ms");
 		Console.WriteLine($"  P95        : {p95Ms,8:F3} ms");
 		Console.WriteLine($"  P99        : {p99Ms,8:F3} ms");
+	}
+
+	private static int GetPercentileIndex(int count, double percentile)
+	{
+		var index = (int)Math.Ceiling(percentile * count) - 1;
+		return Math.Clamp(index, 0, count - 1);
 	}
 }

--- a/SharpMUSH.Tests/Performance/ParserThroughputTests.cs
+++ b/SharpMUSH.Tests/Performance/ParserThroughputTests.cs
@@ -156,13 +156,17 @@ public class ParserThroughputTests
 
 	private static void PrintReport(string label, long[] timings, int iterations)
 	{
+		if (timings.Length == 0)
+			throw new ArgumentException("Timings collection must not be empty.", nameof(timings));
+
 		Array.Sort(timings);
 		var ticksPerMs = (double)Stopwatch.Frequency / 1000.0;
+		var sampleCount = timings.Length;
 
 		var meanMs = timings.Average() / ticksPerMs;
-		var p50Ms = timings[iterations / 2] / ticksPerMs;
-		var p95Ms = timings[(int)(iterations * 0.95)] / ticksPerMs;
-		var p99Ms = timings[(int)(iterations * 0.99)] / ticksPerMs;
+		var p50Ms = timings[GetPercentileIndex(sampleCount, 0.50)] / ticksPerMs;
+		var p95Ms = timings[GetPercentileIndex(sampleCount, 0.95)] / ticksPerMs;
+		var p99Ms = timings[GetPercentileIndex(sampleCount, 0.99)] / ticksPerMs;
 		var opsPerSec = 1000.0 / meanMs;
 
 		Console.WriteLine($"\n[{label}]");
@@ -171,5 +175,11 @@ public class ParserThroughputTests
 		Console.WriteLine($"  P50        : {p50Ms,8:F3} ms");
 		Console.WriteLine($"  P95        : {p95Ms,8:F3} ms");
 		Console.WriteLine($"  P99        : {p99Ms,8:F3} ms");
+	}
+
+	private static int GetPercentileIndex(int count, double percentile)
+	{
+		var index = (int)Math.Ceiling(percentile * count) - 1;
+		return Math.Clamp(index, 0, count - 1);
 	}
 }

--- a/SharpMUSH.Tests/Performance/ParserThroughputTests.cs
+++ b/SharpMUSH.Tests/Performance/ParserThroughputTests.cs
@@ -1,0 +1,175 @@
+using Microsoft.Extensions.DependencyInjection;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Services.Interfaces;
+using System.Diagnostics;
+
+namespace SharpMUSH.Tests.Performance;
+
+/// <summary>
+/// Observational throughput diagnostics for the MUSH parser hot paths.
+/// Reports ops/sec and P50/P95/P99 latency percentiles to the console.
+/// These tests are always-run (not Explicit) to provide warm-path diagnostics in CI output,
+/// but contain no assertions — they are informational only.
+/// </summary>
+public class ParserThroughputTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactory { get; init; }
+
+	private IMUSHCodeParser Parser => WebAppFactory.FunctionParser;
+	private IMUSHCodeParser CommandParser => WebAppFactory.CommandParser;
+
+	private static readonly MString SimpleAdd = MModule.single("[add(1,1)]");
+	private static readonly MString NestedAdd10 = MModule.single(BuildNestedAdd(10));
+	private static readonly MString NestedAdd50 = MModule.single(BuildNestedAdd(50));
+	private static readonly MString Lnum100 = MModule.single("lnum(100)");
+	private static readonly MString Iter100 = MModule.single("iter(lnum(100),%i0)");
+	private static readonly MString ThinkCmd = MModule.single("think hello");
+	private static readonly MString ThinkSubst = MModule.single("think %#");
+
+	private static string BuildNestedAdd(int depth)
+	{
+		var inner = "1";
+		for (var i = 0; i < depth; i++)
+			inner = $"add(1,{inner})";
+		return $"[{inner}]";
+	}
+
+	[Test]
+	public async Task ReportFunctionParseBaseline()
+	{
+		const int iterations = 200;
+		const int warmup = 20;
+
+		// Warm up
+		for (var i = 0; i < warmup; i++)
+			await Parser.FunctionParse(SimpleAdd);
+
+		var timings = new long[iterations];
+		for (var i = 0; i < iterations; i++)
+		{
+			var sw = Stopwatch.StartNew();
+			await Parser.FunctionParse(SimpleAdd);
+			timings[i] = sw.ElapsedTicks;
+		}
+
+		PrintReport("FunctionParse: [add(1,1)]", timings, iterations);
+	}
+
+	[Test]
+	public async Task ReportNestedFunctionParse()
+	{
+		const int iterations = 200;
+		const int warmup = 20;
+
+		for (var i = 0; i < warmup; i++)
+			await Parser.FunctionParse(NestedAdd10);
+
+		var timings10 = new long[iterations];
+		for (var i = 0; i < iterations; i++)
+		{
+			var sw = Stopwatch.StartNew();
+			await Parser.FunctionParse(NestedAdd10);
+			timings10[i] = sw.ElapsedTicks;
+		}
+
+		for (var i = 0; i < warmup; i++)
+			await Parser.FunctionParse(NestedAdd50);
+
+		var timings50 = new long[iterations];
+		for (var i = 0; i < iterations; i++)
+		{
+			var sw = Stopwatch.StartNew();
+			await Parser.FunctionParse(NestedAdd50);
+			timings50[i] = sw.ElapsedTicks;
+		}
+
+		PrintReport("FunctionParse: nested add depth=10", timings10, iterations);
+		PrintReport("FunctionParse: nested add depth=50", timings50, iterations);
+	}
+
+	[Test]
+	public async Task ReportListFunctionThroughput()
+	{
+		const int iterations = 100;
+		const int warmup = 10;
+
+		for (var i = 0; i < warmup; i++)
+			await Parser.FunctionParse(Lnum100);
+
+		var lnumTimings = new long[iterations];
+		for (var i = 0; i < iterations; i++)
+		{
+			var sw = Stopwatch.StartNew();
+			await Parser.FunctionParse(Lnum100);
+			lnumTimings[i] = sw.ElapsedTicks;
+		}
+
+		for (var i = 0; i < warmup; i++)
+			await Parser.FunctionParse(Iter100);
+
+		var iterTimings = new long[iterations];
+		for (var i = 0; i < iterations; i++)
+		{
+			var sw = Stopwatch.StartNew();
+			await Parser.FunctionParse(Iter100);
+			iterTimings[i] = sw.ElapsedTicks;
+		}
+
+		PrintReport("FunctionParse: lnum(100)", lnumTimings, iterations);
+		PrintReport("FunctionParse: iter(lnum(100),%i0)", iterTimings, iterations);
+	}
+
+	[Test]
+	public async Task ReportCommandParseThroughput()
+	{
+		const int iterations = 200;
+		const int warmup = 20;
+
+		var connectionService = WebAppFactory.Services.GetRequiredService<IConnectionService>();
+
+		for (var i = 0; i < warmup; i++)
+			await CommandParser.CommandParse(1, connectionService, ThinkCmd);
+
+		var thinkTimings = new long[iterations];
+		for (var i = 0; i < iterations; i++)
+		{
+			var sw = Stopwatch.StartNew();
+			await CommandParser.CommandParse(1, connectionService, ThinkCmd);
+			thinkTimings[i] = sw.ElapsedTicks;
+		}
+
+		for (var i = 0; i < warmup; i++)
+			await CommandParser.CommandParse(1, connectionService, ThinkSubst);
+
+		var substTimings = new long[iterations];
+		for (var i = 0; i < iterations; i++)
+		{
+			var sw = Stopwatch.StartNew();
+			await CommandParser.CommandParse(1, connectionService, ThinkSubst);
+			substTimings[i] = sw.ElapsedTicks;
+		}
+
+		PrintReport("CommandParse: think hello", thinkTimings, iterations);
+		PrintReport("CommandParse: think %#", substTimings, iterations);
+	}
+
+	private static void PrintReport(string label, long[] timings, int iterations)
+	{
+		Array.Sort(timings);
+		var ticksPerMs = (double)Stopwatch.Frequency / 1000.0;
+
+		var meanMs = timings.Average() / ticksPerMs;
+		var p50Ms = timings[iterations / 2] / ticksPerMs;
+		var p95Ms = timings[(int)(iterations * 0.95)] / ticksPerMs;
+		var p99Ms = timings[(int)(iterations * 0.99)] / ticksPerMs;
+		var opsPerSec = 1000.0 / meanMs;
+
+		Console.WriteLine($"\n[{label}]");
+		Console.WriteLine($"  Iterations : {iterations}");
+		Console.WriteLine($"  Mean       : {meanMs,8:F3} ms  ({opsPerSec:F0} ops/sec)");
+		Console.WriteLine($"  P50        : {p50Ms,8:F3} ms");
+		Console.WriteLine($"  P95        : {p95Ms,8:F3} ms");
+		Console.WriteLine($"  P99        : {p99Ms,8:F3} ms");
+	}
+}


### PR DESCRIPTION
…kflow

- Expand SharpMUSH.Benchmarks with benchmark classes covering parser functions (command parse, string/list functions, substitutions, lock evaluation), database operations (ArangoDB + Memgraph read/write), MString operations, and notify pipeline
- Add AdaptiveBenchmarkConfig: Job.ShortRun when SHARPMUSH_CI_BENCHMARK=true, Job.Default otherwise (nightly / local)
- Add MemgraphBaseBenchmark base class mirroring BaseBenchmark for Memgraph
- Add BenchmarkHelpers for shared NATS container + parser setup
- Add TUnit observational perf tests in SharpMUSH.Tests/Performance/ (ParserThroughputTests, DatabaseLatencyTests) - no assertions, console output
- Add .github/workflows/benchmark-nightly.yml: scheduled 02:00 UTC, workflow_dispatch, uploads BenchmarkDotNet.Artifacts as artifact
- Downgrade Microsoft.CodeAnalysis.CSharp/Analyzers from 5.3.0 to 5.0.0 in both source generator projects to match SDK 10.0.105 (Roslyn 5.0.0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive benchmark suite for database operations, command parsing, and string functions.
  * Added performance latency tests for database queries and parser throughput.

* **Chores**
  * Enhanced testing infrastructure with automated nightly benchmarks via GitHub Actions.
  * Updated project dependencies and test configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->