### PR TITLE
fix(config): render array & dictionary config values as editable element lists

### DIFF
--- a/SharpMUSH.Client/Pages/Admin/Config/DynamicConfig.razor
+++ b/SharpMUSH.Client/Pages/Admin/Config/DynamicConfig.razor
@@ -666,7 +666,7 @@
     private List<string> GetStringListValue(PropertyMetadata prop)
     {
         if (_currentValues.TryGetValue(prop.Path, out var value) && value != null)
-            return CoerceToStringList(value);
+            return NonBlank(CoerceToStringList(value));
         return new List<string>();
     }
 
@@ -750,23 +750,26 @@
         {
             case Dictionary<string, string[]> dict:
                 foreach (var kvp in dict)
-                    result.Add(new DictEntry { Key = kvp.Key, Values = kvp.Value.ToList() });
+                    result.Add(new DictEntry { Key = kvp.Key, Values = NonBlank(kvp.Value) });
                 break;
             case JsonElement { ValueKind: JsonValueKind.Object } je:
                 foreach (var prop in je.EnumerateObject())
-                    result.Add(new DictEntry { Key = prop.Name, Values = CoerceToStringList(prop.Value) });
+                    result.Add(new DictEntry { Key = prop.Name, Values = NonBlank(CoerceToStringList(prop.Value)) });
                 break;
             case System.Collections.IDictionary idict:
                 foreach (System.Collections.DictionaryEntry entry in idict)
                     result.Add(new DictEntry
                     {
                         Key = entry.Key?.ToString() ?? "",
-                        Values = entry.Value != null ? CoerceToStringList(entry.Value) : new List<string>()
+                        Values = entry.Value != null ? NonBlank(CoerceToStringList(entry.Value)) : new List<string>()
                     });
                 break;
         }
         return result;
     }
+
+    private static List<string> NonBlank(IEnumerable<string> values) =>
+        values.Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
 
     private void SyncDictDraft(PropertyMetadata prop)
     {

--- a/SharpMUSH.Client/Pages/Admin/Config/DynamicConfig.razor
+++ b/SharpMUSH.Client/Pages/Admin/Config/DynamicConfig.razor
@@ -202,6 +202,23 @@
         position: relative;
     }
 
