### PR TITLE
test(packages): cover upgrade semantics for attribute removal, flags, locks, powers & attribute flags

### DIFF
--- a/SharpMUSH.Database.ArangoDB/ArangoDatabase.Objects.cs
+++ b/SharpMUSH.Database.ArangoDB/ArangoDatabase.Objects.cs
@@ -707,11 +707,15 @@ public partial class ArangoDatabase
 
 	public async ValueTask UnsetLockAsync(SharpObject target, string lockName, CancellationToken ct = default)
 	{
+		// The Locks object must be REPLACED, not merged: a PATCH with mergeObjects
+		// would merge the filtered dictionary into the stored one and re-add the
+		// very key we are removing. mergeObjects:false replaces the Locks attribute
+		// wholesale (other top-level attributes, absent from this patch, are untouched).
 		await arangoDb.Document.UpdateAsync(handle, DatabaseConstants.Objects, new
 		{
 			_key = target.Key.ToString(),
 			Locks = target.Locks
-				.Where(kvp => kvp.Key != lockName)
+				.Where(kvp => !string.Equals(kvp.Key, lockName, StringComparison.OrdinalIgnoreCase))
 				.Select(kvp => new KeyValuePair<string, SharpLockDataQueryResult>(
 					kvp.Key,
 					new SharpLockDataQueryResult
@@ -720,7 +724,7 @@ public partial class ArangoDatabase
 						Flags = kvp.Value.Flags.ToString()
 					}))
 				.ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
-		}, mergeObjects: true, cancellationToken: ct);
+		}, mergeObjects: false, cancellationToken: ct);
 	}
 	public IAsyncEnumerable<SharpPlayer> GetPlayerByNameOrAliasAsync(string name,
 		CancellationToken ct = default)

--- a/SharpMUSH.Database.ArangoDB/ArangoDatabase.Packages.cs
+++ b/SharpMUSH.Database.ArangoDB/ArangoDatabase.Packages.cs
@@ -40,6 +40,14 @@ public partial class ArangoDatabase : IPackageRegistryService
 		public string BaselineVersion { get; set; } = "";
 	}
 
+	private class ManagedStructureDbDoc
+	{
+		public string PackageId { get; set; } = "";
+		public string Objid { get; set; } = "";
+		public string StructureJson { get; set; } = "";
+		public string BaselineVersion { get; set; } = "";
+	}
+
 	private class PackageDependencyDbDoc
 	{
 		public string PackageId { get; set; } = "";
@@ -136,7 +144,8 @@ public partial class ArangoDatabase : IPackageRegistryService
 	public async Task RemoveInstalledPackageAsync(string packageId)
 	{
 		foreach (var collection in (string[])
-			[DatabaseConstants.PackageObjects, DatabaseConstants.ManagedAttributes, DatabaseConstants.PackageRevisions])
+			[DatabaseConstants.PackageObjects, DatabaseConstants.ManagedAttributes,
+				DatabaseConstants.ManagedStructures, DatabaseConstants.PackageRevisions])
 		{
 			await arangoDb.Query.ExecuteAsync<object>(handle,
 				"FOR d IN @@c FILTER d.PackageId == @id REMOVE d IN @@c",
@@ -274,6 +283,56 @@ public partial class ArangoDatabase : IPackageRegistryService
 				{ "id", packageId },
 				{ "objid", objid },
 				{ "attr", attribute }
+			});
+	}
+
+	// ── Managed object structure ────────────────────────────────────────────
+
+	public async Task UpsertManagedStructureAsync(ManagedStructureRecord record)
+	{
+		await arangoDb.Query.ExecuteAsync<object>(handle,
+			"UPSERT { PackageId: @pkg, Objid: @objid } INSERT @doc REPLACE @doc IN @@c",
+			bindVars: new Dictionary<string, object>
+			{
+				{ "@c", DatabaseConstants.ManagedStructures },
+				{ "pkg", record.PackageId },
+				{ "objid", record.Objid },
+				{
+					"doc", new Dictionary<string, object>
+					{
+						["PackageId"] = record.PackageId,
+						["Objid"] = record.Objid,
+						["StructureJson"] = record.StructureJson,
+						["BaselineVersion"] = record.BaselineVersion
+					}
+				}
+			});
+	}
+
+	public async Task<IReadOnlyList<ManagedStructureRecord>> GetManagedStructuresAsync(string packageId)
+	{
+		var result = await arangoDb.Query.ExecuteAsync<ManagedStructureDbDoc>(handle,
+			"FOR d IN @@c FILTER d.PackageId == @id SORT d.Objid RETURN d",
+			bindVars: new Dictionary<string, object>
+			{
+				{ "@c", DatabaseConstants.ManagedStructures },
+				{ "id", packageId }
+			});
+
+		return result
+			.Select(d => new ManagedStructureRecord(d.PackageId, d.Objid, d.StructureJson, d.BaselineVersion))
+			.ToList();
+	}
+
+	public async Task RemoveManagedStructureAsync(string packageId, string objid)
+	{
+		await arangoDb.Query.ExecuteAsync<object>(handle,
+			"FOR d IN @@c FILTER d.PackageId == @id AND d.Objid == @objid REMOVE d IN @@c",
+			bindVars: new Dictionary<string, object>
+			{
+				{ "@c", DatabaseConstants.ManagedStructures },
+				{ "id", packageId },
+				{ "objid", objid }
 			});
 	}
 

--- a/SharpMUSH.Database.ArangoDB/Migrations/Migration_AddManagedStructures.cs
+++ b/SharpMUSH.Database.ArangoDB/Migrations/Migration_AddManagedStructures.cs
@@ -13,7 +13,7 @@ namespace SharpMUSH.Database.ArangoDB.Migrations;
 /// </summary>
 public class Migration_AddManagedStructures : IArangoMigration
 {
-	public long Id => 20260613_001;
+	public long Id => 20260613_002;
 
 	public string Name => "add_managed_structures";
 

--- a/SharpMUSH.Database.ArangoDB/Migrations/Migration_AddManagedStructures.cs
+++ b/SharpMUSH.Database.ArangoDB/Migrations/Migration_AddManagedStructures.cs
@@ -1,0 +1,63 @@
+using Core.Arango;
+using Core.Arango.Migration;
+using Core.Arango.Protocol;
+
+namespace SharpMUSH.Database.ArangoDB.Migrations;
+
+/// <summary>
+/// Adds <c>sys_managed_structures</c> (decision 20.13, extended for full object
+/// structure diffs): one JSON baseline document per (package, objid) holding the
+/// object flags, powers, locks, and per-attribute flags a package set at its
+/// last install/upgrade. Enables the three-way merge of object structure on
+/// upgrade and exact rollback.
+/// </summary>
+public class Migration_AddManagedStructures : IArangoMigration
+{
+	public long Id => 20260613_001;
+
+	public string Name => "add_managed_structures";
+
+	public async Task Up(IArangoMigrator migrator, ArangoHandle handle)
+	{
+		if (!await migrator.Context.Collection.ExistAsync(handle, DatabaseConstants.ManagedStructures))
+		{
+			await migrator.Context.Collection.CreateAsync(handle, new ArangoCollection
+			{
+				Name = DatabaseConstants.ManagedStructures,
+				Type = ArangoCollectionType.Document,
+				WaitForSync = true,
+				Schema = new ArangoSchema
+				{
+					Rule = new
+					{
+						type = DatabaseConstants.TypeObject,
+						properties = new
+						{
+							PackageId = new { type = DatabaseConstants.TypeString },
+							Objid = new { type = DatabaseConstants.TypeString },
+							StructureJson = new { type = DatabaseConstants.TypeString },
+							BaselineVersion = new { type = DatabaseConstants.TypeString }
+						},
+						required = (string[])["PackageId", "Objid", "StructureJson"],
+						additionalProperties = true
+					}
+				}
+			});
+
+			await migrator.Context.Index.CreateAsync(handle, DatabaseConstants.ManagedStructures, new ArangoIndex
+			{
+				Fields = ["PackageId", "Objid"],
+				Unique = true,
+				Type = ArangoIndexType.Persistent
+			});
+
+			await migrator.Context.Index.CreateAsync(handle, DatabaseConstants.ManagedStructures, new ArangoIndex
+			{
+				Fields = ["Objid"],
+				Type = ArangoIndexType.Persistent
+			});
+		}
+	}
+
+	public Task Down(IArangoMigrator migrator, ArangoHandle handle) => Task.CompletedTask;
+}

--- a/SharpMUSH.Database.Memgraph/MemgraphDatabase.Packages.cs
+++ b/SharpMUSH.Database.Memgraph/MemgraphDatabase.Packages.cs
@@ -79,6 +79,8 @@ public partial class MemgraphDatabase : IPackageRegistryService
 		await ExecuteWithRetryAsync(
 			"MATCH (d:SysManagedAttribute {packageId: $id}) DETACH DELETE d", new { id = packageId });
 		await ExecuteWithRetryAsync(
+			"MATCH (d:SysManagedStructure {packageId: $id}) DETACH DELETE d", new { id = packageId });
+		await ExecuteWithRetryAsync(
 			"MATCH (d:SysPackageRevision {packageId: $id}) DETACH DELETE d", new { id = packageId });
 		await ExecuteWithRetryAsync(
 			"MATCH (p:SysPackage {id: $id}) DETACH DELETE p", new { id = packageId });
@@ -168,6 +170,47 @@ public partial class MemgraphDatabase : IPackageRegistryService
 		await ExecuteWithRetryAsync(
 			"MATCH (d:SysManagedAttribute {packageId: $id, objid: $objid, attribute: $attribute}) DETACH DELETE d",
 			new { id = packageId, objid, attribute });
+	}
+
+	// ── Managed object structure ────────────────────────────────────────────
+
+	public async Task UpsertManagedStructureAsync(ManagedStructureRecord record)
+	{
+		await ExecuteWithRetryAsync("""
+			MERGE (d:SysManagedStructure {packageId: $packageId, objid: $objid})
+			SET d.structureJson = $structureJson, d.baselineVersion = $baselineVersion
+			""",
+			new
+			{
+				packageId = record.PackageId,
+				objid = record.Objid,
+				structureJson = record.StructureJson,
+				baselineVersion = record.BaselineVersion
+			});
+	}
+
+	public async Task<IReadOnlyList<ManagedStructureRecord>> GetManagedStructuresAsync(string packageId)
+	{
+		var result = await ExecuteWithRetryAsync(
+			"MATCH (d:SysManagedStructure {packageId: $id}) RETURN d ORDER BY d.objid",
+			new { id = packageId });
+
+		return result.Result.Select(r =>
+		{
+			var node = r["d"].As<INode>();
+			return new ManagedStructureRecord(
+				node.Properties["packageId"].As<string>(),
+				node.Properties["objid"].As<string>(),
+				node.Properties["structureJson"].As<string>(),
+				node.Properties["baselineVersion"].As<string>());
+		}).ToList();
+	}
+
+	public async Task RemoveManagedStructureAsync(string packageId, string objid)
+	{
+		await ExecuteWithRetryAsync(
+			"MATCH (d:SysManagedStructure {packageId: $id, objid: $objid}) DETACH DELETE d",
+			new { id = packageId, objid });
 	}
 
 	// ── Dependencies ───────────────────────────────────────────────────────

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Packages.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Packages.cs
@@ -40,6 +40,14 @@ internal class SysManagedAttributeDbRecord : Record
 	public string baselineVersion { get; set; } = "";
 }
 
