### PR TITLE
feat: PennMUSH-compatible VERBOSE/DEBUG/PUPPET output formatting

### DIFF
--- a/SharpMUSH.Database.ArangoDB/ArangoDatabase.Navigation.cs
+++ b/SharpMUSH.Database.ArangoDB/ArangoDatabase.Navigation.cs
@@ -142,6 +142,8 @@ public partial class ArangoDatabase
 
 		await foreach (var item in GetContentsAsync(location.Object().DBRef, ct))
 		{
+			// Skip self — already yielded above
+			if (item.Object().DBRef == obj) continue;
 			yield return item.WithRoomOption();
 		}
 	}
@@ -160,6 +162,8 @@ public partial class ArangoDatabase
 
 		await foreach (var item in GetContentsAsync(location.Object().DBRef, ct))
 		{
+			// Skip self — already yielded above
+			if (item.Object().DBRef == obj.Object().DBRef) continue;
 			yield return item.WithRoomOption();
 		}
 	}

--- a/SharpMUSH.Database.Memgraph/MemgraphDatabase.Navigation.cs
+++ b/SharpMUSH.Database.Memgraph/MemgraphDatabase.Navigation.cs
@@ -221,7 +221,11 @@ CREATE (src)-[:AT_LOCATION]->(dest)
 			yield return item.WithRoomOption();
 
 		await foreach (var item in GetContentsAsync(location.Object().DBRef, cancellationToken))
