### PR TITLE
fix(functions): urlencode/urldecode use percent-encoding, not HTML entities

### DIFF
--- a/SharpMUSH.Implementation/Functions/StringFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/StringFunctions.cs
@@ -18,7 +18,6 @@ using SharpMUSH.MarkupString;
 using SharpMUSH.MarkupString.TextAlignerModule;
 using System.Drawing;
 using System.Globalization;
-using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -2152,11 +2151,44 @@ public partial class Functions
 
 	[SharpFunction(Name = "urldecode", MinArgs = 1, MaxArgs = 1, Flags = FunctionFlags.Regular | FunctionFlags.StripAnsi, ParameterNames = ["string"])]
 	public static ValueTask<CallState> URLDecode(IMUSHCodeParser parser, SharpFunctionAttribute _2)
-		=> new(new CallState(WebUtility.HtmlDecode(parser.CurrentState.Arguments["0"].Message!.ToPlainText())));
+		=> new(new CallState(PercentDecode(parser.CurrentState.Arguments["0"].Message!.ToPlainText())));
 
 	[SharpFunction(Name = "urlencode", MinArgs = 1, MaxArgs = 1, Flags = FunctionFlags.Regular | FunctionFlags.StripAnsi, ParameterNames = ["string"])]
 	public static ValueTask<CallState> URLEncode(IMUSHCodeParser parser, SharpFunctionAttribute _2)
-		=> new(new CallState(WebUtility.HtmlEncode(parser.CurrentState.Arguments["0"].Message!.ToPlainText())));
+		=> new(new CallState(Uri.EscapeDataString(parser.CurrentState.Arguments["0"].Message!.ToPlainText())));
+
+	/// <summary>
+	/// Percent-decodes a string the way PennMUSH's <c>urldecode()</c> does (via libcurl's
+	/// <c>curl_easy_unescape</c>): only <c>%XX</c> escapes are decoded — a literal <c>+</c> is
+	/// left untouched (unlike form decoding) — and any decoded byte that is not printable ASCII
+	/// (0x20–0x7E) is replaced with <c>?</c>, matching Penn's per-byte <c>isprint</c> filter.
+	/// </summary>
+	private static string PercentDecode(string input)
+	{
+		var src = Encoding.UTF8.GetBytes(input);
+		var decoded = new List<byte>(src.Length);
+		for (var i = 0; i < src.Length; i++)
+		{
+			if (src[i] == (byte)'%' && i + 2 < src.Length
+				&& Uri.IsHexDigit((char)src[i + 1]) && Uri.IsHexDigit((char)src[i + 2]))
+			{
+				decoded.Add((byte)((Uri.FromHex((char)src[i + 1]) << 4) | Uri.FromHex((char)src[i + 2])));
+				i += 2;
+			}
+			else
+			{
+				decoded.Add(src[i]);
+			}
+		}
+
+		var result = new StringBuilder(decoded.Count);
+		foreach (var b in decoded)
+		{
+			result.Append(b is >= 0x20 and <= 0x7E ? (char)b : '?');
+		}
+
+		return result.ToString();
+	}
 
 	[SharpFunction(Name = "wrap", MinArgs = 2, MaxArgs = 4, Flags = FunctionFlags.Regular, ParameterNames = ["string", "width", "osep", "isep", "indent"])]
 	public static async ValueTask<CallState> Wrap(IMUSHCodeParser parser, SharpFunctionAttribute _2)

--- a/SharpMUSH.Tests.Integration/Profile/ProfileApiTests.cs
+++ b/SharpMUSH.Tests.Integration/Profile/ProfileApiTests.cs
@@ -102,7 +102,10 @@ public class ProfileApiTests(ServerWebAppFactory factory)
 		await Assert.That((int)response.StatusCode).IsEqualTo(200);
 		await Assert.That(response.Content.Headers.ContentType?.MediaType).IsEqualTo("application/json");
 		using var doc = JsonDocument.Parse(body);
-		await Assert.That(doc.RootElement.TryGetProperty("sections", out var sections)).IsTrue();
+		// Schema-driven view (PortalSchemaDocument shape): sections live under pages[].sections.
+		await Assert.That(doc.RootElement.TryGetProperty("pages", out var pages)).IsTrue();
+		await Assert.That(pages.GetArrayLength()).IsEqualTo(1);
+		await Assert.That(pages[0].TryGetProperty("sections", out var sections)).IsTrue();
 		// Public read-only schema: Demographics + Status + Description.
 		await Assert.That(sections.GetArrayLength()).IsEqualTo(3);
 	}

--- a/SharpMUSH.Tests/Client/MudBlazorTestContext.cs
+++ b/SharpMUSH.Tests/Client/MudBlazorTestContext.cs
@@ -1,5 +1,8 @@
+using System.Net;
+using System.Text;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using MudBlazor.Services;
 using NSubstitute;
 using SharpMUSH.Client.Services;
@@ -21,5 +24,27 @@ public abstract class MudBlazorTestContext : BunitContext
 		// NavMenu (and other chrome) inject ITerminalService to gate character-scoped
 		// links on connection state; a disconnected stub is enough for rendering tests.
 		Services.AddSingleton(Substitute.For<ITerminalService>());