+internal class SysManagedStructureDbRecord : Record
+{
+	public string packageId { get; set; } = "";
+	public string objid { get; set; } = "";
+	public string structureJson { get; set; } = "";
+	public string baselineVersion { get; set; } = "";
+}
+
 internal class SysPackageDependencyDbRecord : Record
 {
 	public string packageId { get; set; } = "";
@@ -79,6 +87,9 @@ public partial class SurrealDatabase : IPackageRegistryService
 
 	private const string SysManagedAttributeFields =
 		"id, packageId, objid, attribute, baselineValue, baselineHash, baselineVersion";
+
+	private const string SysManagedStructureFields =
+		"id, packageId, objid, structureJson, baselineVersion";
 
 	private const string SysPackageDependencyFields = "id, packageId, dependsOnId, constraint";
 
@@ -139,6 +150,7 @@ public partial class SurrealDatabase : IPackageRegistryService
 		var parameters = new Dictionary<string, object?> { ["pkg"] = packageId };
 		await ExecuteAsync("DELETE sys_package_object WHERE packageId = $pkg", parameters);
 		await ExecuteAsync("DELETE sys_managed_attribute WHERE packageId = $pkg", parameters);
+		await ExecuteAsync("DELETE sys_managed_structure WHERE packageId = $pkg", parameters);
 		await ExecuteAsync("DELETE sys_package_revision WHERE packageId = $pkg", parameters);
 		await ExecuteAsync("DELETE sys_package_dependency WHERE packageId = $pkg OR dependsOnId = $pkg", parameters);
 		await ExecuteAsync("DELETE type::thing('sys_package', $pkg)", parameters);
@@ -226,6 +238,41 @@ public partial class SurrealDatabase : IPackageRegistryService
 	{
 		await ExecuteAsync("DELETE type::thing('sys_managed_attribute', $key)",
 			new Dictionary<string, object?> { ["key"] = $"{packageId}/{objid}/{attribute}" });
+	}
+
+	// ── Managed object structure ────────────────────────────────────────────
+
+	public async Task UpsertManagedStructureAsync(ManagedStructureRecord record)
+	{
+		var parameters = new Dictionary<string, object?>
+		{
+			["key"] = $"{record.PackageId}/{record.Objid}",
+			["pkg"] = record.PackageId,
+			["objid"] = record.Objid,
+			["structureJson"] = record.StructureJson,
+			["baselineVersion"] = record.BaselineVersion
+		};
+		await ExecuteAsync("""
+			UPSERT type::thing('sys_managed_structure', $key) SET packageId = $pkg, objid = $objid,
+				structureJson = $structureJson, baselineVersion = $baselineVersion
+			""", parameters);
+	}
+
+	public async Task<IReadOnlyList<ManagedStructureRecord>> GetManagedStructuresAsync(string packageId)
+	{
+		var response = await ExecuteAsync(
+			$"SELECT {SysManagedStructureFields} FROM sys_managed_structure WHERE packageId = $pkg ORDER BY objid",
+			new Dictionary<string, object?> { ["pkg"] = packageId });
+		var results = response.GetValue<List<SysManagedStructureDbRecord>>(0) ?? [];
+		return results
+			.Select(r => new ManagedStructureRecord(r.packageId, r.objid, r.structureJson, r.baselineVersion))
+			.ToList();
+	}
+
+	public async Task RemoveManagedStructureAsync(string packageId, string objid)
+	{
+		await ExecuteAsync("DELETE type::thing('sys_managed_structure', $key)",
+			new Dictionary<string, object?> { ["key"] = $"{packageId}/{objid}" });
 	}
 
 	// ── Dependencies ───────────────────────────────────────────────────────

--- a/SharpMUSH.Database/DatabaseConstants.cs
+++ b/SharpMUSH.Database/DatabaseConstants.cs
@@ -30,6 +30,7 @@ public static class DatabaseConstants
 	public const string PackageObjects = "sys_package_objects";
 	public const string PackageDependsOn = "sys_package_depends";
 	public const string ManagedAttributes = "sys_managed_attributes";
+	public const string ManagedStructures = "sys_managed_structures";
 	public const string PackageRemotes = "sys_remotes";
 	public const string PackageRevisions = "sys_package_revisions";
 

--- a/SharpMUSH.Library/Models/Packages/PackageApply.cs
+++ b/SharpMUSH.Library/Models/Packages/PackageApply.cs
@@ -65,13 +65,28 @@ public sealed record PackageRollbackResult(int Revision, int RestoredFromRevisio
 /// <param name="Version">Package version applied.</param>
 /// <param name="Objects">Package objects after this apply (ref, objid, type).</param>
 /// <param name="Attributes">Final effective value of every managed attribute after this apply.</param>
+/// <param name="Structure">Final package-managed object structure (flags/powers/locks/attribute flags) per object after this apply.</param>
 public sealed record PackageRevisionSnapshot(
 	string Version,
 	IReadOnlyList<PackageRevisionSnapshotObject> Objects,
-	IReadOnlyList<PackageRevisionSnapshotAttribute> Attributes);
+	IReadOnlyList<PackageRevisionSnapshotAttribute> Attributes,
+	IReadOnlyList<PackageRevisionSnapshotStructure>? Structure = null);
 
 /// <summary>One object in a revision snapshot.</summary>
 public sealed record PackageRevisionSnapshotObject(string Ref, string Objid, string Type);
 
 /// <summary>One managed attribute's final effective value in a revision snapshot.</summary>
 public sealed record PackageRevisionSnapshotAttribute(string Objid, string Attribute, string Value);
+
+/// <summary>One object's final package-managed structure in a revision snapshot.</summary>
+/// <param name="Objid">Object the structure lives on.</param>
+/// <param name="Flags">Object flag names the package set.</param>
+/// <param name="Powers">Object power names the package set.</param>
+/// <param name="Locks">Lock-type name → resolved lock string the package set.</param>
+/// <param name="AttributeFlags">Attribute name → flag names the package set on it.</param>
+public sealed record PackageRevisionSnapshotStructure(
+	string Objid,
+	IReadOnlyList<string> Flags,
+	IReadOnlyList<string> Powers,
+	IReadOnlyDictionary<string, string> Locks,
+	IReadOnlyDictionary<string, IReadOnlyList<string>> AttributeFlags);

--- a/SharpMUSH.Library/Models/Packages/PackageChangeset.cs
+++ b/SharpMUSH.Library/Models/Packages/PackageChangeset.cs
@@ -21,6 +21,7 @@ public sealed record PackageChangeset(
 	PackageRevisionKind Kind,
 	IReadOnlyList<PackageObjectChange> Objects,
 	IReadOnlyList<PackageAttributeChange> Attributes,
+	IReadOnlyList<PackageStructureChange> Structure,
 	IReadOnlyList<PackageDependencyIssue> DependencyIssues,
 	IReadOnlyList<PackageCommandCollision> CommandCollisions,
 	IReadOnlyList<string> Notes)
@@ -28,8 +29,10 @@ public sealed record PackageChangeset(
 	/// <summary>True when dependency/conflict issues prevent applying at all.</summary>
 	public bool IsBlocked => DependencyIssues.Count > 0;
 
-	/// <summary>True when at least one attribute needs an admin decision.</summary>
-	public bool HasConflicts => Attributes.Any(a => a.Action == PackageAttributeAction.Conflict);
+	/// <summary>True when at least one attribute or structure element needs an admin decision.</summary>
+	public bool HasConflicts =>
+		Attributes.Any(a => a.Action == PackageAttributeAction.Conflict)
+		|| Structure.Any(s => s.Action == PackageStructureAction.Conflict);
 }
 
 /// <summary>Object-level classification.</summary>
@@ -142,6 +145,103 @@ public sealed record PackageAttributeChange(
 	string? NewValue = null,
 	bool RequiresApplyResolution = false);
 
+/// <summary>The kind of object-structure element a <see cref="PackageStructureChange"/> describes.</summary>
+public enum PackageStructureKind
+{
+	/// <summary>An object flag (set-valued, binary presence).</summary>
+	ObjectFlag,
+
+	/// <summary>An object power (set-valued, binary presence).</summary>
+	ObjectPower,
+
+	/// <summary>A flag on a specific attribute (set-valued, binary presence; carries <see cref="PackageStructureChange.Attribute"/>).</summary>
+	AttributeFlag,
+
+	/// <summary>A lock (value-typed: a lock-type name mapped to a lock string; uses the full attribute conflict model).</summary>
+	Lock
+}
+
+/// <summary>
+/// Classification of one object-structure element under the same dpkg/ucf
+/// three-way merge as attributes (decision 20.7), extended for full object
+/// structure diffs: object flags, object powers, attribute flags, and locks.
+/// Binary elements (flags/powers/attribute flags) resolve deterministically and
+/// never conflict; value-typed locks can.
+/// </summary>
+public enum PackageStructureAction
+{
+	/// <summary>Newly declared (or, for locks, a changed value the package owns): set it.</summary>
+	Add,
+
+	/// <summary>Already present live and now package-managed: record a baseline without writing.</summary>
+	Adopt,
+
+	/// <summary>Base, live, and new agree: nothing to do.</summary>
+	NoChange,
+
+	/// <summary>Admin diverged locally and the package did not (removed a binary element it still declares, or edited a lock the package left unchanged): keep the live state (dpkg keep-local).</summary>
+	KeepLocal,
+
+	/// <summary>Removed from the package and still present live (locally unmodified): unset it.</summary>
+	Remove,
+
+	/// <summary>Removed from the package and already gone live: just drop the baseline element.</summary>
+	RemoveBaseline,
+
+	/// <summary>Value-typed (lock) divergence needing an admin decision; see <see cref="PackageConflictKind"/>.</summary>
+	Conflict
+}
+
+/// <summary>
+/// One object-structure-level action (flag/power/attribute-flag/lock add or
+/// remove on upgrade). Binary elements leave the value panes null; locks carry
+/// Base/Live/New lock strings for the three-pane review.
+/// </summary>
+/// <param name="TargetRef">Manifest ref of the target object, or its objid for non-package targets.</param>
+/// <param name="Objid">Resolved target objid when the object already exists.</param>
+/// <param name="Kind">Which structure element this describes.</param>
+/// <param name="Element">Flag name, power name, or lock-type name.</param>
+/// <param name="Action">Classification.</param>
+/// <param name="Attribute">For <see cref="PackageStructureKind.AttributeFlag"/>, the attribute the flag lives on.</param>
+/// <param name="Conflict">Set when <paramref name="Action"/> is <see cref="PackageStructureAction.Conflict"/> (locks only).</param>
+/// <param name="BaseValue">Lock baseline string, or null (binary/absent).</param>
+/// <param name="LiveValue">Current live lock string, or null.</param>
+/// <param name="NewValue">Incoming lock string with refs resolved as far as possible, or null for removals/binary.</param>
+/// <param name="RequiresApplyResolution">True when a lock's new value references objects that only get dbrefs at apply time.</param>
+public sealed record PackageStructureChange(
+	string TargetRef,
+	string? Objid,
+	PackageStructureKind Kind,
+	string Element,
+	PackageStructureAction Action,
+	string? Attribute = null,
+	PackageConflictKind? Conflict = null,
+	string? BaseValue = null,
+	string? LiveValue = null,
+	string? NewValue = null,
+	bool RequiresApplyResolution = false);
+
+/// <summary>
+/// The package-managed object structure baseline for one object (decision
+/// 20.13, extended): the flags, powers, locks, and per-attribute flags the
+/// package set at the last install/upgrade. Persisted as one JSON document per
+/// (package, objid) so the three-way merge and rollback can reason offline.
+/// </summary>
+/// <param name="Flags">Object flag names the package set.</param>
+/// <param name="Powers">Object power names the package set.</param>
+/// <param name="Locks">Lock-type name → resolved lock string the package set.</param>
+/// <param name="AttributeFlags">Attribute name → flag names the package set on it.</param>
+public sealed record PackageStructureBaseline(
+	IReadOnlyList<string> Flags,
+	IReadOnlyList<string> Powers,
+	IReadOnlyDictionary<string, string> Locks,
+	IReadOnlyDictionary<string, IReadOnlyList<string>> AttributeFlags)
+{
+	public static PackageStructureBaseline Empty { get; } = new(
+		[], [], new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+		new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase));
+}
+
 /// <summary>A dependency or conflict violation that blocks apply (decisions 20.6, 20.20).</summary>
 /// <param name="PackageId">The other package involved.</param>
 /// <param name="Constraint">Declared constraint text (empty = any).</param>
@@ -186,12 +286,20 @@ public sealed record LivePackageState(IReadOnlyDictionary<string, LiveObjectStat
 /// <param name="Name">Current in-game name.</param>
 /// <param name="Attributes">Current attribute values by name (case-insensitive keys expected).</param>
 /// <param name="HasContents">True when the object contains things/players (delete-review warning).</param>
+/// <param name="Flags">Current object flag names, or null when not gathered (treated as empty).</param>
+/// <param name="Powers">Current object power names, or null when not gathered (treated as empty).</param>
+/// <param name="Locks">Current lock-type → lock string, or null when not gathered (treated as empty).</param>
+/// <param name="AttributeFlags">Current attribute name → flag names, or null when not gathered (treated as empty).</param>
 public sealed record LiveObjectState(
 	string Objid,
 	bool Exists,
 	string Name,
 	IReadOnlyDictionary<string, string> Attributes,
-	bool HasContents = false);
+	bool HasContents = false,
+	IReadOnlyList<string>? Flags = null,
+	IReadOnlyList<string>? Powers = null,
+	IReadOnlyDictionary<string, string>? Locks = null,
+	IReadOnlyDictionary<string, IReadOnlyList<string>>? AttributeFlags = null);
 
 /// <summary>
 /// Everything the pure plan computation needs (decision 20.7). The caller —