+    .config-list-field {
+        margin-bottom: 8px;
+    }
+
+    .config-chip-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        align-items: center;
+        min-height: 32px;
+        margin-bottom: 8px;
+    }
+
+    .config-dict-panels {
+        margin-bottom: 4px;
+    }
+
     .default-chip {
         position: absolute;
         right: 8px;
@@ -280,6 +297,7 @@
         _hasChanges = false;
         _validationErrors.Clear();
         _dictDrafts.Clear();
+        _listDrafts.Clear();
         
         try
         {
@@ -415,121 +433,131 @@
         {
             var items = GetStringListValue(prop);
             <MudItem xs="12">
-                <div class="d-flex align-center mb-1">
-                    <MudText Typo="Typo.subtitle2">@displayName</MudText>
-                    @if (isChanged)
+                <MudField Label="@displayName" Variant="Variant.Outlined" Class="config-list-field">
+                    @if (!string.IsNullOrEmpty(prop.Description))
                     {
-                        <MudIcon Icon="@Icons.Material.Filled.Edit" Size="Size.Small" Color="Color.Warning" Class="ml-2" />
+                        <MudText Typo="Typo.caption" Class="mud-text-secondary d-block mb-2">@prop.Description</MudText>
                     }
-                </div>
-                @if (!string.IsNullOrEmpty(prop.Description))
-                {
-                    <MudText Typo="Typo.caption" Class="mud-text-secondary d-block mb-2">@prop.Description</MudText>
-                }
-                @for (var i = 0; i < items.Count; i++)
-                {
-                    var index = i;
-                    <div class="d-flex align-center mb-2" @key="@($"{prop.Path}-{index}")">
-                        <MudTextField T="string"
-                                      Value="@items[index]"
-                                      ValueChanged="@(v => UpdateListItem(prop, index, v))"
-                                      Variant="Variant.Outlined"
-                                      Margin="Margin.Dense"
-                                      Class="flex-grow-1" />
-                        <MudIconButton Icon="@Icons.Material.Filled.Delete"
-                                       Color="Color.Error"
-                                       Size="Size.Small"
-                                       Class="ml-1"
-                                       OnClick="@(() => RemoveListItem(prop, index))" />
+                    <div class="config-chip-row">
+                        @if (items.Count == 0)
+                        {
+                            <MudText Typo="Typo.body2" Class="mud-text-secondary">@Loc["NoItems"]</MudText>
+                        }
+                        @for (var i = 0; i < items.Count; i++)
+                        {
+                            var index = i;
+                            <MudChip T="string"
+                                     Text="@items[index]"
+                                     Size="Size.Small"
+                                     Color="@(isChanged ? Color.Warning : Color.Primary)"
+                                     Variant="Variant.Filled"
+                                     OnClose="@(() => RemoveListItemAt(prop, index))" />
+                        }
                     </div>
-                }
-                @if (items.Count == 0)
-                {
-                    <MudText Typo="Typo.caption" Class="mud-text-secondary d-block mb-2">@Loc["NoItems"]</MudText>
-                }
-                <MudButton StartIcon="@Icons.Material.Filled.Add"
-                           Variant="Variant.Text"
-                           Color="Color.Secondary"
-                           Size="Size.Small"
-                           OnClick="@(() => AddListItem(prop))">
-                    @Loc["AddItem"]
-                </MudButton>
+                    <MudTextField T="string"
+                                  Value="@GetListDraft(prop)"
+                                  ValueChanged="@(v => SetListDraft(prop, v))"
+                                  Placeholder="@Loc["AddItem"]"
+                                  Variant="Variant.Text"
+                                  Margin="Margin.Dense"
+                                  Immediate="true"
+                                  Adornment="Adornment.End"
+                                  AdornmentIcon="@Icons.Material.Filled.Add"
+                                  OnAdornmentClick="@(() => CommitListDraft(prop))"
+                                  OnKeyDown="@(e => OnListDraftKeyDown(prop, e))" />
+                </MudField>
             </MudItem>
         }
         else if (prop.Component == "dictionary")
         {
             var entries = GetDictDraft(prop);
             <MudItem xs="12">
-                <div class="d-flex align-center mb-1">
-                    <MudText Typo="Typo.subtitle2">@displayName</MudText>
-                    @if (isChanged)
+                <MudField Label="@displayName" Variant="Variant.Outlined" Class="config-list-field">
+                    @if (!string.IsNullOrEmpty(prop.Description))
                     {
-                        <MudIcon Icon="@Icons.Material.Filled.Edit" Size="Size.Small" Color="Color.Warning" Class="ml-2" />
+                        <MudText Typo="Typo.caption" Class="mud-text-secondary d-block mb-2">@prop.Description</MudText>
                     }
-                </div>
-                @if (!string.IsNullOrEmpty(prop.Description))
-                {
-                    <MudText Typo="Typo.caption" Class="mud-text-secondary d-block mb-2">@prop.Description</MudText>
-                }
-                @for (var e = 0; e < entries.Count; e++)
-                {
-                    var entryIndex = e;
-                    var entry = entries[entryIndex];
-                    <MudPaper Outlined="true" Class="pa-3 mb-2" @key="@($"{prop.Path}-entry-{entryIndex}")">
-                        <div class="d-flex align-center mb-2">
-                            <MudTextField T="string"
-                                          Value="@entry.Key"
-                                          ValueChanged="@(v => UpdateDictKey(prop, entryIndex, v))"
-                                          Label="@Loc["Key"]"
-                                          Variant="Variant.Outlined"
-                                          Margin="Margin.Dense"
-                                          Class="flex-grow-1" />
-                            <MudIconButton Icon="@Icons.Material.Filled.Delete"
-                                           Color="Color.Error"
-                                           Size="Size.Small"
-                                           Class="ml-1"
-                                           OnClick="@(() => RemoveDictEntry(prop, entryIndex))" />
-                        </div>
-                        <div class="ml-4">
-                            @for (var v = 0; v < entry.Values.Count; v++)
+                    @if (entries.Count == 0)
+                    {
+                        <MudText Typo="Typo.body2" Class="mud-text-secondary mb-2">@Loc["NoEntries"]</MudText>
+                    }
+                    else
+                    {
+                        <MudExpansionPanels MultiExpansion="true" Elevation="0" Class="config-dict-panels">
+                            @for (var e = 0; e < entries.Count; e++)
                             {
-                                var valueIndex = v;
-                                <div class="d-flex align-center mb-2" @key="@($"{prop.Path}-{entryIndex}-{valueIndex}")">
-                                    <MudTextField T="string"
-                                                  Value="@entry.Values[valueIndex]"
-                                                  ValueChanged="@(val => UpdateDictValueItem(prop, entryIndex, valueIndex, val))"
-                                                  Label="@Loc["Value"]"
-                                                  Variant="Variant.Outlined"
-                                                  Margin="Margin.Dense"
-                                                  Class="flex-grow-1" />
-                                    <MudIconButton Icon="@Icons.Material.Filled.Delete"
-                                                   Color="Color.Error"
-                                                   Size="Size.Small"
-                                                   Class="ml-1"
-                                                   OnClick="@(() => RemoveDictValueItem(prop, entryIndex, valueIndex))" />
-                                </div>
+                                var entryIndex = e;
+                                var entry = entries[entryIndex];
+                                <MudExpansionPanel @key="@($"{prop.Path}-entry-{entryIndex}")">
+                                    <TitleContent>
+                                        <div class="d-flex align-center">
+                                            <MudIcon Icon="@Icons.Material.Filled.Key" Size="Size.Small" Class="mr-2" />
+                                            <MudText Typo="Typo.body1">
+                                                @(string.IsNullOrWhiteSpace(entry.Key) ? Loc["NewEntry"].Value : entry.Key)
+                                            </MudText>
+                                            <MudChip T="string" Size="Size.Small" Color="Color.Default" Variant="Variant.Text" Class="ml-2">
+                                                @entry.Values.Count
+                                            </MudChip>
+                                        </div>
+                                    </TitleContent>
+                                    <ChildContent>
+                                        <div class="d-flex align-center mb-3">
+                                            <MudTextField T="string"
+                                                          Value="@entry.Key"
+                                                          ValueChanged="@(v => UpdateDictKey(prop, entryIndex, v))"
+                                                          Label="@Loc["Key"]"
+                                                          Variant="Variant.Outlined"
+                                                          Margin="Margin.Dense"
+                                                          Class="flex-grow-1" />
+                                            <MudTooltip Text="@Loc["RemoveEntry"]">
+                                                <MudIconButton Icon="@Icons.Material.Filled.DeleteOutline"
+                                                               Color="Color.Error"
+                                                               Size="Size.Small"
+                                                               Class="ml-1"
+                                                               OnClick="@(() => RemoveDictEntry(prop, entryIndex))" />
+                                            </MudTooltip>
+                                        </div>
+                                        <div class="config-chip-row">
+                                            @if (entry.Values.Count == 0)
+                                            {
+                                                <MudText Typo="Typo.body2" Class="mud-text-secondary">@Loc["NoItems"]</MudText>
+                                            }
+                                            @for (var v = 0; v < entry.Values.Count; v++)
+                                            {
+                                                var valueIndex = v;
+                                                <MudChip T="string"
+                                                         Text="@entry.Values[valueIndex]"
+                                                         Size="Size.Small"
+                                                         Color="Color.Primary"
+                                                         Variant="Variant.Filled"
+                                                         OnClose="@(() => RemoveDictValueItem(prop, entryIndex, valueIndex))" />
+                                            }
+                                        </div>
+                                        <MudTextField T="string"
+                                                      Value="@entry.ValueDraft"
+                                                      ValueChanged="@(v => entry.ValueDraft = v)"
+                                                      Placeholder="@Loc["AddValue"]"
+                                                      Variant="Variant.Text"
+                                                      Margin="Margin.Dense"
+                                                      Immediate="true"
+                                                      Adornment="Adornment.End"
+                                                      AdornmentIcon="@Icons.Material.Filled.Add"
+                                                      OnAdornmentClick="@(() => CommitDictValueDraft(prop, entryIndex))"
+                                                      OnKeyDown="@(e => OnDictValueDraftKeyDown(prop, entryIndex, e))" />
+                                    </ChildContent>
+                                </MudExpansionPanel>
                             }
-                            <MudButton StartIcon="@Icons.Material.Filled.Add"
-                                       Variant="Variant.Text"
-                                       Color="Color.Secondary"
-                                       Size="Size.Small"
-                                       OnClick="@(() => AddDictValueItem(prop, entryIndex))">
-                                @Loc["AddValue"]
-                            </MudButton>
-                        </div>
-                    </MudPaper>
-                }
-                @if (entries.Count == 0)
-                {
-                    <MudText Typo="Typo.caption" Class="mud-text-secondary d-block mb-2">@Loc["NoEntries"]</MudText>
-                }
-                <MudButton StartIcon="@Icons.Material.Filled.Add"
-                           Variant="Variant.Text"
-                           Color="Color.Secondary"
-                           Size="Size.Small"
-                           OnClick="@(() => AddDictEntry(prop))">
-                    @Loc["AddEntry"]
-                </MudButton>
+                        </MudExpansionPanels>
+                    }
+                    <MudButton StartIcon="@Icons.Material.Filled.Add"
+                               Variant="Variant.Text"
+                               Color="Color.Secondary"
+                               Size="Size.Small"
+                               Class="mt-2"
+                               OnClick="@(() => AddDictEntry(prop))">
+                        @Loc["AddEntry"]
+                    </MudButton>
+                </MudField>
             </MudItem>
         }
         else if (prop.Component == "text")
@@ -653,22 +681,35 @@
         _ => new List<string>()
     };
 
-    private void UpdateListItem(PropertyMetadata prop, int index, string newValue)
+    // Transient "add" text for each string-list field, keyed by property path.
+    private readonly Dictionary<string, string> _listDrafts = new();
+
+    private string GetListDraft(PropertyMetadata prop) =>
+        _listDrafts.GetValueOrDefault(prop.Path, string.Empty);
+
+    private void SetListDraft(PropertyMetadata prop, string value) =>
+        _listDrafts[prop.Path] = value;
+
+    private void CommitListDraft(PropertyMetadata prop)
     {
+        var draft = GetListDraft(prop).Trim();
+        _listDrafts[prop.Path] = string.Empty;
+        if (draft.Length == 0) return;
+
         var list = GetStringListValue(prop);
-        if (index >= 0 && index < list.Count)
-            list[index] = newValue;
+        if (list.Contains(draft)) return;
+
+        list.Add(draft);
         UpdateValue(prop, list.ToArray());
     }
 
-    private void AddListItem(PropertyMetadata prop)
+    private void OnListDraftKeyDown(PropertyMetadata prop, KeyboardEventArgs args)
     {
-        var list = GetStringListValue(prop);
-        list.Add(string.Empty);
-        UpdateValue(prop, list.ToArray());
+        if (args.Key == "Enter")
+            CommitListDraft(prop);
     }
 
-    private void RemoveListItem(PropertyMetadata prop, int index)
+    private void RemoveListItemAt(PropertyMetadata prop, int index)
     {
         var list = GetStringListValue(prop);
         if (index >= 0 && index < list.Count)
@@ -684,6 +725,10 @@
     {
         public string Key { get; set; } = string.Empty;
         public List<string> Values { get; set; } = new();
+
+        // Transient "add value" text bound to this entry's input, travels with the entry
+        // regardless of list reordering.
+        public string ValueDraft { get; set; } = string.Empty;
     }
 
     private readonly Dictionary<string, List<DictEntry>> _dictDrafts = new();
@@ -757,21 +802,24 @@
         SyncDictDraft(prop);
     }
 
-    private void UpdateDictValueItem(PropertyMetadata prop, int entryIndex, int valueIndex, string newValue)
+    private void CommitDictValueDraft(PropertyMetadata prop, int entryIndex)
     {
         var draft = GetDictDraft(prop);
-        if (entryIndex >= 0 && entryIndex < draft.Count &&
-            valueIndex >= 0 && valueIndex < draft[entryIndex].Values.Count)
-            draft[entryIndex].Values[valueIndex] = newValue;
+        if (entryIndex < 0 || entryIndex >= draft.Count) return;
+
+        var entry = draft[entryIndex];
+        var value = entry.ValueDraft.Trim();
+        entry.ValueDraft = string.Empty;
+        if (value.Length == 0 || entry.Values.Contains(value)) return;
+
+        entry.Values.Add(value);
         SyncDictDraft(prop);
     }
 
-    private void AddDictValueItem(PropertyMetadata prop, int entryIndex)
+    private void OnDictValueDraftKeyDown(PropertyMetadata prop, int entryIndex, KeyboardEventArgs args)
     {
-        var draft = GetDictDraft(prop);
-        if (entryIndex >= 0 && entryIndex < draft.Count)
-            draft[entryIndex].Values.Add(string.Empty);
-        SyncDictDraft(prop);
+        if (args.Key == "Enter")
+            CommitDictValueDraft(prop, entryIndex);
     }
 
     private void RemoveDictValueItem(PropertyMetadata prop, int entryIndex, int valueIndex)
@@ -905,6 +953,7 @@
             _currentValues[kvp.Key] = kvp.Value;
         }
         _dictDrafts.Clear();