+		{
+			// Skip self — already yielded above
+			if (item.Object().DBRef == obj) continue;
 			yield return item.WithRoomOption();
+		}
 	}
 
 	public async IAsyncEnumerable<AnySharpObject> GetNearbyObjectsAsync(AnySharpObject obj, [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -234,7 +238,11 @@ CREATE (src)-[:AT_LOCATION]->(dest)
 			yield return item.WithRoomOption();
 
 		await foreach (var item in GetContentsAsync(location.Object().DBRef, cancellationToken))
+		{
+			// Skip self — already yielded above
+			if (item.Object().DBRef == obj.Object().DBRef) continue;
 			yield return item.WithRoomOption();
+		}
 	}
 
 	#endregion

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Navigation.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Navigation.cs
@@ -299,7 +299,11 @@ public partial class SurrealDatabase
 			yield return item.WithRoomOption();
 
 		await foreach (var item in GetContentsAsync(location.Object().DBRef, cancellationToken))
+		{
+			// Skip self — already yielded above
+			if (item.Object().DBRef == obj) continue;
 			yield return item.WithRoomOption();
+		}
 	}
 
 	public async IAsyncEnumerable<AnySharpObject> GetNearbyObjectsAsync(AnySharpObject obj, [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -312,7 +316,11 @@ public partial class SurrealDatabase
 			yield return item.WithRoomOption();
 
 		await foreach (var item in GetContentsAsync(location.Object().DBRef, cancellationToken))
+		{
+			// Skip self — already yielded above
+			if (item.Object().DBRef == obj.Object().DBRef) continue;
 			yield return item.WithRoomOption();
+		}
 	}
 
 	public IAsyncEnumerable<SharpObjectFlag> GetObjectFlagsAsync(string id, string type, CancellationToken cancellationToken = default)

--- a/SharpMUSH.Implementation/MUSHCodeParser.cs
+++ b/SharpMUSH.Implementation/MUSHCodeParser.cs
@@ -7,8 +7,10 @@ using OneOf.Types;
 using SharpMUSH.Configuration.Options;
 using SharpMUSH.Implementation.Services;
 using SharpMUSH.Implementation.Visitors;
+using SharpMUSH.Library;
 using SharpMUSH.Library.Definitions;
 using SharpMUSH.Library.DiscriminatedUnions;
+using SharpMUSH.Library.Extensions;
 using SharpMUSH.Library.Models;
 using SharpMUSH.Library.ParserInterfaces;
 using SharpMUSH.Library.Services;
@@ -142,7 +144,22 @@ public record MUSHCodeParser(ILogger<MUSHCodeParser> Logger,
 	/// <param name="parser">Optional parser instance to use. When null, defaults to 'this'.
 	/// Pass a different parser when you need custom parser state (e.g., CommandParse with handle info).</param>
 	/// <returns>The result of visiting the parse tree</returns>
-	private ValueTask<CallState?> ParseInternal<TContext>(
+	private async ValueTask<CallState?> ParseInternal<TContext>(
+		MString text,
+		Func<SharpMUSHParser, TContext> entryPoint,
+		string methodName,
+		IMUSHCodeParser? parser = null,
+		bool lenient = false)
+		where TContext : ParserRuleContext
+	{
+		var (result, _) = await ParseInternalCore(text, entryPoint, methodName, parser, lenient);
+		return result;
+	}
+
+	/// <summary>
+	/// Core parse implementation that returns both the result and visitor metadata.
+	/// </summary>
+	private async ValueTask<(CallState? Result, bool DidEmitFunctionDebug)> ParseInternalCore<TContext>(
 		MString text,
 		Func<SharpMUSHParser, TContext> entryPoint,
 		string methodName,
@@ -196,8 +213,7 @@ public record MUSHCodeParser(ILogger<MUSHCodeParser> Logger,
 		// error-recovery tree so the best-effort split is returned to the caller.
 		if (errorListener.HasErrors && !lenient)
 		{
-			return ValueTask.FromResult<CallState?>(
-				new CallState(MModule.single(errorListener.Errors[0].ToMushFailureString())));
+			return (new CallState(MModule.single(errorListener.Errors[0].ToMushFailureString())), false);
 		}
 
 		SharpMUSHParserVisitor visitor = new(Logger, parser,
@@ -211,7 +227,8 @@ public record MUSHCodeParser(ILogger<MUSHCodeParser> Logger,
 			_hookService,
 			text);
 
-		return visitor.Visit(context);
+		var result = await visitor.Visit(context);
+		return (result, visitor.DidEmitFunctionDebug);
 	}
 
 	public async ValueTask<CallState?> FunctionParse(MString text)
@@ -252,7 +269,84 @@ public record MUSHCodeParser(ILogger<MUSHCodeParser> Logger,
 				LimitExceeded: new LimitExceededFlag()))
 			: this;
 
-		var result = await ParseInternal(text, p => p.startPlainString(), nameof(FunctionParse), parser);
+		var (result, _) = await ParseInternalCore(text, p => p.startPlainString(), nameof(FunctionParse), parser);
+
+		return result;
+	}
+
+	public async ValueTask<CallState?> FunctionParse(MString text, bool emitSubstDebug)
+	{
+		if (!emitSubstDebug)
+			return await FunctionParse(text);
+
+		if (string.IsNullOrEmpty(MModule.plainText(text).ToString()))
+			return CallState.Empty;
+
+		// Replicate the tracking logic from FunctionParse
+		var needsTracking = State.IsEmpty || CurrentState.TotalInvocations == null;
+		var parser = needsTracking
+			? Push(new ParserState(
+				Registers: new([[]]),
+				IterationRegisters: [],
+				RegexRegisters: [],
+				SwitchStack: [],
+				EnvironmentRegisters: [],
+				CurrentEvaluation: null,
+				ExecutionStack: [],
+				ParserFunctionDepth: 0,
+				Function: null,
+				Command: null,
+				CommandInvoker: _ => ValueTask.FromResult(new Option<CallState>(new None())),
+				Switches: [],
+				Arguments: [],
+				Executor: CurrentState.Executor,
+				Enactor: CurrentState.Enactor,
+				Caller: CurrentState.Caller,
+				Handle: null,
+				ParseMode: ParseMode.Default,
+				HttpResponse: null,
+				CallDepth: new InvocationCounter(),
+				FunctionRecursionDepths: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase),
+				TotalInvocations: new InvocationCounter(),
+				LimitExceeded: new LimitExceededFlag()))
+			: this;
+
+		// Capture raw text BEFORE evaluation for substitution-only debug
+		var rawText = MModule.plainText(text).ToString();
+		var (result, didEmitFunctionDebug) = await ParseInternalCore(text, p => p.startPlainString(), nameof(FunctionParse), parser);
+
+		// PennMUSH substitution-only debug: when the argument contains only substitutions
+		// (no function calls), emit a single-line debug trace: "#dbref! raw => evaluated"
+		// Only fires when function-level debug did NOT already emit for this parse.
+		if (!didEmitFunctionDebug && result?.Message is not null)
+		{
+			var evaluatedText = result.Message.ToPlainText();
+			if (rawText != evaluatedText)
+			{
+				var shouldDebug = false;
+				AnySharpObject? executorObj = null;
+
+				var executor = await CurrentState.ExecutorObject(_mediator);
+				if (!executor.IsNone)
+				{
+					executorObj = executor.Known;
+					var stateFlags = CurrentState.Flags;
+					if (stateFlags.HasFlag(ParserStateFlags.NoDebug))
+						shouldDebug = false;
+					else if (stateFlags.HasFlag(ParserStateFlags.Debug))
+						shouldDebug = true;
+					else
+						shouldDebug = await executorObj.HasFlag("DEBUG");
+				}
+
+				if (shouldDebug && executorObj is not null)
+				{
+					var dbrefNumber = executorObj.Object().DBRef.Number;
+					var owner = await executorObj.Object().Owner.WithCancellation(CancellationToken.None);
+					await _notifyService.Notify(owner, MModule.single($"#{dbrefNumber}! {rawText} => {evaluatedText}"));
+				}
+			}
+		}
 
 		return result;
 	}

--- a/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
+++ b/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
@@ -355,7 +355,12 @@ public class SharpMUSHParserVisitor(
 
 		if (shouldDebug && executorObj != null && indent != null)
 		{
-			await SendDebugOrVerboseOutput(executorObj, $"#{dbrefNumber}! {indent}{context.GetText()} :");
+			// PennMUSH wraps the function expression in [...] when the function was invoked
+			// inside bracket evaluation (e.g. think [add(1,2)]), but not for nested calls
+			// within function arguments (e.g. iter(a b, strlen(##)) — strlen is bare).
+			var isBracketed = context.Parent?.Parent is BracketPatternContext;
+			var debugExpr = isBracketed ? $"[{context.GetText()}]" : context.GetText();
+			await SendDebugOrVerboseOutput(executorObj, $"#{dbrefNumber}! {indent}{debugExpr} :");
 		}
 
 		if (shouldDebug) _debugNestDepth++;
@@ -369,8 +374,10 @@ public class SharpMUSHParserVisitor(
 			return result;
 		}
 
+		var isBracketedPost = context.Parent?.Parent is BracketPatternContext;
+		var debugExprPost = isBracketedPost ? $"[{context.GetText()}]" : context.GetText();
 		await SendDebugOrVerboseOutput(executorObj,
-			$"#{dbrefNumber}! {indent}{context.GetText()} => {result.Message?.ToPlainText() ?? ""}");
+			$"#{dbrefNumber}! {indent}{debugExprPost} => {result.Message?.ToPlainText() ?? ""}");
 
 		return result;
 	}

--- a/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
+++ b/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
@@ -60,6 +60,8 @@ public class SharpMUSHParserVisitor(
 	: SharpMUSHParserBaseVisitor<ValueTask<CallState?>>
 {
 	private int _debugNestDepth;
+	private bool _didEmitFunctionDebug;
+	internal bool DidEmitFunctionDebug => _didEmitFunctionDebug;
 	private int _braceDepthCounter;
 	private int _suppressFunctionEval;
 
@@ -361,6 +363,7 @@ public class SharpMUSHParserVisitor(
 			var isBracketed = context.Parent?.Parent is BracketPatternContext;
 			var debugExpr = isBracketed ? $"[{context.GetText()}]" : context.GetText();
 			await SendDebugOrVerboseOutput(executorObj, $"#{dbrefNumber}! {indent}{debugExpr} :");
+			_didEmitFunctionDebug = true;
 		}
 
 		if (shouldDebug) _debugNestDepth++;
@@ -1860,10 +1863,10 @@ public class SharpMUSHParserVisitor(
 			else
 			{
 				arguments.AddRange(await argCallState.Arguments.Skip(1)
-					.ToAsyncEnumerable()
-					.Select((MString argument, CancellationToken _) => prs.FunctionParse(argument))
-					.Select(cs => cs!)
-					.ToListAsync());
+						.ToAsyncEnumerable()
+						.Select((MString argument, CancellationToken _) => prs.FunctionParse(argument, true))
+						.Select(cs => cs!)
+						.ToListAsync());
 			}
 		}
 		else
@@ -1877,7 +1880,7 @@ public class SharpMUSHParserVisitor(
 			{
 				arguments.AddRange(await (argCallState.Arguments ?? [])
 					.ToAsyncEnumerable()
-					.Select((MString argument, CancellationToken _) => prs.FunctionParse(argument))
+					.Select((MString argument, CancellationToken _) => prs.FunctionParse(argument, true))
 					.Select(cs => cs!)
 					.ToListAsync());
 			}

--- a/SharpMUSH.Library/ParserInterfaces/IMUSHCodeParser.cs
+++ b/SharpMUSH.Library/ParserInterfaces/IMUSHCodeParser.cs
@@ -23,6 +23,7 @@ public interface IMUSHCodeParser
 	ValueTask<CallState> CommandParse(MString text);
 	ValueTask<CallState?> CommandSingleArgParse(MString text);
 	ValueTask<CallState?> FunctionParse(MString text);
+	ValueTask<CallState?> FunctionParse(MString text, bool emitSubstDebug);
 	IMUSHCodeParser Empty();
 	IMUSHCodeParser Push(ParserState state);
 	IMUSHCodeParser FromState(ParserState state);

--- a/SharpMUSH.Tests.Infrastructure/ArangoDBTestServer.cs
+++ b/SharpMUSH.Tests.Infrastructure/ArangoDBTestServer.cs
@@ -38,7 +38,23 @@ public class ArangoDbTestServer : IAsyncInitializer, IAsyncDisposable
 	{
 		if (_instance is not null)
 		{
-			await _instance.DisposeAsync();
+			try
+			{
+				await _instance.StopAsync();
+			}
+			catch
+			{
+				// Podman may fail if the network was already removed
+			}
+
+			try
+			{
+				await _instance.DisposeAsync();
+			}
+			catch
+			{
+				// Podman may fail if the network was already removed
+			}
 		}
 	}
 }

--- a/SharpMUSH.Tests.Infrastructure/DockerNetwork.cs
+++ b/SharpMUSH.Tests.Infrastructure/DockerNetwork.cs
@@ -15,5 +15,16 @@ public class DockerNetwork : IAsyncInitializer, IAsyncDisposable
 		.Build();
 
 	public async Task InitializeAsync() => await Instance.CreateAsync();
-	public async ValueTask DisposeAsync() => await Instance.DisposeAsync();
+
+	public async ValueTask DisposeAsync()
+	{
+		try
+		{
+			await Instance.DisposeAsync();
+		}
+		catch
+		{
+			// May fail if containers referencing this network are still being cleaned up
+		}
+	}
 }

--- a/SharpMUSH.Tests.Infrastructure/MemgraphTestServer.cs
+++ b/SharpMUSH.Tests.Infrastructure/MemgraphTestServer.cs
@@ -50,7 +50,23 @@ public class MemgraphTestServer : IAsyncInitializer, IAsyncDisposable
 	{
 		if (_instance is not null)
 		{
-			await _instance.DisposeAsync();
+			try
+			{
+				await _instance.StopAsync();
+			}
+			catch
+			{
+				// Podman may fail if the network was already removed
+			}
+
+			try
+			{
+				await _instance.DisposeAsync();
+			}
+			catch
+			{
+				// Podman may fail if the network was already removed
+			}
 		}
 	}
 }