@@ -208,6 +316,7 @@ public sealed record LiveObjectState(
 /// <param name="WellKnownObjids">Resolution map: well-known ref name → objid.</param>
 /// <param name="ConfigureAnswers">Resolution map: configure key → value (objid for dbref-typed); may be partial before review.</param>
 /// <param name="CrossPackageObjids">Resolution map: <c>pkg/ref</c> → objid for dependency-owned objects.</param>
+/// <param name="StructureBaselines">This package's managed object-structure baselines, keyed by objid (decision 20.13, extended for full structure diffs).</param>
 public sealed record PackagePlanInputs(
 	PackageManifest Manifest,
 	InstalledPackageRecord? Installed,
@@ -218,4 +327,5 @@ public sealed record PackagePlanInputs(
 	LivePackageState Live,
 	IReadOnlyDictionary<string, string> WellKnownObjids,
 	IReadOnlyDictionary<string, string> ConfigureAnswers,
-	IReadOnlyDictionary<string, string> CrossPackageObjids);
+	IReadOnlyDictionary<string, string> CrossPackageObjids,
+	IReadOnlyDictionary<string, PackageStructureBaseline>? StructureBaselines = null);

--- a/SharpMUSH.Library/Models/Packages/PackageManifest.cs
+++ b/SharpMUSH.Library/Models/Packages/PackageManifest.cs
@@ -173,6 +173,7 @@ public enum PackageConfigureType
 /// <param name="Destination">Exit destination; exits only.</param>
 /// <param name="PreviousRefs">Former ref names of this object (rename continuity across versions, decision 20.15).</param>
 /// <param name="Flags">Flag names to set on the object.</param>
+/// <param name="Powers">Power names to set on the object.</param>
 /// <param name="Locks">Lock values keyed by lock type name.</param>
 /// <param name="Attributes">Attributes to set, keyed by attribute name.</param>
 public sealed record PackageObjectSpec(
@@ -185,6 +186,7 @@ public sealed record PackageObjectSpec(
 	PackageRef? Destination,
 	IReadOnlyList<string> PreviousRefs,
 	IReadOnlyList<string> Flags,
+	IReadOnlyList<string> Powers,
 	IReadOnlyDictionary<string, string> Locks,
 	IReadOnlyDictionary<string, PackageAttributeSpec> Attributes)
 {

--- a/SharpMUSH.Library/Models/Packages/PackageRegistryRecords.cs
+++ b/SharpMUSH.Library/Models/Packages/PackageRegistryRecords.cs
@@ -49,6 +49,23 @@ public sealed record ManagedAttributeRecord(
 	string BaselineHash,
 	string BaselineVersion);
 
+/// <summary>
+/// The object-structure baseline a package manages on one object
+/// (sys_managed_structures): the flags, powers, locks, and per-attribute flags
+/// it set at the last install/upgrade, serialized as one JSON document so the
+/// full three-way structure merge and rollback can run offline (decision 20.13,
+/// extended for full object structure diffs).
+/// </summary>
+/// <param name="PackageId">Managing package.</param>
+/// <param name="Objid">Object the structure lives on.</param>
+/// <param name="StructureJson">JSON of <see cref="PackageStructureBaseline"/> as applied at the last install/upgrade.</param>
+/// <param name="BaselineVersion">Package version that set the baseline.</param>
+public sealed record ManagedStructureRecord(
+	string PackageId,
+	string Objid,
+	string StructureJson,
+	string BaselineVersion);
+
 /// <summary>A dependency edge between two installed packages (sys_package_depends).</summary>
 /// <param name="PackageId">The depending package.</param>
 /// <param name="DependsOnId">The package depended upon.</param>

--- a/SharpMUSH.Library/Services/Interfaces/IPackageRegistryService.cs
+++ b/SharpMUSH.Library/Services/Interfaces/IPackageRegistryService.cs
@@ -60,6 +60,17 @@ public interface IPackageRegistryService
 	/// <summary>Removes one managed-attribute record.</summary>
 	Task RemoveManagedAttributeAsync(string packageId, string objid, string attribute);
 
+	// ── Managed object structure (flags/powers/locks/attribute flags) ────────
+
+	/// <summary>Creates or replaces a managed object-structure baseline (keyed by package+objid).</summary>
+	Task UpsertManagedStructureAsync(ManagedStructureRecord record);
+
+	/// <summary>Lists every object-structure baseline a package manages, across all objects.</summary>
+	Task<IReadOnlyList<ManagedStructureRecord>> GetManagedStructuresAsync(string packageId);
+
+	/// <summary>Removes one managed object-structure baseline.</summary>
+	Task RemoveManagedStructureAsync(string packageId, string objid);
+
 	// ── Dependencies ─────────────────────────────────────────────────────────
 
 	/// <summary>

--- a/SharpMUSH.Library/Services/PackageInstallService.cs
+++ b/SharpMUSH.Library/Services/PackageInstallService.cs
@@ -67,13 +67,40 @@ public class PackageInstallService(
 			}
 		}
 
+		var structureBaselines = DeserializeStructureBaselines(await registry.GetManagedStructuresAsync(manifest.Name));
+
 		var wellKnown = await BuildWellKnownMapAsync(cancellationToken);
 		var live = await GatherLiveStateAsync(
 			manifest, installedObjects, baselines, wellKnown, configureAnswers, crossPackageObjids, cancellationToken);
 
 		return new PackagePlanInputs(
 			manifest, installed, installedObjects, baselines, allInstalled, otherManaged, live,
-			wellKnown, configureAnswers, crossPackageObjids);
+			wellKnown, configureAnswers, crossPackageObjids, structureBaselines);
+	}
+
+	/// <summary>
+	/// Deserializes persisted structure baselines into the plan engine's input
+	/// map, normalizing lock-type and attribute keys to case-insensitive so the
+	/// three-way merge lines up regardless of stored casing.
+	/// </summary>
+	private static IReadOnlyDictionary<string, PackageStructureBaseline> DeserializeStructureBaselines(
+		IReadOnlyList<ManagedStructureRecord> records)
+	{
+		var result = new Dictionary<string, PackageStructureBaseline>(StringComparer.Ordinal);
+		foreach (var record in records)
+		{
+			var parsed = JsonSerializer.Deserialize<PackageStructureBaseline>(record.StructureJson, SnapshotJson);
+			result[record.Objid] = parsed is null
+				? PackageStructureBaseline.Empty
+				: parsed with
+				{
+					Locks = new Dictionary<string, string>(parsed.Locks, StringComparer.OrdinalIgnoreCase),
+					AttributeFlags = parsed.AttributeFlags.ToDictionary(
+						kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase)
+				};
+		}
+
+		return result;
 	}
 
 	private async Task<LivePackageState> GatherLiveStateAsync(
@@ -193,6 +220,7 @@ public class PackageInstallService(
 
 		var known = node.Known();
 		var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		var attributeFlags = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
 		foreach (var attribute in attributes)
 		{
 			var leaf = await database
@@ -201,13 +229,21 @@ public class PackageInstallService(
 			if (leaf is not null)
 			{
 				values[attribute] = leaf.Value.ToPlainText();
+				attributeFlags[attribute] = leaf.Flags.Select(f => f.Name).ToList();
 			}
 		}
 
 		var hasContents = checkContents
 			&& await database.GetContentsAsync(dbref.Value, cancellationToken).AnyAsync(cancellationToken);
 
-		return new LiveObjectState(objid, true, known.Object().Name, values, hasContents);
+		// Full live object structure for the three-way structure merge.
+		var sharpObject = known.Object();
+		var flags = await sharpObject.Flags.Value.Select(f => f.Name).ToListAsync(cancellationToken);
+		var powers = await sharpObject.Powers.Value.Select(p => p.Name).ToListAsync(cancellationToken);
+		var locks = sharpObject.Locks.ToDictionary(
+			kv => kv.Key, kv => kv.Value.LockString, StringComparer.OrdinalIgnoreCase);
+
+		return new LiveObjectState(objid, true, sharpObject.Name, values, hasContents, flags, powers, locks, attributeFlags);
 	}
 
 	private async Task<IReadOnlyDictionary<string, string>> BuildWellKnownMapAsync(CancellationToken cancellationToken)
@@ -270,11 +306,15 @@ public class PackageInstallService(
 		var undecided = changeset.Attributes
 			.Where(a => a.Action == PackageAttributeAction.Conflict
 				&& !decisions.ContainsKey(DecisionKey(a.TargetRef, a.Attribute)))
+			.Select(a => $"{a.TargetRef}/{a.Attribute}")
+			.Concat(changeset.Structure
+				.Where(s => s.Action == PackageStructureAction.Conflict
+					&& !decisions.ContainsKey(DecisionKey(s.TargetRef, LockDecisionAttribute(s.Element))))
+				.Select(s => $"{s.TargetRef}/lock:{s.Element}"))
 			.ToList();
 		if (undecided.Count > 0)
 		{
-			return new Error<string>(
-				$"Unresolved conflicts: {string.Join(", ", undecided.Select(a => $"{a.TargetRef}/{a.Attribute}"))}");
+			return new Error<string>($"Unresolved conflicts: {string.Join(", ", undecided)}");
 		}
 
 		var notes = new List<string>(changeset.Notes);
@@ -328,11 +368,11 @@ public class PackageInstallService(
 			created[change.Ref] = createdRef.AsT0;
 		}
 
-		// Pass 2: exits link, parents, names, flags, locks.
+		// Pass 2: exits link, parents, name updates (flags/locks/powers come later).
 		foreach (var spec in manifest.Objects)
 		{
 			var error = await ApplyObjectWiringAsync(
-				spec, objidByRef[spec.Ref], created.ContainsKey(spec.Ref), changeset, Resolve, notes, cancellationToken);
+				spec, objidByRef[spec.Ref], created.ContainsKey(spec.Ref), changeset, Resolve, cancellationToken);
 			if (error is not null)
 			{
 				return new Error<string>(error);
@@ -381,11 +421,41 @@ public class PackageInstallService(
 			{
 				return new Error<string>(error);
 			}
+		}
 
-			if (attrSpec is not null && attrSpec.Flags.Count > 0
-				&& change.Action is not (PackageAttributeAction.Delete or PackageAttributeAction.RemoveBaseline))
+		// Pass 3.5: object structure (flags, powers, locks, attribute flags) per
+		// the three-way merge — add/remove/keep-local/conflict, never additive.
+		foreach (var change in changeset.Structure)
+		{
+			var objid = change.Objid ?? objidByRef.GetValueOrDefault(change.TargetRef);
+			if (objid is null)
 			{
-				await ApplyAttributeFlagsAsync(objid, change.Attribute, attrSpec.Flags, notes, cancellationToken);
+				return new Error<string>($"Internal error: no objid for structure target '{change.TargetRef}'.");
+			}
+
+			// Lock values resolve at apply time (refs to objects created this apply
+			// only get dbrefs now), exactly like attribute code — never trust the
+			// plan-time NewValue for a lock write.
+			var effective = change;
+			if (change.Kind == PackageStructureKind.Lock
+				&& change.Action is PackageStructureAction.Add or PackageStructureAction.Conflict
+				&& manifestByRef.TryGetValue(change.TargetRef, out var lockSpec)
+				&& lockSpec.Locks.TryGetValue(change.Element, out var rawLock))
+			{
+				var resolvedLock = PackageRefSubstitution.Substitute(rawLock, Resolve, out var unresolved);
+				if (unresolved.Count > 0)
+				{
+					return new Error<string>(
+						$"{change.TargetRef}/lock:{change.Element}: ref {unresolved[0]} is unresolved — answer its configure prompt before applying.");
+				}
+
+				effective = change with { NewValue = resolvedLock };
+			}
+
+			var error = await ApplyStructureChangeAsync(effective, objid, decisions, notes, cancellationToken);
+			if (error is not null)
+			{
+				return new Error<string>(error);
 			}
 		}
 
@@ -394,6 +464,7 @@ public class PackageInstallService(
 		{
 			await MarkGoingAsync(change.Objid!, notes, cancellationToken);
 			await registry.RemovePackageObjectAsync(manifest.Name, change.Ref);
+			await registry.RemoveManagedStructureAsync(manifest.Name, change.Objid!);
 		}
 
 		// Pass 5: registry — objects, renames, dependencies, package record, revision.
@@ -409,6 +480,27 @@ public class PackageInstallService(
 		{
 			await registry.UpsertPackageObjectAsync(new PackageObjectRecord(
 				manifest.Name, spec.Ref, objidByRef[spec.Ref], spec.Type.ToString().ToLowerInvariant()));
+		}
+
+		// Persist the object-structure baseline (= the resolved manifest structure)
+		// for every managed object — including attach objects, which own attribute
+		// flags — and capture it for the rollback snapshot. Objects with no managed
+		// structure carry no row (their baseline is cleared if one lingered).
+		var structureSnapshot = new List<PackageRevisionSnapshotStructure>();
+		foreach (var spec in manifest.Objects)
+		{
+			var structObjid = objidByRef[spec.Ref];
+			var resolved = BuildResolvedStructure(spec, Resolve);
+			if (resolved is null)
+			{
+				await registry.RemoveManagedStructureAsync(manifest.Name, structObjid);
+				continue;
+			}
+
+			await registry.UpsertManagedStructureAsync(new ManagedStructureRecord(
+				manifest.Name, structObjid, JsonSerializer.Serialize(resolved, SnapshotJson), manifest.Version.ToString()));
+			structureSnapshot.Add(new PackageRevisionSnapshotStructure(
+				structObjid, resolved.Flags, resolved.Powers, resolved.Locks, resolved.AttributeFlags));
 		}
 
 		// The package record must exist BEFORE its dependency edges: graph
@@ -429,7 +521,8 @@ public class PackageInstallService(
 			manifest.Objects
 				.Select(o => new PackageRevisionSnapshotObject(o.Ref, objidByRef[o.Ref], o.Type.ToString().ToLowerInvariant()))
 				.ToList(),
-			finalValues.Select(kv => new PackageRevisionSnapshotAttribute(kv.Key.Objid, kv.Key.Attribute, kv.Value)).ToList());
+			finalValues.Select(kv => new PackageRevisionSnapshotAttribute(kv.Key.Objid, kv.Key.Attribute, kv.Value)).ToList(),
+			structureSnapshot);
 
 		await registry.AddPackageRevisionAsync(new PackageRevisionRecord(
 			manifest.Name, revision,
@@ -553,7 +646,6 @@ public class PackageInstallService(
 		bool isNew,
 		PackageChangeset changeset,
 		Func<PackageRef, string?> resolve,
-		List<string> notes,
 		CancellationToken cancellationToken)
 	{
 		var node = await GetKnownAsync(objid, cancellationToken);
@@ -596,28 +688,8 @@ public class PackageInstallService(
 			await database.SetObjectParent(node, parentNode, cancellationToken);
 		}
 
-		// Flags.
-		foreach (var flagName in spec.Flags)
-		{
-			var flag = await database.GetObjectFlagAsync(flagName.ToUpperInvariant(), cancellationToken)
-				?? await database.GetObjectFlagAsync(flagName, cancellationToken);
-			if (flag is null)
-			{
-				notes.Add($"Object {{{{{spec.Ref}}}}}: unknown flag '{flagName}' skipped.");
-				continue;
-			}
-
-			await database.SetObjectFlagAsync(node, flag, cancellationToken);
-		}
-
-		// Locks (values may contain refs).
-		foreach (var (lockName, lockValue) in spec.Locks)
-		{
-			var resolved = SubstituteFully(lockValue, resolve, spec.Ref, $"lock:{lockName}", notes);
-			await database.SetLockAsync(node.Object(), lockName, new SharpLockData { LockString = resolved },
-				cancellationToken);
-		}
-
+		// Object flags, powers, locks, and attribute flags are applied in the
+		// dedicated structure pass (three-way merge), not here.
 		return null;
 	}
 
@@ -732,26 +804,175 @@ public class PackageInstallService(
 		}
 	}
 
-	private async Task ApplyAttributeFlagsAsync(
-		string objid, string attribute, IReadOnlyList<string> flags, List<string> notes, CancellationToken cancellationToken)
+	// ── Object structure application (flags/powers/locks/attribute flags) ────
+
+	/// <summary>Synthetic decision-attribute namespacing a lock conflict so it cannot collide with a real attribute name.</summary>
+	private static string LockDecisionAttribute(string lockType) => $"@LOCK`{lockType}";
+
+	/// <summary>The resolved structure a package declares on one object — the baseline it writes on apply.</summary>
+	private static PackageStructureBaseline? BuildResolvedStructure(PackageObjectSpec spec, Func<PackageRef, string?> resolve)
+	{
+		var locks = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		foreach (var (lockType, raw) in spec.Locks)
+		{
+			locks[lockType] = PackageRefSubstitution.Substitute(raw, resolve, out _);
+		}
+
+		var attributeFlags = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+		foreach (var (attrName, attrSpec) in spec.Attributes)
+		{
+			if (attrSpec.Flags.Count > 0)
+			{
+				attributeFlags[attrName] = attrSpec.Flags;
+			}
+		}
+
+		if (spec.Flags.Count == 0 && spec.Powers.Count == 0 && locks.Count == 0 && attributeFlags.Count == 0)
+		{
+			return null;
+		}
+
+		return new PackageStructureBaseline(spec.Flags, spec.Powers, locks, attributeFlags);
+	}
+
+	private async Task<string?> ApplyStructureChangeAsync(
+		PackageStructureChange change, string objid,
+		Dictionary<string, PackageConflictDecision> decisions, List<string> notes, CancellationToken cancellationToken)
 	{
 		var node = await GetKnownAsync(objid, cancellationToken);
 		if (node is null)
 		{
-			return;
+			return $"Internal error: object {objid} for structure '{change.Element}' vanished during apply.";
 		}
 
-		foreach (var flagName in flags)
+		switch (change.Kind)
 		{
-			var flag = await database.GetAttributeFlagAsync(flagName.ToUpperInvariant(), cancellationToken)
-				?? await database.GetAttributeFlagAsync(flagName, cancellationToken);
-			if (flag is null)
+			case PackageStructureKind.ObjectFlag:
+				if (change.Action is PackageStructureAction.Add or PackageStructureAction.Remove)
+				{
+					var flag = await database.GetObjectFlagAsync(change.Element.ToUpperInvariant(), cancellationToken)
+						?? await database.GetObjectFlagAsync(change.Element, cancellationToken);
+					if (flag is null)
+					{
+						notes.Add($"{change.TargetRef}: unknown flag '{change.Element}' skipped.");
+					}
+					else if (change.Action == PackageStructureAction.Add)
+					{
+						await database.SetObjectFlagAsync(node, flag, cancellationToken);
+					}
+					else
+					{
+						await database.UnsetObjectFlagAsync(node, flag, cancellationToken);
+					}
+				}
+
+				return null;
+
+			case PackageStructureKind.ObjectPower:
+				if (change.Action is PackageStructureAction.Add or PackageStructureAction.Remove)
+				{
+					var power = await database.GetPowerAsync(change.Element.ToUpperInvariant(), cancellationToken)
+						?? await database.GetPowerAsync(change.Element, cancellationToken);
+					if (power is null)
+					{
+						notes.Add($"{change.TargetRef}: unknown power '{change.Element}' skipped.");
+					}
+					else if (change.Action == PackageStructureAction.Add)
+					{
+						await database.SetObjectPowerAsync(node, power, cancellationToken);
+					}
+					else
+					{
+						await database.UnsetObjectPowerAsync(node, power, cancellationToken);
+					}
+				}
+
+				return null;
+
+			case PackageStructureKind.AttributeFlag:
+				if (change.Action is PackageStructureAction.Add or PackageStructureAction.Remove)
+				{
+					var flag = await database.GetAttributeFlagAsync(change.Element.ToUpperInvariant(), cancellationToken)
+						?? await database.GetAttributeFlagAsync(change.Element, cancellationToken);
+					var path = change.Attribute!.Split('`');
+					if (flag is null)
+					{
+						notes.Add($"{change.TargetRef}/{change.Attribute}: unknown attribute flag '{change.Element}' skipped.");
+					}
+					else if (change.Action == PackageStructureAction.Add)
+					{
+						// Only flag an attribute that actually exists after apply — a
+						// flag the package adds to an attribute the admin deleted locally
+						// has nothing to land on.
+						var dbref = ParseObjid(objid);
+						var exists = dbref is not null && await database
+							.GetAttributeAsync(dbref.Value, path, cancellationToken)
+							.AnyAsync(cancellationToken);
+						if (exists)
+						{
+							await database.SetAttributeFlagAsync(node.Object(), path, flag, cancellationToken);
+						}
+						else
+						{
+							notes.Add($"{change.TargetRef}/{change.Attribute}: flag '{change.Element}' skipped (attribute not present).");
+						}
+					}
+					else
+					{
+						await database.UnsetAttributeFlagAsync(node.Object(), path, flag, cancellationToken);
+					}
+				}
+
+				return null;
+
+			case PackageStructureKind.Lock:
+				return await ApplyLockChangeAsync(node, change, decisions, cancellationToken);
+
+			default:
+				return null;
+		}
+	}
+
+	private async Task<string?> ApplyLockChangeAsync(
+		AnySharpObject node, PackageStructureChange change,
+		Dictionary<string, PackageConflictDecision> decisions, CancellationToken cancellationToken)
+	{
+		async Task SetAsync(string value) =>
+			await database.SetLockAsync(node.Object(), change.Element, new SharpLockData { LockString = value }, cancellationToken);
+
+		switch (change.Action)
+		{
+			case PackageStructureAction.Add:
+				await SetAsync(change.NewValue ?? "");
+				return null;
+
+			case PackageStructureAction.Remove:
+				await database.UnsetLockAsync(node.Object(), change.Element, cancellationToken);
+				return null;
+
+			case PackageStructureAction.Conflict:
 			{
-				notes.Add($"{objid}/{attribute}: unknown attribute flag '{flagName}' skipped.");
-				continue;
+				var decision = decisions[DecisionKey(change.TargetRef, LockDecisionAttribute(change.Element))];
+				switch (decision.Resolution)
+				{
+					case PackageConflictResolution.TakeTheirs when change.Conflict == PackageConflictKind.ModifyDelete:
+						await database.UnsetLockAsync(node.Object(), change.Element, cancellationToken);
+						return null;
+					case PackageConflictResolution.TakeTheirs:
+						await SetAsync(change.NewValue ?? "");
+						return null;
+					case PackageConflictResolution.UseCustom when decision.CustomValue is not null:
+						await SetAsync(decision.CustomValue);
+						return null;
+					case PackageConflictResolution.UseCustom:
+						return $"Lock conflict {change.TargetRef}/{change.Element}: UseCustom requires a value.";
+					default: // KeepMine — leave the live lock untouched.
+						return null;
+				}
 			}
 
-			await database.SetAttributeFlagAsync(node.Object(), attribute.Split('`'), flag, cancellationToken);
+			default: // Adopt / NoChange / KeepLocal / RemoveBaseline — no write.
+				return null;
 		}
 	}
 
@@ -890,6 +1111,8 @@ public class PackageInstallService(
 			notes.Add($"Removed {managed.Objid}/{managed.Attribute} (not present in revision {revision}).");
 		}
 
+		await RestoreStructureAsync(packageId, snapshot, notes, cancellationToken);
+
 		var installed = installedResult.AsT0;
 		var newRevision = installed.CurrentRevision + 1;
 		await registry.UpsertInstalledPackageAsync(installed with
@@ -906,6 +1129,111 @@ public class PackageInstallService(
 		});
 
 		return new PackageRollbackResult(newRevision, revision, notes);
+	}
+
+	/// <summary>
+	/// Reconciles each object's package-managed structure to a revision snapshot
+	/// (rollback): sets the snapshot's flags/powers/locks/attribute flags and
+	/// unsets package-managed elements absent from it. Scoped to elements the
+	/// package set, so admin-added extras are never disturbed.
+	/// </summary>
+	private async Task RestoreStructureAsync(
+		string packageId, PackageRevisionSnapshot snapshot, List<string> notes, CancellationToken cancellationToken)
+	{
+		var noDecisions = new Dictionary<string, PackageConflictDecision>(StringComparer.Ordinal);
+		var target = (snapshot.Structure ?? []).ToDictionary(s => s.Objid, StringComparer.Ordinal);
+		var current = DeserializeStructureBaselines(await registry.GetManagedStructuresAsync(packageId));
+
+		foreach (var objid in target.Keys.Union(current.Keys, StringComparer.Ordinal).ToList())
+		{
+			if (await GetKnownAsync(objid, cancellationToken) is null)
+			{
+				notes.Add($"Skipped structure for {objid}: object no longer exists.");
+				continue;
+			}
+
+			var want = target.GetValueOrDefault(objid);
+			var have = current.GetValueOrDefault(objid) ?? PackageStructureBaseline.Empty;
+
+			foreach (var change in StructureRollbackChanges(objid, have, want))
+			{
+				var error = await ApplyStructureChangeAsync(change, objid, noDecisions, notes, cancellationToken);
+				if (error is not null)
+				{
+					notes.Add(error);
+				}
+			}
+
+			if (want is null)
+			{
+				await registry.RemoveManagedStructureAsync(packageId, objid);
+			}
+			else
+			{
+				var baseline = new PackageStructureBaseline(want.Flags, want.Powers, want.Locks, want.AttributeFlags);
+				await registry.UpsertManagedStructureAsync(new ManagedStructureRecord(
+					packageId, objid, JsonSerializer.Serialize(baseline, SnapshotJson), snapshot.Version));
+			}
+		}
+	}
+
+	/// <summary>Synthesizes the add/remove structure changes that move <paramref name="have"/> to <paramref name="want"/>.</summary>
+	private static IEnumerable<PackageStructureChange> StructureRollbackChanges(
+		string objid, PackageStructureBaseline have, PackageRevisionSnapshotStructure? want)
+	{
+		var wantFlags = want?.Flags ?? Array.Empty<string>();
+		var wantPowers = want?.Powers ?? Array.Empty<string>();
+		var wantLocks = want?.Locks ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		var wantAttrFlags = want?.AttributeFlags ?? new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+
+		IEnumerable<PackageStructureChange> Set(PackageStructureKind kind, string? attribute,
+			IReadOnlyList<string> haveSet, IReadOnlyList<string> wantSet)
+		{
+			var wantHash = new HashSet<string>(wantSet, StringComparer.OrdinalIgnoreCase);
+			foreach (var element in wantSet)
+			{
+				yield return new PackageStructureChange(objid, objid, kind, element, PackageStructureAction.Add, attribute);
+			}
+
+			foreach (var element in haveSet.Where(e => !wantHash.Contains(e)))
+			{
+				yield return new PackageStructureChange(objid, objid, kind, element, PackageStructureAction.Remove, attribute);
+			}
+		}
+
+		foreach (var change in Set(PackageStructureKind.ObjectFlag, null, have.Flags, wantFlags))
+		{
+			yield return change;
+		}
+
+		foreach (var change in Set(PackageStructureKind.ObjectPower, null, have.Powers, wantPowers))
+		{
+			yield return change;
+		}
+
+		var attrNames = new HashSet<string>(have.AttributeFlags.Keys, StringComparer.OrdinalIgnoreCase);
+		attrNames.UnionWith(wantAttrFlags.Keys);
+		foreach (var attr in attrNames)
+		{
+			var changes = Set(PackageStructureKind.AttributeFlag, attr,
+				have.AttributeFlags.GetValueOrDefault(attr) ?? [], wantAttrFlags.GetValueOrDefault(attr) ?? []);
+			foreach (var change in changes)
+			{
+				yield return change;
+			}
+		}
+
+		foreach (var (lockType, value) in wantLocks)
+		{
+			yield return new PackageStructureChange(
+				objid, objid, PackageStructureKind.Lock, lockType, PackageStructureAction.Add, NewValue: value);
+		}
+
+		foreach (var lockType in have.Locks.Keys.Where(k => !wantLocks.ContainsKey(k)))
+		{
+			yield return new PackageStructureChange(
+				objid, objid, PackageStructureKind.Lock, lockType, PackageStructureAction.Remove);
+		}
 	}
 
 	// ── Helpers ──────────────────────────────────────────────────────────────
@@ -975,18 +1303,6 @@ public class PackageInstallService(
 	}
 
 	private static AnySharpContainer ToContainer(SharpPlayer player) => player;
-
-	private static string SubstituteFully(
-		string value, Func<PackageRef, string?> resolve, string targetRef, string context, List<string> notes)
-	{
-		var substituted = PackageRefSubstitution.Substitute(value, resolve, out var unresolved);
-		foreach (var reference in unresolved)
-		{
-			notes.Add($"{targetRef}/{context}: ref {reference} could not be resolved; left verbatim.");
-		}
-
-		return substituted;
-	}
 
 	private static string? ResolveConfigure(
 		PackageManifest manifest, IReadOnlyDictionary<string, string> answers, string key)

--- a/SharpMUSH.Library/Services/PackageManifestService.cs
+++ b/SharpMUSH.Library/Services/PackageManifestService.cs
@@ -41,12 +41,13 @@ public partial class PackageManifestService : IPackageManifestService
 
 	private static readonly IReadOnlySet<string> KnownObjectKeys = new HashSet<string>(StringComparer.Ordinal)
 	{
-		"ref", "type", "name", "target", "parent", "location", "destination", "previous_refs", "flags", "locks", "attributes"
+		"ref", "type", "name", "target", "parent", "location", "destination", "previous_refs",
+		"flags", "powers", "locks", "attributes"
 	};
 
 	private static readonly IReadOnlySet<string> AttachForbiddenKeys = new HashSet<string>(StringComparer.Ordinal)
 	{
-		"type", "name", "parent", "location", "destination", "previous_refs", "flags", "locks"
+		"type", "name", "parent", "location", "destination", "previous_refs", "flags", "powers", "locks"
 	};
 
 	private const int MaxPackageIdLength = 64;
@@ -1018,11 +1019,13 @@ public partial class PackageManifestService : IPackageManifestService
 			}
 
 			var flags = ReadStringList(obj, "flags", issues);
+			var powers = ReadStringList(obj, "powers", issues);
 			var locks = ReadStringMap(obj, "locks", path, issues);
 			var attributes = ReadAttributes(obj, path, issues);
 
 			objects.Add(new PackageObjectSpec(
-				refName, type, objectName.Trim(), null, parent, location, destination, previousRefs, flags, locks, attributes));
+				refName, type, objectName.Trim(), null, parent, location, destination, previousRefs,
+				flags, powers, locks, attributes));
 		}
 
 		return objects;
@@ -1073,7 +1076,7 @@ public partial class PackageManifestService : IPackageManifestService
 		}
 
 		return new PackageObjectSpec(
-			refName, PackageObjectType.Thing, "", target, null, null, null, [], [],
+			refName, PackageObjectType.Thing, "", target, null, null, null, [], [], [],
 			new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), attributes);
 	}
 