+        _listDrafts.Clear();
         _hasChanges = false;
         _changedCount = 0;
         _validationErrors.Clear();
@@ -918,6 +967,7 @@
             _currentValues[prop.Path] = prop.DefaultValue;
         }
         _dictDrafts.Clear();
+        _listDrafts.Clear();
         RecalculateChanges();
         StateHasChanged();
         Snackbar.Add(Loc["DefaultsRestored"].Value, Severity.Info);

--- a/SharpMUSH.Client/Pages/Admin/Config/DynamicConfig.razor
+++ b/SharpMUSH.Client/Pages/Admin/Config/DynamicConfig.razor
@@ -279,6 +279,7 @@
         _loading = true;
         _hasChanges = false;
         _validationErrors.Clear();
+        _dictDrafts.Clear();
         
         try
         {
@@ -410,6 +411,127 @@
                 }
             </MudItem>
         }
+        else if (prop.Component == "stringlist")
+        {
+            var items = GetStringListValue(prop);
+            <MudItem xs="12">
+                <div class="d-flex align-center mb-1">
+                    <MudText Typo="Typo.subtitle2">@displayName</MudText>
+                    @if (isChanged)
+                    {
+                        <MudIcon Icon="@Icons.Material.Filled.Edit" Size="Size.Small" Color="Color.Warning" Class="ml-2" />
+                    }
+                </div>
+                @if (!string.IsNullOrEmpty(prop.Description))
+                {
+                    <MudText Typo="Typo.caption" Class="mud-text-secondary d-block mb-2">@prop.Description</MudText>
+                }
+                @for (var i = 0; i < items.Count; i++)
+                {
+                    var index = i;
+                    <div class="d-flex align-center mb-2" @key="@($"{prop.Path}-{index}")">
+                        <MudTextField T="string"
+                                      Value="@items[index]"
+                                      ValueChanged="@(v => UpdateListItem(prop, index, v))"
+                                      Variant="Variant.Outlined"
+                                      Margin="Margin.Dense"
+                                      Class="flex-grow-1" />
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                       Color="Color.Error"
+                                       Size="Size.Small"
+                                       Class="ml-1"
+                                       OnClick="@(() => RemoveListItem(prop, index))" />
+                    </div>
+                }
+                @if (items.Count == 0)
+                {
+                    <MudText Typo="Typo.caption" Class="mud-text-secondary d-block mb-2">@Loc["NoItems"]</MudText>
+                }
+                <MudButton StartIcon="@Icons.Material.Filled.Add"
+                           Variant="Variant.Text"
+                           Color="Color.Secondary"
+                           Size="Size.Small"
+                           OnClick="@(() => AddListItem(prop))">
+                    @Loc["AddItem"]
+                </MudButton>
+            </MudItem>
+        }
+        else if (prop.Component == "dictionary")
+        {
+            var entries = GetDictDraft(prop);
+            <MudItem xs="12">
+                <div class="d-flex align-center mb-1">
+                    <MudText Typo="Typo.subtitle2">@displayName</MudText>
+                    @if (isChanged)
+                    {
+                        <MudIcon Icon="@Icons.Material.Filled.Edit" Size="Size.Small" Color="Color.Warning" Class="ml-2" />
+                    }
+                </div>
+                @if (!string.IsNullOrEmpty(prop.Description))
+                {
+                    <MudText Typo="Typo.caption" Class="mud-text-secondary d-block mb-2">@prop.Description</MudText>
+                }
+                @for (var e = 0; e < entries.Count; e++)
+                {
+                    var entryIndex = e;
+                    var entry = entries[entryIndex];
+                    <MudPaper Outlined="true" Class="pa-3 mb-2" @key="@($"{prop.Path}-entry-{entryIndex}")">
+                        <div class="d-flex align-center mb-2">
+                            <MudTextField T="string"
+                                          Value="@entry.Key"
+                                          ValueChanged="@(v => UpdateDictKey(prop, entryIndex, v))"
+                                          Label="@Loc["Key"]"
+                                          Variant="Variant.Outlined"
+                                          Margin="Margin.Dense"
+                                          Class="flex-grow-1" />
+                            <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                           Color="Color.Error"
+                                           Size="Size.Small"
+                                           Class="ml-1"
+                                           OnClick="@(() => RemoveDictEntry(prop, entryIndex))" />
+                        </div>
+                        <div class="ml-4">
+                            @for (var v = 0; v < entry.Values.Count; v++)
+                            {
+                                var valueIndex = v;
+                                <div class="d-flex align-center mb-2" @key="@($"{prop.Path}-{entryIndex}-{valueIndex}")">
+                                    <MudTextField T="string"
+                                                  Value="@entry.Values[valueIndex]"
+                                                  ValueChanged="@(val => UpdateDictValueItem(prop, entryIndex, valueIndex, val))"
+                                                  Label="@Loc["Value"]"
+                                                  Variant="Variant.Outlined"
+                                                  Margin="Margin.Dense"
+                                                  Class="flex-grow-1" />
+                                    <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                                   Color="Color.Error"
+                                                   Size="Size.Small"
+                                                   Class="ml-1"
+                                                   OnClick="@(() => RemoveDictValueItem(prop, entryIndex, valueIndex))" />
+                                </div>
+                            }
+                            <MudButton StartIcon="@Icons.Material.Filled.Add"
+                                       Variant="Variant.Text"
+                                       Color="Color.Secondary"
+                                       Size="Size.Small"
+                                       OnClick="@(() => AddDictValueItem(prop, entryIndex))">
+                                @Loc["AddValue"]
+                            </MudButton>
+                        </div>
+                    </MudPaper>
+                }
+                @if (entries.Count == 0)
+                {
+                    <MudText Typo="Typo.caption" Class="mud-text-secondary d-block mb-2">@Loc["NoEntries"]</MudText>
+                }
+                <MudButton StartIcon="@Icons.Material.Filled.Add"
+                           Variant="Variant.Text"
+                           Color="Color.Secondary"
+                           Size="Size.Small"
+                           OnClick="@(() => AddDictEntry(prop))">
+                    @Loc["AddEntry"]
+                </MudButton>
+            </MudItem>
+        }
         else if (prop.Component == "text")
         {
             <MudItem xs="12" md="6">
@@ -509,6 +631,156 @@
         if (_currentValues.TryGetValue(prop.Path, out var value) && value != null)
             return value.ToString() ?? "";
         return prop.DefaultValue?.ToString() ?? "";
+    }
+
+    // --- String list (string[]) editing ---
+
+    private List<string> GetStringListValue(PropertyMetadata prop)
+    {
+        if (_currentValues.TryGetValue(prop.Path, out var value) && value != null)
+            return CoerceToStringList(value);
+        return new List<string>();
+    }
+
+    private static List<string> CoerceToStringList(object value) => value switch
+    {
+        string[] arr => arr.ToList(),
+        IEnumerable<string> strings => strings.ToList(),
+        JsonElement { ValueKind: JsonValueKind.Array } je =>
+            je.EnumerateArray().Select(x => x.GetString() ?? "").ToList(),
+        System.Collections.IEnumerable enumerable and not string =>
+            enumerable.Cast<object?>().Select(x => x?.ToString() ?? "").ToList(),
+        _ => new List<string>()
+    };
+
+    private void UpdateListItem(PropertyMetadata prop, int index, string newValue)
+    {
+        var list = GetStringListValue(prop);
+        if (index >= 0 && index < list.Count)
+            list[index] = newValue;
+        UpdateValue(prop, list.ToArray());
+    }
+
+    private void AddListItem(PropertyMetadata prop)
+    {
+        var list = GetStringListValue(prop);
+        list.Add(string.Empty);
+        UpdateValue(prop, list.ToArray());
+    }
+
+    private void RemoveListItem(PropertyMetadata prop, int index)
+    {
+        var list = GetStringListValue(prop);
+        if (index >= 0 && index < list.Count)
+            list.RemoveAt(index);
+        UpdateValue(prop, list.ToArray());
+    }
+
+    // --- Dictionary<string, string[]> editing ---
+    // A draft list preserves entry order and allows in-progress (blank) keys while editing;
+    // it is synced back to _currentValues as a Dictionary on every change.
+
+    private sealed class DictEntry
+    {
+        public string Key { get; set; } = string.Empty;
+        public List<string> Values { get; set; } = new();
+    }
+
+    private readonly Dictionary<string, List<DictEntry>> _dictDrafts = new();
+
+    private List<DictEntry> GetDictDraft(PropertyMetadata prop)
+    {
+        if (!_dictDrafts.TryGetValue(prop.Path, out var draft))
+        {
+            draft = BuildDictEntries(_currentValues.GetValueOrDefault(prop.Path));
+            _dictDrafts[prop.Path] = draft;
+        }
+        return draft;
+    }
+
+    private static List<DictEntry> BuildDictEntries(object? value)
+    {
+        var result = new List<DictEntry>();
+        switch (value)
+        {
+            case Dictionary<string, string[]> dict:
+                foreach (var kvp in dict)
+                    result.Add(new DictEntry { Key = kvp.Key, Values = kvp.Value.ToList() });
+                break;
+            case JsonElement { ValueKind: JsonValueKind.Object } je:
+                foreach (var prop in je.EnumerateObject())
+                    result.Add(new DictEntry { Key = prop.Name, Values = CoerceToStringList(prop.Value) });
+                break;
+            case System.Collections.IDictionary idict:
+                foreach (System.Collections.DictionaryEntry entry in idict)
+                    result.Add(new DictEntry
+                    {
+                        Key = entry.Key?.ToString() ?? "",
+                        Values = entry.Value != null ? CoerceToStringList(entry.Value) : new List<string>()
+                    });
+                break;
+        }
+        return result;
+    }
+
+    private void SyncDictDraft(PropertyMetadata prop)
+    {
+        var draft = _dictDrafts[prop.Path];
+        var dict = new Dictionary<string, string[]>();
+        foreach (var entry in draft)
+        {
+            if (string.IsNullOrWhiteSpace(entry.Key)) continue;
+            dict[entry.Key] = entry.Values.ToArray();
+        }
+        UpdateValue(prop, dict);
+    }
+
+    private void UpdateDictKey(PropertyMetadata prop, int entryIndex, string newKey)
+    {
+        var draft = GetDictDraft(prop);
+        if (entryIndex >= 0 && entryIndex < draft.Count)
+            draft[entryIndex].Key = newKey;
+        SyncDictDraft(prop);
+    }
+
+    private void AddDictEntry(PropertyMetadata prop)
+    {
+        GetDictDraft(prop).Add(new DictEntry());
+        SyncDictDraft(prop);
+    }
+
+    private void RemoveDictEntry(PropertyMetadata prop, int entryIndex)
+    {
+        var draft = GetDictDraft(prop);
+        if (entryIndex >= 0 && entryIndex < draft.Count)
+            draft.RemoveAt(entryIndex);
+        SyncDictDraft(prop);
+    }
+
+    private void UpdateDictValueItem(PropertyMetadata prop, int entryIndex, int valueIndex, string newValue)
+    {
+        var draft = GetDictDraft(prop);
+        if (entryIndex >= 0 && entryIndex < draft.Count &&
+            valueIndex >= 0 && valueIndex < draft[entryIndex].Values.Count)
+            draft[entryIndex].Values[valueIndex] = newValue;
+        SyncDictDraft(prop);
+    }
+
+    private void AddDictValueItem(PropertyMetadata prop, int entryIndex)
+    {
+        var draft = GetDictDraft(prop);
+        if (entryIndex >= 0 && entryIndex < draft.Count)
+            draft[entryIndex].Values.Add(string.Empty);
+        SyncDictDraft(prop);
+    }
+
+    private void RemoveDictValueItem(PropertyMetadata prop, int entryIndex, int valueIndex)
+    {
+        var draft = GetDictDraft(prop);
+        if (entryIndex >= 0 && entryIndex < draft.Count &&
+            valueIndex >= 0 && valueIndex < draft[entryIndex].Values.Count)
+            draft[entryIndex].Values.RemoveAt(valueIndex);
+        SyncDictDraft(prop);
     }
 
     private int? GetIntMin(PropertyMetadata prop)
