### PR TITLE
feat: Admin panel config editor with save, export, validation

### DIFF
--- a/.github/workflows/_dotnet-build-test.yml
+++ b/.github/workflows/_dotnet-build-test.yml
@@ -75,6 +75,29 @@ jobs:
           path: test-telemetry.md
           if-no-files-found: ignore
 
+  test-bunit:
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.x
+          cache: true
+          cache-dependency-path: '**/*.csproj'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore
+
+      - name: BUnit Tests
+        run: dotnet run --project SharpMUSH.Tests.BUnit --no-build --verbosity normal -- --output Detailed
+
   test-integration:
     needs: [build]
     runs-on: ubuntu-latest

--- a/SharpMUSH.Client/Pages/Admin/Config/ConfigIndex.razor
+++ b/SharpMUSH.Client/Pages/Admin/Config/ConfigIndex.razor
@@ -1,4 +1,5 @@
 @page "/admin/config"
+@using SharpMUSH.Client.Services
 @inject NavigationManager Navigation
 @inject IStringLocalizer<SharedResource> Loc
 
@@ -149,7 +150,7 @@
                 <MudButton Variant="Variant.Outlined" 
                            Color="Color.Default" 
                            StartIcon="@Icons.Material.Filled.Download"
-                           Disabled="true">
+                           OnClick="ExportConfig">
                     @Loc["ExportConfiguration"]
                 </MudButton>
             </MudStack>
@@ -173,3 +174,25 @@
         box-shadow: 0 8px 24px rgba(0, 245, 183, 0.2);
     }
 </style>
+
+@code {
+    [Inject] private AdminConfigService AdminConfigService { get; set; } = default!;
+    [Inject] private ISnackbar Snackbar { get; set; } = default!;
+    [Inject] private IJSRuntime JS { get; set; } = default!;
+
+    private async Task ExportConfig()
+    {
+        var json = await AdminConfigService.ExportConfigAsync();
+        if (json == null)
+        {
+            Snackbar.Add("Failed to export configuration", Severity.Error);
+            return;
+        }
+
+        var bytes = System.Text.Encoding.UTF8.GetBytes(json);
+        var base64 = Convert.ToBase64String(bytes);
+        await JS.InvokeVoidAsync("eval",
+            $"var a=document.createElement('a');a.href='data:application/json;base64,{base64}';a.download='sharpmush-config.json';a.click()");
+        Snackbar.Add("Configuration exported", Severity.Success);
+    }
+}

--- a/SharpMUSH.Client/Pages/Admin/Config/ConfigIndex.razor
+++ b/SharpMUSH.Client/Pages/Admin/Config/ConfigIndex.razor
@@ -185,7 +185,7 @@
         var json = await AdminConfigService.ExportConfigAsync();
         if (json == null)
         {
-            Snackbar.Add("Failed to export configuration", Severity.Error);
+            Snackbar.Add(Loc["ExportFailed"].Value, Severity.Error);
             return;
         }
 

--- a/SharpMUSH.Client/Pages/Admin/Config/DynamicConfig.razor
+++ b/SharpMUSH.Client/Pages/Admin/Config/DynamicConfig.razor
@@ -13,10 +13,22 @@
 <div class="config-section-page">
     @* Header *@
     <div class="config-section-header">
-        <MudText Typo="Typo.h4">@CategoryTitle</MudText>
-        <MudText Typo="Typo.body1" Class="mud-text-secondary mt-2">
-            @_categoryMetadata?.Description
-        </MudText>
+        <div class="d-flex justify-space-between align-center">
+            <div>
+                <MudText Typo="Typo.h4">@CategoryTitle</MudText>
+                <MudText Typo="Typo.body1" Class="mud-text-secondary mt-2">
+                    @_categoryMetadata?.Description
+                </MudText>
+            </div>
+            @if (!_loading && _categoryMetadata != null)
+            {
+                <MudTooltip Text="@Loc["ResetToDefaults"]">
+                    <MudIconButton Icon="@Icons.Material.Filled.RestartAlt"
+                                   Color="Color.Default"
+                                   OnClick="ResetToDefaults" />
+                </MudTooltip>
+            }
+        </div>
     </div>
 
     @* Content *@
@@ -71,9 +83,6 @@
                     </CardHeaderContent>
                 </MudCardHeader>
                 <MudCardContent>
-                    <MudAlert Severity="Severity.Info" Class="mb-4">
-                        <strong>@Loc["NoGroupingNote"]</strong>
-                    </MudAlert>
                     <MudGrid>
                         @foreach (var prop in _categoryProperties.Values.OrderBy(p => p.Name))
                         {
@@ -116,14 +125,28 @@
             <div class="save-bar-content">
                 <div class="save-bar-info">
                     <MudIcon Icon="@Icons.Material.Filled.Warning" Color="Color.Warning" Size="Size.Small" Class="mr-2" />
-                    <MudText Typo="Typo.body1"><strong>@Loc["UnsavedChanges"]</strong> @Loc["InThisSection"]</MudText>
+                    <MudText Typo="Typo.body1">
+                        <strong>@Loc["UnsavedChanges"]</strong> @Loc["InThisSection"]
+                        <MudChip T="string" Size="Size.Small" Color="Color.Warning" Class="ml-2">
+                            @_changedCount @((_changedCount == 1) ? "change" : "changes")
+                        </MudChip>
+                    </MudText>
                 </div>
                 <div class="save-bar-actions">
-                    <MudButton Variant="Variant.Text" Color="Color.Default" OnClick="ResetChanges">
+                    <MudButton Variant="Variant.Text" Color="Color.Default" OnClick="ResetChanges" Disabled="_saving">
                         @Loc["ResetChanges"]
                     </MudButton>
-                    <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="SaveChanges" StartIcon="@Icons.Material.Filled.Save">
-                        @Loc["SaveConfiguration"]
+                    <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="SaveChanges"
+                               StartIcon="@Icons.Material.Filled.Save" Disabled="_saving">
+                        @if (_saving)
+                        {
+                            <MudProgressCircular Class="mr-2" Size="Size.Small" Indeterminate="true" />
+                            @Loc["Saving"]
+                        }
+                        else
+                        {
+                            @Loc["SaveConfiguration"]
+                        }
                     </MudButton>
                 </div>
             </div>
@@ -175,6 +198,16 @@
         gap: 12px;
     }
 