--- a/SharpMUSH.Tests.Infrastructure/MySqlTestServer.cs
+++ b/SharpMUSH.Tests.Infrastructure/MySqlTestServer.cs
@@ -17,7 +17,27 @@ public class MySqlTestServer : IAsyncInitializer, IAsyncDisposable
 		.Build();
 
 	public async Task InitializeAsync() => await Instance.StartAsync();
-	public async ValueTask DisposeAsync() => await Instance.DisposeAsync();
+
+	public async ValueTask DisposeAsync()
+	{
+		try
+		{
+			await Instance.StopAsync();
+		}
+		catch
+		{
+			// Podman may fail if the network was already removed
+		}
+
+		try
+		{
+			await Instance.DisposeAsync();
+		}
+		catch
+		{
+			// Podman may fail if the network was already removed
+		}
+	}
 
 	/// <summary>
 	/// Gets a connection string for a specific database name. Creates the database if it doesn't exist.

--- a/SharpMUSH.Tests.Infrastructure/NatsTestServer.cs
+++ b/SharpMUSH.Tests.Infrastructure/NatsTestServer.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using DotNet.Testcontainers.Containers;
 using Testcontainers.Nats;
 using TUnit.Core.Interfaces;
@@ -14,19 +13,57 @@ public class NatsTestServer : IAsyncInitializer, IAsyncDisposable
 	private const string NatsImage = "nats:2.14-alpine";
 	private const int MaxPayloadBytes = 6 * 1024 * 1024; // 6 MB
 	private const string NatsConfigPath = "/etc/nats/nats.conf";
-	private static readonly byte[] NatsConfig = Encoding.UTF8.GetBytes(
-		$"max_payload: {MaxPayloadBytes}\njetstream: true\n");
+	private static readonly string NatsConfigContent = $"max_payload: {MaxPayloadBytes}\njetstream: true\n";
+
+	// Write config to a temp file for bind-mount (Podman rootless can't PUT /archive on stopped containers)
+	private readonly string _configTempFile = CreateTempConfigFile();
 
 	[ClassDataSource<DockerNetwork>(Shared = SharedType.PerTestSession)]
 	public required DockerNetwork DockerNetwork { get; init; }
 
 	public IContainer Instance => field ??= new NatsBuilder(NatsImage)
 		.WithNetwork(DockerNetwork.Instance)
-		.WithResourceMapping(NatsConfig, NatsConfigPath)
+		.WithBindMount(_configTempFile, NatsConfigPath)
 		.WithCommand("-c", NatsConfigPath)
 		.WithReuse(false)
 		.Build();
 
 	public async Task InitializeAsync() => await Instance.StartAsync();
-	public async ValueTask DisposeAsync() => await Instance.DisposeAsync();
+
+	public async ValueTask DisposeAsync()
+	{
+		try
+		{
+			await Instance.StopAsync();
+		}
+		catch
+		{
+			// Podman may fail if the network was already removed
+		}
+
+		try
+		{
+			await Instance.DisposeAsync();
+		}
+		catch
+		{
+			// Podman may fail if the network was already removed
+		}
+
+		try
+		{
+			File.Delete(_configTempFile);
+		}
+		catch
+		{
+			// Best-effort cleanup of temp config file
+		}
+	}
+
+	private static string CreateTempConfigFile()
+	{
+		var path = Path.Combine(Path.GetTempPath(), $"nats-{Guid.NewGuid():N}.conf");
+		File.WriteAllText(path, NatsConfigContent);
+		return path;
+	}
 }

--- a/SharpMUSH.Tests/Commands/DebugVerboseTests.cs
+++ b/SharpMUSH.Tests/Commands/DebugVerboseTests.cs
@@ -205,10 +205,12 @@ public class DebugVerboseTests
 	[Test]
 	public async Task AttributeDebugFlag_Diagnostic_FlagsLoadedAfterSet()
 	{
+		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "DiagDbg");
 		// Diagnostic: Create a thing, add attribute, set DEBUG flag, verify flag is readable via inheritance query
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@create DiagDebugThing"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single("&DIAGFUNC_UNIQ2 DiagDebugThing=[add(1,2)]"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@set DiagDebugThing/DIAGFUNC_UNIQ2=DEBUG"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@create DiagDebugThing"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("&DIAGFUNC_UNIQ2 DiagDebugThing=[add(1,2)]"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@set DiagDebugThing/DIAGFUNC_UNIQ2=DEBUG"));
 
 		// Get the DBRef of DiagDebugThing from the notification (created as "#N:...")
 		var createCall = NotifyService.ReceivedCalls()
@@ -267,7 +269,7 @@ public class DebugVerboseTests
 			.Because($"GetAttributeWithInheritanceQuery must also return DEBUG flag (old flags: {string.Join(",", flagsOld.Select(f => f.Name))}, new flags: {string.Join(",", flagsNew.Select(f => f.Name))})");
 
 		// Cleanup
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@destroy DiagDebugThing"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy DiagDebugThing"));
 	}
 
 	[Test]
@@ -329,20 +331,21 @@ public class DebugVerboseTests
 	[Test]
 	public async Task DebugFlag_DoesNotOutputRegisterDumps()
 	{
-		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "DbgNoReg");
 		// Arrange - Create test object and set DEBUG flag
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@create DebugNoRegObj"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@set DebugNoRegObj=DEBUG"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@set DebugNoRegObj=!no_command"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@create DebugNoRegObj"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@set DebugNoRegObj=DEBUG"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@set DebugNoRegObj=!no_command"));
 
-		await Parser.CommandParse(1, ConnectionService, MModule.single("&test_cmd_noreg DebugNoRegObj=$test3command:@pemit me=[setq(a,Hello)][setq(b,World)][strlen(%qa)]"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("&test_cmd_noreg DebugNoRegObj=$test3command:@pemit me=[setq(a,Hello)][setq(b,World)][strlen(%qa)]"));
 
 		// Act
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@force DebugNoRegObj=test3command"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@force DebugNoRegObj=test3command"));
 
 		await NotifyService
 			.DidNotReceive()