@@ -632,6 +904,7 @@
         {
             _currentValues[kvp.Key] = kvp.Value;
         }
+        _dictDrafts.Clear();
         _hasChanges = false;
         _changedCount = 0;
         _validationErrors.Clear();
@@ -644,6 +917,7 @@
         {
             _currentValues[prop.Path] = prop.DefaultValue;
         }
+        _dictDrafts.Clear();
         RecalculateChanges();
         StateHasChanged();
         Snackbar.Add(Loc["DefaultsRestored"].Value, Severity.Info);

--- a/SharpMUSH.Client/Resources/SharedResource.fr.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.fr.resx
@@ -231,6 +231,12 @@
   <data name="AddValue" xml:space="preserve">
     <value>Ajouter une valeur</value>
   </data>
+  <data name="NewEntry" xml:space="preserve">
+    <value>Nouvelle entrée</value>
+  </data>
+  <data name="RemoveEntry" xml:space="preserve">
+    <value>Supprimer l'entrée</value>
+  </data>
   <data name="UnsavedChanges" xml:space="preserve">
     <value>Modifications non enregistrées</value>
   </data>

--- a/SharpMUSH.Client/Resources/SharedResource.fr.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.fr.resx
@@ -216,6 +216,21 @@
   <data name="ResetChanges" xml:space="preserve">
     <value>Réinitialiser les modifications</value>
   </data>
