### PR TITLE
Add @package command to author packages from live objects in-game

### DIFF
--- a/.github/workflows/_dotnet-build-test.yml
+++ b/.github/workflows/_dotnet-build-test.yml
@@ -158,3 +158,11 @@ jobs:
           name: test-telemetry-integration-${{ matrix.database }}
           path: test-telemetry-integration.md
           if-no-files-found: ignore
+
+      - name: Upload Generated Myrddin BBS Package Manifest
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: myrddin-bbs-package-${{ matrix.database }}
+          path: '**/MyrddinBBS_GeneratedPackage.yaml'
+          if-no-files-found: warn

--- a/SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpcmd.md
+++ b/SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpcmd.md
@@ -2989,6 +2989,22 @@ This command sets the parent of `<object>` to `<parent>`. If no `<parent>` is gi
 - [parent()]
 - [lparent()]
 - [ANCESTORS]
+# @package
+`@package/scan <objects>`<br>
+`@package <objects>=<package-id>[,<version>[,<description>]]`
+
+Wizard-only. Turns one or more live objects into a softcode package manifest (`package.yaml`), the same format the web authoring panel produces at `/admin/packages/author`. `<objects>` is a space-separated list of dbrefs or names.
+
+`@package/scan` is read-only: it lists each object, the manifest ref it would be given, and any dbrefs the objects reference *outside* the selection.
+
+`@package <objects>=<package-id>` exports the selection and pemits the resulting manifest back to you. Dbrefs that point at another selected object are converted to symbolic `{{ref}}` tokens automatically. `<version>` defaults to `1.0.0` and `<description>` defaults to an auto-generated note.
+
+This single-step export only succeeds when the selection is **self-contained** — every dbref in the objects' attributes points at another selected object. If any attribute references an object outside the selection, that dbref must be classified as a well-known object or a configure parameter, which is done in the web authoring panel; `@package` will tell you which dbrefs are unresolved and point you there.
+
+
+**See Also:**
+- [@decompile]
+- [PACKAGES]
 # @password
 `@password <old password>=<new password>`
 