-			.Notify(TestHelpers.MatchingObject(executor),
+			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
 						mstr => mstr.ToString().Contains("[Q-Registers:"),
@@ -350,7 +353,7 @@ public class DebugVerboseTests
 
 		await NotifyService
 			.DidNotReceive()
-			.Notify(TestHelpers.MatchingObject(executor),
+			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
 						mstr => mstr.ToString().Contains("[Registers:"),
@@ -358,14 +361,14 @@ public class DebugVerboseTests
 
 		await NotifyService
 			.DidNotReceive()
-			.Notify(TestHelpers.MatchingObject(executor),
+			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
 						mstr => mstr.ToString().Contains("[Iter-Registers:"),
 						str => str.Contains("[Iter-Registers:"))), null, INotifyService.NotificationType.Announce);
 
 		// Cleanup
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@destroy DebugNoRegObj"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy DebugNoRegObj"));
 	}
 
 	[Test]
@@ -464,21 +467,22 @@ public class DebugVerboseTests
 	[Test]
 	public async Task Verbose_ExactPennMUSHFormat()
 	{
-		var executor = WebAppFactoryArg.ExecutorDBRef;
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@create VerboseFmtObj"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@set VerboseFmtObj=VERBOSE"));
+		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "VerbFmt");
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@create VerboseFmtObj"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@set VerboseFmtObj=VERBOSE"));
 
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@force VerboseFmtObj=@pemit me=VerbFmtTest444"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@force VerboseFmtObj=@pemit me=VerbFmtTest444"));
 
 		await NotifyService
 			.Received(1)
-			.Notify(TestHelpers.MatchingObject(executor),
+			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
 						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+\] @pemit me=VerbFmtTest444$"),
 						str => Regex.IsMatch(str, @"^#\d+\] @pemit me=VerbFmtTest444$"))), null, INotifyService.NotificationType.Announce);
 
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@destroy VerboseFmtObj"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy VerboseFmtObj"));
 	}
 
 	[Test]
@@ -498,32 +502,34 @@ public class DebugVerboseTests
 	[Test]
 	public async Task PuppetFlag_CanBeSetOnThing()
 	{
-		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "PupSet");
 		// Pattern B: unique object name is embedded in the flag-set message, making it globally unique.
 		var uniqueName = TestIsolationHelpers.GenerateUniqueName("PuppetThing");
-		await Parser.CommandParse(1, ConnectionService, MModule.single($"@create {uniqueName}"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single($"@set {uniqueName}=PUPPET"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single($"@create {uniqueName}"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single($"@set {uniqueName}=PUPPET"));
 
 		await NotifyService
 			.Received(1)
-			.Notify(TestHelpers.MatchingObject(executor),
+			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					TestHelpers.MessagePlainTextEquals(msg, $"{uniqueName} - PUPPET set.")),
 				(AnySharpObject?)null, INotifyService.NotificationType.Announce);
 
-		await Parser.CommandParse(1, ConnectionService, MModule.single($"@destroy {uniqueName}"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single($"@destroy {uniqueName}"));
 	}
 
 	[Test]
 	public async Task Debug_SendsToOwner_NotToExecutor()
 	{
-		var executor = WebAppFactoryArg.ExecutorDBRef;
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@create DebugOwnerObj"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@set DebugOwnerObj=DEBUG"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@set DebugOwnerObj=!no_command"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single("&dbg_owner DebugOwnerObj=$dbgownercmd:@pemit me=[add(1,1)]"));
+		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "DbgOwner");
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@create DebugOwnerObj"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@set DebugOwnerObj=DEBUG"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@set DebugOwnerObj=!no_command"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("&dbg_owner DebugOwnerObj=$dbgownercmd:@pemit me=[add(1,1)]"));
 
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@force DebugOwnerObj=dbgownercmd"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@force DebugOwnerObj=dbgownercmd"));
 
 		var debugCalls = NotifyService.ReceivedCalls()
 			.Where(c =>
@@ -540,28 +546,29 @@ public class DebugVerboseTests
 
 		var firstArg = debugCalls.First().GetArguments()[0] as AnySharpObject;
 		await Assert.That(firstArg).IsNotNull().Because("Debug should be sent to an object");
-		await Assert.That(firstArg!.Object().DBRef.Number).IsEqualTo(1)
-			.Because("Debug output should go to owner (#1), not executor object");
+		await Assert.That(firstArg!.Object().DBRef.Number).IsEqualTo(testPlayer.DbRef.Number)
+			.Because("Debug output should go to owner (testPlayer), not executor object");
 
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@destroy DebugOwnerObj"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy DebugOwnerObj"));
 	}
 
 	[Test]
 	public async Task Debug_ShowsPercentQRegister_InExpressionText()
 	{
-		var executor = WebAppFactoryArg.ExecutorDBRef;
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@create DebugPctQ"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@set DebugPctQ=DEBUG"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@set DebugPctQ=!no_command"));
+		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "DbgPctQ");
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@create DebugPctQ"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@set DebugPctQ=DEBUG"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@set DebugPctQ=!no_command"));
 
-		await Parser.CommandParse(1, ConnectionService,
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService,
 			MModule.single("&pctq_cmd DebugPctQ=$pctqcmd:@pemit me=[setq(a,Hello)][strlen(%qa)]"));
 
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@force DebugPctQ=pctqcmd"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@force DebugPctQ=pctqcmd"));
 
 		await NotifyService
 			.Received(1)
-			.Notify(TestHelpers.MatchingObject(executor),
+			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
 						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[strlen\(%qa\)\] :$"),
@@ -569,31 +576,32 @@ public class DebugVerboseTests
 
 		await NotifyService
 			.Received(1)
-			.Notify(TestHelpers.MatchingObject(executor),
+			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
 						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[strlen\(%qa\)\] => \d+$"),
 						str => Regex.IsMatch(str, @"^#\d+! +\[strlen\(%qa\)\] => \d+$"))), null, INotifyService.NotificationType.Announce);
 
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@destroy DebugPctQ"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy DebugPctQ"));
 	}
 
 	[Test]
 	public async Task Debug_ShowsPercentZeroArg_InExpressionText()
 	{
-		var executor = WebAppFactoryArg.ExecutorDBRef;
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@create DebugPct0"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@set DebugPct0=DEBUG"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@set DebugPct0=!no_command"));
+		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "DbgPct0");
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@create DebugPct0"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@set DebugPct0=DEBUG"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@set DebugPct0=!no_command"));
 
-		await Parser.CommandParse(1, ConnectionService,
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService,
 			MModule.single("&pct0_cmd DebugPct0=$pct0testcmd *:@pemit me=[strlen(%0)]"));
 
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@force DebugPct0=pct0testcmd World"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@force DebugPct0=pct0testcmd World"));
 
 		await NotifyService
 			.Received(1)
-			.Notify(TestHelpers.MatchingObject(executor),
+			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
 						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[strlen\(%0\)\] :$"),
@@ -601,31 +609,32 @@ public class DebugVerboseTests
 
 		await NotifyService
 			.Received(1)
-			.Notify(TestHelpers.MatchingObject(executor),
+			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
 						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[strlen\(%0\)\] => 5$"),
 						str => Regex.IsMatch(str, @"^#\d+! +\[strlen\(%0\)\] => 5$"))), null, INotifyService.NotificationType.Announce);
 
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@destroy DebugPct0"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy DebugPct0"));
 	}
 
 	[Test]
 	public async Task Debug_ShowsIterTokens_InExpressionText()
 	{
-		var executor = WebAppFactoryArg.ExecutorDBRef;
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@create DebugPctIter"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@set DebugPctIter=DEBUG"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@set DebugPctIter=!no_command"));
+		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "DbgIter");
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@create DebugPctIter"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@set DebugPctIter=DEBUG"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@set DebugPctIter=!no_command"));
 