--- a/SharpMUSH.Library/Services/PackagePlanService.cs
+++ b/SharpMUSH.Library/Services/PackagePlanService.cs
@@ -21,6 +21,7 @@ public partial class PackagePlanService : IPackagePlanService
 		var dependencyIssues = CheckDependenciesAndConflicts(inputs);
 		var (objects, objidByRef, deletedObjids) = ClassifyObjects(inputs, notes);
 		var attributes = ClassifyAttributes(inputs, objidByRef, deletedObjids, notes);
+		var structure = ClassifyStructure(inputs, objidByRef, deletedObjids, notes);
 		var collisions = DetectCommandCollisions(inputs);
 
 		// Application packages (kind: application) carry no objects; surface the
@@ -38,6 +39,7 @@ public partial class PackagePlanService : IPackagePlanService
 			inputs.Installed is null ? PackageRevisionKind.Install : PackageRevisionKind.Upgrade,
 			objects,
 			attributes,
+			structure,
 			dependencyIssues,
 			collisions,
 			notes);
@@ -345,6 +347,206 @@ public partial class PackagePlanService : IPackagePlanService
 			(true, false) => Make(PackageAttributeAction.KeepLocal),
 			(true, true) when liveValue == newValue => Make(PackageAttributeAction.NoChange),
 			(true, true) => Make(PackageAttributeAction.Conflict, PackageConflictKind.ModifyModify)