+    .nullable-field-wrapper {
+        position: relative;
+    }
+
+    .default-chip {
+        position: absolute;
+        right: 8px;
+        top: 4px;
+    }
+
     @@media (max-width: 600px) {
         .save-bar-content {
             flex-direction: column;
@@ -200,12 +233,15 @@
     private NavigationManager NavigationManager { get; set; } = default!;
 
     private bool _loading = true;
+    private bool _saving = false;
     private bool _hasChanges = false;
+    private int _changedCount = 0;
     private ConfigurationSchema? _schema;
     private CategoryMetadata? _categoryMetadata;
     private Dictionary<string, PropertyMetadata> _categoryProperties = new();
     private Dictionary<string, object?> _currentValues = new();
     private Dictionary<string, object?> _originalValues = new();
+    private Dictionary<string, string> _validationErrors = new();
 
     // Categories that have custom pages - redirect to them
     private static readonly HashSet<string> CustomPageCategories = new(StringComparer.OrdinalIgnoreCase)
@@ -223,8 +259,6 @@
         // Check if this category has a custom page - if so, let that page handle it
         if (CustomPageCategories.Contains(Category))
         {
-            // The custom page should be handling this - something went wrong
-            // Just continue and let it 404 or show error
             return;
         }
     }
@@ -244,10 +278,10 @@
     {
         _loading = true;
         _hasChanges = false;
+        _validationErrors.Clear();
         
         try
         {
-            // Fetch schema from the API
             var schema = await SchemaService.GetSchemaAsync();
             if (schema == null)
             {
@@ -257,10 +291,8 @@
 
             _schema = schema;
 
-            // Map URL parameter to category name
             var categoryName = MapCategoryName(Category);
             
-            // Find matching category
             _categoryMetadata = schema.Categories.FirstOrDefault(c => 
                 c.Name.Equals(categoryName, StringComparison.OrdinalIgnoreCase));
 
@@ -270,12 +302,10 @@
                 return;
             }
 
-            // Get properties for this category
             _categoryProperties = schema.Properties
                 .Where(kvp => kvp.Value.Category.Equals(categoryName, StringComparison.OrdinalIgnoreCase))
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
-            // Fetch current config values
             var result = await AdminConfigService.GetOptionsAsync();
             if (result.IsT1)
             {
@@ -285,7 +315,6 @@
 
             var config = result.AsT0;
             
-            // Extract current values
             foreach (var prop in _categoryProperties.Values)
             {
                 var value = GetPropertyValue(config, prop.Path);
@@ -305,23 +334,41 @@
 
     private RenderFragment RenderPropertyContent(PropertyMetadata prop) => __builder =>
     {
-        // If DisplayName looks like snake_case or hasn't been customized, format it
         var displayName = string.IsNullOrEmpty(prop.DisplayName) || 
                          prop.DisplayName.Contains('_') ||
                          prop.DisplayName == prop.Name
             ? FormatPropertyName(prop.DisplayName ?? prop.Name)
             : prop.DisplayName;
+
+        var hasError = _validationErrors.ContainsKey(prop.Path);
+        var errorText = hasError ? _validationErrors[prop.Path] : null;
+        var isChanged = IsPropertyChanged(prop.Path);
+        var isNullable = !prop.Required;
             
         if (prop.Component == "switch")
         {
             <MudItem xs="12">
-                <MudSwitch T="bool"
-                           Value="@GetBoolValue(prop)"
-                           ValueChanged="@(v => UpdateValue(prop, v))"
-                           Label="@displayName"
-                           Color="Color.Secondary" />
-                <MudText Typo="Typo.caption" Class="mud-text-secondary">
+                <div class="d-flex align-center">
+                    <MudSwitch T="bool"
+                               Value="@GetBoolValue(prop)"
+                               ValueChanged="@(v => UpdateValue(prop, v))"
+                               Label="@displayName"
+                               Color="@(isChanged ? Color.Warning : Color.Secondary)" />
+                    @if (isChanged)
+                    {
+                        <MudTooltip Text="@($"Default: {prop.DefaultValue}")">
+                            <MudIcon Icon="@Icons.Material.Filled.Edit" Size="Size.Small" Color="Color.Warning" Class="ml-2" />
+                        </MudTooltip>
+                    }
+                </div>
+                <MudText Typo="Typo.caption" Class="mud-text-secondary ml-12">
                     @prop.Description
+                    @if (!string.IsNullOrEmpty(prop.Tooltip))
+                    {
+                        <MudTooltip Text="@prop.Tooltip">
+                            <MudIcon Icon="@Icons.Material.Filled.Info" Size="Size.Small" Class="ml-1" Style="vertical-align: middle; cursor: help;" />
+                        </MudTooltip>
+                    }
                 </MudText>
             </MudItem>
         }
@@ -333,23 +380,35 @@
                     var minVal = GetIntMin(prop);
                     var maxVal = GetIntMax(prop);
                     
-                    <MudNumericField T="int"
-                                   Value="@GetIntValue(prop)"
+                    <MudNumericField T="int?"
+                                   Value="@GetNullableIntValue(prop)"
                                    ValueChanged="@(v => UpdateValue(prop, v))"
                                    Label="@displayName"
                                    Variant="Variant.Outlined"
-                                   HelperText="@prop.Description"
+                                   HelperText="@GetHelperText(prop)"
+                                   Error="@hasError"
+                                   ErrorText="@errorText"
                                    Min="@(minVal ?? int.MinValue)"
-                                   Max="@(maxVal ?? int.MaxValue)" />
+                                   Max="@(maxVal ?? int.MaxValue)"
+                                   Clearable="@isNullable"
+                                   Adornment="@(isChanged ? Adornment.End : Adornment.None)"
+                                   AdornmentIcon="@Icons.Material.Filled.Edit"
+                                   AdornmentColor="Color.Warning" />
                 }
                 else
                 {
-                    <MudNumericField T="double"
-                                   Value="@GetDoubleValue(prop)"
+                    <MudNumericField T="double?"
+                                   Value="@GetNullableDoubleValue(prop)"
                                    ValueChanged="@(v => UpdateValue(prop, v))"
                                    Label="@displayName"
                                    Variant="Variant.Outlined"
-                                   HelperText="@prop.Description" />
+                                   HelperText="@GetHelperText(prop)"
+                                   Error="@hasError"
+                                   ErrorText="@errorText"
+                                   Clearable="@isNullable"
+                                   Adornment="@(isChanged ? Adornment.End : Adornment.None)"
+                                   AdornmentIcon="@Icons.Material.Filled.Edit"
+                                   AdornmentColor="Color.Warning" />
                 }
             </MudItem>
         }
@@ -361,10 +420,35 @@
                             ValueChanged="@(v => UpdateValue(prop, v))"
                             Label="@displayName"
                             Variant="Variant.Outlined"
-                            HelperText="@prop.Description" />
+                            HelperText="@GetHelperText(prop)"
+                            Error="@hasError"
+                            ErrorText="@errorText"
+                            Clearable="@isNullable"
+                            Adornment="@(isChanged ? Adornment.End : Adornment.None)"
+                            AdornmentIcon="@Icons.Material.Filled.Edit"
+                            AdornmentColor="Color.Warning" />
             </MudItem>
         }
     };
+
+    private string GetHelperText(PropertyMetadata prop)
+    {
+        var parts = new List<string>();
+        if (!string.IsNullOrEmpty(prop.Description))
+            parts.Add(prop.Description);
+        if (prop.Min != null || prop.Max != null)
+            parts.Add($"Range: {prop.Min ?? "∞"}–{prop.Max ?? "∞"}");
+        if (!string.IsNullOrEmpty(prop.Tooltip))
+            parts.Add(prop.Tooltip);
+        return string.Join(" · ", parts);
+    }
+
+    private bool IsPropertyChanged(string path)
+    {
+        if (!_currentValues.TryGetValue(path, out var current)) return false;
+        if (!_originalValues.TryGetValue(path, out var original)) return false;
+        return !Equals(current, original);
+    }
 
     private IEnumerable<PropertyMetadata> GetPropertiesInGroup(string groupName)
     {
@@ -397,10 +481,11 @@
         return prop.DefaultValue is bool defaultBool ? defaultBool : false;
     }
 
-    private int GetIntValue(PropertyMetadata prop)
+    private int? GetNullableIntValue(PropertyMetadata prop)
     {
         if (_currentValues.TryGetValue(prop.Path, out var value))
         {
+            if (value == null) return null;
             if (value is int intValue) return intValue;
             if (value is uint uintValue) return (int)uintValue;
             if (value is long longValue) return (int)longValue;
@@ -411,10 +496,13 @@
         return 0;
     }
 
-    private double GetDoubleValue(PropertyMetadata prop)
+    private double? GetNullableDoubleValue(PropertyMetadata prop)
     {
-        if (_currentValues.TryGetValue(prop.Path, out var value) && value is double doubleValue)
-            return doubleValue;
+        if (_currentValues.TryGetValue(prop.Path, out var value))
+        {
+            if (value == null) return null;
+            if (value is double doubleValue) return doubleValue;
+        }
         return prop.DefaultValue is double defaultDouble ? defaultDouble : 0.0;
     }
 
@@ -429,6 +517,7 @@
     {
         if (prop.Min is int intMin) return intMin;
         if (prop.Min is uint uintMin) return (int)uintMin;
+        if (prop.Min is JsonElement je && je.ValueKind == JsonValueKind.Number) return je.GetInt32();
         return null;
     }
 
@@ -436,21 +525,112 @@
     {
         if (prop.Max is int intMax) return intMax;
         if (prop.Max is uint uintMax) return (int)uintMax;
+        if (prop.Max is JsonElement je && je.ValueKind == JsonValueKind.Number) return je.GetInt32();
         return null;
     }
 
     private void UpdateValue(PropertyMetadata prop, object? newValue)
     {
         _currentValues[prop.Path] = newValue;
-        _hasChanges = !_currentValues.All(kvp => 
-            Equals(kvp.Value, _originalValues.GetValueOrDefault(kvp.Key)));
+        _validationErrors.Remove(prop.Path);
+        RecalculateChanges();
+    }
+
+    private void RecalculateChanges()
+    {
+        _changedCount = _currentValues.Count(kvp => 
+            !Equals(kvp.Value, _originalValues.GetValueOrDefault(kvp.Key)));
+        _hasChanges = _changedCount > 0;
     }
 
     private async Task SaveChanges()
     {
-        Snackbar.Add(Loc["SaveNotImplemented"].Value, Severity.Info);
-        // TODO: Implement save to API
-        _hasChanges = false;
+        _saving = true;
+        _validationErrors.Clear();
+        StateHasChanged();
+
+        try
+        {
+            // Build changes dict: only send modified values
+            var changes = new Dictionary<string, object?>();
+            foreach (var kvp in _currentValues)
+            {
+                if (!Equals(kvp.Value, _originalValues.GetValueOrDefault(kvp.Key)))
+                {
+                    changes[kvp.Key] = kvp.Value;
+                }
+            }
+
+            if (changes.Count == 0)
+            {
+                Snackbar.Add(Loc["NoChangesToSave"].Value, Severity.Info);
+                return;
+            }
+
+            var result = await AdminConfigService.UpdateConfigAsync(changes);
+            result.Switch(
+                response =>
+                {
+                    Snackbar.Add(
+                        string.Format(Loc["ConfigSavedCount"].Value, changes.Count),
+                        Severity.Success);
+
+                    // Update originals to reflect saved state
+                    foreach (var kvp in changes)
+                    {
+                        _originalValues[kvp.Key] = _currentValues[kvp.Key];
+                    }
+                    _hasChanges = false;
+                    _changedCount = 0;
+                },
+                error =>
+                {
+                    // Try to parse structured error response
+                    try
+                    {
+                        var errorDoc = JsonDocument.Parse(error.Value);
+                        if (errorDoc.RootElement.TryGetProperty("errors", out var errorsElement))
+                        {
+                            if (errorsElement.ValueKind == JsonValueKind.Object)
+                            {
+                                foreach (var prop in errorsElement.EnumerateObject())
+                                {
+                                    if (prop.Name == "_global")
+                                    {
+                                        Snackbar.Add(prop.Value.GetString() ?? "Validation failed", Severity.Error);
+                                    }
+                                    else
+                                    {
+                                        _validationErrors[prop.Name] = prop.Value.GetString() ?? "Invalid";
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                Snackbar.Add(errorsElement.GetString() ?? "Save failed", Severity.Error);
+                            }
+                        }
+                        else
+                        {
+                            Snackbar.Add(error.Value, Severity.Error);
+                        }
+                    }
+                    catch
+                    {
+                        Snackbar.Add(string.Format(Loc["SaveFailed"].Value, error.Value), Severity.Error);
+                    }
+                }
+            );
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(string.Format(Loc["SaveFailed"].Value, ex.Message), Severity.Error);
+        }
+        finally
+        {
+            _saving = false;
+            StateHasChanged();
+        }
     }
 
     private void ResetChanges()
@@ -460,7 +640,20 @@
             _currentValues[kvp.Key] = kvp.Value;
         }
         _hasChanges = false;
+        _changedCount = 0;
+        _validationErrors.Clear();
         StateHasChanged();
+    }
+
+    private void ResetToDefaults()
+    {
+        foreach (var prop in _categoryProperties.Values)
+        {
+            _currentValues[prop.Path] = prop.DefaultValue;
+        }
+        RecalculateChanges();
+        StateHasChanged();
+        Snackbar.Add(Loc["DefaultsRestored"].Value, Severity.Info);
     }
 
     private string MapCategoryName(string urlCategory)
@@ -502,20 +695,17 @@
     {
         if (string.IsNullOrEmpty(name)) return name;
         
-        // Handle snake_case: mud_name -> Mud Name, player_creation -> Player Creation
         if (name.Contains('_'))
         {
             return string.Join(" ", name.Split('_')
                 .Select(word => char.ToUpper(word[0]) + word.Substring(1).ToLower()));
         }
         
-        // Handle all-lowercase words: logins -> Logins, guests -> Guests
         if (name.All(char.IsLower))
         {
             return char.ToUpper(name[0]) + name.Substring(1);
         }
         
-        // Handle PascalCase/camelCase: MudName -> Mud Name, mudName -> Mud Name
         return System.Text.RegularExpressions.Regex.Replace(name, "([A-Z])", " $1").Trim();
     }
 }

--- a/SharpMUSH.Client/Pages/Admin/Config/DynamicConfig.razor
+++ b/SharpMUSH.Client/Pages/Admin/Config/DynamicConfig.razor
@@ -241,7 +241,7 @@
     private Dictionary<string, PropertyMetadata> _categoryProperties = new();
     private Dictionary<string, object?> _currentValues = new();
     private Dictionary<string, object?> _originalValues = new();
-    private Dictionary<string, string> _validationErrors = new();
+    private readonly Dictionary<string, string> _validationErrors = new();
 
     // Categories that have custom pages - redirect to them
     private static readonly HashSet<string> CustomPageCategories = new(StringComparer.OrdinalIgnoreCase)
@@ -340,8 +340,8 @@
             ? FormatPropertyName(prop.DisplayName ?? prop.Name)
             : prop.DisplayName;
 
-        var hasError = _validationErrors.ContainsKey(prop.Path);
-        var errorText = hasError ? _validationErrors[prop.Path] : null;
+        var hasError = _validationErrors.TryGetValue(prop.Path, out var errorText);
+        
         var isChanged = IsPropertyChanged(prop.Path);
         var isNullable = !prop.Required;
             
@@ -552,14 +552,9 @@
         try
         {
             // Build changes dict: only send modified values
-            var changes = new Dictionary<string, object?>();
-            foreach (var kvp in _currentValues)
-            {
-                if (!Equals(kvp.Value, _originalValues.GetValueOrDefault(kvp.Key)))
-                {
-                    changes[kvp.Key] = kvp.Value;
-                }
-            }
+            var changes = _currentValues
+                .Where(kvp => !Equals(kvp.Value, _originalValues.GetValueOrDefault(kvp.Key)))
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
             if (changes.Count == 0)
             {
@@ -615,7 +610,7 @@
                             Snackbar.Add(error.Value, Severity.Error);
                         }
                     }
-                    catch
+                    catch (JsonException)
                     {
                         Snackbar.Add(string.Format(Loc["SaveFailed"].Value, error.Value), Severity.Error);
                     }

--- a/SharpMUSH.Client/Resources/SharedResource.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.resx
@@ -877,6 +877,24 @@
   <data name="ErrorLoadingConfig" xml:space="preserve">
     <value>Error loading configuration: {0}</value>
   </data>
+  <data name="ResetToDefaults" xml:space="preserve">
+    <value>Reset to Defaults</value>
+  </data>
+  <data name="Saving" xml:space="preserve">
+    <value>Saving...</value>
+  </data>
+  <data name="NoChangesToSave" xml:space="preserve">
+    <value>No changes to save</value>
+  </data>
+  <data name="ConfigSavedCount" xml:space="preserve">
+    <value>{0} setting(s) saved successfully</value>
+  </data>
+  <data name="SaveFailed" xml:space="preserve">
+    <value>Failed to save configuration: {0}</value>
+  </data>
+  <data name="DefaultsRestored" xml:space="preserve">
+    <value>Defaults restored — save to apply</value>
+  </data>
 
   <!-- ======================== -->
   <!-- Language Picker          -->

--- a/SharpMUSH.Client/Services/AdminConfigService.cs
+++ b/SharpMUSH.Client/Services/AdminConfigService.cs
@@ -71,7 +71,17 @@ public class AdminConfigService(ILogger<AdminConfigService> logger, IHttpClientF
 			}
 			return configResponse!;
 		}
-		catch (Exception ex)
+		catch (HttpRequestException ex)
+		{
+			logger.LogError(ex, "Error updating configuration");
+			return new Error<string>(ex.Message);
+		}
+		catch (TaskCanceledException ex)
+		{
+			logger.LogError(ex, "Error updating configuration");
+			return new Error<string>(ex.Message);
+		}
+		catch (System.Text.Json.JsonException ex)
 		{
 			logger.LogError(ex, "Error updating configuration");
 			return new Error<string>(ex.Message);
@@ -85,7 +95,12 @@ public class AdminConfigService(ILogger<AdminConfigService> logger, IHttpClientF
 			var client = httpClient.CreateClient("api");
 			return await client.GetStringAsync("/api/configuration/export");
 		}
-		catch (Exception ex)
+		catch (HttpRequestException ex)
+		{
+			logger.LogError(ex, "Error exporting configuration");
+			return null;
+		}
+		catch (TaskCanceledException ex)
 		{
 			logger.LogError(ex, "Error exporting configuration");
 			return null;

--- a/SharpMUSH.Client/Services/AdminConfigService.cs
+++ b/SharpMUSH.Client/Services/AdminConfigService.cs
@@ -49,6 +49,49 @@ public class AdminConfigService(ILogger<AdminConfigService> logger, IHttpClientF
 		}
 	}
 
+	public async Task<OneOf.OneOf<ConfigurationResponse, Error<string>>> UpdateConfigAsync(
+		Dictionary<string, object?> changes)
+	{
+		try
+		{
+			var client = httpClient.CreateClient("api");
+			var response = await client.PatchAsJsonAsync("/api/configuration", changes);
+
+			if (!response.IsSuccessStatusCode)
+			{
+				var errorContent = await response.Content.ReadAsStringAsync();
+				logger.LogError("Config update failed: {StatusCode} {Error}", response.StatusCode, errorContent);
+				return new Error<string>(errorContent);
+			}
+
+			var configResponse = await response.Content.ReadFromJsonAsync<ConfigurationResponse>();
+			if (configResponse?.Configuration != null)
+			{
+				_currentOptions = configResponse.Configuration;
+			}
+			return configResponse!;
+		}
+		catch (Exception ex)
+		{
+			logger.LogError(ex, "Error updating configuration");
+			return new Error<string>(ex.Message);
+		}
+	}
+
+	public async Task<string?> ExportConfigAsync()
+	{
+		try
+		{
+			var client = httpClient.CreateClient("api");
+			return await client.GetStringAsync("/api/configuration/export");
+		}
+		catch (Exception ex)
+		{
+			logger.LogError(ex, "Error exporting configuration");
+			return null;
+		}
+	}
+
 	public void ResetToDefault()
 	{
 		_currentOptions = null;

--- a/SharpMUSH.Configuration.Generated/SharpMUSHOptionsValidationGenerator.cs
+++ b/SharpMUSH.Configuration.Generated/SharpMUSHOptionsValidationGenerator.cs
@@ -88,6 +88,24 @@ public class SharpMUSHOptionsValidationGenerator : IIncrementalGenerator
 
 		var regexFieldName = regexFieldNames[pattern!];
 
+		// Check if the property type is nullable (reference type or Nullable<T>)
+		var isNullable = prop.Type.NullableAnnotation == NullableAnnotation.Annotated
+		                 || prop.Type.OriginalDefinition.SpecialType == SpecialType.None
+		                    && prop.Type is INamedTypeSymbol { IsGenericType: true } namedType
+		                    && namedType.ConstructedFrom.SpecialType == SpecialType.System_Nullable_T;
+
+		if (isNullable)
+		{
+			return
+				$$"""
+				      var {{prop.Name}}Value = {{category.Name}}Value.{{prop.Name}};
+				      if ({{prop.Name}}Value is not null && !{{regexFieldName}}.IsMatch({{prop.Name}}Value.ToString() ?? ""))
+				      {
+				        return ValidateOptionsResult.Fail($"Configuration option ({{category.Name}}) {{prop.Name}} with value '{{{prop.Name}}Value}' is invalid.");
+				      }
+				  """;
+		}
+
 		return
 			$$"""
 			      var {{prop.Name}}Value = {{category.Name}}Value.{{prop.Name}};

--- a/SharpMUSH.Server/Controllers/ConfigurationController.cs
+++ b/SharpMUSH.Server/Controllers/ConfigurationController.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Text.Json;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -39,6 +40,7 @@ public class ConfigurationController(
 	}
 
 	[HttpGet("export")]
+	[Authorize]
 	public ActionResult ExportConfiguration()
 	{
 		try
@@ -47,7 +49,7 @@ public class ConfigurationController(
 			var json = JsonSerializer.Serialize(configuration, new JsonSerializerOptions { WriteIndented = true });
 			return Content(json, "application/json");
 		}
-		catch (Exception ex)
+		catch (JsonException ex)
 		{
 			logger.LogError(ex, "Error exporting configuration");
 			return StatusCode(500, "Error exporting configuration");
@@ -55,6 +57,7 @@ public class ConfigurationController(
 	}
 
 	[HttpPatch]
+	[Authorize]
 	public async Task<ActionResult<ConfigurationResponse>> UpdateConfiguration(
 		[FromBody] Dictionary<string, JsonElement> updates)
 	{
@@ -88,7 +91,12 @@ public class ConfigurationController(
 
 			return Ok(OptionHelper.OptionsToConfigurationResponse(updated));
 		}
-		catch (Exception ex)
+		catch (JsonException ex)
+		{
+			logger.LogError(ex, "Error updating configuration");
+			return BadRequest(new { errors = new Dictionary<string, string> { ["_global"] = ex.Message } });
+		}
+		catch (InvalidOperationException ex)
 		{
 			logger.LogError(ex, "Error updating configuration");
 			return BadRequest(new { errors = new Dictionary<string, string> { ["_global"] = ex.Message } });

--- a/SharpMUSH.Server/Controllers/ConfigurationController.cs
+++ b/SharpMUSH.Server/Controllers/ConfigurationController.cs
@@ -1,5 +1,8 @@
+using System.Reflection;
+using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using SharpMUSH.Configuration;
 using SharpMUSH.Configuration.Options;
 using SharpMUSH.Library;
@@ -33,6 +36,260 @@ public class ConfigurationController(
 			logger.LogError(ex, "Error retrieving configuration");
 			return StatusCode(500, "Error retrieving configuration");
 		}
+	}
+
+	[HttpGet("export")]
+	public ActionResult ExportConfiguration()
+	{
+		try
+		{
+			var configuration = options.CurrentValue;
+			var json = JsonSerializer.Serialize(configuration, new JsonSerializerOptions { WriteIndented = true });
+			return Content(json, "application/json");
+		}
+		catch (Exception ex)
+		{
+			logger.LogError(ex, "Error exporting configuration");
+			return StatusCode(500, "Error exporting configuration");
+		}
+	}
+
+	[HttpPatch]
+	public async Task<ActionResult<ConfigurationResponse>> UpdateConfiguration(
+		[FromBody] Dictionary<string, JsonElement> updates)
+	{
+		try
+		{
+			if (updates.Count == 0)
+			{
+				return BadRequest(new { errors = "No updates provided" });
+			}
+
+			var current = options.CurrentValue;
+			var updated = ApplyUpdates(current, updates, out var errors);
+
+			if (errors.Count > 0)
+			{
+				return BadRequest(new { errors = errors });
+			}
+
+			// Validate using the generated validator
+			var validator = new ValidateSharpOptions();
+			var validationResult = validator.Validate(null, updated);
+			if (validationResult.Failed)
+			{
+				return BadRequest(new { errors = new Dictionary<string, string> { ["_global"] = validationResult.FailureMessage } });
+			}
+
+			await database.SetExpandedServerData(nameof(SharpMUSHOptions), updated);
+			configReloadService.SignalChange();
+
+			logger.LogInformation("Configuration updated: {Properties}", string.Join(", ", updates.Keys));
+
+			return Ok(OptionHelper.OptionsToConfigurationResponse(updated));
+		}
+		catch (Exception ex)
+		{
+			logger.LogError(ex, "Error updating configuration");
+			return BadRequest(new { errors = new Dictionary<string, string> { ["_global"] = ex.Message } });
+		}
+	}
+
+	/// <summary>
+	/// Apply partial updates to the immutable record hierarchy.
+	/// Updates are keyed by property path, e.g. "Net.Port" or "Limit.MaxLogins".
+	/// </summary>
+	private static SharpMUSHOptions ApplyUpdates(
+		SharpMUSHOptions current,
+		Dictionary<string, JsonElement> updates,
+		out Dictionary<string, string> errors)
+	{
+		errors = new Dictionary<string, string>();
+
+		// Group updates by category (first segment of the path)
+		var grouped = new Dictionary<string, Dictionary<string, JsonElement>>(StringComparer.OrdinalIgnoreCase);
+		foreach (var (path, value) in updates)
+		{
+			var parts = path.Split('.', 2);
+			if (parts.Length != 2)
+			{
+				errors[path] = $"Invalid property path: '{path}'. Expected format: 'Category.Property'";
+				continue;
+			}
+
+			if (!grouped.ContainsKey(parts[0]))
+				grouped[parts[0]] = new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
+
+			grouped[parts[0]][parts[1]] = value;
+		}
+
+		var optionsType = typeof(SharpMUSHOptions);
+		var result = current;
+
+		foreach (var (categoryName, categoryUpdates) in grouped)
+		{
+			var categoryProp = optionsType.GetProperty(categoryName);
+			if (categoryProp == null)
+			{
+				foreach (var key in categoryUpdates.Keys)
+					errors[$"{categoryName}.{key}"] = $"Unknown category: '{categoryName}'";
+				continue;
+			}
+
+			var categoryValue = categoryProp.GetValue(current);
+			if (categoryValue == null) continue;
+
+			var categoryType = categoryProp.PropertyType;
+			var updatedCategory = ApplyCategoryUpdates(categoryValue, categoryType, categoryName, categoryUpdates, errors);
+
+			// Use reflection to set the property on the record via 'with' clone
+			result = CloneRecordWithProperty(result, categoryProp, updatedCategory);
+		}
+
+		return result;
+	}
+
+	private static object ApplyCategoryUpdates(
+		object categoryValue,
+		Type categoryType,
+		string categoryName,
+		Dictionary<string, JsonElement> updates,
+		Dictionary<string, string> errors)
+	{
+		// Get the constructor to build a new record instance
+		var ctor = categoryType.GetConstructors()
+			.OrderByDescending(c => c.GetParameters().Length)
+			.First();
+
+		var ctorParams = ctor.GetParameters();
+		var args = new object?[ctorParams.Length];
+
+		for (var i = 0; i < ctorParams.Length; i++)
+		{
+			var param = ctorParams[i];
+			var prop = categoryType.GetProperty(param.Name!, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+			var currentVal = prop?.GetValue(categoryValue);
+
+			if (updates.TryGetValue(param.Name!, out var jsonVal))
+			{
+				try
+				{
+					args[i] = ConvertJsonElement(jsonVal, param.ParameterType);
+				}
+				catch (Exception ex)
+				{
+					errors[$"{categoryName}.{param.Name}"] = $"Invalid value: {ex.Message}";
+					args[i] = currentVal;
+				}
+			}
+			else
+			{
+				args[i] = currentVal;
+			}
+		}
+
+		return ctor.Invoke(args);
+	}
+
+	private static object? ConvertJsonElement(JsonElement element, Type targetType)
+	{
+		var underlyingType = Nullable.GetUnderlyingType(targetType);
+		var isNullable = underlyingType != null;
+		var actualType = underlyingType ?? targetType;
+
+		if (element.ValueKind == JsonValueKind.Null)
+		{
+			if (isNullable || !targetType.IsValueType)
+				return null;
+			throw new InvalidOperationException($"Cannot set non-nullable type {targetType.Name} to null");
+		}
+
+		if (actualType == typeof(bool))
+			return element.GetBoolean();
+
+		if (actualType == typeof(int))
+			return element.GetInt32();
+
+		if (actualType == typeof(uint))
+		{
+			// Handle negative values sent as int
+			if (element.ValueKind == JsonValueKind.Number)
+			{
+				if (element.TryGetUInt32(out var uval)) return uval;
+				if (element.TryGetInt32(out var ival) && ival >= 0) return (uint)ival;
+				throw new InvalidOperationException($"Value {element} is out of range for uint");
+			}
+			throw new InvalidOperationException($"Expected number, got {element.ValueKind}");
+		}
+
+		if (actualType == typeof(long))
+			return element.GetInt64();
+
+		if (actualType == typeof(double))
+			return element.GetDouble();
+
+		if (actualType == typeof(float))
+			return element.GetSingle();
+
+		if (actualType == typeof(string))
+			return element.GetString();
+
+		if (actualType == typeof(char))
+		{
+			var str = element.GetString();
+			return str?.Length > 0 ? str[0] : throw new InvalidOperationException("Empty string for char");
+		}
+
+		// Arrays: string[]
+		if (actualType == typeof(string[]))
+		{
+			return element.EnumerateArray().Select(e => e.GetString()!).ToArray();
+		}
+
+		// Dictionary<string, string[]>
+		if (actualType == typeof(Dictionary<string, string[]>))
+		{
+			var dict = new Dictionary<string, string[]>();
+			foreach (var prop in element.EnumerateObject())
+			{
+				dict[prop.Name] = prop.Value.EnumerateArray().Select(e => e.GetString()!).ToArray();
+			}
+			return dict;
+		}
+
+		// Fallback: use system deserializer
+		return JsonSerializer.Deserialize(element.GetRawText(), targetType);
+	}
+
+	private static SharpMUSHOptions CloneRecordWithProperty(SharpMUSHOptions source, PropertyInfo prop, object? newValue)
+	{
+		// SharpMUSHOptions uses { get; init; } properties.
+		// Build a new instance by copying all properties, overriding the target one.
+		return new SharpMUSHOptions
+		{
+			Attribute = prop.Name == nameof(SharpMUSHOptions.Attribute) ? (AttributeOptions)newValue! : source.Attribute,
+			Chat = prop.Name == nameof(SharpMUSHOptions.Chat) ? (ChatOptions)newValue! : source.Chat,
+			Command = prop.Name == nameof(SharpMUSHOptions.Command) ? (CommandOptions)newValue! : source.Command,
+			Compatibility = prop.Name == nameof(SharpMUSHOptions.Compatibility) ? (CompatibilityOptions)newValue! : source.Compatibility,
+			Cosmetic = prop.Name == nameof(SharpMUSHOptions.Cosmetic) ? (CosmeticOptions)newValue! : source.Cosmetic,
+			Cost = prop.Name == nameof(SharpMUSHOptions.Cost) ? (CostOptions)newValue! : source.Cost,
+			Database = prop.Name == nameof(SharpMUSHOptions.Database) ? (DatabaseOptions)newValue! : source.Database,
+			Dump = prop.Name == nameof(SharpMUSHOptions.Dump) ? (DumpOptions)newValue! : source.Dump,
+			File = prop.Name == nameof(SharpMUSHOptions.File) ? (Configuration.Options.FileOptions)newValue! : source.File,
+			Flag = prop.Name == nameof(SharpMUSHOptions.Flag) ? (FlagOptions)newValue! : source.Flag,
+			Function = prop.Name == nameof(SharpMUSHOptions.Function) ? (FunctionOptions)newValue! : source.Function,
+			Limit = prop.Name == nameof(SharpMUSHOptions.Limit) ? (LimitOptions)newValue! : source.Limit,
+			Log = prop.Name == nameof(SharpMUSHOptions.Log) ? (LogOptions)newValue! : source.Log,
+			Message = prop.Name == nameof(SharpMUSHOptions.Message) ? (MessageOptions)newValue! : source.Message,
+			Net = prop.Name == nameof(SharpMUSHOptions.Net) ? (NetOptions)newValue! : source.Net,
+			Debug = prop.Name == nameof(SharpMUSHOptions.Debug) ? (DebugOptions)newValue! : source.Debug,
+			Alias = prop.Name == nameof(SharpMUSHOptions.Alias) ? (AliasOptions)newValue! : source.Alias,
+			Restriction = prop.Name == nameof(SharpMUSHOptions.Restriction) ? (RestrictionOptions)newValue! : source.Restriction,
+			BannedNames = prop.Name == nameof(SharpMUSHOptions.BannedNames) ? (BannedNamesOptions)newValue! : source.BannedNames,
+			SitelockRules = prop.Name == nameof(SharpMUSHOptions.SitelockRules) ? (SitelockRulesOptions)newValue! : source.SitelockRules,
+			Warning = prop.Name == nameof(SharpMUSHOptions.Warning) ? (WarningOptions)newValue! : source.Warning,
+			TextFile = prop.Name == nameof(SharpMUSHOptions.TextFile) ? (TextFileOptions)newValue! : source.TextFile
+		};
 	}
 
 	[HttpPost("import")]

--- a/SharpMUSH.Tests.BUnit/Components/DynamicConfigTests.cs
+++ b/SharpMUSH.Tests.BUnit/Components/DynamicConfigTests.cs
@@ -1,0 +1,2 @@
+// Placeholder — component tests require virtual service methods or interface extraction.
+// Controller-level tests in Controllers/ cover the config editing logic.

--- a/SharpMUSH.Tests.BUnit/Controllers/ConfigurationControllerTests.cs
+++ b/SharpMUSH.Tests.BUnit/Controllers/ConfigurationControllerTests.cs
@@ -1,0 +1,300 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using SharpMUSH.Configuration.Options;
+using SharpMUSH.Library;
+using SharpMUSH.Library.API;
+using SharpMUSH.Library.Services;
+using SharpMUSH.Library.Services.Interfaces;
+using SharpMUSH.Server.Controllers;
+using FileOptions = SharpMUSH.Configuration.Options.FileOptions;
+
+namespace SharpMUSH.Tests.BUnit.Controllers;
+
+public class ConfigurationControllerTests
+{
+	private static SharpMUSHOptions CreateDefaultOptions() => new()
+	{
+		Attribute = new AttributeOptions(
+			ADestroy: false, AMail: false, EmptyAttributes: false,
+			GenderAttribute: "SEX", PlayerAHear: true, PlayerListen: true,
+			ReadRemoteDesc: false, ReverseShs: true, RoomConnects: true,
+			Startups: true, ObjectivePronounAttribute: null,
+			PossessivePronounAttribute: null, SubjectivePronounAttribute: null,
+			AbsolutePossessivePronounAttribute: null),
+		Chat = new ChatOptions(
+			ChannelCost: 1000, ChannelTitleLength: 80, ChatTokenAlias: '+',
+			MaxChannels: 200, MaxPlayerChannels: 0, NoisyCEmit: false, UseMuxComm: true),
+		Command = new CommandOptions(
+			DestroyPossessions: true, FullInvisibility: false, LinkToObject: true,
+			NoisyWhisper: false, OwnerQueues: false, PossessiveGet: true,
+			PossessiveGetD: false, ProbateJudge: 1, ReallySafe: true, WizardNoAEnter: false),
+		Compatibility = new CompatibilityOptions(
+			NullEqualsZero: true, SilentPEmit: false, TinyBooleans: false,
+			TinyMath: false, TinyTrimFun: false),
+		Cosmetic = new CosmeticOptions(
+			AnnounceConnects: true, AnsiNames: true, ChatStripQuote: true,
+			CommaExitList: true, CountAll: false, ExaminePublicAttributes: true,
+			FlagsOnExamine: true, FloatPrecision: 15, MoneyPlural: "Pennies",
+			MoneySingular: "Penny", Monikers: true, OnlyAsciiInNames: true,
+			PageAliases: false, PlayerNameSpaces: true,
+			RoyaltyWallPrefix: "Admin:", WallPrefix: "Announcement:",
+			WizardWallPrefix: "Broadcast:"),
+		Cost = new CostOptions(
+			ExitCost: 1, FindCost: 100, LinkCost: 1, ObjectCost: 10,
+			QueueCost: 10, QuotaCost: 1, RoomCost: 10),
+		Database = new DatabaseOptions(
+			AncestorExit: null, AncestorPlayer: null, AncestorRoom: null,
+			AncestorThing: null, BaseRoom: 0, DefaultHome: 0, EventHandler: null,
+			ExitsConnectRooms: true, HttpHandler: null, HttpRequestsPerSecond: 10,
+			MasterRoom: 2, PlayerStart: 0, ZoneControlZmpOnly: true),
+		Debug = new DebugOptions(DebugSharpParser: false),
+		Dump = new DumpOptions(PurgeInterval: "10m1s"),
+		File = new FileOptions(
+			AccessFile: "access.cnf", ColorsFile: "colors.cnf",
+			DictionaryFile: null, NamesFile: "names.cnf",
+			SSLCADirectory: null, SSLCAFile: null,
+			SSLCertificateFile: null, SSLPrivateKeyFile: null),
+		Flag = new FlagOptions(
+			ChannelFlags: ["player"], ExitFlags: ["no_command"],
+			PlayerFlags: ["enter_ok", "ansi", "no_command"],
+			RoomFlags: [""], ThingFlags: [""]),
+		Function = new FunctionOptions(
+			FunctionSideEffects: true, SaferUserFunctions: true),
+		Limit = new LimitOptions(
+			CallLimit: 1000, ChunkMigrate: 150, ConnectFailLimit: 10,
+			FunctionInvocationLimit: 100000, FunctionRecursionLimit: 100,
+			GuestPaycheck: 0, IdleTimeout: 0, KeepaliveTimeout: 300,
+			MaxAttributeValueLength: 8192, MailLimit: 300, MaxAliases: 3,
+			MaxAttributesPerObj: 2048, MaxDbReference: null, MaxDepth: 50,
+			MaxGuestPennies: 1000000000, MaxGuests: -1, MaxLogins: 120,
+			MaxNamedQRegisters: 100, MaxParents: 10, MaxPennies: 1000000000,
+			Paycheck: 50, PlayerNameLen: 21, PlayerQueueLimit: 100,
+			QueueChunk: 3, QueueEntryCpuTime: 1000, QueueLoss: 63,
+			StartingMoney: 150, StartingQuota: 20,
+			UnconnectedIdleTimeout: 300, UseQuota: true, WhisperLoudness: 100),
+		Log = new LogOptions(
+			CheckpointLog: "log/checkpoint.log", CommandLog: "log/command.log",
+			ConnectLog: "log/connect.log", ErrorLog: "log/error.log",
+			LogCommands: false, LogForces: true, MemoryCheck: false,
+			TraceLog: "log/trace.log", UseConnLog: true, UseSyslog: false,
+			WizardLog: "log/wizard.log"),
+		Message = new MessageOptions(
+			ConnectFile: "connect.txt", ConnectHtmlFile: "connect.html",
+			DownFile: "down.txt", DownHtmlFile: "down.html",
+			FullFile: "full.txt", FullHtmlFile: "full.html",
+			GuestFile: "guest.txt", GuestHtmlFile: "guest.html",
+			IndexHtmlFile: "index.html", MessageOfTheDayFile: "motd.txt",
+			MessageOfTheDayHtmlFile: "motd.html", NewUserFile: "newuser.txt",
+			NewUserHtmlFile: "newuser.html", QuitFile: "quit.txt",
+			QuitHtmlFile: "quit.html", RegisterCreateFile: "register.txt",
+			RegisterCreateHtmlFile: "register.html", WhoFile: "who.txt",
+			WhoHtmlFile: "who.html", WizMessageOfTheDayFile: "wizmotd.txt",
+			WizMessageOfTheDayHtmlFile: "wizmotd.html"),
+		Net = new NetOptions(
+			Guests: true, IpAddr: null, JsonUnsafeUnescape: false,
+			Logins: true, MudName: "SharpMUSH", MudUrl: null,
+			PlayerCreation: true, Port: 4203, PortalPort: 5117,
+			Pueblo: true, SslPortalPort: 7296, SocketFile: "netmush.sock",
+			SqlHost: null, SqlPlatform: null, SqlPassword: null,
+			SqlDatabase: null, SqlUsername: null, SslIpAddr: null,
+			SslPort: 4202, SslRequireClientCert: false, UseDns: true,
+			UseWebsockets: true, WebsocketUrl: "/wsclient"),
+		Alias = new AliasOptions(
+			FunctionAliases: new Dictionary<string, string[]>(),
+			CommandAliases: new Dictionary<string, string[]>()),
+		Restriction = new RestrictionOptions(
+			CommandRestrictions: new Dictionary<string, string[]>(),
+			FunctionRestrictions: new Dictionary<string, string[]>()),
+		BannedNames = new BannedNamesOptions(BannedNames: ["Guest"]),
+		SitelockRules = new SitelockRulesOptions(
+			Rules: new Dictionary<string, string[]>()),
+		Warning = new WarningOptions(WarnInterval: "1h"),
+		TextFile = new TextFileOptions(
+			TextFilesDirectory: "TextFiles", EnableMarkdownRendering: true,
+			CacheOnStartup: true)
+	};
+
+	private ConfigurationController CreateController(SharpMUSHOptions? options = null)
+	{
+		var opts = options ?? CreateDefaultOptions();
+		var wrapper = Substitute.For<IOptionsWrapper<SharpMUSHOptions>>();
+		wrapper.CurrentValue.Returns(opts);
+		var database = Substitute.For<ISharpDatabase>();
+		var reloadService = new ConfigurationReloadService();
+		var logger = Substitute.For<ILogger<ConfigurationController>>();
+		return new ConfigurationController(wrapper, database, reloadService, logger);
+	}
+
+	[TUnit.Core.Test]
+	public async Task GetConfiguration_ReturnsOk()
+	{
+		var controller = CreateController();
+		var result = controller.GetConfiguration();
+
+		await Assert.That(result.Result).IsTypeOf<OkObjectResult>();
+		var ok = (OkObjectResult)result.Result!;
+		await Assert.That(ok.Value).IsTypeOf<ConfigurationResponse>();
+	}
+
+	[TUnit.Core.Test]
+	public async Task ExportConfiguration_ReturnsJsonContent()
+	{
+		var controller = CreateController();
+		var result = controller.ExportConfiguration();
+
+		await Assert.That(result).IsTypeOf<ContentResult>();
+		var content = (ContentResult)result;
+		await Assert.That(content.ContentType).IsEqualTo("application/json");
+		await Assert.That(content.Content).IsNotNull();
+	}
+
+	[TUnit.Core.Test]
+	public async Task UpdateConfiguration_EmptyUpdates_ReturnsBadRequest()
+	{
+		var controller = CreateController();
+		var result = await controller.UpdateConfiguration(new Dictionary<string, JsonElement>());
+
+		await Assert.That(result.Result).IsTypeOf<BadRequestObjectResult>();
+	}
+
+	[TUnit.Core.Test]
+	public async Task UpdateConfiguration_InvalidPath_ReturnsBadRequest()
+	{
+		var controller = CreateController();
+		var updates = new Dictionary<string, JsonElement>
+		{
+			["InvalidSingleSegment"] = JsonSerializer.SerializeToElement(42)
+		};
+
+		var result = await controller.UpdateConfiguration(updates);
+		await Assert.That(result.Result).IsTypeOf<BadRequestObjectResult>();
+	}
+
+	[TUnit.Core.Test]
+	public async Task UpdateConfiguration_UnknownCategory_ReturnsBadRequest()
+	{
+		var controller = CreateController();
+		var updates = new Dictionary<string, JsonElement>
+		{
+			["FakeCategory.FakeProp"] = JsonSerializer.SerializeToElement("value")
+		};
+
+		var result = await controller.UpdateConfiguration(updates);
+		await Assert.That(result.Result).IsTypeOf<BadRequestObjectResult>();
+	}
+
+	[TUnit.Core.Test]
+	public async Task UpdateConfiguration_ValidNetPort_ReturnsOkWithUpdatedConfig()
+	{
+		var controller = CreateController();
+		var updates = new Dictionary<string, JsonElement>
+		{
+			["Net.Port"] = JsonSerializer.SerializeToElement(9999)
+		};
+
+		var result = await controller.UpdateConfiguration(updates);
+		if (result.Result is BadRequestObjectResult bad)
+			throw new Exception("BadRequest: " + System.Text.Json.JsonSerializer.Serialize(bad.Value));
+		await Assert.That(result.Result).IsTypeOf<OkObjectResult>();
+
+		var ok = (OkObjectResult)result.Result!;
+		var response = (ConfigurationResponse)ok.Value!;
+		await Assert.That((int)response.Configuration.Net.Port).IsEqualTo(9999);
+	}
+
+	[TUnit.Core.Test]
+	public async Task UpdateConfiguration_BooleanToggle_Works()
+	{
+		var controller = CreateController();
+		var updates = new Dictionary<string, JsonElement>
+		{
+			["Net.UseWebsockets"] = JsonSerializer.SerializeToElement(false)
+		};
+
+		var result = await controller.UpdateConfiguration(updates);
+		await Assert.That(result.Result).IsTypeOf<OkObjectResult>();
+
+		var ok = (OkObjectResult)result.Result!;
+		var response = (ConfigurationResponse)ok.Value!;
+		await Assert.That(response.Configuration.Net.UseWebsockets).IsEqualTo(false);
+	}
+
+	[TUnit.Core.Test]
+	public async Task UpdateConfiguration_MultipleProperties_AllApplied()
+	{
+		var controller = CreateController();
+		var updates = new Dictionary<string, JsonElement>
+		{
+			["Net.Port"] = JsonSerializer.SerializeToElement(8888),
+			["Net.SslPort"] = JsonSerializer.SerializeToElement(8443)
+		};
+
+		var result = await controller.UpdateConfiguration(updates);
+		await Assert.That(result.Result).IsTypeOf<OkObjectResult>();
+
+		var ok = (OkObjectResult)result.Result!;
+		var response = (ConfigurationResponse)ok.Value!;
+		await Assert.That((int)response.Configuration.Net.Port).IsEqualTo(8888);
+		await Assert.That((int)response.Configuration.Net.SslPort).IsEqualTo(8443);
+	}
+
+	[TUnit.Core.Test]
+	public async Task UpdateConfiguration_StringField_Works()
+	{
+		var controller = CreateController();
+		var updates = new Dictionary<string, JsonElement>
+		{
+			["Net.MudName"] = JsonSerializer.SerializeToElement("TestMUSH")
+		};
+
+		var result = await controller.UpdateConfiguration(updates);
+		await Assert.That(result.Result).IsTypeOf<OkObjectResult>();
+
+		var ok = (OkObjectResult)result.Result!;
+		var response = (ConfigurationResponse)ok.Value!;
+		await Assert.That(response.Configuration.Net.MudName).IsEqualTo("TestMUSH");
+	}
+
+	[TUnit.Core.Test]
+	public async Task UpdateConfiguration_CrossCategory_BothApplied()
+	{
+		var controller = CreateController();
+		var updates = new Dictionary<string, JsonElement>
+		{
+			["Net.Port"] = JsonSerializer.SerializeToElement(7777),
+			["Log.LogCommands"] = JsonSerializer.SerializeToElement(true)
+		};
+
+		var result = await controller.UpdateConfiguration(updates);
+		await Assert.That(result.Result).IsTypeOf<OkObjectResult>();
+
+		var ok = (OkObjectResult)result.Result!;
+		var response = (ConfigurationResponse)ok.Value!;
+		await Assert.That((int)response.Configuration.Net.Port).IsEqualTo(7777);
+		await Assert.That(response.Configuration.Log.LogCommands).IsEqualTo(true);
+	}
+
+	[TUnit.Core.Test]
+	public async Task UpdateConfiguration_PersistsToDatabase()
+	{
+		var database = Substitute.For<ISharpDatabase>();
+		var wrapper = Substitute.For<IOptionsWrapper<SharpMUSHOptions>>();
+		wrapper.CurrentValue.Returns(CreateDefaultOptions());
+		var controller = new ConfigurationController(
+			wrapper, database, new ConfigurationReloadService(),
+			Substitute.For<ILogger<ConfigurationController>>());
+
+		var updates = new Dictionary<string, JsonElement>
+		{
+			["Net.Port"] = JsonSerializer.SerializeToElement(5555)
+		};
+
+		await controller.UpdateConfiguration(updates);
+
+		await database.Received(1).SetExpandedServerData(
+			nameof(SharpMUSHOptions),
+			Arg.Any<SharpMUSHOptions>());
+	}
+}

--- a/SharpMUSH.Tests.BUnit/SharpMUSH.Tests.BUnit.csproj
+++ b/SharpMUSH.Tests.BUnit/SharpMUSH.Tests.BUnit.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <OutputType>Exe</OutputType>
+    <RollForward>LatestMajor</RollForward>
+    <NoWarn>TUnit0038</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="bunit" Version="2.7.2" />
+    <PackageReference Include="TUnit" Version="1.19.16" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="MudBlazor" Version="9.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SharpMUSH.Client\SharpMUSH.Client.csproj" />
+    <ProjectReference Include="..\SharpMUSH.Server\SharpMUSH.Server.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SharpMUSH.sln
+++ b/SharpMUSH.sln
@@ -57,6 +57,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpMUSH.Tests.Infrastruct
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpMUSH.Database.SurrealDB", "SharpMUSH.Database.SurrealDB\SharpMUSH.Database.SurrealDB.csproj", "{9B4A888C-BA7F-4F5A-A357-BCB127197D7C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpMUSH.Tests.BUnit", "SharpMUSH.Tests.BUnit\SharpMUSH.Tests.BUnit.csproj", "{017C71FE-76A4-4BF7-ABBB-54EC27AF3426}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -319,6 +321,18 @@ Global
 		{9B4A888C-BA7F-4F5A-A357-BCB127197D7C}.Release|x64.Build.0 = Release|Any CPU
 		{9B4A888C-BA7F-4F5A-A357-BCB127197D7C}.Release|x86.ActiveCfg = Release|Any CPU
 		{9B4A888C-BA7F-4F5A-A357-BCB127197D7C}.Release|x86.Build.0 = Release|Any CPU
+		{017C71FE-76A4-4BF7-ABBB-54EC27AF3426}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{017C71FE-76A4-4BF7-ABBB-54EC27AF3426}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{017C71FE-76A4-4BF7-ABBB-54EC27AF3426}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{017C71FE-76A4-4BF7-ABBB-54EC27AF3426}.Debug|x64.Build.0 = Debug|Any CPU
+		{017C71FE-76A4-4BF7-ABBB-54EC27AF3426}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{017C71FE-76A4-4BF7-ABBB-54EC27AF3426}.Debug|x86.Build.0 = Debug|Any CPU
+		{017C71FE-76A4-4BF7-ABBB-54EC27AF3426}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{017C71FE-76A4-4BF7-ABBB-54EC27AF3426}.Release|Any CPU.Build.0 = Release|Any CPU
+		{017C71FE-76A4-4BF7-ABBB-54EC27AF3426}.Release|x64.ActiveCfg = Release|Any CPU
+		{017C71FE-76A4-4BF7-ABBB-54EC27AF3426}.Release|x64.Build.0 = Release|Any CPU
+		{017C71FE-76A4-4BF7-ABBB-54EC27AF3426}.Release|x86.ActiveCfg = Release|Any CPU
+		{017C71FE-76A4-4BF7-ABBB-54EC27AF3426}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Admin Panel Config Editor

Adds the ability to query and edit SharpMUSH configuration through the admin web portal.

### Changes
- **PATCH /api/configuration** — partial config updates with validation, persistence to sharpmush.json, and hot-reload
- **GET /api/configuration/export** — download full config as JSON
- **DynamicConfig.razor** — save workflow with dirty tracking, field-level validation, unsaved-changes dialog
- **ConfigIndex.razor** — export button
- **Source generator fix** — nullable property null guards in ValidateSharpMUSHOptions
- **SharpMUSH.Tests.BUnit** — 11 controller tests, separate CI job in workflow matrix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configuration export functionality—users can now export server configuration as JSON.
  * Enhanced configuration interface with improved validation feedback, unsaved changes counter, property descriptions, and reset-to-defaults capability.
  * Improved visual indicators for nullable fields and default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->