-		await Parser.CommandParse(1, ConnectionService,
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService,
 			MModule.single("&pctiter_cmd DebugPctIter=$pctitercmd:@pemit me=[iter(Hello,strlen(##))]"));
 
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@force DebugPctIter=pctitercmd"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@force DebugPctIter=pctitercmd"));
 
 		await NotifyService
 			.Received(1)
-			.Notify(TestHelpers.MatchingObject(executor),
+			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
 						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[iter\(Hello,strlen\(##\)\)\] :$"),
@@ -633,7 +642,7 @@ public class DebugVerboseTests
 
 		await NotifyService
 			.Received(1)
-			.Notify(TestHelpers.MatchingObject(executor),
+			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
 						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! {2,}strlen\(##\) :$"),
@@ -641,31 +650,32 @@ public class DebugVerboseTests
 
 		await NotifyService
 			.Received(1)
-			.Notify(TestHelpers.MatchingObject(executor),
+			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
 						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! {2,}strlen\(Hello\) => 5$"),
 						str => Regex.IsMatch(str, @"^#\d+! {2,}strlen\(Hello\) => 5$"))), null, INotifyService.NotificationType.Announce);
 
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@destroy DebugPctIter"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy DebugPctIter"));
 	}
 
 	[Test]
 	public async Task Debug_SetqShowsRegisterName_InExpressionText()
 	{
-		var executor = WebAppFactoryArg.ExecutorDBRef;
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@create DebugSetq"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@set DebugSetq=DEBUG"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@set DebugSetq=!no_command"));
+		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "DbgSetq");
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@create DebugSetq"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@set DebugSetq=DEBUG"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@set DebugSetq=!no_command"));
 
-		await Parser.CommandParse(1, ConnectionService,
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService,
 			MModule.single("&setq_cmd DebugSetq=$setqcmd:@pemit me=[setq(a,TestVal123)]"));
 
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@force DebugSetq=setqcmd"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@force DebugSetq=setqcmd"));
 
 		await NotifyService
 			.Received(1)
-			.Notify(TestHelpers.MatchingObject(executor),
+			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
 						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[setq\(a,TestVal123\)\] :$"),
@@ -673,59 +683,61 @@ public class DebugVerboseTests
 
 		await NotifyService
 			.Received(1)
-			.Notify(TestHelpers.MatchingObject(executor),
+			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
 						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[setq\(a,TestVal123\)\] => $"),
 						str => Regex.IsMatch(str, @"^#\d+! +\[setq\(a,TestVal123\)\] => $"))), null, INotifyService.NotificationType.Announce);
 
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@destroy DebugSetq"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy DebugSetq"));
 	}
 
 	[Test]
 	public async Task Verbose_ShowsEvaluatedCommand_InOutput()
 	{
-		var executor = WebAppFactoryArg.ExecutorDBRef;
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@create VerbosePctObj"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@set VerbosePctObj=VERBOSE"));
+		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "VerbPct");
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@create VerbosePctObj"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@set VerbosePctObj=VERBOSE"));
 
-		await Parser.CommandParse(1, ConnectionService,
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService,
 			MModule.single("@force VerbosePctObj=think [add(10,20)]"));
 
 		await NotifyService
 			.Received(1)
-			.Notify(TestHelpers.MatchingObject(executor),
+			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
 						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+\] think 30$"),
 						str => Regex.IsMatch(str, @"^#\d+\] think 30$"))), null, INotifyService.NotificationType.Announce);
 
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@destroy VerbosePctObj"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy VerbosePctObj"));
 	}
 
 	[Test]
 	public async Task Debug_SubstitutionOnly_ShowsSingleLineFormat()
 	{
-		var executor = WebAppFactoryArg.ExecutorDBRef;
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@create DebugSubst"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@set DebugSubst=DEBUG"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@set DebugSubst=!no_command"));
+		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "DbgSubst");
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@create DebugSubst"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@set DebugSubst=DEBUG"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@set DebugSubst=!no_command"));
 
-		await Parser.CommandParse(1, ConnectionService,
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService,
 			MModule.single("&subst_cmd DebugSubst=$substcmd:@pemit me=%# and %#"));
 
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@force DebugSubst=substcmd"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@force DebugSubst=substcmd"));
 
 		// PennMUSH substitution-only debug format: "#dbref! %# and %# => #<dbref> and #<dbref>"
 		// Single line, no colon — fires when argument has substitutions but no function calls.
 		await NotifyService
 			.Received(1)
-			.Notify(TestHelpers.MatchingObject(executor),
+			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
 						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! %# and %# => #\d+ and #\d+$"),
 						str => Regex.IsMatch(str, @"^#\d+! %# and %# => #\d+ and #\d+$"))), null, INotifyService.NotificationType.Announce);
 
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@destroy DebugSubst"));
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy DebugSubst"));
 	}
 }

--- a/SharpMUSH.Tests/Commands/DebugVerboseTests.cs
+++ b/SharpMUSH.Tests/Commands/DebugVerboseTests.cs
@@ -740,4 +740,168 @@ public class DebugVerboseTests
 
 		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy DebugSubst"));
 	}