+		};
+	}
+
+	// ── Object structure: flags, powers, locks, attribute flags ─────────────
+	// Full three-way merge (decision 20.7, extended). Binary elements
+	// (flags/powers/attribute flags) resolve deterministically and never
+	// conflict; value-typed locks reuse the attribute conflict model. Only
+	// elements the package manages now or managed at the last apply are
+	// considered — admin-added extras are left untouched and unmentioned.
+
+	private static List<PackageStructureChange> ClassifyStructure(
+		PackagePlanInputs inputs,
+		Dictionary<string, string> objidByRef,
+		HashSet<string> deletedObjids,
+		List<string> notes)
+	{
+		var changes = new List<PackageStructureChange>();
+		var baselines = inputs.StructureBaselines ?? new Dictionary<string, PackageStructureBaseline>();
+		var unresolvedLocks = 0;
+
+		string? Resolve(PackageRef reference) => reference switch
+		{
+			{ Kind: PackageRefKind.Internal, Package: not null } =>
+				inputs.CrossPackageObjids.GetValueOrDefault($"{reference.Package}/{reference.Name}"),
+			{ Kind: PackageRefKind.Internal } => objidByRef.GetValueOrDefault(reference.Name),
+			{ Kind: PackageRefKind.WellKnown } => inputs.WellKnownObjids.GetValueOrDefault(reference.Name),
+			{ Kind: PackageRefKind.Configure } => inputs.ConfigureAnswers.GetValueOrDefault(reference.Name),
+			_ => null
+		};
+
+		foreach (var obj in inputs.Manifest.Objects)
+		{
+			var objid = objidByRef.GetValueOrDefault(obj.Ref);
+			if (objid is not null && deletedObjids.Contains(objid))
+			{
+				continue;
+			}
+
+			var live = objid is not null ? inputs.Live.Objects.GetValueOrDefault(objid) : null;
+			var baseline = objid is not null ? baselines.GetValueOrDefault(objid) : null;
+			var existing = live is { Exists: true };
+
+			var liveFlags = (existing ? live!.Flags : null) ?? Array.Empty<string>();
+			var livePowers = (existing ? live!.Powers : null) ?? Array.Empty<string>();
+
+			// Object-level flags and powers (attach objects declare none).
+			ClassifySet(obj.Ref, objid, PackageStructureKind.ObjectFlag, attribute: null,
+				baseline?.Flags ?? Array.Empty<string>(), liveFlags, obj.Flags, changes);
+			ClassifySet(obj.Ref, objid, PackageStructureKind.ObjectPower, attribute: null,
+				baseline?.Powers ?? Array.Empty<string>(), livePowers, obj.Powers, changes);
+
+			// Per-attribute flags (created objects, attach objects, and existing objects alike).
+			var baseAttrFlags = baseline?.AttributeFlags
+				?? new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+			var liveAttrFlags = existing ? live!.AttributeFlags : null;
+			foreach (var (attrName, attrSpec) in obj.Attributes)
+			{
+				ClassifySet(obj.Ref, objid, PackageStructureKind.AttributeFlag, attrName,
+					baseAttrFlags.GetValueOrDefault(attrName) ?? [],
+					liveAttrFlags?.GetValueOrDefault(attrName) ?? [],
+					attrSpec.Flags, changes);
+			}
+
+			// Locks (value-typed; refs resolved directly, not via PM`REFS).
+			var baseLocks = baseline?.Locks ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+			var liveLocks = (existing ? live!.Locks : null)
+				?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+			var lockTypes = new HashSet<string>(baseLocks.Keys, StringComparer.OrdinalIgnoreCase);
+			lockTypes.UnionWith(obj.Locks.Keys);
+			foreach (var lockType in lockTypes.OrderBy(t => t, StringComparer.Ordinal))
+			{
+				string? newValue = null;
+				var requiresApply = false;
+				if (obj.Locks.TryGetValue(lockType, out var rawNew))
+				{
+					newValue = PackageRefSubstitution.Substitute(rawNew, Resolve, out var unresolved);
+					if (unresolved.Count > 0)
+					{
+						requiresApply = true;
+						unresolvedLocks++;
+					}
+				}
+
+				var baseValue = baseLocks.GetValueOrDefault(lockType);
+				var liveValue = liveLocks.GetValueOrDefault(lockType);
+				var (action, conflict) = ClassifyLock(baseValue, liveValue, newValue, requiresApply);
+				changes.Add(new PackageStructureChange(
+					obj.Ref, objid, PackageStructureKind.Lock, lockType, action,
+					Attribute: null, Conflict: conflict,
+					BaseValue: baseValue, LiveValue: liveValue, NewValue: newValue,
+					RequiresApplyResolution: requiresApply));
+			}
+		}
+
+		if (unresolvedLocks > 0)
+		{
+			notes.Add($"{unresolvedLocks} lock value{(unresolvedLocks == 1 ? "" : "s")} resolve at apply time (new objects or unanswered configure prompts).");
+		}
+
+		return changes;
+	}
+
+	/// <summary>
+	/// Three-way merge of a set-valued structure element (flags/powers/attribute
+	/// flags). Iterates only elements the package manages now or managed before;
+	/// binary presence resolves deterministically (never a conflict).
+	/// </summary>
+	private static void ClassifySet(
+		string targetRef, string? objid, PackageStructureKind kind, string? attribute,
+		IReadOnlyList<string> baseline, IReadOnlyList<string> live, IReadOnlyList<string> @new,
+		List<PackageStructureChange> changes)
+	{
+		var baseSet = new HashSet<string>(baseline, StringComparer.OrdinalIgnoreCase);
+		var liveSet = new HashSet<string>(live, StringComparer.OrdinalIgnoreCase);
+		var newSet = new HashSet<string>(@new, StringComparer.OrdinalIgnoreCase);
+
+		// Canonical element name → display spelling; prefer the manifest spelling.
+		var names = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		foreach (var n in @new)
+		{
+			names[n] = n;
+		}
+
+		foreach (var n in baseline)
+		{
+			names.TryAdd(n, n);
+		}
+
+		foreach (var element in names.Values.OrderBy(n => n, StringComparer.Ordinal))
+		{
+			var action = ClassifyPresence(baseSet.Contains(element), liveSet.Contains(element), newSet.Contains(element));
+			changes.Add(new PackageStructureChange(targetRef, objid, kind, element, action, attribute));
+		}
+	}
+
+	/// <summary>Binary-presence three-way table (no conflicts possible).</summary>
+	private static PackageStructureAction ClassifyPresence(bool inBaseline, bool inLive, bool inNew)
+	{
+		if (!inBaseline)
+		{
+			// Only iterated for elements in baseline ∪ new, so here inNew is true.
+			return inLive ? PackageStructureAction.Adopt : PackageStructureAction.Add;
+		}
+
+		return (inNew, inLive) switch
+		{
+			(true, true) => PackageStructureAction.NoChange,
+			(true, false) => PackageStructureAction.KeepLocal,    // admin removed it; package still declares it
+			(false, true) => PackageStructureAction.Remove,       // package dropped it; admin still has it
+			(false, false) => PackageStructureAction.RemoveBaseline
+		};
+	}
+
+	/// <summary>Value-typed (lock) three-way table — the attribute truth table, mapped to structure actions.</summary>
+	private static (PackageStructureAction Action, PackageConflictKind? Conflict) ClassifyLock(
+		string? baseValue, string? liveValue, string? newValue, bool requiresApply)
+	{
+		// Lock dropped from the manifest (only reached for a baseline key absent from new).
+		if (newValue is null)
+		{
+			return liveValue switch
+			{
+				null => (PackageStructureAction.RemoveBaseline, null),
+				_ when liveValue == baseValue => (PackageStructureAction.Remove, null),
+				_ => (PackageStructureAction.Conflict, PackageConflictKind.ModifyDelete)
+			};
+		}
+
+		// A still-unresolved ref means we cannot compare yet — set it at apply.
+		if (requiresApply)
+		{
+			return (PackageStructureAction.Add, null);
+		}
+
+		if (baseValue is null)
+		{
+			return liveValue switch
+			{
+				null => (PackageStructureAction.Add, null),
+				_ when liveValue == newValue => (PackageStructureAction.Adopt, null),
+				_ => (PackageStructureAction.Conflict, PackageConflictKind.AddAdd)
+			};
+		}
+
+		if (liveValue is null)
+		{
+			return baseValue == newValue
+				? (PackageStructureAction.KeepLocal, null)
+				: (PackageStructureAction.Conflict, PackageConflictKind.DeleteModify);
+		}
+
+		var userChanged = liveValue != baseValue;
+		var packageChanged = newValue != baseValue;
+		return (userChanged, packageChanged) switch
+		{
+			(false, false) => (PackageStructureAction.NoChange, null),
+			(false, true) => (PackageStructureAction.Add, null),        // package changed the lock; admin didn't
+			(true, false) => (PackageStructureAction.KeepLocal, null),  // admin changed the lock; package didn't
+			(true, true) when liveValue == newValue => (PackageStructureAction.NoChange, null),
+			(true, true) => (PackageStructureAction.Conflict, PackageConflictKind.ModifyModify)
 		};
 	}
 

--- a/SharpMUSH.Tests/Database/PackageRegistryTests.cs
+++ b/SharpMUSH.Tests/Database/PackageRegistryTests.cs
@@ -108,6 +108,32 @@ public class PackageRegistryTests
 	}
 
 	[Test, NotInParallel]
