### PR TITLE
feat(packages): application package kind — register portal apps via the package manager

### DIFF
--- a/SharpMUSH.Database.ArangoDB/ArangoDatabase.Applications.cs
+++ b/SharpMUSH.Database.ArangoDB/ArangoDatabase.Applications.cs
@@ -24,6 +24,7 @@ public partial class ArangoDatabase : IApplicationRegistryService
 		public string? NavPlacement { get; set; }
 		public string Zones { get; set; } = "";
 		public int Order { get; set; }
+		public string? OwningPackage { get; set; }
 	}
 
 	public async Task UpsertApplicationAsync(RegisteredApplication application)
@@ -50,7 +51,8 @@ public partial class ArangoDatabase : IApplicationRegistryService
 			["MinimumRole"] = a.MinimumRole.ToString(),
 			["NavPlacement"] = a.NavPlacement,
 			["Zones"] = ApplicationRegistryMapping.ZonesToString(a.Zones),
-			["Order"] = a.Order
+			["Order"] = a.Order,
+			["OwningPackage"] = a.OwningPackage
 		};
 	}
 
@@ -98,7 +100,8 @@ public partial class ArangoDatabase : IApplicationRegistryService
 		Enum.Parse<PortalRole>(d.MinimumRole, ignoreCase: true),
 		d.NavPlacement,
 		ApplicationRegistryMapping.ZonesFromString(d.Zones),
-		d.Order);
+		d.Order,
+		d.OwningPackage);
 
 	#endregion
 }

--- a/SharpMUSH.Database.Memgraph/MemgraphDatabase.Applications.cs
+++ b/SharpMUSH.Database.Memgraph/MemgraphDatabase.Applications.cs
@@ -19,7 +19,7 @@ public partial class MemgraphDatabase : IApplicationRegistryService
 			MERGE (a:SysApplication {slug: $slug})
 			SET a.displayName = $displayName, a.icon = $icon, a.kind = $kind, a.schemaUrl = $schemaUrl,
 			    a.dataUrl = $dataUrl, a.submitRoute = $submitRoute, a.minimumRole = $minimumRole,
-			    a.navPlacement = $navPlacement, a.zones = $zones, a.order = $order
+			    a.navPlacement = $navPlacement, a.zones = $zones, a.order = $order, a.owningPackage = $owningPackage
 			""",
 			new
 			{
@@ -33,7 +33,8 @@ public partial class MemgraphDatabase : IApplicationRegistryService
 				minimumRole = application.MinimumRole.ToString(),
 				navPlacement = application.NavPlacement,
 				zones = ApplicationRegistryMapping.ZonesToString(application.Zones),
-				order = application.Order
+				order = application.Order,
+				owningPackage = application.OwningPackage
 			});
 	}
 
@@ -71,7 +72,8 @@ public partial class MemgraphDatabase : IApplicationRegistryService
 		Enum.Parse<PortalRole>(node.Properties["minimumRole"].As<string>(), ignoreCase: true),
 		OptionalString(node, "navPlacement"),
 		ApplicationRegistryMapping.ZonesFromString(OptionalString(node, "zones")),
-		node.Properties["order"].As<int>());
+		node.Properties["order"].As<int>(),
+		OptionalString(node, "owningPackage"));
 
 	#endregion
 }

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Applications.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Applications.cs
@@ -23,6 +23,7 @@ internal class SysApplicationDbRecord : Record
 	public string? navPlacement { get; set; }
 	public string zones { get; set; } = "";
 	public int sortOrder { get; set; }
+	public string? owningPackage { get; set; }
 }
 
 public partial class SurrealDatabase : IApplicationRegistryService
@@ -30,7 +31,7 @@ public partial class SurrealDatabase : IApplicationRegistryService
 	#region Application Registry
 
 	private const string SysApplicationFields =
-		"id, slug, displayName, icon, kind, schemaUrl, dataUrl, submitRoute, minimumRole, navPlacement, zones, sortOrder";
+		"id, slug, displayName, icon, kind, schemaUrl, dataUrl, submitRoute, minimumRole, navPlacement, zones, sortOrder, owningPackage";
 
 	public async Task UpsertApplicationAsync(RegisteredApplication application)
 	{
@@ -46,13 +47,14 @@ public partial class SurrealDatabase : IApplicationRegistryService
 			["minimumRole"] = application.MinimumRole.ToString(),
 			["navPlacement"] = application.NavPlacement,
 			["zones"] = ApplicationRegistryMapping.ZonesToString(application.Zones),
-			["sortOrder"] = application.Order
+			["sortOrder"] = application.Order,
+			["owningPackage"] = application.OwningPackage
 		};
 		await ExecuteAsync("""
 			UPSERT type::thing('sys_application', $slug) SET slug = $slug, displayName = $displayName,
 				icon = $icon, kind = $kind, schemaUrl = $schemaUrl, dataUrl = $dataUrl,
 				submitRoute = $submitRoute, minimumRole = $minimumRole, navPlacement = $navPlacement,