+  <data name="AddItem" xml:space="preserve">
+    <value>Ajouter un élément</value>
+  </data>
+  <data name="NoItems" xml:space="preserve">
+    <value>Aucun élément</value>
+  </data>
+  <data name="AddEntry" xml:space="preserve">
+    <value>Ajouter une entrée</value>
+  </data>
+  <data name="NoEntries" xml:space="preserve">
+    <value>Aucune entrée</value>
+  </data>
+  <data name="AddValue" xml:space="preserve">
+    <value>Ajouter une valeur</value>
+  </data>
   <data name="UnsavedChanges" xml:space="preserve">
     <value>Modifications non enregistrées</value>
   </data>

--- a/SharpMUSH.Client/Resources/SharedResource.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.resx
@@ -895,6 +895,12 @@
   <data name="AddValue" xml:space="preserve">
     <value>Add Value</value>
   </data>
+  <data name="NewEntry" xml:space="preserve">
+    <value>New entry</value>
+  </data>
+  <data name="RemoveEntry" xml:space="preserve">
+    <value>Remove entry</value>
+  </data>
   <data name="SaveConfiguration" xml:space="preserve">
     <value>Save Configuration</value>
   </data>

--- a/SharpMUSH.Client/Resources/SharedResource.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.resx
@@ -880,6 +880,21 @@
   <data name="ResetChanges" xml:space="preserve">
     <value>Reset Changes</value>
   </data>