+
+	[Test]
+	public async Task DebugForwardList_SendsDebugToSpecifiedPlayer()
+	{
+		// Arrange - Two players: owner and forward target
+		var ownerPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "DbgFwdOwner");
+		var forwardPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "DbgFwdTarget");
+
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService, MModule.single("@create DbgFwdObj"));
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService, MModule.single("@set DbgFwdObj=DEBUG"));
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService, MModule.single("@set DbgFwdObj=!no_command"));
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService,
+			MModule.single("&test_fwd DbgFwdObj=$dbgfwdcmd:@pemit me=[add(10,20)]"));
+
+		// Set DEBUGFORWARDLIST to the forward target's dbref
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService,
+			MModule.single($"&DEBUGFORWARDLIST DbgFwdObj=#{forwardPlayer.DbRef.Number}"));
+
+		// Act
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService, MModule.single("@force DbgFwdObj=dbgfwdcmd"));
+
+		// Assert - Forward target receives debug output
+		await NotifyService
+			.Received()
+			.Notify(TestHelpers.MatchingObject(forwardPlayer.DbRef),
+				Arg.Is<OneOf<MString, string>>(msg =>
+					msg.Match(
+						mstr => mstr.ToString().Contains("! [add(10,20)]"),
+						str => str.Contains("! [add(10,20)]"))), null, INotifyService.NotificationType.Announce);
+
+		// Assert - Owner also still receives debug output
+		await NotifyService
+			.Received()
+			.Notify(TestHelpers.MatchingObject(ownerPlayer.DbRef),
+				Arg.Is<OneOf<MString, string>>(msg =>
+					msg.Match(
+						mstr => mstr.ToString().Contains("! [add(10,20)]"),
+						str => str.Contains("! [add(10,20)]"))), null, INotifyService.NotificationType.Announce);
+
+		// Cleanup
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService, MModule.single("@destroy DbgFwdObj"));
+	}
+
+	[Test]
+	public async Task DebugForwardList_MultipleTargets_SendsToAll()
+	{
+		// Arrange - Owner plus two forward targets
+		var ownerPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "DbgMFwdOwn");
+		var target1 = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "DbgMFwdT1");
+		var target2 = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "DbgMFwdT2");
+
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService, MModule.single("@create DbgMFwdObj"));
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService, MModule.single("@set DbgMFwdObj=DEBUG"));
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService, MModule.single("@set DbgMFwdObj=!no_command"));
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService,
+			MModule.single("&test_mfwd DbgMFwdObj=$dbgmfwdcmd:@pemit me=[mul(3,7)]"));
+
+		// Set DEBUGFORWARDLIST with two space-separated dbrefs
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService,
+			MModule.single($"&DEBUGFORWARDLIST DbgMFwdObj=#{target1.DbRef.Number} #{target2.DbRef.Number}"));
+
+		// Act
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService, MModule.single("@force DbgMFwdObj=dbgmfwdcmd"));
+
+		// Assert - Both targets receive debug
+		await NotifyService
+			.Received()
+			.Notify(TestHelpers.MatchingObject(target1.DbRef),
+				Arg.Is<OneOf<MString, string>>(msg =>
+					msg.Match(
+						mstr => mstr.ToString().Contains("! [mul(3,7)]"),
+						str => str.Contains("! [mul(3,7)]"))), null, INotifyService.NotificationType.Announce);
+
+		await NotifyService
+			.Received()
+			.Notify(TestHelpers.MatchingObject(target2.DbRef),
+				Arg.Is<OneOf<MString, string>>(msg =>
+					msg.Match(
+						mstr => mstr.ToString().Contains("! [mul(3,7)]"),
+						str => str.Contains("! [mul(3,7)]"))), null, INotifyService.NotificationType.Announce);
+
+		// Cleanup
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService, MModule.single("@destroy DbgMFwdObj"));
+	}
+
+	[Test]
+	public async Task DebugForwardList_NoAttribute_OnlySendsToOwner()
+	{
+		// Arrange - No DEBUGFORWARDLIST set
+		var ownerPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "DbgNoFwdOwn");
+		var otherPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "DbgNoFwdOth");
+
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService, MModule.single("@create DbgNoFwdObj"));
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService, MModule.single("@set DbgNoFwdObj=DEBUG"));
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService, MModule.single("@set DbgNoFwdObj=!no_command"));
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService,
+			MModule.single("&test_nofwd DbgNoFwdObj=$dbgnofwdcmd:@pemit me=[sub(9,4)]"));
+
+		// No DEBUGFORWARDLIST set
+
+		// Act
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService, MModule.single("@force DbgNoFwdObj=dbgnofwdcmd"));
+
+		// Assert - Owner receives debug
+		await NotifyService
+			.Received()
+			.Notify(TestHelpers.MatchingObject(ownerPlayer.DbRef),
+				Arg.Is<OneOf<MString, string>>(msg =>
+					msg.Match(
+						mstr => mstr.ToString().Contains("! [sub(9,4)]"),
+						str => str.Contains("! [sub(9,4)]"))), null, INotifyService.NotificationType.Announce);
+
+		// Assert - Other player does NOT receive debug
+		await NotifyService
+			.DidNotReceive()
+			.Notify(TestHelpers.MatchingObject(otherPlayer.DbRef),
+				Arg.Is<OneOf<MString, string>>(msg =>
+					msg.Match(
+						mstr => mstr.ToString().Contains("! [sub(9,4)]"),
+						str => str.Contains("! [sub(9,4)]"))), null, INotifyService.NotificationType.Announce);
+
+		// Cleanup
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService, MModule.single("@destroy DbgNoFwdObj"));
+	}
+
+	[Test]
+	public async Task DebugForwardList_InvalidTarget_DoesNotCrash()
+	{
+		// Arrange - DEBUGFORWARDLIST contains an invalid dbref
+		var ownerPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "DbgBadFwdOwn");
+
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService, MModule.single("@create DbgBadFwdObj"));
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService, MModule.single("@set DbgBadFwdObj=DEBUG"));
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService, MModule.single("@set DbgBadFwdObj=!no_command"));
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService,
+			MModule.single("&test_badfwd DbgBadFwdObj=$dbgbadfwdcmd:@pemit me=[add(5,5)]"));
+
+		// Set DEBUGFORWARDLIST to a nonexistent dbref
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService,
+			MModule.single("&DEBUGFORWARDLIST DbgBadFwdObj=#99999"));
+
+		// Act - Should not throw
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService, MModule.single("@force DbgBadFwdObj=dbgbadfwdcmd"));
+
+		// Assert - Owner still gets debug output (forwarding failure doesn't break normal flow)
+		await NotifyService
+			.Received()
+			.Notify(TestHelpers.MatchingObject(ownerPlayer.DbRef),
+				Arg.Is<OneOf<MString, string>>(msg =>
+					msg.Match(
+						mstr => mstr.ToString().Contains("! [add(5,5)]"),
+						str => str.Contains("! [add(5,5)]"))), null, INotifyService.NotificationType.Announce);
+
+		// Cleanup
+		await Parser.CommandParse(ownerPlayer.Handle, ConnectionService, MModule.single("@destroy DbgBadFwdObj"));
+	}
 }

--- a/SharpMUSH.Tests/Commands/DebugVerboseTests.cs
+++ b/SharpMUSH.Tests/Commands/DebugVerboseTests.cs
@@ -702,4 +702,30 @@ public class DebugVerboseTests
 
 		await Parser.CommandParse(1, ConnectionService, MModule.single("@destroy VerbosePctObj"));
 	}
+
+	[Test]
+	public async Task Debug_SubstitutionOnly_ShowsSingleLineFormat()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		await Parser.CommandParse(1, ConnectionService, MModule.single("@create DebugSubst"));
+		await Parser.CommandParse(1, ConnectionService, MModule.single("@set DebugSubst=DEBUG"));
+		await Parser.CommandParse(1, ConnectionService, MModule.single("@set DebugSubst=!no_command"));
+
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single("&subst_cmd DebugSubst=$substcmd:@pemit me=%# and %#"));
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single("@force DebugSubst=substcmd"));
+
+		// PennMUSH substitution-only debug format: "#dbref! %# and %# => #<dbref> and #<dbref>"
+		// Single line, no colon — fires when argument has substitutions but no function calls.
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf<MString, string>>(msg =>
+					msg.Match(
+						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! %# and %# => #\d+ and #\d+$"),
+						str => Regex.IsMatch(str, @"^#\d+! %# and %# => #\d+ and #\d+$"))), null, INotifyService.NotificationType.Announce);
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single("@destroy DebugSubst"));
+	}
 }

--- a/SharpMUSH.Tests/Commands/DebugVerboseTests.cs
+++ b/SharpMUSH.Tests/Commands/DebugVerboseTests.cs
@@ -293,8 +293,8 @@ public class DebugVerboseTests
 			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
-						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +add\(88,77\) => 165$"),
-						str => Regex.IsMatch(str, @"^#\d+! +add\(88,77\) => 165$"))), null, INotifyService.NotificationType.Announce);
+						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[add\(88,77\)\] => 165$"),
+						str => Regex.IsMatch(str, @"^#\d+! +\[add\(88,77\)\] => 165$"))), null, INotifyService.NotificationType.Announce);
 
 		// Cleanup
 		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy AttrDebugForceTest"));
@@ -537,7 +537,7 @@ public class DebugVerboseTests
 				var args = c.GetArguments();
 				if (args.Length < 2) return false;
 				return args[1] is OneOf<MString, string> msg &&