+		// NavMenu renders <ApplicationNavLinks>, which calls ApplicationRegistryClient.ListAsync()
+		// on init. Back it with a stub HTTP factory that returns an empty list so chrome renders
+		// without a live API; application-specific tests register their own client.
+		Services.AddSingleton(new ApplicationRegistryClient(
+			StubFactoryReturningEmptyList(), NullLogger<ApplicationRegistryClient>.Instance));
+	}
+
+	private static IHttpClientFactory StubFactoryReturningEmptyList()
+	{
+		var factory = Substitute.For<IHttpClientFactory>();
+		factory.CreateClient(Arg.Any<string>())
+			.Returns(_ => new HttpClient(new EmptyJsonArrayHandler()) { BaseAddress = new Uri("http://localhost/") });
+		return factory;
+	}
+
+	private sealed class EmptyJsonArrayHandler : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+			=> Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+			{
+				Content = new StringContent("[]", Encoding.UTF8, "application/json")
+			});
 	}
 }

--- a/SharpMUSH.Tests/Functions/WebFunctionUnitTests.cs
+++ b/SharpMUSH.Tests/Functions/WebFunctionUnitTests.cs
@@ -9,20 +9,35 @@ public class WebFunctionUnitTests
 
 	private IMUSHCodeParser Parser => WebAppFactoryArg.FunctionParser;
 
+	// PennMUSH urlencode() uses libcurl's curl_easy_escape: RFC 3986 percent-encoding,
+	// space -> %20 (not +), only A-Za-z0-9-._~ left unescaped, hex digits uppercased.
+	// (\% in the input keeps a percent literal past the MUSH substitution layer.)
 	[Test]
-	[Arguments("urlencode(test string)", "test+string")]
+	[Arguments(@"urlencode(test string)", "test%20string")]
+	[Arguments(@"urlencode(a/b c)", "a%2Fb%20c")]
+	[Arguments(@"urlencode(a+b)", "a%2Bb")]
+	[Arguments(@"urlencode(a&b=c)", "a%26b%3Dc")]
+	[Arguments(@"urlencode(foo-_.~bar)", "foo-_.~bar")]
+	[Arguments(@"urlencode(100\%)", "100%25")]
 	public async Task Urlencode(string str, string expected)
 	{
 		var result = (await Parser.FunctionParse(MModule.single(str)))?.Message!;
-		await Assert.That(result.ToPlainText()).IsNotNull();
+		await Assert.That(result.ToPlainText()).IsEqualTo(expected);
 	}
 
+	// PennMUSH urldecode() uses libcurl's curl_easy_unescape: only %XX is decoded; a literal
+	// '+' is left untouched (unlike form decoding); non-printable decoded bytes become '?'.
 	[Test]
-	[Arguments("urldecode(test+string)", "test string")]
+	[Arguments(@"urldecode(test\%20string)", "test string")]
+	[Arguments(@"urldecode(a\%2Fb\%20c)", "a/b c")]
+	[Arguments(@"urldecode(test+string)", "test+string")]
+	[Arguments(@"urldecode(a\%2Fb+c)", "a/b+c")]
+	[Arguments(@"urldecode(100\%25)", "100%")]
+	[Arguments(@"urldecode(a\%09b)", "a?b")]
 	public async Task Urldecode(string str, string expected)
 	{
 		var result = (await Parser.FunctionParse(MModule.single(str)))?.Message!;
-		await Assert.That(result.ToPlainText()).IsNotNull();
+		await Assert.That(result.ToPlainText()).IsEqualTo(expected);
 	}
 
 	[Test]


### PR DESCRIPTION
## Problem

`urlencode()` / `urldecode()` (`SharpMUSH.Implementation/Functions/StringFunctions.cs`) were implemented with `WebUtility.HtmlEncode` / `HtmlDecode` — HTML *entity* encoding (`&amp;`, `&lt;`…) — instead of URL **percent**-encoding (`%2F`, `%20`…) as PennMUSH implements them.

Fixes #633.

## Parity reference

PennMUSH (`src/funstr.c`) delegates both functions to **libcurl** (`curl_easy_escape` / `curl_easy_unescape`), which pins the exact semantics:

- **encode** keeps only RFC 3986 unreserved `A-Za-z0-9-._~`; everything else → uppercase `%XX`; space → `%20` (**not** `+`).
- **decode** handles only `%XX`; a literal `+` is **left untouched** (curl's unescape — used by both `fun_urldecode` *and* `fun_formdecode` — never maps `+`→space); non-printable decoded bytes are replaced with `?`.

## Fix

- `urlencode` → `Uri.EscapeDataString(...)`, which matches curl's escape set byte-for-byte (space → `%20`, unreserved set identical).
- `urldecode` → new `PercentDecode` helper that decodes `%XX` over the UTF-8 byte stream, preserves `+`, and replaces non-printable bytes (outside `0x20–0x7E`) with `?`.
- Removed the now-unused `using System.Net;`.

This finally matches the **existing help text** (`sharpfunc.md` already documented percent-encoding and "unprintable characters → question marks") — the docs were correct; only the code was wrong, so no doc changes were needed.

## Tests

Replaced the two weak `IsNotNull` assertions in `WebFunctionUnitTests` with **12 real parity cases** (using `\%` to pass literal percents past the MUSH substitution layer): `%20`/`%2F` round-trips, `+` preservation, unreserved chars, `%25`, and the `%09`→`?` non-printable rule. All 12 pass.

## Note on one deviation from the issue text

The issue suggested `urldecode(a%2Fb+c)` → `a/b c` (i.e. `+`→space). This PR implements `a/b+c` (`+` preserved), because that is what libcurl/PennMUSH actually does — the `+`→space convention belongs to `formdecode()`/`formq()`, not `urldecode()`. The issue author hedged on this point ("or `+` for space"); the faithful behavior preserves `+`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL handling to properly encode and decode special characters according to industry standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->