+  <data name="AddItem" xml:space="preserve">
+    <value>Add Item</value>
+  </data>
+  <data name="NoItems" xml:space="preserve">
+    <value>No items</value>
+  </data>
+  <data name="AddEntry" xml:space="preserve">
+    <value>Add Entry</value>
+  </data>
+  <data name="NoEntries" xml:space="preserve">
+    <value>No entries</value>
+  </data>
+  <data name="AddValue" xml:space="preserve">
+    <value>Add Value</value>
+  </data>
   <data name="SaveConfiguration" xml:space="preserve">
     <value>Save Configuration</value>
   </data>

--- a/SharpMUSH.Configuration/ReadPennMUSHConfig.cs
+++ b/SharpMUSH.Configuration/ReadPennMUSHConfig.cs
@@ -144,11 +144,11 @@ public static partial class ReadPennMushConfig
 				RequiredString(Get(nameof(FileOptions.ColorsFile)), "colors.json")
 			),
 			Flag = new FlagOptions(
-				PlayerFlags: RequiredString(Get(nameof(FlagOptions.PlayerFlags)), "enter_ok ansi no_command").Split(' '),
-				RoomFlags: RequiredString(Get(nameof(FlagOptions.RoomFlags)), "no_command").Split(' '),
-				ThingFlags: RequiredString(Get(nameof(FlagOptions.ThingFlags)), "").Split(' '),
-				ExitFlags: RequiredString(Get(nameof(FlagOptions.ExitFlags)), "no_command").Split(' '),
-				ChannelFlags: RequiredString(Get(nameof(FlagOptions.ChannelFlags)), "player").Split(' ')
+				PlayerFlags: RequiredString(Get(nameof(FlagOptions.PlayerFlags)), "enter_ok ansi no_command").Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+				RoomFlags: RequiredString(Get(nameof(FlagOptions.RoomFlags)), "no_command").Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+				ThingFlags: RequiredString(Get(nameof(FlagOptions.ThingFlags)), "").Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+				ExitFlags: RequiredString(Get(nameof(FlagOptions.ExitFlags)), "no_command").Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+				ChannelFlags: RequiredString(Get(nameof(FlagOptions.ChannelFlags)), "player").Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
 			),
 			Function = new FunctionOptions(
 				SaferUserFunctions: Boolean(Get(nameof(FunctionOptions.SaferUserFunctions)), true),

--- a/SharpMUSH.Library/API/SchemaBuilder.cs
+++ b/SharpMUSH.Library/API/SchemaBuilder.cs
@@ -166,6 +166,8 @@ public static partial class SchemaBuilder
 				underlyingType == typeof(decimal)) return "number";
 		if (underlyingType == typeof(string)) return "string";
 		if (underlyingType.IsEnum) return "enum";