-					msg.Match(m => m.ToString().Contains("! add(1,1)"), s => s.Contains("! add(1,1)"));
+					msg.Match(m => m.ToString().Contains("! [add(1,1)]"), s => s.Contains("! [add(1,1)]"));
 			})
 			.ToList();
 
@@ -645,16 +645,16 @@ public class DebugVerboseTests
 			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
-						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! {2,}strlen\(##\) :$"),
-						str => Regex.IsMatch(str, @"^#\d+! {2,}strlen\(##\) :$"))), null, INotifyService.NotificationType.Announce);
+						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +strlen\(%iL\) :$"),
+						str => Regex.IsMatch(str, @"^#\d+! +strlen\(%iL\) :$"))), null, INotifyService.NotificationType.Announce);
 
 		await NotifyService
 			.Received(1)
 			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
-						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! {2,}strlen\(Hello\) => 5$"),
-						str => Regex.IsMatch(str, @"^#\d+! {2,}strlen\(Hello\) => 5$"))), null, INotifyService.NotificationType.Announce);
+						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +strlen\(%iL\) => 5$"),
+						str => Regex.IsMatch(str, @"^#\d+! +strlen\(%iL\) => 5$"))), null, INotifyService.NotificationType.Announce);
 
 		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy DebugPctIter"));
 	}

--- a/SharpMUSH.Tests/Commands/DebugVerboseTests.cs
+++ b/SharpMUSH.Tests/Commands/DebugVerboseTests.cs
@@ -48,8 +48,8 @@ public class DebugVerboseTests
 			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
-						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +add\(123,456\) :$"),
-						str => Regex.IsMatch(str, @"^#\d+! +add\(123,456\) :$"))), null, INotifyService.NotificationType.Announce);
+						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[add\(123,456\)\] :$"),
+						str => Regex.IsMatch(str, @"^#\d+! +\[add\(123,456\)\] :$"))), null, INotifyService.NotificationType.Announce);
 
 		// Assert - Verify debug output contains the specific result
 		await NotifyService
@@ -57,8 +57,8 @@ public class DebugVerboseTests
 			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
-						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +add\(123,456\) => 579$"),
-						str => Regex.IsMatch(str, @"^#\d+! +add\(123,456\) => 579$"))), null, INotifyService.NotificationType.Announce);
+						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[add\(123,456\)\] => 579$"),
+						str => Regex.IsMatch(str, @"^#\d+! +\[add\(123,456\)\] => 579$"))), null, INotifyService.NotificationType.Announce);
 
 		// Cleanup
 		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy DebugEvalObj"));
@@ -86,8 +86,8 @@ public class DebugVerboseTests
 			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
-						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +mul\(add\(11,22\),3\) :$"),
-						str => Regex.IsMatch(str, @"^#\d+! +mul\(add\(11,22\),3\) :$"))), null, INotifyService.NotificationType.Announce);
+						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[mul\(add\(11,22\),3\)\] :$"),
+						str => Regex.IsMatch(str, @"^#\d+! +\[mul\(add\(11,22\),3\)\] :$"))), null, INotifyService.NotificationType.Announce);
 
 		// Assert - Inner function (has extra space for nesting indentation, matching PennMUSH)
 		await NotifyService
@@ -104,8 +104,8 @@ public class DebugVerboseTests
 			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
-						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +mul\(add\(11,22\),3\) => 99$"),
-						str => Regex.IsMatch(str, @"^#\d+! +mul\(add\(11,22\),3\) => 99$"))), null, INotifyService.NotificationType.Announce);
+						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[mul\(add\(11,22\),3\)\] => 99$"),
+						str => Regex.IsMatch(str, @"^#\d+! +\[mul\(add\(11,22\),3\)\] => 99$"))), null, INotifyService.NotificationType.Announce);
 
 		// Cleanup
 		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy DebugNestObj"));
@@ -385,8 +385,8 @@ public class DebugVerboseTests
 			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
-						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +add\(7,8\) :$"),
-						str => Regex.IsMatch(str, @"^#\d+! +add\(7,8\) :$"))), null, INotifyService.NotificationType.Announce);
+						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[add\(7,8\)\] :$"),
+						str => Regex.IsMatch(str, @"^#\d+! +\[add\(7,8\)\] :$"))), null, INotifyService.NotificationType.Announce);
 
 		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy DebugFmtPre"));
 	}
@@ -408,8 +408,8 @@ public class DebugVerboseTests
 			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
-						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +add\(7,8\) => 15$"),
-						str => Regex.IsMatch(str, @"^#\d+! +add\(7,8\) => 15$"))), null, INotifyService.NotificationType.Announce);
+						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[add\(7,8\)\] => 15$"),
+						str => Regex.IsMatch(str, @"^#\d+! +\[add\(7,8\)\] => 15$"))), null, INotifyService.NotificationType.Announce);
 
 		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy DebugFmtPost"));
 	}
@@ -431,8 +431,8 @@ public class DebugVerboseTests
 			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
-						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +strlen\(add\(2,3\)\) :$"),
-						str => Regex.IsMatch(str, @"^#\d+! +strlen\(add\(2,3\)\) :$"))), null, INotifyService.NotificationType.Announce);
+						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[strlen\(add\(2,3\)\)\] :$"),
+							str => Regex.IsMatch(str, @"^#\d+! +\[strlen\(add\(2,3\)\)\] :$"))), null, INotifyService.NotificationType.Announce);
 
 		await NotifyService
 			.Received(1)
@@ -455,8 +455,8 @@ public class DebugVerboseTests
 			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
-						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +strlen\(add\(2,3\)\) => 1$"),
-						str => Regex.IsMatch(str, @"^#\d+! +strlen\(add\(2,3\)\) => 1$"))), null, INotifyService.NotificationType.Announce);
+						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[strlen\(add\(2,3\)\)\] => 1$"),
+							str => Regex.IsMatch(str, @"^#\d+! +\[strlen\(add\(2,3\)\)\] => 1$"))), null, INotifyService.NotificationType.Announce);
 
 		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy DebugNestFmt"));
 	}
@@ -564,16 +564,16 @@ public class DebugVerboseTests
 			.Notify(TestHelpers.MatchingObject(executor),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
-						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +strlen\(%qa\) :$"),
-						str => Regex.IsMatch(str, @"^#\d+! +strlen\(%qa\) :$"))), null, INotifyService.NotificationType.Announce);
+						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[strlen\(%qa\)\] :$"),
+						str => Regex.IsMatch(str, @"^#\d+! +\[strlen\(%qa\)\] :$"))), null, INotifyService.NotificationType.Announce);
 
 		await NotifyService
 			.Received(1)
 			.Notify(TestHelpers.MatchingObject(executor),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
-						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +strlen\(%qa\) => \d+$"),
-						str => Regex.IsMatch(str, @"^#\d+! +strlen\(%qa\) => \d+$"))), null, INotifyService.NotificationType.Announce);
+						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[strlen\(%qa\)\] => \d+$"),
+						str => Regex.IsMatch(str, @"^#\d+! +\[strlen\(%qa\)\] => \d+$"))), null, INotifyService.NotificationType.Announce);
 
 		await Parser.CommandParse(1, ConnectionService, MModule.single("@destroy DebugPctQ"));
 	}
