### PR TITLE
ci: fix docker-dev image build + bump deprecated Node 20 actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,12 @@
 **/packages/
 *.nupkg
 
+# ...but keep the bundled example packages: SharpMUSH.Server embeds their
+# package.yaml files as resources (see SharpMUSH.Server.csproj), so the
+# **/packages/ rule above must not strip examples/packages out of the build context.
+!examples/packages
+!examples/packages/**
+
 # Visual Studio cache/options
 .vs/
 *.user

--- a/.github/workflows/_dotnet-build-test.yml
+++ b/.github/workflows/_dotnet-build-test.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
           cache: true
@@ -34,10 +34,10 @@ jobs:
         database: [arangodb, memgraph, surrealdb]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
           cache: true
@@ -50,7 +50,7 @@ jobs:
         run: dotnet build --no-restore
 
       - name: Test (${{ matrix.database }})
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         env:
           SHARPMUSH_ENABLE_TEST_TELEMETRY: true
           SHARPMUSH_TELEMETRY_OUTPUT_PATH: ${{ github.workspace }}/test-telemetry.md
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload Telemetry Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-telemetry-${{ matrix.database }}
           path: test-telemetry.md
@@ -84,10 +84,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
           cache: true
@@ -100,7 +100,7 @@ jobs:
         run: dotnet build --no-restore
 
       - name: BUnit Tests
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -114,10 +114,10 @@ jobs:
         database: [arangodb, memgraph, surrealdb]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
           cache: true
@@ -130,7 +130,7 @@ jobs:
         run: dotnet build --no-restore
 
       - name: Integration Test (${{ matrix.database }})
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         env:
           SHARPMUSH_ENABLE_TEST_TELEMETRY: true
           SHARPMUSH_TELEMETRY_OUTPUT_PATH: ${{ github.workspace }}/test-telemetry-integration.md
@@ -153,7 +153,7 @@ jobs:
 
       - name: Upload Integration Telemetry Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-telemetry-integration-${{ matrix.database }}
           path: test-telemetry-integration.md
@@ -161,7 +161,7 @@ jobs:
 
       - name: Upload Generated Myrddin BBS Package Manifest
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: myrddin-bbs-package-${{ matrix.database }}
           path: '**/MyrddinBBS_GeneratedPackage.yaml'

--- a/.github/workflows/benchmark-nightly.yml
+++ b/.github/workflows/benchmark-nightly.yml
@@ -15,16 +15,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Java (required for ANTLR parser generation)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x
           cache: true
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload Benchmark Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-results-${{ github.run_id }}
           path: BenchmarkDotNet.Artifacts/

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,10 +26,10 @@ jobs:
     # If you do not check out your code, Copilot will do this for you.
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET (Latest Stable)
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           # Use 'x' to always get the latest stable version
           dotnet-version: 10.x

--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -19,19 +19,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push SharpMUSH Server (dev)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -47,7 +47,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push ConnectionServer (dev)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./SharpMUSH.ConnectionServer/Dockerfile

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,13 +19,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
           echo "Building version: $VERSION"
 
       - name: Build and push SharpMUSH Server
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -57,7 +57,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push ConnectionServer
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./SharpMUSH.ConnectionServer/Dockerfile


### PR DESCRIPTION
## Problem

The [`docker-dev.yml`](https://github.com/SharpMUSH/SharpMUSH/actions/workflows/docker-dev.yml) workflow has been failing on every push to `main` since #636. The `build-and-test` job passes (build + all DB test matrices), but `build-and-push-dev` fails at the Docker image build:

```
CSC : error CS1566: Error reading resource 'SharpMUSH.Server.BundledPackages.http-handler.package.yaml'
   -- 'Could not find a part of the path '/src/examples/packages/http-handler/package.yaml'.'
```

## Root cause

#636 (Softcode Package Manager) added `<EmbeddedResource>` entries to `SharpMUSH.Server.csproj` that embed `examples/packages/{http-handler,profile-handler}/package.yaml` into the server assembly.

`.dockerignore` contained `**/packages/` (intended to strip NuGet `packages/` folders), which **also matched `examples/packages/`** — so `COPY . .` silently omitted those YAML files from the Docker build context and the compiler couldn't find them. Host `dotnet build`/`dotnet test` and the runner-based `build-and-test` job were unaffected because they don't go through the Docker context; only the Dockerized publish broke.

## Fix

1. **`.dockerignore`** — re-include the bundled example packages so they survive the `**/packages/` glob. Verified locally with a throwaway `COPY . .` build that both `package.yaml` files now land in the context.
2. **Workflow actions** — the run annotations also warn that Node 20 actions are forced to Node 24 starting **June 16, 2026**. Bumped all actions to their latest Node 24 majors (verified each `runs.using: node24` and that input names are unchanged):
   - `actions/checkout` v4 → v6
   - `actions/setup-dotnet` v4 → v5
   - `actions/setup-java` v4 → v5
   - `actions/upload-artifact` v4 → v7
   - `nick-fields/retry` v3 → v4
   - `docker/setup-buildx-action` v3 → v4
   - `docker/login-action` v3 → v4
   - `docker/build-push-action` v6 → v7

This affects `docker-dev.yml`, `docker-publish.yml`, `_dotnet-build-test.yml`, `benchmark-nightly.yml`, `claude.yml`, `claude-code-review.yml`, and `copilot-setup-steps.yml`. (`docker-publish.yml` had the same latent `.dockerignore` bug — fixed by the same change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to explicitly retain example package resources and their dependencies within the Docker image build context.
  * Upgraded GitHub Actions to newer major versions across multiple CI/CD workflows, including actions for repository checkout, .NET and Java setup, artifact uploading, and Docker image building and publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->