+		if (underlyingType == typeof(string[])) return "array";
+		if (underlyingType == typeof(Dictionary<string, string[]>)) return "dictionary";
 
 		return "string";
 	}
@@ -181,6 +183,8 @@ public static partial class SchemaBuilder
 				underlyingType == typeof(float) || underlyingType == typeof(double) ||
 				underlyingType == typeof(decimal)) return "numeric";
 		if (underlyingType.IsEnum) return "select";
+		if (underlyingType == typeof(string[])) return "stringlist";
+		if (underlyingType == typeof(Dictionary<string, string[]>)) return "dictionary";
 
 		return "text";
 	}

--- a/SharpMUSH.Tests/Configuration/ReadPennMushConfigFlagTests.cs
+++ b/SharpMUSH.Tests/Configuration/ReadPennMushConfigFlagTests.cs
@@ -1,0 +1,53 @@
+using SharpMUSH.Configuration;
+
+namespace SharpMUSH.Tests.Configuration;
+
+/// <summary>
+/// Regression tests for flag-list parsing: splitting on spaces must not produce
+/// empty entries (which rendered as blank chips on the Flags config page), even
+/// when the configured value has extra whitespace or the default is empty.
+/// </summary>
+public class ReadPennMushConfigFlagTests
+{
+	private static string WriteTempConfig(params string[] lines)
+	{
+		var path = Path.Combine(Path.GetTempPath(), $"sharpmush-cnf-{Guid.NewGuid():N}.cnf");
+		File.WriteAllLines(path, lines);
+		return path;
+	}
+
+	[Test]
+	public async Task PlayerFlags_WithExtraWhitespace_HasNoEmptyEntries()
+	{
+		var path = WriteTempConfig("player_flags enter_ok  ansi   no_command");
+		try
+		{
+			var options = ReadPennMushConfig.Create(path);
+
+			await Assert.That(options.Flag.PlayerFlags).IsEquivalentTo(new[] { "enter_ok", "ansi", "no_command" });
+			await Assert.That(options.Flag.PlayerFlags!).DoesNotContain(string.Empty);
+		}
+		finally
+		{
+			File.Delete(path);
+		}
+	}
+
+	[Test]
+	public async Task ThingFlags_WithEmptyDefault_IsEmptyNotASingleBlankEntry()
+	{
+		// No thing_flags line -> falls back to the empty default, which previously
+		// produced [""] (one blank chip) instead of an empty list.
+		var path = WriteTempConfig("player_flags enter_ok");
+		try
+		{
+			var options = ReadPennMushConfig.Create(path);
+
+			await Assert.That(options.Flag.ThingFlags!).IsEmpty();
+		}
+		finally
+		{
+			File.Delete(path);
+		}
+	}
+}