@@ -596,16 +596,16 @@ public class DebugVerboseTests
 			.Notify(TestHelpers.MatchingObject(executor),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
-						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +strlen\(%0\) :$"),
-						str => Regex.IsMatch(str, @"^#\d+! +strlen\(%0\) :$"))), null, INotifyService.NotificationType.Announce);
+						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[strlen\(%0\)\] :$"),
+						str => Regex.IsMatch(str, @"^#\d+! +\[strlen\(%0\)\] :$"))), null, INotifyService.NotificationType.Announce);
 
 		await NotifyService
 			.Received(1)
 			.Notify(TestHelpers.MatchingObject(executor),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
-						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +strlen\(%0\) => 5$"),
-						str => Regex.IsMatch(str, @"^#\d+! +strlen\(%0\) => 5$"))), null, INotifyService.NotificationType.Announce);
+						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[strlen\(%0\)\] => 5$"),
+						str => Regex.IsMatch(str, @"^#\d+! +\[strlen\(%0\)\] => 5$"))), null, INotifyService.NotificationType.Announce);
 
 		await Parser.CommandParse(1, ConnectionService, MModule.single("@destroy DebugPct0"));
 	}
@@ -628,8 +628,8 @@ public class DebugVerboseTests
 			.Notify(TestHelpers.MatchingObject(executor),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
-						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +iter\(Hello,strlen\(##\)\) :$"),
-						str => Regex.IsMatch(str, @"^#\d+! +iter\(Hello,strlen\(##\)\) :$"))), null, INotifyService.NotificationType.Announce);
+						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[iter\(Hello,strlen\(##\)\)\] :$"),
+						str => Regex.IsMatch(str, @"^#\d+! +\[iter\(Hello,strlen\(##\)\)\] :$"))), null, INotifyService.NotificationType.Announce);
 
 		await NotifyService
 			.Received(1)
@@ -668,16 +668,16 @@ public class DebugVerboseTests
 			.Notify(TestHelpers.MatchingObject(executor),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
-						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +setq\(a,TestVal123\) :$"),
-						str => Regex.IsMatch(str, @"^#\d+! +setq\(a,TestVal123\) :$"))), null, INotifyService.NotificationType.Announce);
+						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[setq\(a,TestVal123\)\] :$"),
+						str => Regex.IsMatch(str, @"^#\d+! +\[setq\(a,TestVal123\)\] :$"))), null, INotifyService.NotificationType.Announce);
 
 		await NotifyService
 			.Received(1)
 			.Notify(TestHelpers.MatchingObject(executor),
 				Arg.Is<OneOf<MString, string>>(msg =>
 					msg.Match(
-						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +setq\(a,TestVal123\) => $"),
-						str => Regex.IsMatch(str, @"^#\d+! +setq\(a,TestVal123\) => $"))), null, INotifyService.NotificationType.Announce);
+						mstr => Regex.IsMatch(mstr.ToString(), @"^#\d+! +\[setq\(a,TestVal123\)\] => $"),
+						str => Regex.IsMatch(str, @"^#\d+! +\[setq\(a,TestVal123\)\] => $"))), null, INotifyService.NotificationType.Announce);
 
 		await Parser.CommandParse(1, ConnectionService, MModule.single("@destroy DebugSetq"));
 	}

--- a/SharpMUSH.Tests/Commands/DebugVerboseTests.cs
+++ b/SharpMUSH.Tests/Commands/DebugVerboseTests.cs
@@ -25,7 +25,7 @@ public class DebugVerboseTests
 	private IAttributeService AttributeService => WebAppFactoryArg.Services.GetRequiredService<IAttributeService>();
 	private IMediator Mediator => WebAppFactoryArg.Services.GetRequiredService<IMediator>();
 
-	[Test, Skip("Failing debug output - it's showing up twice")]
+	[Test]
 	public async Task DebugFlag_OutputsFunctionEvaluation_WithSpecificValues()
 	{
 		// Create a unique player as executor: the owned object's debug output goes to its owner.
@@ -64,7 +64,7 @@ public class DebugVerboseTests
 		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy DebugEvalObj"));
 	}
 
-	[Test, Skip("Failing debug output - it's showing up twice")]
+	[Test]
 	public async Task DebugFlag_ShowsNesting_WithIndentation()
 	{
 		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
@@ -368,7 +368,7 @@ public class DebugVerboseTests
 		await Parser.CommandParse(1, ConnectionService, MModule.single("@destroy DebugNoRegObj"));
 	}
 
-	[Test, Skip("Failing debug output - it's showing up twice")]
+	[Test]
 	public async Task Debug_ExactPennMUSHFormat_PreEvalColon()
 	{
 		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
@@ -391,7 +391,7 @@ public class DebugVerboseTests
 		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy DebugFmtPre"));
 	}
 
-	[Test, Skip("Failing debug output - it's showing up twice")]
+	[Test]
 	public async Task Debug_ExactPennMUSHFormat_PostEvalArrow()
 	{
 		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
@@ -414,7 +414,7 @@ public class DebugVerboseTests
 		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@destroy DebugFmtPost"));
 	}
 
-	[Test, Skip("Failing debug output - it's showing up twice")]
+	[Test]
 	public async Task Debug_NestingUsesSpaceIndentation_MatchesPennMUSH()
 	{
 		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
@@ -546,7 +546,7 @@ public class DebugVerboseTests
 		await Parser.CommandParse(1, ConnectionService, MModule.single("@destroy DebugOwnerObj"));
 	}
 
-	[Test, Skip("Failing debug output - it's showing up twice")]
+	[Test]
 	public async Task Debug_ShowsPercentQRegister_InExpressionText()
 	{
 		var executor = WebAppFactoryArg.ExecutorDBRef;
@@ -578,7 +578,7 @@ public class DebugVerboseTests
 		await Parser.CommandParse(1, ConnectionService, MModule.single("@destroy DebugPctQ"));
 	}
 
-	[Test, Skip("Failing debug output - it's showing up twice")]
+	[Test]
 	public async Task Debug_ShowsPercentZeroArg_InExpressionText()
 	{
 		var executor = WebAppFactoryArg.ExecutorDBRef;
@@ -610,7 +610,7 @@ public class DebugVerboseTests
 		await Parser.CommandParse(1, ConnectionService, MModule.single("@destroy DebugPct0"));
 	}
 
-	[Test, Skip("Failing debug output - it's showing up twice")]
+	[Test]
 	public async Task Debug_ShowsIterTokens_InExpressionText()
 	{
 		var executor = WebAppFactoryArg.ExecutorDBRef;
@@ -650,7 +650,7 @@ public class DebugVerboseTests
 		await Parser.CommandParse(1, ConnectionService, MModule.single("@destroy DebugPctIter"));
 	}
 
-	[Test, Skip("Failing debug output - it's showing up twice")]
+	[Test]
 	public async Task Debug_SetqShowsRegisterName_InExpressionText()
 	{
 		var executor = WebAppFactoryArg.ExecutorDBRef;


### PR DESCRIPTION
Match PennMUSH output character-for-character for VERBOSE, DEBUG, and PUPPET flags.

## Scope
- **VERBOSE**: Output raw unevaluated command text before execution
- **DEBUG**: Indented trace with pre-eval/post-eval markers, substitution tracing
- **PUPPET**: Prefix formatting for puppet relay messages

## Approach
Oracle-driven: validated against real PennMUSH test harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate results in nearby object location queries across all database backends.

* **New Features**
  * Added debug output for substitution operations, displaying raw vs. evaluated text differences during parsing.

* **Tests**
  * Updated debug output tests with standardized formatting and improved test server cleanup resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->