+	public async Task ManagedStructures_UpsertGetReplaceRemove_ClearedOnUninstall()
+	{
+		await Registry.UpsertInstalledPackageAsync(SamplePackage("struct-pkg"));
+		const string json = """{"flags":["no_command","dark"],"powers":["pueblo"],"locks":{"use":"=#1"},"attributeFlags":{"FN_X":["veiled"]}}""";
+		await Registry.UpsertManagedStructureAsync(new ManagedStructureRecord("struct-pkg", "#900:123", json, "1.2.0"));
+		await Registry.UpsertManagedStructureAsync(new ManagedStructureRecord("struct-pkg", "#901:123", "{}", "1.2.0"));
+
+		var fetched = await Registry.GetManagedStructuresAsync("struct-pkg");
+		await Assert.That(fetched.Count).IsEqualTo(2);
+		await Assert.That(fetched.First(s => s.Objid == "#900:123").StructureJson).IsEqualTo(json);
+
+		// Upsert on (package, objid) replaces the JSON payload.
+		await Registry.UpsertManagedStructureAsync(new ManagedStructureRecord("struct-pkg", "#900:123", "{}", "1.3.0"));
+		var replaced = await Registry.GetManagedStructuresAsync("struct-pkg");
+		await Assert.That(replaced.First(s => s.Objid == "#900:123").StructureJson).IsEqualTo("{}");
+		await Assert.That(replaced.First(s => s.Objid == "#900:123").BaselineVersion).IsEqualTo("1.3.0");
+
+		await Registry.RemoveManagedStructureAsync("struct-pkg", "#901:123");
+		await Assert.That((await Registry.GetManagedStructuresAsync("struct-pkg")).Count).IsEqualTo(1);
+
+		// RemoveInstalledPackage cascades to structure baselines.
+		await Registry.RemoveInstalledPackageAsync("struct-pkg");
+		await Assert.That((await Registry.GetManagedStructuresAsync("struct-pkg")).Count).IsEqualTo(0);
+	}
+
+	[Test, NotInParallel]
 	public async Task Dependencies_SetGetDependents_ReplaceSemantics()
 	{
 		await Registry.UpsertInstalledPackageAsync(SamplePackage("dep-core"));

--- a/SharpMUSH.Tests/Packages/PackageInstallServiceTests.cs
+++ b/SharpMUSH.Tests/Packages/PackageInstallServiceTests.cs
@@ -517,4 +517,85 @@ public class PackageInstallServiceTests
 
 		await Assert.That((await Installer.UninstallAsync("flags-pkg")).IsT0).IsTrue();
 	}
+
+	private async Task<IReadOnlyList<string>> ReadObjectFlagsAsync(string objid)
+	{
+		var node = await Database.GetObjectNodeAsync(PackageInstallService.ParseObjid(objid)!.Value);
+		var flags = new List<string>();
+		await foreach (var flag in node.Known().Object().Flags.Value)
+		{
+			flags.Add(flag.Name);
+		}
+
+		return flags;
+	}
+
+	private async Task<bool> HasLockAsync(string objid, string lockType)
+	{
+		var node = await Database.GetObjectNodeAsync(PackageInstallService.ParseObjid(objid)!.Value);
+		return node.Known().Object().Locks.ContainsKey(lockType);
+	}
+
+	[Test, NotInParallel]
+	public async Task Upgrade_AddsAndRemovesObjectFlagsAndLocks()
+	{
+		// v1 sets two flags and a lock; v2 drops one flag and the lock entirely.
+		// Full object-structure diff: the dropped flag is unset and the lock removed,
+		// while the retained flag survives — never additive.
+		var v1 = Parse(
+			"""
+			package: struct-pkg
+			version: "1.0"
+			objects:
+			  - ref: gadget
+			    type: thing
+			    name: Struct Gadget
+			    flags: [dark, opaque]
+			    locks:
+			      use: "=#1"
+			    attributes:
+			      FN: |-
+			        x
+			""");
+
+		var install = await Installer.ApplyAsync(v1, new PackageApplyRequest(Source(), new Dictionary<string, string>(), []));
+		await Assert.That(install.IsT0).IsTrue();
+		var gadgetObjid = install.AsT0.CreatedObjects["gadget"];
+
+		var flagsV1 = await ReadObjectFlagsAsync(gadgetObjid);
+		await Assert.That(flagsV1).Contains("DARK");
+		await Assert.That(flagsV1).Contains("OPAQUE");
+		await Assert.That(await HasLockAsync(gadgetObjid, "use")).IsTrue();
+
+		var v2 = Parse(
+			"""
+			package: struct-pkg
+			version: "1.1"
+			objects:
+			  - ref: gadget
+			    type: thing
+			    name: Struct Gadget
+			    flags: [dark]
+			    attributes:
+			      FN: |-
+			        x
+			""");
+
+		var plan = await Installer.PlanAsync(v2);
+		await Assert.That(plan.Structure.Single(s =>
+				s.Kind == PackageStructureKind.ObjectFlag && string.Equals(s.Element, "opaque", StringComparison.OrdinalIgnoreCase))
+			.Action).IsEqualTo(PackageStructureAction.Remove);
+		await Assert.That(plan.Structure.Single(s => s.Kind == PackageStructureKind.Lock).Action)
+			.IsEqualTo(PackageStructureAction.Remove);
+
+		var upgrade = await Installer.ApplyAsync(v2, new PackageApplyRequest(Source("commit-2"), new Dictionary<string, string>(), []));
+		await Assert.That(upgrade.IsT0).IsTrue();
+
+		var flagsV2 = await ReadObjectFlagsAsync(gadgetObjid);
+		await Assert.That(flagsV2).Contains("DARK");
+		await Assert.That(flagsV2).DoesNotContain("OPAQUE");
+		await Assert.That(await HasLockAsync(gadgetObjid, "use")).IsFalse();
+
+		await Assert.That((await Installer.UninstallAsync("struct-pkg")).IsT0).IsTrue();
+	}
 }

--- a/SharpMUSH.Tests/Packages/PackageInstallServiceTests.cs
+++ b/SharpMUSH.Tests/Packages/PackageInstallServiceTests.cs
@@ -101,6 +101,14 @@ public class PackageInstallServiceTests
 		return leaf?.Value.ToPlainText() ?? "";
 	}
 
+	private async Task<IReadOnlyList<string>> ReadAttributeFlagsAsync(string objid, string attribute)
+	{
+		var dbref = PackageInstallService.ParseObjid(objid)!.Value;
+		var leaf = await Database.GetAttributeAsync(dbref, attribute.Split('`'), CancellationToken.None)
+			.LastOrDefaultAsync();
+		return leaf?.Flags.Select(f => f.Name).ToList() ?? [];
+	}
+
 	[Test, NotInParallel]
 	public async Task InstallUpgradeRollbackUninstall_EndToEnd()
 	{
@@ -439,5 +447,74 @@ public class PackageInstallServiceTests
 		await Assert.That((await Registry.GetInstalledPackageAsync("appdep-app")).IsT1).IsTrue();
 
 		await Assert.That((await Installer.UninstallAsync("appdep-routes")).IsT0).IsTrue();
+	}
+
+	[Test, NotInParallel]
+	public async Task Upgrade_AppliesAttributeFlags_AndRemovesDroppedAttribute()
+	{
+		// Two apply-side upgrade behaviours the end-to-end test above does not
+		// cover: declared attribute flags are applied to the live attribute, and
+		// an attribute dropped from the new version (locally untouched) is cleanly
+		// deleted — value cleared AND its baseline record removed.
+		var v1 = Parse(
+			"""
+			package: flags-pkg
+			version: "1.0"
+			objects:
+			  - ref: widget
+			    type: thing
+			    name: Flags Widget
+			    attributes:
+			      FN_KEEP:
+			        value: |-
+			          keep-me
+			        flags: [no_command, veiled]
+			      FN_DROP: |-
+			        drop-me-next-version
+			""");
+
+		var install = await Installer.ApplyAsync(v1, new PackageApplyRequest(Source(), new Dictionary<string, string>(), []));
+		await Assert.That(install.IsT0).IsTrue();
+		var widgetObjid = install.AsT0.CreatedObjects["widget"];
+
+		// Attribute flags landed on the live attribute (applied additively at apply).
+		var keepFlags = await ReadAttributeFlagsAsync(widgetObjid, "FN_KEEP");
+		await Assert.That(keepFlags).Contains("no_command");
+		await Assert.That(keepFlags).Contains("veiled");
+		await Assert.That(await ReadAttributeAsync(widgetObjid, "FN_DROP")).IsEqualTo("drop-me-next-version");
+		await Assert.That((await Registry.GetManagedAttributesAsync("flags-pkg")).Any(b => b.Attribute == "FN_DROP")).IsTrue();
+
+		// Upgrade to v2: FN_DROP is gone from the manifest and was never modified
+		// locally, so the plan classifies it as a clean Delete.
+		var v2 = Parse(
+			"""
+			package: flags-pkg
+			version: "1.1"
+			objects:
+			  - ref: widget
+			    type: thing
+			    name: Flags Widget
+			    attributes:
+			      FN_KEEP:
+			        value: |-
+			          keep-me
+			        flags: [no_command, veiled]
+			""");
+
+		var plan = await Installer.PlanAsync(v2);
+		await Assert.That(plan.Attributes.Single(a => a.Attribute == "FN_DROP").Action)
+			.IsEqualTo(PackageAttributeAction.Delete);
+
+		var upgrade = await Installer.ApplyAsync(v2, new PackageApplyRequest(Source("commit-2"), new Dictionary<string, string>(), []));
+		await Assert.That(upgrade.IsT0).IsTrue();
+
+		// FN_DROP is gone from both the live object and the baseline registry...
+		await Assert.That(await ReadAttributeAsync(widgetObjid, "FN_DROP")).IsEqualTo("");
+		await Assert.That((await Registry.GetManagedAttributesAsync("flags-pkg")).Any(b => b.Attribute == "FN_DROP")).IsFalse();
+		// ...while FN_KEEP and its flags survive the upgrade untouched.
+		await Assert.That(await ReadAttributeAsync(widgetObjid, "FN_KEEP")).IsEqualTo("keep-me");
+		await Assert.That(await ReadAttributeFlagsAsync(widgetObjid, "FN_KEEP")).Contains("veiled");
+
+		await Assert.That((await Installer.UninstallAsync("flags-pkg")).IsT0).IsTrue();
 	}
 }

--- a/SharpMUSH.Tests/Packages/PackageManifestServiceTests.cs
+++ b/SharpMUSH.Tests/Packages/PackageManifestServiceTests.cs
@@ -791,18 +791,35 @@ public class PackageManifestServiceTests
 	}
 
 	[Test]
-	public async Task Powers_AreNotASupportedObjectKey_WarnAndIgnore()
+	public async Task ObjectPowers_Parse()
 	{
-		// The package format models flags and locks on objects, but has no concept
-		// of powers: a 'powers' key is an unknown key — warned and dropped, never
-		// applied. (If powers ever become supported, this test should flip to an
-		// assertion that they parse onto the spec.)
 		var result = _service.ParseManifest(MinimalManifest(objectExtras: "    powers: [pueblo, idle]"));
 
 		await Assert.That(result.IsT0).IsTrue();
-		await Assert.That(result.AsT0.Warnings.Any(w => w.Path == "objects[0].powers")).IsTrue();
-		// Nothing power-shaped survives onto the parsed object.
-		await Assert.That(result.AsT0.Manifest.Objects.Single().Flags.Count).IsEqualTo(0);
+		await Assert.That(result.AsT0.Manifest.Objects.Single().Powers.ToArray())
+			.IsEquivalentTo((string[])["pueblo", "idle"]);
+	}
+
+	[Test]
+	public async Task AttachObject_RejectsPowers()
+	{
+		// Attach objects manage attributes only — object-level powers (like flags
+		// and locks) are creation-only and rejected.
+		var result = _service.ParseManifest(
+			"""
+			package: hooks
+			version: "1.0"
+			objects:
+			  - ref: handler
+			    target: "{{$http_handler}}"
+			    powers: [pueblo]
+			    attributes:
+			      GET: |-
+			        think hi
+			""");
+
+		await Assert.That(result.IsT1).IsTrue();
+		await Assert.That(result.AsT1.Errors.Any(e => e.Path == "objects[0].powers")).IsTrue();
 	}
 
 	#endregion

--- a/SharpMUSH.Tests/Packages/PackageManifestServiceTests.cs
+++ b/SharpMUSH.Tests/Packages/PackageManifestServiceTests.cs
@@ -757,6 +757,54 @@ public class PackageManifestServiceTests
 		await Assert.That(bad.IsT1).IsTrue();
 	}
 