--- a/SharpMUSH.Tests/Configuration/SchemaBuilderTests.cs
+++ b/SharpMUSH.Tests/Configuration/SchemaBuilderTests.cs
@@ -1,0 +1,51 @@
+using SharpMUSH.Configuration;
+using SharpMUSH.Library.API;
+
+namespace SharpMUSH.Tests.Configuration;
+
+/// <summary>
+/// Verifies that <see cref="SchemaBuilder"/> classifies collection-typed configuration
+/// properties (string arrays and string-array dictionaries) with dedicated UI components,
+/// so the config pages render editable element lists instead of a bare "string[]" type name.
+/// </summary>
+public class SchemaBuilderTests
+{
+	private static ConfigurationSchema BuildSchema()
+	{
+		var configFile = Path.Combine(AppContext.BaseDirectory, "Configuration", "Testfile", "mushcnf.dst");
+		var options = ReadPennMushConfig.Create(configFile);
+		return SchemaBuilder.BuildSchema(options);
+	}
+
+	[Test]
+	public async Task StringArrayProperty_UsesStringListComponent()
+	{
+		var schema = BuildSchema();
+
+		var playerFlags = schema.Properties["Flag.PlayerFlags"];
+
+		await Assert.That(playerFlags.Type).IsEqualTo("array");
+		await Assert.That(playerFlags.Component).IsEqualTo("stringlist");
+	}
+
+	[Test]
+	public async Task StringArrayDictionaryProperty_UsesDictionaryComponent()
+	{
+		var schema = BuildSchema();
+
+		var functionAliases = schema.Properties["Alias.FunctionAliases"];
+
+		await Assert.That(functionAliases.Type).IsEqualTo("dictionary");
+		await Assert.That(functionAliases.Component).IsEqualTo("dictionary");
+	}
+
+	[Test]
+	public async Task ScalarProperties_KeepTheirExistingComponents()
+	{
+		var schema = BuildSchema();
+
+		// A boolean still maps to a switch, a string still maps to a text field.
+		await Assert.That(schema.Properties["Cosmetic.AnnounceConnects"].Component).IsEqualTo("switch");
+		await Assert.That(schema.Properties["Cosmetic.MoneySingular"].Component).IsEqualTo("text");
+	}
+}


### PR DESCRIPTION
## Problem

On the admin Config pages, collection-typed settings displayed their .NET type name instead of their contents:
- `string[]` properties (Flags page) rendered as `System.String[]`
- `Dictionary<string,string[]>` properties (Aliases page) rendered as the dictionary's type name

The page only knew how to render `switch`/`numeric`/`text`/`select` components; collection types fell through to the text branch, which called `.ToString()` on the value.

## Changes

**Rendering the elements (`862e7256`)**
- `SchemaBuilder` now classifies `string[]` → `stringlist` and `Dictionary<string,string[]>` → `dictionary` components/types.
- `DynamicConfig` renders editors for both. Values are written back as real `string[]` / `Dictionary<string,string[]>`, which the existing PATCH endpoint already deserializes — no server change needed.

**Modern UI (`ed9cc125`)**
- String lists render as closable `MudChip`s inside a `MudField`, with a single add-field (Enter or **+** to add; duplicates rejected).
- Dictionaries render as `MudExpansionPanels` — one collapsible panel per key with a value-count badge, an editable key, value chips, and a per-entry add-field.

**Empty chips (`44d09bc6`)**
- Root cause: flag parsing used `RequiredString(...).Split(' ')`. `"".Split(' ')` yields `[""]` (the empty-default `ThingFlags` became a blank entry), and repeated/edge whitespace produced blanks too — surfacing as empty chips.
- Fixed at the source with `RemoveEmptyEntries | TrimEntries`; the page also filters blanks defensively so any already-persisted blanks don't render.

## Tests
- `SchemaBuilderTests` — array/dictionary components classified correctly; scalar components unchanged.
- `ReadPennMushConfigFlagTests` — flag parsing drops empty entries with extra whitespace and empty defaults.
- `SharpMUSH.Client` and `SharpMUSH.Tests.BUnit` build clean under `TreatWarningsAsErrors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for editing list and dictionary configuration properties with interactive UI controls, including item/value management and empty-state handling.

* **Bug Fixes**
  * Fixed configuration flag parsing to properly handle extra whitespace and trim entries.

* **Localization**
  * Added French translations for new configuration management UI labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->