--- a/SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpcmd.md
+++ b/SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpcmd.md
@@ -3001,6 +3001,8 @@ Wizard-only. Turns one or more live objects into a softcode package manifest (`p
 
 This single-step export only succeeds when the selection is **self-contained** — every dbref in the objects' attributes points at another selected object. If any attribute references an object outside the selection, that dbref must be classified as a well-known object or a configure parameter, which is done in the web authoring panel; `@package` will tell you which dbrefs are unresolved and point you there.
 
+`@package` obeys the same visibility rules as `@decompile`: an object must pass your examine permission, and only the attributes you can see — VEILED attributes excluded — are scanned or written into the manifest.
+
 
 **See Also:**
 - [@decompile]

--- a/SharpMUSH.Implementation/Commands/PackageCommands.cs
+++ b/SharpMUSH.Implementation/Commands/PackageCommands.cs
@@ -1,0 +1,222 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.DependencyInjection;
+using OneOf.Types;
+using SharpMUSH.Library.Attributes;
+using SharpMUSH.Library.Definitions;
+using SharpMUSH.Library.DiscriminatedUnions;
+using SharpMUSH.Library.Extensions;
+using SharpMUSH.Library.Models.Packages;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Services.Interfaces;
+using CB = SharpMUSH.Library.Definitions.CommandBehavior;
+
+namespace SharpMUSH.Implementation.Commands;
+
+public partial class Commands
+{
+	[GeneratedRegex("^[a-z][a-z0-9-]*$")]
+	private static partial Regex PackageIdRegex();
+
+	/// <summary>
+	/// @PACKAGE — the in-game shortcut to the softcode package authoring service
+	/// (the same engine behind /admin/packages/author). Wraps scan + export so a
+	/// wizard can turn a cluster of live objects into a package.yaml manifest
+	/// without leaving the game.
+	///
+	/// <para>
+	/// <c>@package/scan obj1 obj2 ...</c> — read-only report: shows the suggested
+	/// ref for each object and any dbrefs referenced outside the selection.
+	/// </para>
+	/// <para>
+	/// <c>@package obj1 obj2 ...=&lt;id&gt;[,&lt;version&gt;[,&lt;description&gt;]]</c> — exports the
+	/// selection as a manifest, pemitted back to you. In-selection dbrefs become
+	/// <c>{{ref}}</c> tokens automatically. This single-step path only succeeds when
+	/// the selection is self-contained (every dbref in their attributes points at
+	/// another selected object); anything referencing the outside world needs the
+	/// well-known / configure classification step in the web authoring panel.
+	/// </para>
+	/// </summary>
+	[SharpCommand(Name = "@PACKAGE", Switches = ["SCAN"],
+		Behavior = CB.Default | CB.EqSplit | CB.RSArgs | CB.NoGagged,
+		CommandLock = "FLAG^WIZARD", MinArgs = 1, MaxArgs = 4,
+		ParameterNames = ["objects", "package", "version", "description"])]
+	public static async ValueTask<Option<CallState>> Package(IMUSHCodeParser parser, SharpCommandAttribute _2)
+	{
+		var args = parser.CurrentState.Arguments;
+		var switches = parser.CurrentState.Switches;
+		var enactor = (await parser.CurrentState.EnactorObject(Mediator!)).WithoutNone();
+		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
+
+		var objectList = args["0"].Message?.ToPlainText() ?? string.Empty;
+		var tokens = objectList.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+		if (tokens.Length == 0)
+		{
+			await NotifyService!.Notify(executor, "PACKAGE: You must name at least one object to package.");
+			return new CallState(string.Empty);
+		}
+
+		// Resolve every named object to a stable objid the authoring service understands.
+		var objids = new List<string>();
+		foreach (var token in tokens)
+		{
+			var locate = await LocateService!.LocateAndNotifyIfInvalid(parser, enactor, executor, token, LocateFlags.All);
+			if (!locate.IsValid())
+			{
+				return new None();
+			}
+
+			var found = locate.WithoutError();
+			if (found.IsNone())
+			{
+				return new None();
+			}
+
+			var known = found.Known();
+			if (!await PermissionService!.CanExamine(executor, known))
+			{
+				await NotifyService!.Notify(executor, $"PACKAGE: You can't examine {known.Object().Name}.");
+				return new CallState(string.Empty);
+			}
+
+			objids.Add(known.Object().DBRef.ToString());
+		}
+
+		var authoring = parser.ServiceProvider.GetRequiredService<IPackageAuthoringService>();
+
+		var scan = await authoring.ScanAsync(objids.Distinct().ToList());
+		if (scan.IsT1)
+		{
+			await NotifyService!.Notify(executor, $"PACKAGE: {scan.AsT1.Value}");
+			return new CallState(string.Empty);
+		}
+
+		var scanResult = scan.AsT0;
+
+		// /SCAN: read-only report only — never produces a manifest.
+		if (switches.Contains("SCAN"))
+		{
+			var report = new StringBuilder();
+			report.AppendLine($"PACKAGE SCAN: {scanResult.Objects.Count} object(s) selected.");
+			foreach (var obj in scanResult.Objects)
+			{
+				report.AppendLine(
+					$"  {obj.Name} ({obj.Type}, {obj.Objid}) -> ref '{obj.SuggestedRef}'; {obj.Attributes.Count} attr(s), {obj.Flags.Count} flag(s).");
+			}
+
+			if (scanResult.ExternalDbrefs.Count == 0)
+			{
+				report.AppendLine("Self-contained: no external dbrefs. Ready to package with:");
+				report.Append($"  @package {objectList}=<package-id>");
+			}
+			else
+			{
+				report.AppendLine(
+					$"External references ({scanResult.ExternalDbrefs.Count}) must be classified in the web authoring panel:");
+				foreach (var ext in scanResult.ExternalDbrefs)
+				{
+					report.AppendLine($"  {ext.Dbref}  ({ext.Occurrences} occurrence(s), e.g. {ext.ExampleAttribute})");
+				}
+
+				report.Append("Finish at: /admin/packages/author");
+			}
+
+			await NotifyService!.Notify(executor, report.ToString());
+			return new CallState(string.Empty);
+		}
+
+		// Export path needs a package id on the right-hand side.
+		if (!args.TryGetValue("1", out var idArg) || string.IsNullOrWhiteSpace(idArg.Message?.ToPlainText()))
+		{
+			await NotifyService!.Notify(executor,
+				"PACKAGE: Usage: @package <objects>=<package-id>[,<version>[,<description>]]  (or @package/scan <objects>)");
+			return new CallState(string.Empty);
+		}
+
+		var packageId = idArg.Message!.ToPlainText().Trim();
+		if (!PackageIdRegex().IsMatch(packageId))
+		{
+			await NotifyService!.Notify(executor,
+				$"PACKAGE: '{packageId}' is not a valid package id (lowercase letters, digits and hyphens; must start with a letter).");
+			return new CallState(string.Empty);
+		}
+
+		// Self-contained only: any dbref pointing outside the selection needs the
+		// well-known/configure classification the web authoring panel provides.
+		if (scanResult.ExternalDbrefs.Count > 0)
+		{
+			var blocked = new StringBuilder();
+			blocked.AppendLine(
+				$"PACKAGE: These objects reference {scanResult.ExternalDbrefs.Count} dbref(s) outside your selection, so they aren't self-contained:");
+			foreach (var ext in scanResult.ExternalDbrefs)
+			{
+				blocked.AppendLine($"  {ext.Dbref}  ({ext.Occurrences} occurrence(s), e.g. {ext.ExampleAttribute})");
+			}
+
+			blocked.AppendLine(
+				"Each must be classified as a well-known object or a configure parameter — finish this package at:");
+			blocked.Append("  /admin/packages/author");
+			await NotifyService!.Notify(executor, blocked.ToString());
+			return new CallState(string.Empty);
+		}
+
+		var version = args.TryGetValue("2", out var versionArg)
+			? versionArg.Message?.ToPlainText().Trim() ?? string.Empty
+			: string.Empty;
+		if (string.IsNullOrEmpty(version))
+		{
+			version = "1.0.0";
+		}
+
+		var description = args.TryGetValue("3", out var descriptionArg)
+			? descriptionArg.Message?.ToPlainText().Trim() ?? string.Empty
+			: string.Empty;
+		if (string.IsNullOrEmpty(description))
+		{
+			description = $"Exported from {executor.Object().Name} via @package.";
+		}
+
+		// Give every object a unique manifest ref derived from its suggested slug.
+		var usedRefs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		var selections = new List<AuthoringObjectSelection>();
+		foreach (var obj in scanResult.Objects)
+		{
+			var refName = obj.SuggestedRef;
+			if (!usedRefs.Add(refName))
+			{
+				var n = 2;
+				string candidate;
+				do
+				{
+					candidate = $"{refName}_{n}";
+					n++;
+				} while (!usedRefs.Add(candidate));
+
+				refName = candidate;
+			}
+
+			selections.Add(new AuthoringObjectSelection(obj.Objid, refName, []));
+		}
+
+		var export = await authoring.ExportAsync(new PackageAuthoringRequest(
+			packageId, version, description, null, [executor.Object().Name],
+			selections,
+			new Dictionary<string, string>(),
+			new Dictionary<string, AuthoringConfigureClassification>()));
+
+		if (export.IsT1)
+		{
+			await NotifyService!.Notify(executor, $"PACKAGE: {export.AsT1.Value}");
+			return new CallState(string.Empty);
+		}
+
+		var output = new StringBuilder();
+		output.AppendLine($"PACKAGE: Generated manifest for '{packageId}' v{version} ({selections.Count} object(s)).");
+		output.AppendLine("Copy everything between the markers into a package.yaml:");
+		output.AppendLine("----- BEGIN package.yaml -----");
+		output.AppendLine(export.AsT0.TrimEnd());
+		output.Append("----- END package.yaml -----");
+		await NotifyService!.Notify(executor, output.ToString());
+		return new CallState(string.Empty);
+	}
+}

--- a/SharpMUSH.Implementation/Commands/PackageCommands.cs
+++ b/SharpMUSH.Implementation/Commands/PackageCommands.cs
@@ -18,12 +18,22 @@ public partial class Commands
 	[GeneratedRegex("^[a-z][a-z0-9-]*$")]
 	private static partial Regex PackageIdRegex();
 
+	[GeneratedRegex(@"#(?<number>\d+)(?::\d+)?")]
+	private static partial Regex PackageDbrefRegex();
+
+	private const string VeiledAttributeFlag = "VEILED";
+
 	/// <summary>
 	/// @PACKAGE — the in-game face of the softcode package authoring service
 	/// (the same engine behind /admin/packages/author). Wraps scan + export so a
 	/// wizard can turn a cluster of live objects into a package.yaml manifest
 	/// without leaving the game.
 	///
+	/// <para>
+	/// Visibility matches @decompile: an object must pass <c>CanExamine</c>, and only
+	/// the attributes the executor can see (per <c>GetVisibleAttributesAsync</c>, with
+	/// VEILED attributes skipped) are ever scanned or exported.
+	/// </para>
 	/// <para>
 	/// <c>@package/scan obj1 obj2 ...</c> — read-only report: shows the suggested
 	/// ref for each object and any dbrefs referenced outside the selection.
@@ -32,8 +42,8 @@ public partial class Commands
 	/// <c>@package obj1 obj2 ...=&lt;id&gt;[,&lt;version&gt;[,&lt;description&gt;]]</c> — exports the
 	/// selection as a manifest, pemitted back to you. In-selection dbrefs become
 	/// <c>{{ref}}</c> tokens automatically. This single-step path only succeeds when
-	/// the selection is self-contained (every dbref in their attributes points at
-	/// another selected object); anything referencing the outside world needs the
+	/// the selection is self-contained (every dbref in the visible attributes points
+	/// at another selected object); anything referencing the outside world needs the
 	/// well-known / configure classification step in the web authoring panel.
 	/// </para>
 	/// </summary>
@@ -57,7 +67,9 @@ public partial class Commands
 		}
 
 		// Resolve every named object to a stable objid the authoring service understands.
+		// Object visibility matches @decompile: each must pass CanExamine.
 		var objids = new List<string>();
+		var knownByObjid = new Dictionary<string, AnySharpObject>(StringComparer.Ordinal);
 		foreach (var token in tokens)
 		{
 			var locate = await LocateService!.LocateAndNotifyIfInvalid(parser, enactor, executor, token, LocateFlags.All);
@@ -79,7 +91,9 @@ public partial class Commands
 				return new CallState(string.Empty);
 			}
 
-			objids.Add(known.Object().DBRef.ToString());
+			var objid = known.Object().DBRef.ToString();
+			objids.Add(objid);
+			knownByObjid[objid] = known;
 		}
 
 		var authoring = parser.ServiceProvider.GetRequiredService<IPackageAuthoringService>();
@@ -93,18 +107,51 @@ public partial class Commands
 
 		var scanResult = scan.AsT0;
 
-		// /SCAN: read-only report only — never produces a manifest.
+		// Attribute visibility matches @decompile: keep only the attributes the
+		// executor may see (GetVisibleAttributesAsync), minus VEILED. Everything else
+		// is excluded from the export and ignored when judging self-containment.
+		var visibleByObjid = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+		foreach (var obj in scanResult.Objects)
+		{
+			var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+			if (knownByObjid.TryGetValue(obj.Objid, out var known))
+			{
+				var visible = await AttributeService!.GetVisibleAttributesAsync(executor, known);
+				if (visible.IsAttribute)
+				{
+					foreach (var attr in visible.AsAttributes)
+					{
+						if (!attr.Flags.Any(f => f.Name.Equals(VeiledAttributeFlag, StringComparison.OrdinalIgnoreCase)))
+						{
+							names.Add(attr.Name);
+						}
+					}
+				}
+			}
+
+			visibleByObjid[obj.Objid] = names;
+		}
+
+		var selectedNumbers = knownByObjid.Values.Select(k => k.Object().DBRef.Number).ToHashSet();
+
+		// /SCAN: read-only report only — never produces a manifest. External dbrefs are
+		// computed over the visible attributes so the report agrees with what export does.
 		if (switches.Contains("SCAN"))
 		{
+			var external = ExternalDbrefsOverVisible(scanResult, visibleByObjid, selectedNumbers);
+
 			var report = new StringBuilder();
 			report.AppendLine($"PACKAGE SCAN: {scanResult.Objects.Count} object(s) selected.");
 			foreach (var obj in scanResult.Objects)
 			{
+				var visibleCount = visibleByObjid[obj.Objid].Count;
+				var hidden = obj.Attributes.Count - visibleCount;
+				var hiddenNote = hidden > 0 ? $", {hidden} hidden" : string.Empty;
 				report.AppendLine(
-					$"  {obj.Name} ({obj.Type}, {obj.Objid}) -> ref '{obj.SuggestedRef}'; {obj.Attributes.Count} attr(s), {obj.Flags.Count} flag(s).");
+					$"  {obj.Name} ({obj.Type}, {obj.Objid}) -> ref '{obj.SuggestedRef}'; {visibleCount} visible attr(s){hiddenNote}, {obj.Flags.Count} flag(s).");
 			}
 
-			if (scanResult.ExternalDbrefs.Count == 0)
+			if (external.Count == 0)
 			{
 				report.AppendLine("Self-contained: no external dbrefs. Ready to package with:");
 				report.Append($"  @package {objectList}=<package-id>");
@@ -112,10 +159,10 @@ public partial class Commands
 			else
 			{
 				report.AppendLine(
-					$"External references ({scanResult.ExternalDbrefs.Count}) must be classified in the web authoring panel:");
-				foreach (var ext in scanResult.ExternalDbrefs)
+					$"External references ({external.Count}) must be classified in the web authoring panel:");
+				foreach (var (dbref, count, example) in external)
 				{
-					report.AppendLine($"  {ext.Dbref}  ({ext.Occurrences} occurrence(s), e.g. {ext.ExampleAttribute})");
+					report.AppendLine($"  {dbref}  ({count} occurrence(s), e.g. {example})");
 				}
 
 				report.Append("Finish at: /admin/packages/author");
@@ -143,25 +190,6 @@ public partial class Commands
 			return new CallState(string.Empty);
 		}
 
-		// Self-contained only: any dbref pointing outside the selection needs the
-		// well-known/configure classification the web authoring panel provides.
-		if (scanResult.ExternalDbrefs.Count > 0)
-		{
-			var blocked = new StringBuilder();
-			blocked.AppendLine(
-				$"PACKAGE: These objects reference {scanResult.ExternalDbrefs.Count} dbref(s) outside your selection, so they aren't self-contained:");
-			foreach (var ext in scanResult.ExternalDbrefs)
-			{
-				blocked.AppendLine($"  {ext.Dbref}  ({ext.Occurrences} occurrence(s), e.g. {ext.ExampleAttribute})");
-			}
-
-			blocked.AppendLine(
-				"Each must be classified as a well-known object or a configure parameter — finish this package at:");
-			blocked.Append("  /admin/packages/author");
-			await NotifyService!.Notify(executor, blocked.ToString(), executor);
-			return new CallState(string.Empty);
-		}
-
 		var version = args.TryGetValue("2", out var versionArg)
 			? versionArg.Message?.ToPlainText().Trim() ?? string.Empty
 			: string.Empty;
@@ -178,7 +206,10 @@ public partial class Commands
 			description = $"Exported from {executor.Object().Name} via @package.";
 		}
 
-		// Give every object a unique manifest ref derived from its suggested slug.
+		// Give every object a unique manifest ref derived from its suggested slug, and
+		// exclude every attribute the executor cannot see (parity with @decompile). The
+		// authoring exporter only inspects included attributes when resolving dbrefs, so
+		// self-containment is judged over exactly the visible set.
 		var usedRefs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 		var selections = new List<AuthoringObjectSelection>();
 		foreach (var obj in scanResult.Objects)
@@ -197,7 +228,9 @@ public partial class Commands
 				refName = candidate;
 			}
 
-			selections.Add(new AuthoringObjectSelection(obj.Objid, refName, []));
+			var visible = visibleByObjid[obj.Objid];
+			var excluded = obj.Attributes.Keys.Where(k => !visible.Contains(k)).ToList();
+			selections.Add(new AuthoringObjectSelection(obj.Objid, refName, excluded));
 		}
 
 		var export = await authoring.ExportAsync(new PackageAuthoringRequest(
@@ -208,7 +241,13 @@ public partial class Commands
 
 		if (export.IsT1)
 		{
-			await NotifyService!.Notify(executor, $"PACKAGE: {export.AsT1.Value}", executor);
+			var error = export.AsT1.Value;
+			// Unclassified dbrefs mean the selection isn't self-contained — point the
+			// user at the web panel where they can classify them.
+			var hint = error.StartsWith("Unclassified", StringComparison.Ordinal)
+				? "\nThese objects reference the outside world — finish this package at: /admin/packages/author"
+				: string.Empty;
+			await NotifyService!.Notify(executor, $"PACKAGE: {error}{hint}", executor);
 			return new CallState(string.Empty);
 		}
 
@@ -220,5 +259,47 @@ public partial class Commands
 		output.Append("----- END package.yaml -----");
 		await NotifyService!.Notify(executor, output.ToString(), executor);
 		return new CallState(string.Empty);
+	}
+
+	/// <summary>
+	/// Finds dbrefs referenced in the <em>visible</em> attribute values that are not
+	/// themselves in the selection. Mirrors the authoring service's scan, but scoped to
+	/// the attributes the executor may see so the scan report matches the export.
+	/// </summary>
+	private static List<(string Dbref, int Count, string Example)> ExternalDbrefsOverVisible(
+		PackageAuthoringScan scanResult,
+		IReadOnlyDictionary<string, HashSet<string>> visibleByObjid,
+		IReadOnlySet<int> selectedNumbers)
+	{
+		var external = new Dictionary<int, (int Count, string Example)>();
+		foreach (var obj in scanResult.Objects)
+		{
+			var visible = visibleByObjid[obj.Objid];
+			foreach (var (attrName, value) in obj.Attributes)
+			{
+				if (!visible.Contains(attrName))
+				{
+					continue;
+				}
+
+				foreach (Match match in PackageDbrefRegex().Matches(value))
+				{
+					var number = int.Parse(match.Groups["number"].Value);
+					if (selectedNumbers.Contains(number))
+					{
+						continue;
+					}
+
+					external[number] = external.TryGetValue(number, out var existing)
+						? (existing.Count + 1, existing.Example)
+						: (1, $"{obj.Objid}/{attrName}");
+				}
+			}
+		}
+
+		return external
+			.OrderByDescending(kv => kv.Value.Count)
+			.Select(kv => ($"#{kv.Key}", kv.Value.Count, kv.Value.Example))
+			.ToList();
 	}
 }

--- a/SharpMUSH.Implementation/Commands/PackageCommands.cs
+++ b/SharpMUSH.Implementation/Commands/PackageCommands.cs
@@ -19,7 +19,7 @@ public partial class Commands
 	private static partial Regex PackageIdRegex();
 
 	/// <summary>
-	/// @PACKAGE — the in-game shortcut to the softcode package authoring service
+	/// @PACKAGE — the in-game face of the softcode package authoring service
 	/// (the same engine behind /admin/packages/author). Wraps scan + export so a
 	/// wizard can turn a cluster of live objects into a package.yaml manifest
 	/// without leaving the game.
@@ -52,7 +52,7 @@ public partial class Commands
 		var tokens = objectList.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 		if (tokens.Length == 0)
 		{
-			await NotifyService!.Notify(executor, "PACKAGE: You must name at least one object to package.");
+			await NotifyService!.Notify(executor, "PACKAGE: You must name at least one object to package.", executor);
 			return new CallState(string.Empty);
 		}
 
@@ -75,7 +75,7 @@ public partial class Commands
 			var known = found.Known();
 			if (!await PermissionService!.CanExamine(executor, known))
 			{
-				await NotifyService!.Notify(executor, $"PACKAGE: You can't examine {known.Object().Name}.");
+				await NotifyService!.Notify(executor, $"PACKAGE: You can't examine {known.Object().Name}.", executor);
 				return new CallState(string.Empty);
 			}
 
@@ -87,7 +87,7 @@ public partial class Commands
 		var scan = await authoring.ScanAsync(objids.Distinct().ToList());
 		if (scan.IsT1)
 		{
-			await NotifyService!.Notify(executor, $"PACKAGE: {scan.AsT1.Value}");
+			await NotifyService!.Notify(executor, $"PACKAGE: {scan.AsT1.Value}", executor);
 			return new CallState(string.Empty);
 		}
 
@@ -121,7 +121,7 @@ public partial class Commands
 				report.Append("Finish at: /admin/packages/author");
 			}
 
-			await NotifyService!.Notify(executor, report.ToString());
+			await NotifyService!.Notify(executor, report.ToString(), executor);
 			return new CallState(string.Empty);
 		}
 
@@ -129,7 +129,8 @@ public partial class Commands
 		if (!args.TryGetValue("1", out var idArg) || string.IsNullOrWhiteSpace(idArg.Message?.ToPlainText()))
 		{
 			await NotifyService!.Notify(executor,
-				"PACKAGE: Usage: @package <objects>=<package-id>[,<version>[,<description>]]  (or @package/scan <objects>)");
+				"PACKAGE: Usage: @package <objects>=<package-id>[,<version>[,<description>]]  (or @package/scan <objects>)",
+				executor);
 			return new CallState(string.Empty);
 		}
 
@@ -137,7 +138,8 @@ public partial class Commands
 		if (!PackageIdRegex().IsMatch(packageId))
 		{
 			await NotifyService!.Notify(executor,
-				$"PACKAGE: '{packageId}' is not a valid package id (lowercase letters, digits and hyphens; must start with a letter).");
+				$"PACKAGE: '{packageId}' is not a valid package id (lowercase letters, digits and hyphens; must start with a letter).",
+				executor);
 			return new CallState(string.Empty);
 		}
 
@@ -156,7 +158,7 @@ public partial class Commands
 			blocked.AppendLine(
 				"Each must be classified as a well-known object or a configure parameter — finish this package at:");
 			blocked.Append("  /admin/packages/author");
-			await NotifyService!.Notify(executor, blocked.ToString());
+			await NotifyService!.Notify(executor, blocked.ToString(), executor);
 			return new CallState(string.Empty);
 		}
 
@@ -206,7 +208,7 @@ public partial class Commands
 
 		if (export.IsT1)
 		{
-			await NotifyService!.Notify(executor, $"PACKAGE: {export.AsT1.Value}");
+			await NotifyService!.Notify(executor, $"PACKAGE: {export.AsT1.Value}", executor);
 			return new CallState(string.Empty);
 		}
 
@@ -216,7 +218,7 @@ public partial class Commands
 		output.AppendLine("----- BEGIN package.yaml -----");
 		output.AppendLine(export.AsT0.TrimEnd());
 		output.Append("----- END package.yaml -----");
-		await NotifyService!.Notify(executor, output.ToString());
+		await NotifyService!.Notify(executor, output.ToString(), executor);
 		return new CallState(string.Empty);
 	}
 }

--- a/SharpMUSH.Library/Services/PackageAuthoringService.cs
+++ b/SharpMUSH.Library/Services/PackageAuthoringService.cs
@@ -191,7 +191,11 @@ public partial class PackageAuthoringService(
 				foreach (var (attrName, value) in included)
 				{
 					body.AppendLine($"      {attrName}:");
-					body.AppendLine("        value: |-");
+					// Explicit block-indentation indicator (content is indented 2 past the
+					// `value:` key). Without it, YamlDotNet cannot auto-detect indentation
+					// for values whose only line is blank/whitespace-only (e.g. an empty
+					// attribute), and rejects the manifest with "extra spaces in first line".
+					body.AppendLine("        value: |2-");
 					foreach (var line in Tokenize(value).Replace("\r\n", "\n").Split('\n'))
 					{
 						body.AppendLine($"          {line}");

--- a/SharpMUSH.Library/Services/PackageAuthoringService.cs
+++ b/SharpMUSH.Library/Services/PackageAuthoringService.cs
@@ -191,14 +191,27 @@ public partial class PackageAuthoringService(
 				foreach (var (attrName, value) in included)
 				{
 					body.AppendLine($"      {attrName}:");
-					// Explicit block-indentation indicator (content is indented 2 past the
-					// `value:` key). Without it, YamlDotNet cannot auto-detect indentation
-					// for values whose only line is blank/whitespace-only (e.g. an empty
-					// attribute), and rejects the manifest with "extra spaces in first line".
-					body.AppendLine("        value: |2-");
-					foreach (var line in Tokenize(value).Replace("\r\n", "\n").Split('\n'))
+					var tokenized = Tokenize(value).Replace("\r\n", "\n");
+					// Empty or leading/trailing-whitespace single-line values cannot ride in
+					// a literal block scalar: YamlDotNet can't anchor indentation on an
+					// all-blank line (it rejects the manifest with "extra spaces in first
+					// line"), and leading whitespace would be silently lost. Carry those as a
+					// single-quoted scalar, which preserves whitespace exactly. Everything
+					// else stays a block scalar so MUSHcode diffs stay readable.
+					if (!tokenized.Contains('\n')
+						&& (tokenized.Length == 0
+							|| char.IsWhiteSpace(tokenized[0])
+							|| char.IsWhiteSpace(tokenized[^1])))
 					{
-						body.AppendLine($"          {line}");
+						body.AppendLine($"        value: {QuoteYaml(tokenized)}");
+					}
+					else
+					{
+						body.AppendLine("        value: |-");
+						foreach (var line in tokenized.Split('\n'))
+						{
+							body.AppendLine($"          {line}");
+						}
 					}
 				}
 			}

--- a/SharpMUSH.Tests.Integration/Integration/MyrddinBBSIntegrationTests.cs
+++ b/SharpMUSH.Tests.Integration/Integration/MyrddinBBSIntegrationTests.cs
@@ -495,30 +495,55 @@ public class MyrddinBBSIntegrationTests
 		await Assert.That(scanReport).Contains("Self-contained")
 			.Because("after install the BBS objects reference only each other (no external dbrefs)");
 
-		// 2) @package export — produce the manifest in one step.
-		var pkgMsgs = await RunAndCollect($"@package {bbpocket} {mbboard}=myrddin-bbs");
-		var manifest = pkgMsgs.FirstOrDefault(m => m.Contains("BEGIN package.yaml"))
+		// 2) @package export — produce the manifest in one step. Version (the BBS's
+		//    own 4.0.6) and a description are supplied so the CI-generated artifact is
+		//    publishable as-is.
+		var pkgMsgs = await RunAndCollect(
+			$"@package {bbpocket} {mbboard}=myrddin-bbs,4.0.6,Myrddin's Global Bulletin Board v4.0.6");
+		var packageMessage = pkgMsgs.FirstOrDefault(m => m.Contains("BEGIN package.yaml"))
 			?? string.Join("\n", pkgMsgs);
-		Log($"\n--- @package export ---\n{manifest}");
 
-		var outputPath = Path.Combine(AppContext.BaseDirectory, TestDataDir, "MyrddinBBS_Package_TestOutput.txt");
-		await File.WriteAllTextAsync(outputPath, output.ToString());
-		Console.WriteLine($"[BBS PACKAGE] Full test output written to: {outputPath}");
+		// Extract just the YAML between the markers — this is the publishable manifest.
+		const string beginMarker = "----- BEGIN package.yaml -----";
+		const string endMarker = "----- END package.yaml -----";
+		var begin = packageMessage.IndexOf(beginMarker, StringComparison.Ordinal);
+		var end = packageMessage.IndexOf(endMarker, StringComparison.Ordinal);
+		var manifestYaml = begin >= 0 && end > begin
+			? packageMessage[(begin + beginMarker.Length)..end].Trim('\r', '\n')
+			: packageMessage;
 
-		// Manifest metadata and both objects (bbpocket keeps its name; mbboard was
-		// renamed to "BBS - Myrddin's Global BBS v4.0.6" at the end of install).
-		await Assert.That(manifest).Contains("package: myrddin-bbs");
-		await Assert.That(manifest).Contains("ref: bbpocket")
+		Log($"\n--- generated myrddin-bbs/package.yaml ---\n{manifestYaml}");
+
+		// Write the run log AND the standalone manifest so CI publishes both. The
+		// .yaml is the real generated package.yaml, sourced from a live @package run
+		// (this is how the manifest is obtained without a local SDK/DB).
+		var logPath = Path.Combine(AppContext.BaseDirectory, TestDataDir, "MyrddinBBS_Package_TestOutput.txt");
+		var manifestPath = Path.Combine(AppContext.BaseDirectory, TestDataDir, "MyrddinBBS_GeneratedPackage.yaml");
+		await File.WriteAllTextAsync(logPath, output.ToString());
+		await File.WriteAllTextAsync(manifestPath, manifestYaml);
+		Console.WriteLine($"[BBS PACKAGE] Run log: {logPath}");
+		Console.WriteLine($"[BBS PACKAGE] Generated manifest: {manifestPath}");
+
+		// The extracted artifact is a complete manifest with the expected metadata.
+		await Assert.That(manifestYaml).Contains("format: 1")
+			.Because("the generated artifact should be a complete package manifest");
+		await Assert.That(manifestYaml).Contains("package: myrddin-bbs");
+		await Assert.That(manifestYaml).Contains("version: \"4.0.6\"")
+			.Because("the version passed to @package should be carried into the manifest");
+
+		// Both objects (bbpocket keeps its name; mbboard was renamed to
+		// "BBS - Myrddin's Global BBS v4.0.6" at the end of install).
+		await Assert.That(manifestYaml).Contains("ref: bbpocket")
 			.Because("bbpocket should be exported under its own ref");
-		await Assert.That(manifest).Contains("type: thing")
+		await Assert.That(manifestYaml).Contains("type: thing")
 			.Because("the BBS objects are things");
-		await Assert.That(manifest).Contains("Global BBS v4.0.6")
+		await Assert.That(manifestYaml).Contains("Global BBS v4.0.6")
 			.Because("the renamed mbboard object should be present in the manifest");
 
 		// bbpocket's function/config attribute schema.
 		foreach (var attr in new[] { "GET_GROUP", "NXT_MESS", "VALID_GROUPS", "VERSION", "BUFFER_SIZE" })
 		{
-			await Assert.That(manifest).Contains(attr)
+			await Assert.That(manifestYaml).Contains(attr)
 				.Because($"bbpocket should export its {attr} attribute");
 		}
 
@@ -526,18 +551,18 @@ public class MyrddinBBSIntegrationTests
 		// regardless of how attribute names containing '+' are rendered.
 		foreach (var cmd in new[] { "$+bbread", "$+bbpost", "$+bbnewgroup", "$+bblist" })
 		{
-			await Assert.That(manifest).Contains(cmd)
+			await Assert.That(manifestYaml).Contains(cmd)
 				.Because($"mbboard should export the {cmd} command");
 		}
 
-		await Assert.That(manifest).Contains("CREDITS")
+		await Assert.That(manifestYaml).Contains("CREDITS")
 			.Because("mbboard's CREDITS attribute should be exported");
 
 		// Cross-reference rewriting: mbboard's references to bbpocket become a symbolic
 		// ref, and no raw dbref of bbpocket survives in the manifest.
-		await Assert.That(manifest).Contains("{{bbpocket}}")
+		await Assert.That(manifestYaml).Contains("{{bbpocket}}")
 			.Because("references to bbpocket must be tokenized as a symbolic ref");
-		await Assert.That(manifest).DoesNotContain($"{bbpocket}/")
+		await Assert.That(manifestYaml).DoesNotContain($"{bbpocket}/")
 			.Because("no raw dbref of bbpocket should remain — manifests never carry dbrefs");
 	}
 

--- a/SharpMUSH.Tests.Integration/Integration/MyrddinBBSIntegrationTests.cs
+++ b/SharpMUSH.Tests.Integration/Integration/MyrddinBBSIntegrationTests.cs
@@ -454,6 +454,94 @@ public class MyrddinBBSIntegrationTests
 	}
 
 	/// <summary>
+	/// Uses the in-game @package command to confirm the installed Myrddin BBS
+	/// (bbpocket + mbboard) can be turned into a package, and that the combined
+	/// schema of both objects is as expected from the command's own output.
+	///
+	/// After install, Myrddin's hardcoded #222 has been rewritten to bbpocket's
+	/// real dbref, so the two objects reference only each other — the selection is
+	/// self-contained and exports as a manifest in a single step. Runs before any
+	/// BBS group is created so bbpocket carries no external group dbrefs yet.
+	/// </summary>
+	[Test]
+	[DependsOn(nameof(InstallMyrddinBBS_AndRunBBRead_ShouldNotCrash))]
+	public async Task BBS_CanBeTurnedIntoPackage()
+	{
+		var output = new StringBuilder();
+		void Log(string message) { output.AppendLine(message); Console.WriteLine(message); }
+
+		Log(new string('=', 78));
+		Log("MYRDDIN BBS -> @package");
+		Log(new string('=', 78));
+
+		await Assert.That(_bbpocketDbref).IsNotNull()
+			.Because("bbpocket must have been created during install");
+		await Assert.That(_mbboardDbref).IsNotNull()
+			.Because("mbboard must have been created during install");
+		var bbpocket = _bbpocketDbref!;
+		var mbboard = _mbboardDbref!;
+		Log($"bbpocket={bbpocket}, mbboard={mbboard}");
+
+		// 1) @package/scan — read-only schema report. Both install objects reference
+		//    only each other, so the report should declare the selection self-contained.
+		var scanMsgs = await RunAndCollect($"@package/scan {bbpocket} {mbboard}");
+		var scanReport = string.Join("\n", scanMsgs);
+		Log($"\n--- @package/scan ---\n{scanReport}");
+
+		await Assert.That(scanReport).Contains("PACKAGE SCAN: 2 object(s) selected")
+			.Because("both BBS objects should be scanned together");
+		await Assert.That(scanReport).Contains("bbpocket")
+			.Because("the scan should list bbpocket and its suggested ref");
+		await Assert.That(scanReport).Contains("Self-contained")
+			.Because("after install the BBS objects reference only each other (no external dbrefs)");
+
+		// 2) @package export — produce the manifest in one step.
+		var pkgMsgs = await RunAndCollect($"@package {bbpocket} {mbboard}=myrddin-bbs");
+		var manifest = pkgMsgs.FirstOrDefault(m => m.Contains("BEGIN package.yaml"))
+			?? string.Join("\n", pkgMsgs);
+		Log($"\n--- @package export ---\n{manifest}");
+
+		var outputPath = Path.Combine(AppContext.BaseDirectory, TestDataDir, "MyrddinBBS_Package_TestOutput.txt");
+		await File.WriteAllTextAsync(outputPath, output.ToString());
+		Console.WriteLine($"[BBS PACKAGE] Full test output written to: {outputPath}");
+
+		// Manifest metadata and both objects (bbpocket keeps its name; mbboard was
+		// renamed to "BBS - Myrddin's Global BBS v4.0.6" at the end of install).
+		await Assert.That(manifest).Contains("package: myrddin-bbs");
+		await Assert.That(manifest).Contains("ref: bbpocket")
+			.Because("bbpocket should be exported under its own ref");
+		await Assert.That(manifest).Contains("type: thing")
+			.Because("the BBS objects are things");
+		await Assert.That(manifest).Contains("Global BBS v4.0.6")
+			.Because("the renamed mbboard object should be present in the manifest");
+
+		// bbpocket's function/config attribute schema.
+		foreach (var attr in new[] { "GET_GROUP", "NXT_MESS", "VALID_GROUPS", "VERSION", "BUFFER_SIZE" })
+		{
+			await Assert.That(manifest).Contains(attr)
+				.Because($"bbpocket should export its {attr} attribute");
+		}
+
+		// mbboard's command schema — assert via the $-command bodies, which are stable
+		// regardless of how attribute names containing '+' are rendered.
+		foreach (var cmd in new[] { "$+bbread", "$+bbpost", "$+bbnewgroup", "$+bblist" })
+		{
+			await Assert.That(manifest).Contains(cmd)
+				.Because($"mbboard should export the {cmd} command");
+		}
+
+		await Assert.That(manifest).Contains("CREDITS")
+			.Because("mbboard's CREDITS attribute should be exported");
+
+		// Cross-reference rewriting: mbboard's references to bbpocket become a symbolic
+		// ref, and no raw dbref of bbpocket survives in the manifest.
+		await Assert.That(manifest).Contains("{{bbpocket}}")
+			.Because("references to bbpocket must be tokenized as a symbolic ref");
+		await Assert.That(manifest).DoesNotContain($"{bbpocket}/")
+			.Because("no raw dbref of bbpocket should remain — manifests never carry dbrefs");
+	}
+
+	/// <summary>
 	/// Truncates a string to the specified maximum length, appending "..." if truncated.
 	/// </summary>
 	private static string Truncate(string value, int maxLength)
@@ -516,7 +604,8 @@ public class MyrddinBBSIntegrationTests
 	/// Validates no ANTLR parser errors and no #-1 errors during the workflow.
 	/// </summary>
 	[Test]
-	[DependsOn(nameof(InstallMyrddinBBS_AndRunBBRead_ShouldNotCrash))]
+	// Runs after the packaging test so bbpocket has no group dbrefs when it is packaged.
+	[DependsOn(nameof(BBS_CanBeTurnedIntoPackage))]
 	public async Task BBS_NewGroup_ThenBBRead_ShowsGroup()
 	{
 		var output = new StringBuilder();

--- a/SharpMUSH.Tests/Commands/PackageCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/PackageCommandTests.cs
@@ -1,0 +1,142 @@
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using OneOf;
+using SharpMUSH.Library;
+using SharpMUSH.Library.DiscriminatedUnions;
+using SharpMUSH.Library.Extensions;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Services.Interfaces;
+
+namespace SharpMUSH.Tests.Commands;
+
+/// <summary>
+/// Tests for the @package command: the in-game face of the package authoring
+/// service. Exercises the self-contained one-step export, the read-only scan
+/// report, the not-self-contained hand-off to the web panel, and the
+/// wizard-only command lock. The manifest is produced through the same
+/// IPackageAuthoringService the /admin/packages/author panel uses.
+/// </summary>
+[NotInParallel] // shared NotifyService substitute + ClearReceivedCalls must not race
+public class PackageCommandTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactoryArg { get; init; }
+
+	private IMUSHCodeParser Parser => WebAppFactoryArg.CommandParser;
+	private ISharpDatabase Database => WebAppFactoryArg.Services.GetRequiredService<ISharpDatabase>();
+	private INotifyService NotifyService => WebAppFactoryArg.Services.GetRequiredService<INotifyService>();
+	private IConnectionService ConnectionService => WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
+	private IMediator Mediator => WebAppFactoryArg.Services.GetRequiredService<IMediator>();
+
+	/// <summary>Command feedback is "spoken by" the executor (here, God), per orator semantics.</summary>
+	private async Task ExpectNotify(DBRef player, string contains)
+		=> await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(player), Arg.Is<OneOf<MString, string>>(msg =>
+				(msg.IsT0 && msg.AsT0.ToString().Contains(contains)) ||
+				(msg.IsT1 && msg.AsT1.Contains(contains))), TestHelpers.MatchingObject(player),
+				INotifyService.NotificationType.Announce);
+
+	/// <summary>Creates a Thing owned by, and located in, the PM wizard (#3) — mirrors the authoring service tests.</summary>
+	private async Task<DBRef> CreateThingAsync(string name)
+	{
+		var pmNode = (await Database.GetObjectNodeAsync(new DBRef(3))).Known();
+		var pm = pmNode.Match(p => p, _ => null!, _ => null!, _ => null!);
+		var location = pmNode.Match<AnySharpContainer>(p => p, _ => null!, _ => null!, t => t);
+		return await Database.CreateThingAsync(name, location, pm, location);
+	}
+
+	private async Task SetAttrAsync(DBRef target, string attr, string value)
+	{
+		var pm = (await Database.GetObjectNodeAsync(new DBRef(3))).Known()
+			.Match(p => p, _ => null!, _ => null!, _ => null!);
+		await Database.SetAttributeAsync(target, [attr], MModule.single(value), pm);
+	}
+
+	[Test]
+	public async ValueTask Package_SelfContainedSelection_PemitsManifest()
+	{
+		var god = WebAppFactoryArg.ExecutorDBRef;
+
+		// Two things where the second references the first (and nothing else) — self-contained.
+		var core = await CreateThingAsync("PkgSelfCore");
+		var global = await CreateThingAsync("PkgSelfGlobal");
+		await SetAttrAsync(core, "FN_FMT", "formatted output");
+		await SetAttrAsync(global, "CMD_SELF", $"$+self:@pemit %#=[u(#{core.Number}/FN_FMT)]");
+
+		NotifyService.ClearReceivedCalls();
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"@package #{core.Number} #{global.Number}=test-pkg,2.0.0,A self-contained test"));
+
+		// The whole manifest comes back in one pemit: header markers, metadata, and
+		// the cross-reference rewritten to a symbolic {{ref}} (no raw dbref survives).
+		await ExpectNotify(god, "----- BEGIN package.yaml -----");
+		await ExpectNotify(god, "package: test-pkg");
+		await ExpectNotify(god, "version: \"2.0.0\"");
+		await ExpectNotify(god, "{{pkgselfcore}}");
+	}
+
+	[Test]
+	public async ValueTask PackageScan_ReportsRefsAndExternalDbrefs()
+	{
+		var god = WebAppFactoryArg.ExecutorDBRef;
+
+		var thing = await CreateThingAsync("PkgScanThing");
+		await SetAttrAsync(thing, "FN_GREET", $"Hello from here, near #0");
+
+		NotifyService.ClearReceivedCalls();
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"@package/scan #{thing.Number}"));
+
+		await ExpectNotify(god, "PACKAGE SCAN: 1 object(s) selected");
+		await ExpectNotify(god, "pkgscanthing");
+		await ExpectNotify(god, "#0");
+	}
+
+	[Test]
+	public async ValueTask Package_NotSelfContained_DirectsToWebPanel()
+	{
+		var god = WebAppFactoryArg.ExecutorDBRef;
+
+		var thing = await CreateThingAsync("PkgExternalThing");
+		await SetAttrAsync(thing, "FN_GREET", $"References the outside world: #0");
+
+		NotifyService.ClearReceivedCalls();
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"@package #{thing.Number}=ext-pkg"));
+
+		// No manifest — the external dbref must be classified in the web panel.
+		await ExpectNotify(god, "aren't self-contained");
+		await ExpectNotify(god, "/admin/packages/author");
+	}
+
+	[Test]
+	public async ValueTask Package_InvalidPackageId_IsRejected()
+	{
+		var god = WebAppFactoryArg.ExecutorDBRef;
+
+		var thing = await CreateThingAsync("PkgBadIdThing");
+		await SetAttrAsync(thing, "FN_X", "self-contained value");
+
+		NotifyService.ClearReceivedCalls();
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"@package #{thing.Number}=Not A Valid Id"));
+
+		await ExpectNotify(god, "is not a valid package id");
+	}
+
+	[Test]
+	public async ValueTask Package_NonWizard_IsBlockedByCommandLock()
+	{
+		var nonWizardDbRef = await TestIsolationHelpers.CreateTestPlayerAsync(
+			WebAppFactoryArg.Services, Mediator, "NonWizPackage");
+		var nonWizParser = Parser.Push(Parser.CurrentState with { Executor = nonWizardDbRef });
+
+		var result = await nonWizParser.CommandParse(MModule.single("@package #1"));
+		var resultText = result.Message?.ToPlainText() ?? "";
+
+		await Assert.That(resultText).Contains("PERMISSION DENIED");
+	}
+}

--- a/SharpMUSH.Tests/Commands/PackageCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/PackageCommandTests.cs
@@ -108,9 +108,43 @@ public class PackageCommandTests
 			MModule.single($"@package #{thing.Number}=ext-pkg"));
 
 		// No manifest — the external dbref must be classified in the web panel.
-		await ExpectNotify(god, "aren't self-contained");
+		await ExpectNotify(god, "Unclassified");
 		await ExpectNotify(god, "/admin/packages/author");
 	}
+
+	[Test]
+	public async ValueTask Package_VeiledAttribute_IsExcludedFromManifest()
+	{
+		var god = WebAppFactoryArg.ExecutorDBRef;
+
+		var thing = await CreateThingAsync("PkgVeiledThing");
+		// A public attribute (exported) and a VEILED one (@decompile hides it, so must we).
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"&PUBLICATTR #{thing.Number}=public shown value"));
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"&SECRETATTR #{thing.Number}=veiled secret value"));
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"@set #{thing.Number}/SECRETATTR=VEILED"));
+
+		NotifyService.ClearReceivedCalls();
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"@package #{thing.Number}=veil-pkg"));
+
+		// The manifest is produced, includes the public attribute, and omits the
+		// VEILED one entirely — matching what @decompile would show.
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(god), Arg.Is<OneOf<MString, string>>(msg =>
+				MessageContains(msg, "----- BEGIN package.yaml -----") &&
+				MessageContains(msg, "PUBLICATTR") &&
+				!MessageContains(msg, "SECRETATTR") &&
+				!MessageContains(msg, "veiled secret value")),
+				TestHelpers.MatchingObject(god), INotifyService.NotificationType.Announce);
+	}
+
+	private static bool MessageContains(OneOf<MString, string> msg, string contains)
+		=> (msg.IsT0 && msg.AsT0.ToString().Contains(contains)) ||
+		   (msg.IsT1 && msg.AsT1.Contains(contains));
 
 	[Test]
 	public async ValueTask Package_InvalidPackageId_IsRejected()

--- a/SharpMUSH.Tests/Packages/PackageAuthoringServiceTests.cs
+++ b/SharpMUSH.Tests/Packages/PackageAuthoringServiceTests.cs
@@ -143,4 +143,38 @@ public class PackageAuthoringServiceTests
 		await Assert.That(result.IsT1).IsTrue();
 		await Assert.That(result.AsT1.Value).Contains("#4242");
 	}
+
+	[Test, NotInParallel]
+	public async Task Export_BlankAndWhitespaceAttributeValues_ProduceValidManifest()
+	{
+		var pmNode = (await Database.GetObjectNodeAsync(new DBRef(3))).Known();
+		var pm = pmNode.Match(p => p, _ => null!, _ => null!, _ => null!);
+		var location = pmNode.Match<AnySharpContainer>(p => p, _ => null!, _ => null!, t => t);
+
+		var dbref = await Database.CreateThingAsync("Whitespace Edge", location, pm, location);
+		// A whitespace-only value is the regression: emitted as a block scalar whose
+		// only line is blank, YamlDotNet rejected it with "extra spaces in first line"
+		// before the explicit indentation indicator was added.
+		await Database.SetAttributeAsync(dbref, ["WS_ONLY"], MModule.single("   "), pm);
+		await Database.SetAttributeAsync(dbref, ["LEADING"], MModule.single("  indented body"), pm);
+		await Database.SetAttributeAsync(dbref, ["NORMAL"], MModule.single("plain value"), pm);
+		var objid = (await Database.GetObjectNodeAsync(dbref)).Known().Object().DBRef.ToString();
+
+		var result = await Authoring.ExportAsync(new PackageAuthoringRequest(
+			"ws-edge", "1.0.0", "whitespace edge cases", null, ["Tester"],
+			[new AuthoringObjectSelection(objid, "ws_obj", [])],
+			new Dictionary<string, string>(),
+			new Dictionary<string, AuthoringConfigureClassification>()));
+
+		await Assert.That(result.IsT0).IsTrue()
+			.Because("block scalars must round-trip even when a value is blank or whitespace-only");
+
+		var parsed = new PackageManifestService().ParseManifest(result.AsT0);
+		await Assert.That(parsed.IsT0).IsTrue();
+		var attrs = parsed.AsT0.Manifest.Objects.Single(o => o.Ref == "ws_obj").Attributes;
+		await Assert.That(attrs.ContainsKey("WS_ONLY")).IsTrue();
+		await Assert.That(attrs.ContainsKey("LEADING")).IsTrue();
+		await Assert.That(attrs["NORMAL"].Value).IsEqualTo("plain value");
+		await Assert.That(attrs["LEADING"].Value).Contains("indented body");
+	}
 }

--- a/SharpMUSH.Tests/Packages/PackageAuthoringServiceTests.cs
+++ b/SharpMUSH.Tests/Packages/PackageAuthoringServiceTests.cs
@@ -167,7 +167,7 @@ public class PackageAuthoringServiceTests
 			new Dictionary<string, AuthoringConfigureClassification>()));
 
 		await Assert.That(result.IsT0).IsTrue()
-			.Because("block scalars must round-trip even when a value is blank or whitespace-only");
+			.Because($"export must produce a valid manifest for blank/whitespace values; got: {(result.IsT1 ? result.AsT1.Value : "success")}");
 
 		var parsed = new PackageManifestService().ParseManifest(result.AsT0);
 		await Assert.That(parsed.IsT0).IsTrue();


### PR DESCRIPTION
Adds a wizard-only @package command that wraps the existing
IPackageAuthoringService (scan + export) so a package.yaml manifest can be
produced from one or more live objects without leaving the game — the same
engine behind the /admin/packages/author web panel.

- @package/scan <objects> reports each object's suggested manifest ref and
  any dbrefs referenced outside the selection (read-only).
- @package <objects>=<id>[,<version>[,<description>]] exports the selection
  and pemits the manifest back. In-selection dbrefs become {{ref}} tokens
  automatically; version defaults to 1.0.0.

The single-step export is intentionally limited to self-contained
selections. When an attribute references an object outside the selection,
that dbref needs well-known / configure classification, so the command
lists the unresolved dbrefs and directs the user to the web authoring panel
rather than guessing.

Includes a help-file entry for @package.

https://claude.ai/code/session_01CaDLKYesd4anECAd5wgswg