-				zones = $zones, sortOrder = $sortOrder
+				zones = $zones, sortOrder = $sortOrder, owningPackage = $owningPackage
 			""", parameters);
 	}
 
@@ -91,7 +93,8 @@ public partial class SurrealDatabase : IApplicationRegistryService
 		Enum.Parse<PortalRole>(r.minimumRole, ignoreCase: true),
 		r.navPlacement,
 		ApplicationRegistryMapping.ZonesFromString(r.zones),
-		r.sortOrder);
+		r.sortOrder,
+		r.owningPackage);
 
 	#endregion
 }

--- a/SharpMUSH.Library/Models/Packages/PackageManifest.cs
+++ b/SharpMUSH.Library/Models/Packages/PackageManifest.cs
@@ -19,7 +19,9 @@ namespace SharpMUSH.Library.Models.Packages;
 /// <param name="Conflicts">Packages that cannot be installed alongside this one.</param>
 /// <param name="Dependencies">Packages this package requires, with version constraints.</param>
 /// <param name="Configure"><c>{{?configure}}</c> parameters the installing admin supplies, keyed by name.</param>
-/// <param name="Objects">Objects the package manages, in manifest order.</param>
+/// <param name="Objects">Objects the package manages, in manifest order (empty for <see cref="PackageKind.Application"/> packages).</param>
+/// <param name="Kind">Package kind: a softcode package (objects/attributes) or an application package (a portal registration).</param>
+/// <param name="Application">The dynamic-application registration this package installs, when <see cref="Kind"/> is <see cref="PackageKind.Application"/>; otherwise null.</param>
 public sealed record PackageManifest(
 	PackageFormatVersion Format,
 	string Name,
@@ -35,7 +37,66 @@ public sealed record PackageManifest(
 	IReadOnlyList<PackageDependencySpec> Conflicts,
 	IReadOnlyList<PackageDependencySpec> Dependencies,
 	IReadOnlyDictionary<string, PackageConfigureSpec> Configure,
-	IReadOnlyList<PackageObjectSpec> Objects);
+	IReadOnlyList<PackageObjectSpec> Objects,
+	PackageKind Kind = PackageKind.Softcode,
+	PackageApplicationSpec? Application = null);
+
+/// <summary>
+/// The two kinds of package the manager installs. A <see cref="Softcode"/>
+/// package creates objects and manages attributes (the original Area-20 model).
+/// An <see cref="Application"/> package carries no objects of its own — it
+/// registers a Dynamic Application (Area 21) in the portal and <c>depends</c>
+/// on the softcode package that provides its HTTP-handler routes.
+/// </summary>
+public enum PackageKind
+{
+	/// <summary>Objects and attributes (the default). Requires <c>objects:</c>; forbids <c>application:</c>.</summary>
+	Softcode,
+
+	/// <summary>A portal application registration. Requires <c>application:</c>; forbids <c>objects:</c>.</summary>
+	Application
+}
+
+/// <summary>
+/// The portal registration an application package installs: it maps one-to-one
+/// onto a <c>RegisteredApplication</c> in the Area-21 application registry, but
+/// its string fields may carry <c>{{?configure}}</c>/<c>{{$well_known}}</c>/
+/// <c>{{dependency/ref}}</c> refs that are resolved at apply time, so the
+/// installing admin can tune role, placement, and endpoints per game.
+/// </summary>
+/// <param name="Slug">URL-safe unique key; the application renders at <c>/apps/{slug}</c>. Defaults to the package id.</param>
+/// <param name="DisplayName">Human-readable label shown in nav and the widget palette.</param>
+/// <param name="Icon">Material icon name, or null for a default.</param>
+/// <param name="Kind">Full-page (<c>page</c>) or placeable widget (<c>widget</c>).</param>
+/// <param name="SchemaUrl">Relative HTTP-handler route returning the Portal Schema Document (e.g. <c>http/chargen/schema</c>).</param>
+/// <param name="DataUrl">Optional relative route returning data values (view display / form prefill).</param>
+/// <param name="SubmitRoute">Optional base relative route for the schema's POST actions.</param>
+/// <param name="MinimumRole">Lowest portal role that may see the nav entry / open the route (may be a configure ref, resolved at apply).</param>
+/// <param name="NavPlacement">Nav section hint for page apps, or null to hide from nav.</param>
+/// <param name="Zones">Allowed layout zones for widget apps, or null/empty for none.</param>
+/// <param name="Order">Sort order within nav / listings.</param>
+public sealed record PackageApplicationSpec(
+	string Slug,
+	string DisplayName,
+	string? Icon,
+	PackageApplicationDisplay Kind,
+	string SchemaUrl,
+	string? DataUrl,
+	string? SubmitRoute,
+	string MinimumRole,
+	string? NavPlacement,
+	IReadOnlyList<string> Zones,
+	int Order);
+
+/// <summary>How an application surfaces in the portal (mirrors <c>ApplicationKind</c>).</summary>
+public enum PackageApplicationDisplay
+{
+	/// <summary>A nav-linked full-page application at <c>/apps/{slug}</c>.</summary>
+	Page,
+
+	/// <summary>A schema-driven widget that can be placed into a layout zone.</summary>
+	Widget
+}
 
 /// <summary>
 /// The manifest format version (decision 20.17). Consumers warn on a newer
@@ -46,7 +107,7 @@ public sealed record PackageManifest(
 public sealed record PackageFormatVersion(int Major, int Minor)
 {
 	/// <summary>The format version this parser implements.</summary>
-	public static PackageFormatVersion Supported { get; } = new(1, 0);
+	public static PackageFormatVersion Supported { get; } = new(1, 1);
 
 	public override string ToString() => Minor == 0 ? $"{Major}" : $"{Major}.{Minor}";
 }

--- a/SharpMUSH.Library/Models/Portal/Applications/RegisteredApplication.cs
+++ b/SharpMUSH.Library/Models/Portal/Applications/RegisteredApplication.cs
@@ -31,6 +31,11 @@ public enum ApplicationKind
 /// <param name="NavPlacement">Nav section hint for Page apps, or null to hide from nav.</param>
 /// <param name="Zones">Allowed layout zones for Widget apps, or null for none.</param>
 /// <param name="Order">Sort order within nav / listings (ascending).</param>
+/// <param name="OwningPackage">
+/// Package id that installed this application (Area-20 application package), or null for a manually
+/// registered application. When set, the package manager owns the record's lifecycle: uninstalling the
+/// package removes it.
+/// </param>
 public sealed record RegisteredApplication(
 	string Slug,
 	string DisplayName,
@@ -42,4 +47,5 @@ public sealed record RegisteredApplication(
 	PortalRole MinimumRole,
 	string? NavPlacement,
 	IReadOnlyList<WidgetZone>? Zones,
-	int Order);
+	int Order,
+	string? OwningPackage = null);

--- a/SharpMUSH.Library/Services/PackageInstallService.cs
+++ b/SharpMUSH.Library/Services/PackageInstallService.cs
@@ -4,10 +4,13 @@ using System.Text.Json;
 using OneOf;
 using OneOf.Types;
 using SharpMUSH.Configuration.Options;
+using SharpMUSH.Library.Authorization;
 using SharpMUSH.Library.DiscriminatedUnions;
 using SharpMUSH.Library.Extensions;
 using SharpMUSH.Library.Models;
 using SharpMUSH.Library.Models.Packages;
+using SharpMUSH.Library.Models.Portal.Applications;
+using SharpMUSH.Library.Models.Portal.Widgets;
 using SharpMUSH.Library.Services.Interfaces;
 
 namespace SharpMUSH.Library.Services;
@@ -21,6 +24,7 @@ namespace SharpMUSH.Library.Services;
 public class PackageInstallService(
 	ISharpDatabase database,
 	IPackageRegistryService registry,
+	IApplicationRegistryService applications,
 	IPackagePlanService planner,
 	IOptionsWrapper<SharpMUSHOptions> configuration) : IPackageInstallService
 {
@@ -437,7 +441,66 @@ public class PackageInstallService(
 			DateTimeOffset.UtcNow));
 		await registry.PrunePackageRevisionsAsync(manifest.Name, request.KeepRevisions);
 
+		// Application packages (kind: application) register a portal app instead
+		// of creating objects; its string fields resolve through the same ref map
+		// as objects/attributes, so {{?configure}} settings land here too.
+		if (manifest is { Kind: PackageKind.Application, Application: not null })
+		{
+			var built = BuildRegisteredApplication(manifest.Application, manifest.Name, Resolve);
+			if (built.IsT1)
+			{
+				return built.AsT1;
+			}
+
+			await applications.UpsertApplicationAsync(built.AsT0);
+			notes.Add($"Registered application '{built.AsT0.Slug}' ({built.AsT0.Kind}) at /apps/{built.AsT0.Slug}.");
+		}
+
 		return new PackageApplyResult(revision, created, notes);
+	}
+
+	/// <summary>
+	/// Resolves an application package's <c>application:</c> block into a
+	/// <see cref="RegisteredApplication"/>, substituting refs in its string
+	/// fields and parsing the role/kind/zone enums. Provenance is stamped with
+	/// the package id so uninstall can reclaim it.
+	/// </summary>
+	private static OneOf<RegisteredApplication, Error<string>> BuildRegisteredApplication(
+		PackageApplicationSpec spec, string packageId, Func<PackageRef, string?> resolve)
+	{
+		string? Sub(string? value) =>
+			value is null ? null : PackageRefSubstitution.Substitute(value, resolve, out _);
+
+		var roleText = Sub(spec.MinimumRole) ?? nameof(PortalRole.Player);
+		if (!Enum.TryParse<PortalRole>(roleText, ignoreCase: true, out var role))
+		{
+			return new Error<string>(
+				$"Application '{spec.Slug}': minimum_role '{roleText}' is not a valid role — answer its configure prompt or fix the manifest.");
+		}
+
+		var zones = spec.Zones
+			.Select(z => Sub(z))
+			.Where(z => !string.IsNullOrWhiteSpace(z))
+			.Select(z => Enum.TryParse<WidgetZone>(z, ignoreCase: true, out var zone) ? zone : (WidgetZone?)null)
+			.Where(z => z is not null)
+			.Select(z => z!.Value)
+			.ToList();
+
+		var application = new RegisteredApplication(
+			spec.Slug,
+			Sub(spec.DisplayName) ?? spec.Slug,
+			Sub(spec.Icon),
+			Enum.Parse<ApplicationKind>(spec.Kind.ToString()),
+			Sub(spec.SchemaUrl) ?? spec.SchemaUrl,
+			Sub(spec.DataUrl),
+			Sub(spec.SubmitRoute),
+			role,
+			Sub(spec.NavPlacement),
+			zones.Count == 0 ? null : zones,
+			spec.Order,
+			packageId);
+
+		return application;
 	}
 
 	private async Task<OneOf<string, Error<string>>> CreateObjectAsync(
@@ -753,6 +816,15 @@ public class PackageInstallService(
 		foreach (var record in ownObjects)
 		{
 			await MarkGoingAsync(record.Objid, notes, cancellationToken);
+		}
+
+		// Application packages own portal registrations rather than objects;
+		// reclaim every application this package installed.
+		foreach (var app in (await applications.GetApplicationsAsync())
+			.Where(a => string.Equals(a.OwningPackage, packageId, StringComparison.Ordinal)))
+		{
+			await applications.RemoveApplicationAsync(app.Slug);
+			notes.Add($"Removed application '{app.Slug}'.");
 		}
 
 		await registry.RemoveInstalledPackageAsync(packageId);

--- a/SharpMUSH.Library/Services/PackageManifestService.cs
+++ b/SharpMUSH.Library/Services/PackageManifestService.cs
@@ -1,7 +1,9 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
 using OneOf;
+using SharpMUSH.Library.Authorization;
 using SharpMUSH.Library.Models.Packages;
+using SharpMUSH.Library.Models.Portal.Widgets;
 using SharpMUSH.Library.Services.Interfaces;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
@@ -22,7 +24,14 @@ public partial class PackageManifestService : IPackageManifestService
 	private static readonly IReadOnlySet<string> KnownManifestKeys = new HashSet<string>(StringComparer.Ordinal)
 	{
 		"format", "package", "version", "authors", "description", "license", "homepage", "keywords",
-		"convention_prefix", "requires_server", "replaces", "conflicts", "depends", "configure", "objects"
+		"convention_prefix", "requires_server", "replaces", "conflicts", "depends", "configure", "objects",
+		"kind", "application"
+	};
+
+	private static readonly IReadOnlySet<string> KnownApplicationKeys = new HashSet<string>(StringComparer.Ordinal)
+	{
+		"slug", "display_name", "icon", "type", "schema_url", "data_url", "submit_route",
+		"minimum_role", "nav_placement", "zones", "order"
 	};
 
 	private static readonly IReadOnlySet<string> ReservedManifestKeys = new HashSet<string>(StringComparer.Ordinal)
@@ -132,9 +141,20 @@ public partial class PackageManifestService : IPackageManifestService
 		}
 
 		var configure = ReadConfigure(doc, issues);
-		var objects = ReadObjects(doc, issues);
 
-		ValidateRefs(objects, configure, dependencies, issues);
+		var kind = ReadKind(doc, issues);
+
+		// A softcode package requires objects and forbids an application block;
+		// an application package is the mirror — it registers a portal app and
+		// carries no objects of its own (it depends on a softcode package for
+		// its routes). Read both unconditionally so every issue is reported, but
+		// gate the requirement/forbidden checks on the declared kind.
+		var objects = kind == PackageKind.Application
+			? ReadObjectsForApplication(doc, issues)
+			: ReadObjects(doc, issues);
+		var application = ReadApplication(doc, name, kind, issues);
+
+		ValidateRefs(objects, application, configure, dependencies, issues);
 
 		if (issues.Any(i => i.Severity == PackageManifestIssueSeverity.Error))
 		{
@@ -156,7 +176,9 @@ public partial class PackageManifestService : IPackageManifestService
 			conflicts,
 			dependencies,
 			configure,
-			objects);
+			objects,
+			kind,
+			application);
 
 		return new ParsedPackageManifest(manifest, issues);
 	}
@@ -732,6 +754,157 @@ public partial class PackageManifestService : IPackageManifestService
 		}
 	}
 
+	private static PackageKind ReadKind(Dictionary<string, object?> doc, List<PackageManifestIssue> issues)
+	{
+		if (!doc.TryGetValue("kind", out var node) || node is null)
+		{
+			return PackageKind.Softcode;
+		}
+
+		if (node is string text && Enum.TryParse<PackageKind>(text, ignoreCase: true, out var kind))
+		{
+			return kind;
+		}
+
+		issues.Add(PackageManifestIssue.Error("kind", $"'{node}' is not a valid package kind (softcode, application)."));
+		return PackageKind.Softcode;
+	}
+
+	/// <summary>
+	/// Application packages register a portal app and own no objects; an
+	/// <c>objects:</c> key is therefore an error. Returns an empty object list.
+	/// </summary>
+	private static IReadOnlyList<PackageObjectSpec> ReadObjectsForApplication(
+		Dictionary<string, object?> doc, List<PackageManifestIssue> issues)
+	{
+		if (doc.ContainsKey("objects"))
+		{
+			issues.Add(PackageManifestIssue.Error("objects",
+				"An application package owns no objects — declare the routes in a softcode package and 'depends' on it. Remove 'objects'."));
+		}
+
+		return [];
+	}
+
+	/// <summary>
+	/// Reads the <c>application:</c> block (decision 20.22). Required for an
+	/// application package, forbidden otherwise. String fields may carry
+	/// <c>{{?configure}}</c>/<c>{{$well_known}}</c>/<c>{{dependency/ref}}</c>
+	/// refs resolved at apply; literal values are validated against the role and
+	/// zone enums here.
+	/// </summary>
+	private static PackageApplicationSpec? ReadApplication(
+		Dictionary<string, object?> doc, string? packageName, PackageKind kind, List<PackageManifestIssue> issues)
+	{
+		var present = doc.TryGetValue("application", out var node) && node is not null;
+
+		if (kind != PackageKind.Application)
+		{
+			if (present)
+			{
+				issues.Add(PackageManifestIssue.Error("application",
+					"'application' is only valid when 'kind: application'."));
+			}
+
+			return null;
+		}
+
+		if (!present)
+		{
+			issues.Add(PackageManifestIssue.Error("application", "An application package requires an 'application' block."));
+			return null;
+		}
+
+		if (node is not Dictionary<object, object> rawApp)
+		{
+			issues.Add(PackageManifestIssue.Error("application", "'application' must be a mapping."));
+			return null;
+		}
+
+		var app = Normalize(rawApp);
+		foreach (var key in app.Keys.Where(k => !KnownApplicationKeys.Contains(k)))
+		{
+			issues.Add(PackageManifestIssue.Warning($"application.{key}", $"Unknown key '{key}' is ignored."));
+		}
+
+		string? AppString(string key)
+		{
+			if (!app.TryGetValue(key, out var value) || value is null)
+			{
+				return null;
+			}
+
+			if (value is string text)
+			{
+				return text;
+			}
+
+			issues.Add(PackageManifestIssue.Error($"application.{key}", $"'{key}' must be a string."));
+			return null;
+		}
+
+		var slug = AppString("slug")?.Trim().ToLowerInvariant() ?? packageName;
+		if (string.IsNullOrEmpty(slug) || !PackageSlugRegex().IsMatch(slug) || slug.Length > MaxPackageIdLength)
+		{
+			issues.Add(PackageManifestIssue.Error("application.slug",
+				$"'{slug}' is not a valid application slug (lowercase letters, digits, hyphens; must start with a letter)."));
+		}
+
+		var displayName = AppString("display_name");
+		if (string.IsNullOrWhiteSpace(displayName))
+		{
+			issues.Add(PackageManifestIssue.Error("application.display_name", "An application requires a 'display_name'."));
+		}
+
+		var displayKind = PackageApplicationDisplay.Page;
+		if (AppString("type") is { } typeText && !Enum.TryParse(typeText, ignoreCase: true, out displayKind))
+		{
+			issues.Add(PackageManifestIssue.Error("application.type", $"'{typeText}' is not a valid application type (page, widget)."));
+		}
+
+		var schemaUrl = AppString("schema_url");
+		if (string.IsNullOrWhiteSpace(schemaUrl))
+		{
+			issues.Add(PackageManifestIssue.Error("application.schema_url", "An application requires a 'schema_url'."));
+		}
+
+		var minimumRole = AppString("minimum_role")?.Trim() ?? nameof(PortalRole.Player);
+		if (!ContainsRef(minimumRole) && !Enum.TryParse<PortalRole>(minimumRole, ignoreCase: true, out _))
+		{
+			issues.Add(PackageManifestIssue.Error("application.minimum_role",
+				$"'{minimumRole}' is not a valid role (guest, player, builder, royalty, wizard, god) or a configure ref."));
+		}
+
+		var zones = ReadStringList(app, "zones", issues);
+		foreach (var zone in zones.Where(z => !ContainsRef(z) && !Enum.TryParse<WidgetZone>(z, ignoreCase: true, out _)))
+		{
+			issues.Add(PackageManifestIssue.Error("application.zones", $"'{zone}' is not a valid widget zone."));
+		}
+
+		var order = 0;
+		if (app.TryGetValue("order", out var orderNode) && orderNode is not null
+			&& !int.TryParse(orderNode.ToString(), out order))
+		{
+			issues.Add(PackageManifestIssue.Error("application.order", $"'{orderNode}' is not a valid order (integer)."));
+		}
+
+		return new PackageApplicationSpec(
+			slug ?? "",
+			displayName ?? "",
+			AppString("icon"),
+			displayKind,
+			schemaUrl ?? "",
+			AppString("data_url"),
+			AppString("submit_route"),
+			minimumRole,
+			AppString("nav_placement"),
+			zones,
+			order);
+	}
+
+	/// <summary>True when a field carries at least one <c>{{ref}}</c> token (validated separately by <see cref="ValidateRefs"/>).</summary>
+	private static bool ContainsRef(string value) => value.Contains("{{", StringComparison.Ordinal);
+
 	private static IReadOnlyList<PackageObjectSpec> ReadObjects(
 		Dictionary<string, object?> doc, List<PackageManifestIssue> issues)
 	{
@@ -1027,6 +1200,7 @@ public partial class PackageManifestService : IPackageManifestService
 	/// </summary>
 	private void ValidateRefs(
 		IReadOnlyList<PackageObjectSpec> objects,
+		PackageApplicationSpec? application,
 		IReadOnlyDictionary<string, PackageConfigureSpec> configure,
 		IReadOnlyList<PackageDependencySpec> dependencies,
 		List<PackageManifestIssue> issues)
@@ -1120,6 +1294,32 @@ public partial class PackageManifestService : IPackageManifestService
 			foreach (var (lockName, lockValue) in obj.Locks)
 			{
 				ScanText(lockValue, $"{path}.locks.{lockName}");
+			}
+		}
+
+		// Application-package fields share the configure machinery: any
+		// {{?configure}}/{{$well_known}}/{{dependency/ref}} token in a string
+		// field must resolve, exactly as attribute values do.
+		if (application is not null)
+		{
+			(string Field, string? Value)[] appFields =
+			[
+				("display_name", application.DisplayName), ("icon", application.Icon),
+				("schema_url", application.SchemaUrl), ("data_url", application.DataUrl),
+				("submit_route", application.SubmitRoute), ("minimum_role", application.MinimumRole),
+				("nav_placement", application.NavPlacement)
+			];
+			foreach (var (fieldName, value) in appFields)
+			{
+				if (value is not null)
+				{
+					ScanText(value, $"application.{fieldName}");
+				}
+			}
+
+			foreach (var zone in application.Zones)
+			{
+				ScanText(zone, "application.zones");
 			}
 		}
 

--- a/SharpMUSH.Library/Services/PackagePlanService.cs
+++ b/SharpMUSH.Library/Services/PackagePlanService.cs
@@ -23,6 +23,14 @@ public partial class PackagePlanService : IPackagePlanService
 		var attributes = ClassifyAttributes(inputs, objidByRef, deletedObjids, notes);
 		var collisions = DetectCommandCollisions(inputs);
 
+		// Application packages (kind: application) carry no objects; surface the
+		// portal registration the apply will perform so the review is not blank.
+		if (manifest is { Kind: PackageKind.Application, Application: { } app })
+		{
+			var verb = inputs.Installed is null ? "Registers" : "Updates";
+			notes.Add($"{verb} application '{app.Slug}' ({app.Kind}) at /apps/{app.Slug}, served from '{app.SchemaUrl}'.");
+		}
+
 		return new PackageChangeset(
 			manifest.Name,
 			inputs.Installed?.Version,

--- a/SharpMUSH.Server/Controllers/ApplicationsController.cs
+++ b/SharpMUSH.Server/Controllers/ApplicationsController.cs
@@ -43,7 +43,8 @@ public class ApplicationsController(
 		string MinimumRole,
 		string? NavPlacement,
 		string[] Zones,
-		int Order);
+		int Order,
+		string? OwningPackage = null);
 
 	[HttpGet]
 	public async Task<ActionResult<IReadOnlyList<ApplicationDto>>> List()
@@ -89,6 +90,11 @@ public class ApplicationsController(
 			return BadRequest(new { error = $"Schema endpoint validation failed: {reason}" });
 		}
 
+		// Preserve provenance: a manual edit of a package-installed application keeps its OwningPackage,
+		// so uninstalling the package still reclaims the record. Manual registrations stay unowned.
+		var existing = await registry.GetApplicationAsync(dto.Slug.Trim());
+		var owningPackage = existing.Match(app => app.OwningPackage, _ => null);
+
 		var application = new RegisteredApplication(
 			dto.Slug.Trim(),
 			dto.DisplayName.Trim(),
@@ -100,7 +106,8 @@ public class ApplicationsController(
 			role,
 			string.IsNullOrWhiteSpace(dto.NavPlacement) ? null : dto.NavPlacement.Trim(),
 			ParseZones(dto.Zones),
-			dto.Order);
+			dto.Order,
+			owningPackage);
 
 		await registry.UpsertApplicationAsync(application);
 		logger.LogInformation("Registered application '{Slug}' ({Kind}).", application.Slug, application.Kind);
@@ -192,5 +199,6 @@ public class ApplicationsController(
 		a.MinimumRole.ToString(),
 		a.NavPlacement,
 		(a.Zones ?? []).Select(z => z.ToString()).ToArray(),
-		a.Order);
+		a.Order,
+		a.OwningPackage);
 }

--- a/SharpMUSH.Tests/Packages/ApplicationPackageManifestTests.cs
+++ b/SharpMUSH.Tests/Packages/ApplicationPackageManifestTests.cs
@@ -1,0 +1,236 @@
+using SharpMUSH.Library.Models.Packages;
+using SharpMUSH.Library.Services;
+
+namespace SharpMUSH.Tests.Packages;
+
+/// <summary>
+/// Unit tests for the application package kind (decision 20.22): a
+/// <c>kind: application</c> manifest registers a portal application, owns no
+/// objects, and may carry <c>{{?configure}}</c> refs in its application fields.
+/// </summary>
+public class ApplicationPackageManifestTests
+{
+	private readonly PackageManifestService _service = new();
+
+	private const string ValidApplication =
+		"""
+		format: 1.1
+		package: chargen-app
+		version: 1.0.0
+		kind: application
+		description: "Registers the chargen form as a portal page."
+		depends:
+		  - chargen: ">=1.0 <2.0"
+		configure:
+		  access:
+		    label: "Minimum role"
+		    type: string
+		    default: player
+		application:
+		  slug: chargen
+		  display_name: Character Application
+		  icon: assignment_ind
+		  type: page
+		  schema_url: http/chargen/schema
+		  submit_route: http/chargen
+		  minimum_role: "{{?access}}"
+		  nav_placement: main
+		  order: 50
+		""";
+
+	[Test]
+	public async Task ValidApplicationPackage_Parses()
+	{
+		var result = _service.ParseManifest(ValidApplication);
+
+		await Assert.That(result.IsT0).IsTrue();
+		var (manifest, warnings) = result.AsT0;
+
+		await Assert.That(manifest.Kind).IsEqualTo(PackageKind.Application);
+		await Assert.That(manifest.Objects.Count).IsEqualTo(0);
+		await Assert.That(warnings.Count).IsEqualTo(0);
+
+		var app = manifest.Application!;
+		await Assert.That(app.Slug).IsEqualTo("chargen");
+		await Assert.That(app.DisplayName).IsEqualTo("Character Application");
+		await Assert.That(app.Kind).IsEqualTo(PackageApplicationDisplay.Page);
+		await Assert.That(app.SchemaUrl).IsEqualTo("http/chargen/schema");
+		await Assert.That(app.SubmitRoute).IsEqualTo("http/chargen");
+		await Assert.That(app.MinimumRole).IsEqualTo("{{?access}}");
+		await Assert.That(app.NavPlacement).IsEqualTo("main");
+		await Assert.That(app.Order).IsEqualTo(50);
+	}
+
+	[Test]
+	public async Task SoftcodeIsTheDefaultKind()
+	{
+		var result = _service.ParseManifest(
+			"""
+			package: plain
+			version: 1.0.0
+			objects:
+			  - ref: room
+			    type: room
+			    name: A Room
+			""");
+
+		await Assert.That(result.IsT0).IsTrue();
+		await Assert.That(result.AsT0.Manifest.Kind).IsEqualTo(PackageKind.Softcode);
+		await Assert.That(result.AsT0.Manifest.Application).IsNull();
+	}
+
+	[Test]
+	public async Task ApplicationPackage_WithObjects_IsRejected()
+	{
+		var result = _service.ParseManifest(
+			"""
+			package: bad-app
+			version: 1.0.0
+			kind: application
+			application:
+			  slug: bad-app
+			  display_name: Bad
+			  schema_url: http/bad/schema
+			objects:
+			  - ref: room
+			    type: room
+			    name: A Room
+			""");
+
+		await Assert.That(result.IsT1).IsTrue();
+		await Assert.That(result.AsT1.Errors.Any(e => e.Path == "objects")).IsTrue();
+	}
+
+	[Test]
+	public async Task ApplicationPackage_MissingApplicationBlock_IsRejected()
+	{
+		var result = _service.ParseManifest(
+			"""
+			package: no-block
+			version: 1.0.0
+			kind: application
+			""");
+
+		await Assert.That(result.IsT1).IsTrue();
+		await Assert.That(result.AsT1.Errors.Any(e => e.Path == "application")).IsTrue();
+	}
+
+	[Test]
+	public async Task SoftcodePackage_WithApplicationBlock_IsRejected()
+	{
+		var result = _service.ParseManifest(
+			"""
+			package: misplaced
+			version: 1.0.0
+			application:
+			  slug: misplaced
+			  display_name: Nope
+			  schema_url: http/x/schema
+			objects:
+			  - ref: room
+			    type: room
+			    name: A Room
+			""");
+
+		await Assert.That(result.IsT1).IsTrue();
+		await Assert.That(result.AsT1.Errors.Any(e =>
+			e.Path == "application" && e.Message.Contains("kind: application"))).IsTrue();
+	}
+
+	[Test]
+	public async Task ApplicationPackage_UndeclaredConfigureRef_IsRejected()
+	{
+		var result = _service.ParseManifest(
+			"""
+			package: undeclared
+			version: 1.0.0
+			kind: application
+			application:
+			  slug: undeclared
+			  display_name: Undeclared
+			  schema_url: http/x/schema
+			  minimum_role: "{{?mystery}}"
+			""");
+
+		await Assert.That(result.IsT1).IsTrue();
+		await Assert.That(result.AsT1.Errors.Any(e => e.Message.Contains("{{?mystery}}"))).IsTrue();
+	}
+
+	[Test]
+	public async Task ApplicationPackage_InvalidLiteralRole_IsRejected()
+	{
+		var result = _service.ParseManifest(
+			"""
+			package: badrole
+			version: 1.0.0
+			kind: application
+			application:
+			  slug: badrole
+			  display_name: Bad Role
+			  schema_url: http/x/schema
+			  minimum_role: superuser
+			""");
+
+		await Assert.That(result.IsT1).IsTrue();
+		await Assert.That(result.AsT1.Errors.Any(e => e.Path == "application.minimum_role")).IsTrue();
+	}
+
+	[Test]
+	public async Task ApplicationPackage_InvalidType_IsRejected()
+	{
+		var result = _service.ParseManifest(
+			"""
+			package: badtype
+			version: 1.0.0
+			kind: application
+			application:
+			  slug: badtype
+			  display_name: Bad Type
+			  type: dashboard
+			  schema_url: http/x/schema
+			""");
+
+		await Assert.That(result.IsT1).IsTrue();
+		await Assert.That(result.AsT1.Errors.Any(e => e.Path == "application.type")).IsTrue();
+	}
+
+	[Test]
+	public async Task ApplicationSlug_DefaultsToPackageId()
+	{
+		var result = _service.ParseManifest(
+			"""
+			package: my-widget
+			version: 1.0.0
+			kind: application
+			application:
+			  display_name: My Widget
+			  type: widget
+			  schema_url: http/widget/schema
+			  zones: [MainContent, RightSidebar]
+			""");
+
+		await Assert.That(result.IsT0).IsTrue();
+		var app = result.AsT0.Manifest.Application!;
+		await Assert.That(app.Slug).IsEqualTo("my-widget");
+		await Assert.That(app.Kind).IsEqualTo(PackageApplicationDisplay.Widget);
+		await Assert.That(app.Zones.Count).IsEqualTo(2);
+	}
+
+	[Test]
+	public async Task InvalidKind_IsRejected()
+	{
+		var result = _service.ParseManifest(
+			"""
+			package: weird
+			version: 1.0.0
+			kind: plugin
+			objects:
+			  - ref: room
+			    type: room
+			    name: A Room
+			""");
+
+		await Assert.That(result.IsT1).IsTrue();
+		await Assert.That(result.AsT1.Errors.Any(e => e.Path == "kind")).IsTrue();
+	}
+}

--- a/SharpMUSH.Tests/Packages/PackageInstallServiceTests.cs
+++ b/SharpMUSH.Tests/Packages/PackageInstallServiceTests.cs
@@ -1,8 +1,10 @@
 using Microsoft.Extensions.DependencyInjection;
 using SharpMUSH.Library;
+using SharpMUSH.Library.Authorization;
 using SharpMUSH.Library.Extensions;
 using SharpMUSH.Library.Models;
 using SharpMUSH.Library.Models.Packages;
+using SharpMUSH.Library.Models.Portal.Applications;
 using SharpMUSH.Library.Services;
 using SharpMUSH.Library.Services.Interfaces;
 
@@ -20,6 +22,7 @@ public class PackageInstallServiceTests
 
 	private ISharpDatabase Database => WebAppFactoryArg.Services.GetRequiredService<ISharpDatabase>();
 	private IPackageRegistryService Registry => (IPackageRegistryService)Database;
+	private IApplicationRegistryService Applications => (IApplicationRegistryService)Database;
 	private IPackageInstallService Installer => WebAppFactoryArg.Services.GetRequiredService<IPackageInstallService>();
 	private PackageManifestService Manifests { get; } = new();
 
@@ -355,5 +358,86 @@ public class PackageInstallServiceTests
 
 		await Assert.That((await Installer.UninstallAsync("e2e-child")).IsT0).IsTrue();
 		await Assert.That((await Installer.UninstallAsync("e2e-base")).IsT0).IsTrue();
+	}
+
+	[Test, NotInParallel]
+	public async Task ApplicationPackage_RegistersAndUnregisters_PortalApplication()
+	{
+		// An application package owns no objects: it depends on a softcode package
+		// and registers a portal application, with a {{?configure}} ref tuning the
+		// minimum role at apply (decision 20.22).
+		var routes = Parse(
+			"""
+			package: appdep-routes
+			version: "1.0"
+			objects:
+			  - ref: marker
+			    type: thing
+			    name: Appdep Routes Marker
+			""");
+
+		var appPackage = Parse(
+			"""
+			package: appdep-app
+			version: 1.0.0
+			kind: application
+			depends:
+			  - appdep-routes: ">=1.0"
+			configure:
+			  access:
+			    label: "Minimum role"
+			    type: string
+			    default: player
+			application:
+			  slug: appdep
+			  display_name: Appdep Application
+			  icon: assignment_ind
+			  type: page
+			  schema_url: http/appdep/schema
+			  submit_route: http/appdep
+			  minimum_role: "{{?access}}"
+			  nav_placement: main
+			  order: 50
+			""");
+
+		var answers = new Dictionary<string, string> { ["access"] = "wizard" };
+
+		// The dependency must be present first — the plan blocks until then.
+		var blockedPlan = await Installer.PlanAsync(appPackage, answers);
+		await Assert.That(blockedPlan.IsBlocked).IsTrue();
+
+		await Assert.That((await Installer.ApplyAsync(routes, new PackageApplyRequest(Source(), new Dictionary<string, string>(), []))).IsT0).IsTrue();
+
+		// Now the plan resolves and surfaces the registration as a note.
+		var plan = await Installer.PlanAsync(appPackage, answers);
+		await Assert.That(plan.IsBlocked).IsFalse();
+		await Assert.That(plan.Objects.Count).IsEqualTo(0);
+		await Assert.That(plan.Notes.Any(n => n.Contains("Registers application 'appdep'"))).IsTrue();
+
+		// Apply registers the portal application with the configure-resolved role.
+		var apply = await Installer.ApplyAsync(appPackage, new PackageApplyRequest(Source(), answers, []));
+		await Assert.That(apply.IsT0).IsTrue();
+		await Assert.That(apply.AsT0.CreatedObjects.Count).IsEqualTo(0);
+
+		var registered = await Applications.GetApplicationAsync("appdep");
+		await Assert.That(registered.IsT0).IsTrue();
+		var app = registered.AsT0;
+		await Assert.That(app.DisplayName).IsEqualTo("Appdep Application");
+		await Assert.That(app.Kind).IsEqualTo(ApplicationKind.Page);
+		await Assert.That(app.SchemaUrl).IsEqualTo("http/appdep/schema");
+		await Assert.That(app.MinimumRole).IsEqualTo(PortalRole.Wizard);
+		await Assert.That(app.OwningPackage).IsEqualTo("appdep-app");
+
+		// The dependency cannot be removed while the application depends on it.
+		var blockedUninstall = await Installer.UninstallAsync("appdep-routes");
+		await Assert.That(blockedUninstall.IsT1).IsTrue();
+		await Assert.That(blockedUninstall.AsT1.Value).Contains("appdep-app");
+
+		// Uninstalling the application package reclaims the registration.
+		await Assert.That((await Installer.UninstallAsync("appdep-app")).IsT0).IsTrue();
+		await Assert.That((await Applications.GetApplicationAsync("appdep")).IsT1).IsTrue();
+		await Assert.That((await Registry.GetInstalledPackageAsync("appdep-app")).IsT1).IsTrue();
+
+		await Assert.That((await Installer.UninstallAsync("appdep-routes")).IsT0).IsTrue();
 	}
 }

--- a/docs/design/architectural-decisions.md
+++ b/docs/design/architectural-decisions.md
@@ -1053,6 +1053,28 @@ manifests may not define attributes under it, authoring exports exclude it,
 and same-package ref names must be unique across kinds (internal /
 well-known-used / configure) since they share the namespace.
 
+### 20.22 Application Packages (Area 21 ↔ Area 20)
+
+**Decision:** A package declares a `kind:` — `softcode` (the default; the
+original object/attribute model) or `application`. An **application package**
+registers a Dynamic Application (Area 21) in the portal and owns **no objects
+of its own**: it carries an `application:` block (the `RegisteredApplication`
+fields — slug, display name, icon, page/widget kind, schema/data/submit
+routes, minimum role, nav placement, zones, order) and `depends:` on the
+softcode package that provides its HTTP-handler routes. The two kinds are
+mutually exclusive about payload: a softcode package requires `objects:` and
+forbids `application:`; an application package requires `application:` and
+forbids `objects:`. Application-block string fields accept the same
+`{{?configure}}` / `{{$well_known}}` / `{{dependency/ref}}` refs as attribute
+values, resolved at apply, so one published application package adapts its
+role/placement/endpoints per game. Applying registers the application (stamped
+with `OwningPackage` for provenance); uninstalling reclaims it. This collapses
+the former two-step setup (install softcode, then hand-register in
+`/admin/applications`) into a single installable, versioned, uninstallable
+unit, while a manual registration stays available for one-offs (its
+`OwningPackage` is null). The manifest format minor bumps to **1.1** for the
+new `kind`/`application` keys. Decision: confirmed 2026-06-13.
+
 ---
 
 ## Design Documents Index

--- a/docs/design/dynamic-applications.md
+++ b/docs/design/dynamic-applications.md
@@ -301,6 +301,18 @@ are backtick children of the verb routers from the bundled `http-handler` packag
 schema/data/submit endpoints, allowed roles, and nav/zone placement → the DB registry
 record. The portal validates the schema endpoint returns parseable JSON before saving.
 
+**One-step alternative (application packages, decision 20.22).** Step (b) can also ship
+as an Area-20 **application package** (`kind: application`): a manifest carrying only the
+`application:` block, depending on the softcode package from (a). Installing it registers
+the application (stamped with its `OwningPackage`); uninstalling it removes the
+registration. This makes the linking step distributable, versioned, and reversible through
+the package manager instead of a hand registration — see
+`examples/packages/chargen-app/` and the application-packages section of
+`examples/packages/README.md`. Its application-field strings (role, placement, endpoints)
+accept `{{?configure}}` refs, so the installing admin tunes them at apply. Manual
+registration in `/admin/applications` remains for one-offs (such records have a null
+`OwningPackage`).
+
 ## Permissions
 
 - **Field/section visibility is softcode-owned** — the per-datum `visible` flag, exactly

--- a/docs/todo/area-20-packages.md
+++ b/docs/todo/area-20-packages.md
@@ -252,6 +252,29 @@
 - [x] Fixed pre-existing GitPackageSourceServiceTests shared-fixture ordering
       flake (.Single() assumed one package; now selects who-where by path)
 
+### Iteration: Application packages (decision 20.22)
+- [x] Manifest `kind:` discriminator — `softcode` (default) or `application`;
+      format minor bumped to 1.1. Softcode requires `objects:`/forbids
+      `application:`; application requires `application:`/forbids `objects:`
+      (parser + validation, `PackageManifestService`)
+- [x] `application:` block parses into `PackageApplicationSpec` (mirrors
+      `RegisteredApplication`); string fields accept `{{?configure}}`/
+      `{{$well_known}}`/`{{dependency/ref}}` refs (validated like attr values,
+      substituted at apply)
+- [x] Apply registers the application via `IApplicationRegistryService`,
+      stamping `RegisteredApplication.OwningPackage`; uninstall reclaims every
+      application a package owns. Plan surfaces the registration as a note
+- [x] `OwningPackage` round-trips on all three providers (Arango/Memgraph/
+      Surreal); `ApplicationsController` preserves it on manual edits and
+      manual registrations stay unowned (null)
+- [x] Example `chargen-app` package (`kind: application`, depends on `chargen`,
+      configurable `minimum_role`) + index entry + README section; kept honest
+      by `ExamplePackageTests`
+- [x] Tests: `ApplicationPackageManifestTests` (parse/validation) +
+      `PackageInstallServiceTests.ApplicationPackage_RegistersAndUnregisters_PortalApplication`
+      (dep-gated plan, configure-resolved role, owning-package provenance,
+      dependents block, uninstall reclaim)
+
 ## Deferred to v2 (post-merge polish)
 - [ ] Dependency graph visualization (deps render as text/blockers today)
 - [ ] Dbref linking in review panes (clickable, resolution tooltip)

--- a/examples/packages/README.md
+++ b/examples/packages/README.md
@@ -26,6 +26,7 @@ which games can add as a remote in the admin panel.
 | [`who-where/`](who-where/) | Multiple objects, internal refs, parents, flags, a convention prefix |
 | [`starter-area/`](starter-area/) | Rooms and exits (`location:` / `destination:`) |
 | [`bbs-lite/`](bbs-lite/) | Dependencies with source hints, typed configure params, cross-package refs, conflicts, locks, prerelease versions |
+| [`chargen-app/`](chargen-app/) | An application package (`kind: application`): registers a portal page, depends on a softcode package, configurable role |
 
 ## The manifest: `package.yaml`
 
@@ -246,12 +247,61 @@ attributes, or dependency ids; any invalid or unresolvable `{{token}}`;
 parent cycles; exits without location/destination (or location on a room /
 destination on a non-exit); configure type violations (dbref defaults,
 non-dbref refs in placement fields); self/overlapping depends-conflicts;
-format major newer than supported.
+an invalid `kind`; an application package missing its `application:` block or
+declaring `objects:` (and vice-versa for a softcode package); an invalid
+application slug, type, role, or zone; format major newer than supported.
 
 Warnings (manifest is accepted): unknown keys (typo detection); reserved keys
 (`provides`, `recommends`, `suggests`, configure `pattern`); declared-but-
 unused configure refs; more than 5 keywords; format minor newer than
 supported.
+
+## Application packages (`kind: application`)
+
+Most packages are **softcode** packages (`kind: softcode`, the default): they
+create objects and manage attributes. An **application** package
+(`kind: application`) is the portal counterpart — it registers a
+[Dynamic Application](../../docs/design/dynamic-applications.md) (Area 21) and
+owns **no objects of its own**. Instead it `depends:` on the softcode package
+that provides its HTTP-handler routes (the schema/data/submit attributes).
+
+```yaml
+format: 1.1
+package: chargen-app
+kind: application                 # softcode (default) | application
+version: 1.0.0
+depends:
+  - chargen: ">=1.0 <2.0"         # the softcode package providing the routes
+
+configure:
+  access:                         # an application field can be admin-configured
+    label: "Minimum role"
+    type: string
+    default: player
+
+application:                      # required for kind: application; forbidden otherwise
+  slug: chargen                   # URL key; the app renders at /apps/chargen (defaults to the package id)
+  display_name: Character Application
+  icon: assignment_ind            # optional Material icon
+  type: page                      # page | widget
+  schema_url: http/chargen/schema # GET → Portal Schema Document
+  data_url: http/chargen          # optional GET → data (view display / form prefill)
+  submit_route: http/chargen      # optional POST base for actions
+  minimum_role: "{{?access}}"     # guest|player|builder|royalty|wizard|god, or a {{?configure}} ref
+  nav_placement: main             # optional nav section (page apps)
+  zones: [MainContent]            # optional layout zones (widget apps)
+  order: 50                       # optional sort order
+```
+
+The string fields (`display_name`, `icon`, `schema_url`, `data_url`,
+`submit_route`, `minimum_role`, `nav_placement`, `zones`) accept the same
+`{{?configure}}` / `{{$well_known}}` / `{{dependency/ref}}` refs as attribute
+values, resolved at apply — so one published application package adapts its
+role, placement, and endpoints to each game it is installed on. Applying the
+package registers the application (the same record `/admin/applications`
+creates by hand); uninstalling it removes the registration. A `kind:
+application` manifest must **not** declare `objects:` — keep the softcode in a
+separate package and depend on it.
 
 ## Repos, discovery, and releases
 

--- a/examples/packages/chargen-app/README.md
+++ b/examples/packages/chargen-app/README.md
@@ -1,0 +1,39 @@
+# chargen-app
+
+An **application package** (`kind: application`) — the second half of the
+two-part Dynamic Application story (Area 21). Where [`chargen`](../chargen/)
+ships the softcode *routes* (the schema and submit handlers on the HTTP
+handler), `chargen-app` ships the *portal registration* that turns those routes
+into a live page at `/apps/chargen`.
+
+Application packages own no objects of their own. They **depend** on the
+softcode package that provides their routes, and carry only the
+`application:` block — the same fields as a manually registered application,
+but distributable, versioned, and uninstallable through the package manager.
+
+```yaml
+kind: application
+depends:
+  - package: chargen          # provides GET`CHARGEN`SCHEMA, POST`CHARGEN`SUBMIT
+application:
+  slug: chargen
+  display_name: Character Application
+  type: page
+  schema_url: http/chargen/schema
+  submit_route: http/chargen
+  minimum_role: "{{?access}}" # admin picks the role at install
+  nav_placement: main
+```
+
+Installing it:
+
+1. resolves the `chargen` dependency (the plan is **blocked** until `chargen`
+   is installed),
+2. prompts for `access` (the minimum role — a `{{?configure}}` ref in an
+   application field, substituted at apply), and
+3. registers the application, so `/apps/chargen` renders the schema and the nav
+   gains a "Character Application" entry for the chosen role and up.
+
+Uninstalling `chargen-app` removes the portal registration (the `chargen`
+softcode stays until you uninstall it too). Because it depends on `chargen`,
+the manager also blocks uninstalling `chargen` while this app is present.

--- a/examples/packages/chargen-app/package.yaml
+++ b/examples/packages/chargen-app/package.yaml
@@ -1,0 +1,40 @@
+format: 1.1
+package: chargen-app
+version: 1.0.0
+kind: application
+authors: [SharpMUSH]
+description: "Registers the character-application form (chargen) as a portal page at /apps/chargen."
+license: MIT
+homepage: https://github.com/SharpMUSH/SharpMUSH-Packages
+keywords: [portal, application, form, chargen]
+requires_server: ">=0.1"
+
+# An application package owns no objects — it depends on the softcode package
+# that provides its HTTP-handler routes (the schema + submit handlers) and
+# registers the portal entry point that renders them.
+depends:
+  - package: chargen
+    version: ">=1.0 <2.0"
+    source:
+      repo: https://github.com/SharpMUSH/SharpMUSH-Packages
+      path: chargen/
+
+# The installing admin chooses who may open the application. A {{?configure}}
+# ref in an application field is prompted at review and substituted at apply,
+# exactly like refs in attribute values.
+configure:
+  access:
+    label: "Minimum portal role that may open the application"
+    type: string
+    default: player
+
+application:
+  slug: chargen
+  display_name: Character Application
+  icon: assignment_ind
+  type: page
+  schema_url: http/chargen/schema
+  submit_route: http/chargen
+  minimum_role: "{{?access}}"
+  nav_placement: main
+  order: 50

--- a/examples/packages/index.yaml
+++ b/examples/packages/index.yaml
@@ -31,3 +31,7 @@ packages:
     package: chargen
     version: 1.0.0
     description: Dynamic Application (Area 21) — a character-application form (requires http-handler)
+  - path: chargen-app/
+    package: chargen-app
+    version: 1.0.0
+    description: Application package (Area 21) — registers chargen as a portal page (requires chargen)


### PR DESCRIPTION
Adds `kind: application` to the package manifest (format 1.1), making a Dynamic
Application (Area 21) its own distributable, versioned, uninstallable package
that depends on the softcode package providing its HTTP-handler routes
(decision 20.22). This collapses the former two-step setup (install softcode,
then hand-register in /admin/applications) into a single install.

Manifest & parsing
- `PackageKind` (softcode default | application) + `PackageApplicationSpec`
  (mirrors RegisteredApplication) on PackageManifest.
- Parser reads `kind:`/`application:`; a softcode package requires `objects:`
  and forbids `application:`, an application package the reverse. Application
  string fields accept {{?configure}}/{{$well_known}}/{{dependency/ref}} refs,
  validated like attribute values and substituted at apply, so role/placement/
  endpoints adapt per game. Supported format bumped to 1.1.

Lifecycle
- Apply registers the application via IApplicationRegistryService, stamping
  RegisteredApplication.OwningPackage for provenance; uninstall reclaims every
  application a package owns. Plan surfaces the registration as a note.
- OwningPackage round-trips on all three providers (Arango/Memgraph/Surreal);
  ApplicationsController exposes it and preserves it across manual edits, while
  manual registrations stay unowned.

Example, tests, docs
- examples/packages/chargen-app (kind: application, depends on chargen,
  configurable minimum_role) + index entry + README section.
- ApplicationPackageManifestTests (parse/validation) and an end-to-end
  install/register/uninstall integration test.
- architectural-decisions 20.22, dynamic-applications + area-20 todo updates.

https://claude.ai/code/session_014TVLjQbhY5vgr6sLWPALPf