+	[Test]
+	public async Task ObjectFlagsAndLocks_Parse()
+	{
+		var result = _service.ParseManifest(MinimalManifest(
+			objectExtras: "    flags: [no_command, dark]\n    locks:\n      use: \"{{a}}\"\n      page: \"=#1\""));
+
+		await Assert.That(result.IsT0).IsTrue();
+		var obj = result.AsT0.Manifest.Objects.Single();
+		await Assert.That(obj.Flags.ToArray()).IsEquivalentTo((string[])["no_command", "dark"]);
+		await Assert.That(obj.Locks["use"]).IsEqualTo("{{a}}");
+		await Assert.That(obj.Locks["page"]).IsEqualTo("=#1");
+	}
+
+	[Test]
+	public async Task AttributeFlags_ParseFromMappingForm_ShorthandHasNone()
+	{
+		// Attribute flags are supported only via the mapping form (value: + flags:);
+		// the bare-string shorthand carries no flags.
+		var result = _service.ParseManifest(MinimalManifest(attributes:
+			"""
+			      WITH_FLAGS:
+			        value: |-
+			          think hi
+			        flags: [no_command, veiled]
+			      SHORTHAND: "plain value"
+			"""));
+
+		await Assert.That(result.IsT0).IsTrue();
+		var attrs = result.AsT0.Manifest.Objects.Single().Attributes;
+		await Assert.That(attrs["WITH_FLAGS"].Flags.ToArray()).IsEquivalentTo((string[])["no_command", "veiled"]);
+		await Assert.That(attrs["SHORTHAND"].Flags.Count).IsEqualTo(0);
+	}
+
+	[Test]
+	public async Task Powers_AreNotASupportedObjectKey_WarnAndIgnore()
+	{
+		// The package format models flags and locks on objects, but has no concept
+		// of powers: a 'powers' key is an unknown key — warned and dropped, never
+		// applied. (If powers ever become supported, this test should flip to an
+		// assertion that they parse onto the spec.)
+		var result = _service.ParseManifest(MinimalManifest(objectExtras: "    powers: [pueblo, idle]"));
+
+		await Assert.That(result.IsT0).IsTrue();
+		await Assert.That(result.AsT0.Warnings.Any(w => w.Path == "objects[0].powers")).IsTrue();
+		// Nothing power-shaped survives onto the parsed object.
+		await Assert.That(result.AsT0.Manifest.Objects.Single().Flags.Count).IsEqualTo(0);
+	}
+
 	#endregion
 
 	#region Index

--- a/SharpMUSH.Tests/Packages/PackagePlanServiceTests.cs
+++ b/SharpMUSH.Tests/Packages/PackagePlanServiceTests.cs
@@ -609,4 +609,160 @@ public class PackagePlanServiceTests
 	}
 
 	#endregion
+
+	#region Removed-object attributes fold into the object delete
+
+	[Test]
+	public async Task RemovedObject_ItsManagedAttributes_AreNotSeparatelyClassified()
+	{
+		// When an entire object is dropped from the new version, the object-level
+		// Delete is the unit of change (decision 20.15): its managed-attribute
+		// baselines must NOT each surface as their own Delete/Conflict. This pins
+		// the deletedObjids short-circuit in the baseline sweep — even a locally
+		// modified attribute (which on a SURVIVING object would be a ModifyDelete
+		// conflict) is folded into the single object Delete.
+		var manifest = Parse(SimpleManifest); // only object {{a}} remains
+		var installed = Installed("probe");
+		var installedObjects = new[]
+		{
+			new PackageObjectRecord("probe", "a", "#10:1", "thing"),
+			new PackageObjectRecord("probe", "gone", "#20:5", "thing")
+		};
+		var baselines = new[]
+		{
+			new ManagedAttributeRecord("probe", "#10:1", "FN_X", "value-new", "h1", "1.0.0"),
+			new ManagedAttributeRecord("probe", "#20:5", "FN_OLD", "base", "h2", "1.0.0"),
+			new ManagedAttributeRecord("probe", "#20:5", "FN_OLD2", "base2", "h3", "1.0.0")
+		};
+		var live = new LivePackageState(new Dictionary<string, LiveObjectState>
+		{
+			["#10:1"] = LiveObject("#10:1", "Thing A", ("FN_X", "value-new")),
+			["#20:5"] = LiveObject("#20:5", "Gone Thing", ("FN_OLD", "locally-changed"), ("FN_OLD2", "base2"))
+		});
+
+		var changeset = _service.ComputeChangeset(Inputs(manifest, installed, installedObjects, baselines, live: live));
+
+		var deleted = changeset.Objects.Single(o => o.Ref == "gone");
+		await Assert.That(deleted.Action).IsEqualTo(PackageObjectAction.Delete);
+		// None of the deleted object's attributes appear as separate changes.
+		await Assert.That(changeset.Attributes.Any(a => a.Objid == "#20:5")).IsFalse();
+		await Assert.That(changeset.Attributes.Any(a => a.Attribute is "FN_OLD" or "FN_OLD2")).IsFalse();
+	}
+
+	#endregion
+
+	#region Flags, locks & powers are outside the upgrade diff
+
+	// The live snapshot the plan engine compares against (LiveObjectState) carries
+	// only an object's name and attribute VALUES — it has no flag, lock, or power
+	// state, nor does PackageObjectChange/PackageAttributeChange model any of them.
+	// Object flags and locks are therefore never part of the upgrade review: the
+	// apply engine re-applies them additively (set, never unset), and powers are
+	// not a package concept at all. These tests pin that contract so any future
+	// move to diff flags/locks is a deliberate, visible decision rather than an
+	// accidental behaviour change.
+
+	[Test]
+	public async Task ObjectFlags_DoNotProduceAChangeset_OnUpgrade()
+	{
+		var manifest = Parse(
+			"""
+			package: probe
+			version: "1.1"
+			objects:
+			  - ref: a
+			    type: thing
+			    name: Thing A
+			    flags: [wizard, royalty]
+			    attributes:
+			      FN_X: "value-new"
+			""");
+		var installed = Installed("probe");
+		var installedObjects = new[] { new PackageObjectRecord("probe", "a", "#10:1", "thing") };
+		var baselines = new[] { new ManagedAttributeRecord("probe", "#10:1", "FN_X", "value-new", "h", "1.0.0") };
+		var live = new LivePackageState(new Dictionary<string, LiveObjectState>
+		{
+			["#10:1"] = LiveObject("#10:1", "Thing A", ("FN_X", "value-new"))
+		});
+
+		var changeset = _service.ComputeChangeset(Inputs(manifest, installed, installedObjects, baselines, live: live));
+
+		// Flags are parsed onto the manifest spec...
+		await Assert.That(manifest.Objects.Single().Flags.ToArray()).IsEquivalentTo((string[])["wizard", "royalty"]);
+		// ...but the object plan is driven by name alone — no flag drift is surfaced.
+		var obj = changeset.Objects.Single();
+		await Assert.That(obj.Action).IsEqualTo(PackageObjectAction.NoChange);
+		await Assert.That(obj.MetadataDiffs?.Count ?? 0).IsEqualTo(0);
+	}
+
+	[Test]
+	public async Task ObjectLocks_DoNotProduceAChangeset_OnUpgrade()
+	{
+		var manifest = Parse(
+			"""
+			package: probe
+			version: "1.1"
+			objects:
+			  - ref: a
+			    type: thing
+			    name: Thing A
+			    locks:
+			      use: "{{a}}"
+			    attributes:
+			      FN_X: "value-new"
+			""");
+		var installed = Installed("probe");
+		var installedObjects = new[] { new PackageObjectRecord("probe", "a", "#10:1", "thing") };
+		var baselines = new[] { new ManagedAttributeRecord("probe", "#10:1", "FN_X", "value-new", "h", "1.0.0") };
+		var live = new LivePackageState(new Dictionary<string, LiveObjectState>
+		{
+			["#10:1"] = LiveObject("#10:1", "Thing A", ("FN_X", "value-new"))
+		});
+
+		var changeset = _service.ComputeChangeset(Inputs(manifest, installed, installedObjects, baselines, live: live));
+
+		await Assert.That(manifest.Objects.Single().Locks.ContainsKey("use")).IsTrue();
+		await Assert.That(changeset.Objects.Single().Action).IsEqualTo(PackageObjectAction.NoChange);
+		// Lock strings are not function-evaluated, so they synthesize no PM`REFS
+		// attrs and never surface as a changeset entry.
+		await Assert.That(changeset.Attributes.Any(a => a.Attribute.StartsWith("PM`REFS"))).IsFalse();
+		await Assert.That(changeset.Attributes.Single().Attribute).IsEqualTo("FN_X");
+	}
+
+	[Test]
+	public async Task AttributeFlags_DoNotAffectPlanClassification()
+	{
+		// An attribute declares flags but its value is unchanged from baseline and
+		// live. The three-way table keys on VALUE only, so the result is NoChange —
+		// attribute-flag drift is not part of the review (the apply engine applies
+		// the declared flags additively whenever it writes the value).
+		var manifest = Parse(
+			"""
+			package: probe
+			version: "1.1"
+			objects:
+			  - ref: a
+			    type: thing
+			    name: Thing A
+			    attributes:
+			      FN_X:
+			        value: "value-new"
+			        flags: [no_command, veiled]
+			""");
+		var installed = Installed("probe");
+		var installedObjects = new[] { new PackageObjectRecord("probe", "a", "#10:1", "thing") };
+		var baselines = new[] { new ManagedAttributeRecord("probe", "#10:1", "FN_X", "value-new", "h", "1.0.0") };
+		var live = new LivePackageState(new Dictionary<string, LiveObjectState>
+		{
+			["#10:1"] = LiveObject("#10:1", "Thing A", ("FN_X", "value-new"))
+		});
+
+		var changeset = _service.ComputeChangeset(Inputs(manifest, installed, installedObjects, baselines, live: live));
+
+		await Assert.That(manifest.Objects.Single().Attributes["FN_X"].Flags.ToArray())
+			.IsEquivalentTo((string[])["no_command", "veiled"]);
+		await Assert.That(changeset.Attributes.Single().Action).IsEqualTo(PackageAttributeAction.NoChange);
+	}
+
+	#endregion
 }

--- a/SharpMUSH.Tests/Packages/PackagePlanServiceTests.cs
+++ b/SharpMUSH.Tests/Packages/PackagePlanServiceTests.cs
@@ -32,7 +32,8 @@ public class PackagePlanServiceTests
 		IReadOnlyList<InstalledPackageRecord>? allInstalled = null,
 		IReadOnlyList<ManagedAttributeRecord>? otherManaged = null,
 		LivePackageState? live = null,
