### PR TITLE
feat(templates): SharpMUSH.Templates dotnet-new pack + keyless publish

### DIFF
--- a/.github/workflows/publish-templates.yml
+++ b/.github/workflows/publish-templates.yml
@@ -1,0 +1,76 @@
+name: Publish Templates NuGet
+
+# Packs and pushes the SharpMUSH.Templates `dotnet new` template pack (sharpmush-softcode /
+# sharpmush-application / sharpmush-plugin) so authors can `dotnet new install SharpMUSH.Templates`.
+#
+# Keyless via NuGet Trusted Publishing (OIDC) — no long-lived API key. Triggered by a tag like
+# sharpmush-templates/v1.0.0; the version after the slash+v becomes the package version. Versioned
+# INDEPENDENTLY of the contract packages (SharpMUSH.Library / SharpMUSH.Implementation.Generated),
+# so the templates can ship on their own cadence.
+#
+# Requires (one-time): a nuget.org Trusted Publishing policy bound to this workflow file
+#   owner=SharpMUSH, repository=SharpMUSH, workflow file=publish-templates.yml
+# plus the NUGET_USER secret (nuget.org profile name). Must be on the default branch for the tag
+# trigger to fire.
+
+on:
+  push:
+    tags:
+      - 'sharpmush-templates/v*'  # e.g. sharpmush-templates/v1.0.0
+  workflow_dispatch:               # manual run uses the csproj <Version>
+
+permissions:
+  contents: read
+
+jobs:
+  pack-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read    # checkout
+      id-token: write   # mint the GitHub OIDC token for NuGet Trusted Publishing (keyless)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Derive version from tag
+        id: meta
+        run: |
+          # sharpmush-templates/v1.0.0 -> 1.0.0 ; on workflow_dispatch leave empty (csproj default).
+          REF="${GITHUB_REF}"
+          if [[ "$REF" == refs/tags/sharpmush-templates/v* ]]; then
+            VERSION="${REF#refs/tags/sharpmush-templates/v}"
+            echo "version_arg=-p:Version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "Packing SharpMUSH.Templates at version: $VERSION"
+          else
+            echo "version_arg=" >> "$GITHUB_OUTPUT"
+            echo "Packing SharpMUSH.Templates at csproj <Version> (manual run)"
+          fi
+
+      - name: Pack template pack (SharpMUSH.Templates)
+        run: dotnet pack templates/SharpMUSH.Templates.csproj
+             --configuration Release
+             --output ${{ runner.temp }}/nupkgs
+             ${{ steps.meta.outputs.version_arg }}
+
+      - name: List produced packages
+        run: ls -la ${{ runner.temp }}/nupkgs
+
+      # Trusted Publishing (OIDC): exchange this job's short-lived GitHub OIDC token for a ~1h
+      # nuget.org API key — no long-lived NUGET_API_KEY secret. NUGET_USER is the nuget.org profile name.
+      - name: NuGet login (OIDC -> short-lived key)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
+      - name: Push to NuGet
+        run: dotnet nuget push "${{ runner.temp }}/nupkgs/*.nupkg"
+             --api-key "${{ steps.login.outputs.NUGET_API_KEY }}"
+             --source https://api.nuget.org/v3/index.json
+             --skip-duplicate

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,9 +1,12 @@
 # SharpMUSH plugin templates
 
 Starter scaffolds for authoring [SharpMUSH](https://github.com/SharpMUSH/SharpMUSH)
-plugins of all three kinds. Each is delivered **both** as a "Use this template"
-GitHub-template directory **and** as a `dotnet new` template, so you can scaffold a
-fresh, ready-to-fill repo either way.
+plugins of all three kinds. Two ways to start:
+
+- **Fork the whole thing** — the [**SharpMUSH.Template**](https://github.com/SharpMUSH/SharpMUSH.Template)
+  repo bundles a working example of all three layers; click **Use this template**.
+- **Scaffold one piece** — `dotnet new install SharpMUSH.Templates`, then
+  `dotnet new sharpmush-softcode|sharpmush-application|sharpmush-plugin` (handles all renaming).
 
 SharpMUSH extends at three layers (see the
 [extensibility overview](../docs/design/extensibility-overview.md)); these templates

--- a/templates/README.md
+++ b/templates/README.md
@@ -24,7 +24,21 @@ Authoring background:
 
 ## Use them via `dotnet new`
 
-Install one (or all) of the templates from a local checkout, then scaffold:
+### From nuget.org (recommended)
+
+All three ship together in the **`SharpMUSH.Templates`** pack — install once, scaffold any kind:
+
+```bash
+dotnet new install SharpMUSH.Templates
+```
+
+`dotnet new` handles all the renaming and token substitution (e.g. `sharpmush-plugin -n MyPlugin`
+renames `PLUGIN_NAME.csproj` → `MyPlugin.csproj` and rewrites the namespace), so there are no files
+to rename by hand.
+
+### From a local checkout
+
+Or install individual templates straight from this repo, then scaffold:
 
 ```bash
 # Install (point at the template directory containing .template.config/):

--- a/templates/SharpMUSH.Templates.csproj
+++ b/templates/SharpMUSH.Templates.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- ============================================================================================
+       `dotnet new` template PACK. Bundles the three SharpMUSH extension templates so authors can:
+
+           dotnet new install SharpMUSH.Templates
+           dotnet new sharpmush-softcode    -n my-package
+           dotnet new sharpmush-application -n my-app
+           dotnet new sharpmush-plugin      -n MyPlugin   # renames PLUGIN_NAME.csproj etc.
+
+       This is a content-only NuGet (PackageType=Template) — it ships the template trees under
+       content/ and builds no assembly. NoDefaultExcludes keeps the .template.config and .github
+       folders (NuGet strips dotfiles otherwise). Published via Trusted Publishing (see
+       publish-templates.yml); version is aligned to PluginContractVersion.Current (1.0.0). -->
+
+  <PropertyGroup>
+    <PackageType>Template</PackageType>
+    <PackageId>SharpMUSH.Templates</PackageId>
+    <Version>1.0.0</Version>
+    <Title>SharpMUSH Extension Templates</Title>
+    <Authors>SharpMUSH Contributors</Authors>
+    <Description>`dotnet new` templates for SharpMUSH extensions: a softcode package (sharpmush-softcode), a Dynamic Application (sharpmush-application), and a C# DLL plugin (sharpmush-plugin). Aligned to PluginContractVersion 1.0.0.</Description>
+    <PackageTags>dotnet-new;templates;sharpmush;mush;plugin;softcode;dynamic-application</PackageTags>
+    <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/SharpMUSH/SharpMUSH</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/SharpMUSH/SharpMUSH</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+
+    <!-- Content-only template pack: no compile, no build output, ship under content/. -->
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <ContentTargetFolders>content</ContentTargetFolders>
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <NoDefaultExcludes>true</NoDefaultExcludes>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+    <IsPackable>true</IsPackable>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="plugin-dll/**/*;plugin-softcode/**/*;plugin-application/**/*"
+             Exclude="**/bin/**;**/obj/**" />
+    <Compile Remove="**/*" />
+  </ItemGroup>
+
+</Project>

--- a/templates/plugin-dll/Plugin.cs
+++ b/templates/plugin-dll/Plugin.cs
@@ -1,6 +1,7 @@
 using Mediator;
 using Microsoft.Extensions.DependencyInjection;
 using SharpMUSH.Library.Attributes;
+using SharpMUSH.Library.Definitions;
 using SharpMUSH.Library.DiscriminatedUnions;
 using SharpMUSH.Library.Models;
 using SharpMUSH.Library.ParserInterfaces;


### PR DESCRIPTION
Bundles the three existing extension templates into a single **`dotnet new` template pack** so authors can install once and scaffold any kind — `dotnet new` does the renaming, so **no manual CSPROJ renaming**.

## What's here
- **`templates/SharpMUSH.Templates.csproj`** — a `PackageType=Template` content-only NuGet bundling `sharpmush-softcode`, `sharpmush-application`, `sharpmush-plugin` (under `content/`; `NoDefaultExcludes` keeps `.template.config` + `.github`; no build output; not in the `.sln`).
- **`.github/workflows/publish-templates.yml`** — keyless **Trusted Publishing** (OIDC), versioned **independently** of the contract packages (tag `sharpmush-templates/v*`).
- **`templates/README.md`** — documents `dotnet new install SharpMUSH.Templates`.

## Verified locally
`dotnet pack` → `dotnet new install ./...nupkg` → scaffolded all three:
- `sharpmush-plugin -n MyCoolPlugin` → `PLUGIN_NAME.csproj` renamed to `MyCoolPlugin.csproj`, `<AssemblyName>MyCoolPlugin</AssemblyName>` substituted.
- `sharpmush-softcode -n my-widgets` → `package: my-widgets` substituted.
- clean uninstall. No `PLUGIN_NAME`/token leftovers.

## One-time setup before tagging (your side)
1. Merge this PR (so `publish-templates.yml` is on the default branch — tag triggers require it).
2. Add a nuget.org **Trusted Publishing policy** bound to this workflow: owner `SharpMUSH`, repo `SharpMUSH`, workflow file `publish-templates.yml` (the existing `NUGET_USER` secret is reused).
3. Tag `sharpmush-templates/v1.0.0` → keyless publish → `dotnet new install SharpMUSH.Templates` works for everyone.

The unified GitHub "Use this template" repo (the second half of the ask) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)