-		IReadOnlyDictionary<string, string>? configure = null) => new(
+		IReadOnlyDictionary<string, string>? configure = null,
+		IReadOnlyDictionary<string, PackageStructureBaseline>? structureBaselines = null) => new(
 		manifest,
 		installed,
 		installedObjects ?? [],
@@ -42,7 +43,8 @@ public class PackagePlanServiceTests
 		live ?? LivePackageState.Empty,
 		new Dictionary<string, string> { ["room_zero"] = "#0:0" },
 		configure ?? new Dictionary<string, string>(),
-		new Dictionary<string, string>());
+		new Dictionary<string, string>(),
+		structureBaselines);
 
 	private const string SimpleManifest =
 		"""
@@ -651,54 +653,155 @@ public class PackagePlanServiceTests
 
 	#endregion
 
-	#region Flags, locks & powers are outside the upgrade diff
+	#region Object structure three-way merge (flags, powers, locks, attribute flags)
 
-	// The live snapshot the plan engine compares against (LiveObjectState) carries
-	// only an object's name and attribute VALUES — it has no flag, lock, or power
-	// state, nor does PackageObjectChange/PackageAttributeChange model any of them.
-	// Object flags and locks are therefore never part of the upgrade review: the
-	// apply engine re-applies them additively (set, never unset), and powers are
-	// not a package concept at all. These tests pin that contract so any future
-	// move to diff flags/locks is a deliberate, visible decision rather than an
-	// accidental behaviour change.
+	// Full object-structure diffs (decision 20.7, extended): object flags, object
+	// powers, attribute flags, and locks all merge three-way against a persisted
+	// per-object structure baseline. Binary elements resolve deterministically and
+	// never conflict; value-typed locks reuse the attribute conflict model.
+
+	private const string FlaggedManifest =
+		"""
+		package: probe
+		version: "1.1"
+		objects:
+		  - ref: a
+		    type: thing
+		    name: Thing A
+		    flags: [no_command, dark]
+		    powers: [pueblo]
+		    attributes:
+		      FN_X:
+		        value: "value-new"
+		        flags: [no_command, veiled]
+		""";
+
+	/// <summary>Builds inputs where {{a}} is installed at #10:1 with the given live structure and baseline.</summary>
+	private PackagePlanInputs StructureInputs(
+		string manifest, LiveObjectState liveA, PackageStructureBaseline? baselineA)
+	{
+		var live = new LivePackageState(new Dictionary<string, LiveObjectState> { ["#10:1"] = liveA });
+		var structureBaselines = baselineA is null
+			? null
+			: new Dictionary<string, PackageStructureBaseline> { ["#10:1"] = baselineA };
+		return Inputs(
+			Parse(manifest), Installed("probe"),
+			[new PackageObjectRecord("probe", "a", "#10:1", "thing")],
+			[new ManagedAttributeRecord("probe", "#10:1", "FN_X", "value-new", "h", "1.0.0")],
+			live: live, structureBaselines: structureBaselines);
+	}
+
+	private static LiveObjectState LiveStructured(
+		IReadOnlyList<string>? flags = null, IReadOnlyList<string>? powers = null,
+		IReadOnlyDictionary<string, string>? locks = null,
+		IReadOnlyDictionary<string, IReadOnlyList<string>>? attrFlags = null) => new(
+		"#10:1", true, "Thing A",
+		new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["FN_X"] = "value-new" },
+		false, flags, powers, locks, attrFlags);
+
+	private static PackageStructureChange Flag(PackageChangeset cs, string name) =>
+		cs.Structure.Single(s => s.Kind == PackageStructureKind.ObjectFlag && s.Element == name);
 
 	[Test]
-	public async Task ObjectFlags_DoNotProduceAChangeset_OnUpgrade()
+	public async Task FreshInstall_AllStructureIsAdd()
 	{
-		var manifest = Parse(
-			"""
-			package: probe
-			version: "1.1"
-			objects:
-			  - ref: a
-			    type: thing
-			    name: Thing A
-			    flags: [wizard, royalty]
-			    attributes:
-			      FN_X: "value-new"
-			""");
-		var installed = Installed("probe");
-		var installedObjects = new[] { new PackageObjectRecord("probe", "a", "#10:1", "thing") };
-		var baselines = new[] { new ManagedAttributeRecord("probe", "#10:1", "FN_X", "value-new", "h", "1.0.0") };
-		var live = new LivePackageState(new Dictionary<string, LiveObjectState>
-		{
-			["#10:1"] = LiveObject("#10:1", "Thing A", ("FN_X", "value-new"))
-		});
+		// No installed record/baseline: every flag, power, and attribute flag is Add.
+		var changeset = _service.ComputeChangeset(Inputs(Parse(FlaggedManifest)));
 
-		var changeset = _service.ComputeChangeset(Inputs(manifest, installed, installedObjects, baselines, live: live));
-
-		// Flags are parsed onto the manifest spec...
-		await Assert.That(manifest.Objects.Single().Flags.ToArray()).IsEquivalentTo((string[])["wizard", "royalty"]);
-		// ...but the object plan is driven by name alone — no flag drift is surfaced.
-		var obj = changeset.Objects.Single();
-		await Assert.That(obj.Action).IsEqualTo(PackageObjectAction.NoChange);
-		await Assert.That(obj.MetadataDiffs?.Count ?? 0).IsEqualTo(0);
+		await Assert.That(Flag(changeset, "no_command").Action).IsEqualTo(PackageStructureAction.Add);
+		await Assert.That(Flag(changeset, "dark").Action).IsEqualTo(PackageStructureAction.Add);
+		await Assert.That(changeset.Structure.Single(s => s.Kind == PackageStructureKind.ObjectPower).Element)
+			.IsEqualTo("pueblo");
+		await Assert.That(changeset.Structure
+			.Where(s => s.Kind == PackageStructureKind.AttributeFlag)
+			.All(s => s.Action == PackageStructureAction.Add)).IsTrue();
 	}
 
 	[Test]
-	public async Task ObjectLocks_DoNotProduceAChangeset_OnUpgrade()
+	public async Task NewFlag_Added_DroppedFlag_Removed()
 	{
-		var manifest = Parse(
+		// Baseline + live had [no_command]; the new version declares [no_command, dark]
+		// and drops the previously-set [royalty] → dark Add, royalty Remove, no_command NoChange.
+		var baseline = new PackageStructureBaseline(
+			["no_command", "royalty"], [], new Dictionary<string, string>(),
+			new Dictionary<string, IReadOnlyList<string>>());
+		var live = LiveStructured(flags: ["no_command", "royalty"]);
+
+		var changeset = _service.ComputeChangeset(StructureInputs(FlaggedManifest, live, baseline));
+
+		await Assert.That(Flag(changeset, "no_command").Action).IsEqualTo(PackageStructureAction.NoChange);
+		await Assert.That(Flag(changeset, "dark").Action).IsEqualTo(PackageStructureAction.Add);
+		await Assert.That(Flag(changeset, "royalty").Action).IsEqualTo(PackageStructureAction.Remove);
+	}
+
+	[Test]
+	public async Task AdminRemovedFlag_PackageStillDeclares_KeepLocal()
+	{
+		// Baseline had no_command; admin unset it live; the package still declares it.
+		var baseline = new PackageStructureBaseline(
+			["no_command", "dark"], ["pueblo"], new Dictionary<string, string>(),
+			new Dictionary<string, IReadOnlyList<string>>());
+		var live = LiveStructured(flags: ["dark"], powers: ["pueblo"]); // admin removed no_command
+
+		var changeset = _service.ComputeChangeset(StructureInputs(FlaggedManifest, live, baseline));
+
+		await Assert.That(Flag(changeset, "no_command").Action).IsEqualTo(PackageStructureAction.KeepLocal);
+		await Assert.That(Flag(changeset, "dark").Action).IsEqualTo(PackageStructureAction.NoChange);
+	}
+
+	[Test]
+	public async Task AdminAddedFlag_NotPackageManaged_LeftUntouched()
+	{
+		// The admin set an unrelated flag (wizard) the package neither knew nor wants:
+		// it is not in baseline ∪ new, so it produces no structure change at all.
+		var baseline = new PackageStructureBaseline(
+			["no_command", "dark"], ["pueblo"], new Dictionary<string, string>(),
+			new Dictionary<string, IReadOnlyList<string>>());
+		var live = LiveStructured(flags: ["no_command", "dark", "wizard"], powers: ["pueblo"]);
+
+		var changeset = _service.ComputeChangeset(StructureInputs(FlaggedManifest, live, baseline));
+
+		await Assert.That(changeset.Structure.Any(s => s.Element == "wizard")).IsFalse();
+	}
+
+	[Test]
+	public async Task UnmanagedFlagMatchingNew_Adopt()
+	{
+		// No baseline (not previously managed) but the flag is already set live and
+		// the new version declares it → Adopt (record baseline, no write).
+		var live = LiveStructured(flags: ["no_command", "dark"], powers: ["pueblo"],
+			attrFlags: new Dictionary<string, IReadOnlyList<string>> { ["FN_X"] = ["no_command", "veiled"] });
+
+		var changeset = _service.ComputeChangeset(StructureInputs(FlaggedManifest, live, baselineA: null));
+
+		await Assert.That(Flag(changeset, "no_command").Action).IsEqualTo(PackageStructureAction.Adopt);
+	}
+
+	[Test]
+	public async Task AttributeFlag_AddedAndRemoved_AcrossVersions()
+	{
+		// Baseline attr-flags were [no_command]; new declares [no_command, veiled] →
+		// veiled Add, no_command NoChange.
+		var baseline = new PackageStructureBaseline(
+			["no_command", "dark"], ["pueblo"], new Dictionary<string, string>(),
+			new Dictionary<string, IReadOnlyList<string>> { ["FN_X"] = ["no_command"] });
+		var live = LiveStructured(flags: ["no_command", "dark"], powers: ["pueblo"],
+			attrFlags: new Dictionary<string, IReadOnlyList<string>> { ["FN_X"] = ["no_command"] });
+
+		var changeset = _service.ComputeChangeset(StructureInputs(FlaggedManifest, live, baseline));
+
+		var attrFlagChanges = changeset.Structure
+			.Where(s => s.Kind == PackageStructureKind.AttributeFlag && s.Attribute == "FN_X")
+			.ToDictionary(s => s.Element, s => s.Action);
+		await Assert.That(attrFlagChanges["veiled"]).IsEqualTo(PackageStructureAction.Add);
+		await Assert.That(attrFlagChanges["no_command"]).IsEqualTo(PackageStructureAction.NoChange);
+	}
+
+	[Test]
+	public async Task Lock_BothChanged_Conflict_AdminUnchanged_AutoUpgrade()
+	{
+		// Locks are value-typed and reuse the attribute conflict model.
+		const string manifest =
 			"""
 			package: probe
 			version: "1.1"
@@ -707,36 +810,34 @@ public class PackagePlanServiceTests
 			    type: thing
 			    name: Thing A
 			    locks:
-			      use: "{{a}}"
+			      use: "=#5"
 			    attributes:
 			      FN_X: "value-new"
-			""");
-		var installed = Installed("probe");
-		var installedObjects = new[] { new PackageObjectRecord("probe", "a", "#10:1", "thing") };
-		var baselines = new[] { new ManagedAttributeRecord("probe", "#10:1", "FN_X", "value-new", "h", "1.0.0") };
-		var live = new LivePackageState(new Dictionary<string, LiveObjectState>
-		{
-			["#10:1"] = LiveObject("#10:1", "Thing A", ("FN_X", "value-new"))
-		});
+			""";
 
-		var changeset = _service.ComputeChangeset(Inputs(manifest, installed, installedObjects, baselines, live: live));
+		// Package changed the lock (base "=#1" -> new "=#5"); admin left it at base.
+		var baselineAuto = new PackageStructureBaseline(
+			[], [], new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["use"] = "=#1" },
+			new Dictionary<string, IReadOnlyList<string>>());
+		var liveAuto = LiveStructured(locks: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["use"] = "=#1" });
+		var auto = _service.ComputeChangeset(StructureInputs(manifest, liveAuto, baselineAuto));
+		var autoLock = auto.Structure.Single(s => s.Kind == PackageStructureKind.Lock);
+		await Assert.That(autoLock.Action).IsEqualTo(PackageStructureAction.Add); // write the package's new lock
+		await Assert.That(autoLock.NewValue).IsEqualTo("=#5");
 
-		await Assert.That(manifest.Objects.Single().Locks.ContainsKey("use")).IsTrue();
-		await Assert.That(changeset.Objects.Single().Action).IsEqualTo(PackageObjectAction.NoChange);
-		// Lock strings are not function-evaluated, so they synthesize no PM`REFS
-		// attrs and never surface as a changeset entry.
-		await Assert.That(changeset.Attributes.Any(a => a.Attribute.StartsWith("PM`REFS"))).IsFalse();
-		await Assert.That(changeset.Attributes.Single().Attribute).IsEqualTo("FN_X");
+		// Admin also changed it locally → ModifyModify conflict.
+		var liveConflict = LiveStructured(locks: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["use"] = "=#9" });
+		var conflict = _service.ComputeChangeset(StructureInputs(manifest, liveConflict, baselineAuto));
+		var conflictLock = conflict.Structure.Single(s => s.Kind == PackageStructureKind.Lock);
+		await Assert.That(conflictLock.Action).IsEqualTo(PackageStructureAction.Conflict);
+		await Assert.That(conflictLock.Conflict).IsEqualTo(PackageConflictKind.ModifyModify);
+		await Assert.That(conflict.HasConflicts).IsTrue();
 	}
 
 	[Test]
-	public async Task AttributeFlags_DoNotAffectPlanClassification()
+	public async Task Lock_DroppedFromManifest_Unmodified_Remove()
 	{
-		// An attribute declares flags but its value is unchanged from baseline and
-		// live. The three-way table keys on VALUE only, so the result is NoChange —
-		// attribute-flag drift is not part of the review (the apply engine applies
-		// the declared flags additively whenever it writes the value).
-		var manifest = Parse(
+		const string manifest =
 			"""
 			package: probe
 			version: "1.1"
@@ -745,23 +846,17 @@ public class PackagePlanServiceTests
 			    type: thing
 			    name: Thing A
 			    attributes:
-			      FN_X:
-			        value: "value-new"
-			        flags: [no_command, veiled]
-			""");
-		var installed = Installed("probe");
-		var installedObjects = new[] { new PackageObjectRecord("probe", "a", "#10:1", "thing") };
-		var baselines = new[] { new ManagedAttributeRecord("probe", "#10:1", "FN_X", "value-new", "h", "1.0.0") };
-		var live = new LivePackageState(new Dictionary<string, LiveObjectState>
-		{
-			["#10:1"] = LiveObject("#10:1", "Thing A", ("FN_X", "value-new"))
-		});
+			      FN_X: "value-new"
+			""";
+		var baseline = new PackageStructureBaseline(
+			[], [], new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["use"] = "=#1" },
+			new Dictionary<string, IReadOnlyList<string>>());
+		var live = LiveStructured(locks: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["use"] = "=#1" });
 
-		var changeset = _service.ComputeChangeset(Inputs(manifest, installed, installedObjects, baselines, live: live));
+		var changeset = _service.ComputeChangeset(StructureInputs(manifest, live, baseline));
 
-		await Assert.That(manifest.Objects.Single().Attributes["FN_X"].Flags.ToArray())
-			.IsEquivalentTo((string[])["no_command", "veiled"]);
-		await Assert.That(changeset.Attributes.Single().Action).IsEqualTo(PackageAttributeAction.NoChange);
+		var lockChange = changeset.Structure.Single(s => s.Kind == PackageStructureKind.Lock);
+		await Assert.That(lockChange.Action).IsEqualTo(PackageStructureAction.Remove);
 	}
 
 	#endregion


### PR DESCRIPTION
Add tests pinning the package-upgrade contract that was previously
under-covered:

- Plan engine (no DB):
  - a whole-object deletion folds in its managed attributes rather than
    classifying each baseline separately
  - object flags and locks are outside the upgrade diff (the live snapshot
    carries no flag/lock state) and never produce a changeset entry
  - attribute flags do not affect three-way classification (value-only)
- Manifest parsing (no DB):
  - object flags and locks parse
  - attribute flags parse from the mapping form; the shorthand has none
  - `powers` is not a supported object key — warned and ignored
- Apply engine (end-to-end): declared attribute flags are applied to the
  live attribute, and an attribute dropped from the new version (locally
  untouched) is cleanly deleted with its baseline removed

https://claude.ai/code/session_01P6GrnQZPwTBWF5Te1WgRyR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for upgrades to ensure dropped attributes are cleared, attribute flags persist correctly, and object flags/locks are added/removed as expected.
  * Added manifest parsing tests for object `flags`, `locks`, and `powers`, including validation that attach objects reject `powers`.
  * Added package planning/classification tests for structure three-way merges (flags, powers, locks, attribute flags) and for ensuring removed objects don’t produce separate managed-attribute deletes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->