### PR TITLE
fix($command): match $commands with surrounding whitespace and per-command in ';' lists

### DIFF
--- a/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
+++ b/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
@@ -817,6 +817,17 @@ public class SharpMUSHParserVisitor(
 			if (command.Length == 0)
 				return new None();
 
+			// Per-command, markup-preserving slice of this command out of the (possibly whole-list) src.
+			// In a ';' command-list, src is the entire list (e.g. "alpha;beta"); each command is addressed
+			// by its evaluationString span. Built-in commands already re-slice src this exact way in
+			// ArgumentSplit; $command matching must use the same slice (commandText) rather than the whole
+			// src, otherwise a $command in a list is matched against the entire list and its ^...$ pattern
+			// never matches. This is the same arithmetic as ArgumentSplit's realSubtext.
+			var commandText = MModule.substring(
+				firstCommandMatch.Start.StartIndex,
+				firstCommandMatch.Stop.StopIndex - firstCommandMatch.Start.StartIndex + 1,
+				src);
+
 			if (parser.CurrentState.Handle is not null && command != "IDLE")
 			{
 				ConnectionService.Update(parser.CurrentState.Handle.Value, "LastConnectionSignal",
@@ -1009,7 +1020,7 @@ public class SharpMUSHParserVisitor(
 			var userDefinedCommandMatches = await CommandDiscoveryService.MatchUserDefinedCommand(
 				parser,
 				nearbyObjects,
-				src);
+				commandText);
 
 			if (userDefinedCommandMatches.IsSome())
 			{
@@ -1036,7 +1047,7 @@ public class SharpMUSHParserVisitor(
 					var userDefinedCommandMatchesOnZMR = await CommandDiscoveryService.MatchUserDefinedCommand(
 						parser,
 						zmrContents,
-						src);
+						commandText);
 
 					if (userDefinedCommandMatchesOnZMR.IsSome())
 					{
@@ -1052,7 +1063,7 @@ public class SharpMUSHParserVisitor(
 				var userDefinedCommandMatchesOnLocation = await CommandDiscoveryService.MatchUserDefinedCommand(
 					parser,
 					item.ToAsyncEnumerable(),
-					src);
+					commandText);
 
 				if (userDefinedCommandMatchesOnLocation.IsSome())
 				{
@@ -1073,7 +1084,7 @@ public class SharpMUSHParserVisitor(
 				var userDefinedCommandMatchesOnPersonalZMR = await CommandDiscoveryService.MatchUserDefinedCommand(
 					parser,
 					personalZMRContents,
-					src);
+					commandText);
 
 				if (userDefinedCommandMatchesOnPersonalZMR.IsSome())
 				{
@@ -1094,7 +1105,7 @@ public class SharpMUSHParserVisitor(
 			var userDefinedCommandMatchesOnGlobal = await CommandDiscoveryService.MatchUserDefinedCommand(
 				parser,
 				globalObjects.ToAsyncEnumerable().Union(globalObjectContent),
-				src);
+				commandText);
 
 			if (userDefinedCommandMatchesOnGlobal.IsSome())
 			{

--- a/SharpMUSH.Library/Services/CommandDiscoveryService.cs
+++ b/SharpMUSH.Library/Services/CommandDiscoveryService.cs
@@ -35,7 +35,13 @@ public partial class CommandDiscoveryService(IMediator mediator) : ICommandDisco
 			.Where(async (x, _) => !await x.HasFlag("NO_COMMAND"))
 			.SelectMany(MatchUserDefinedCommandSelectMany);
 
-		var plainCommandString = MModule.plainText(commandString);
+		// Strip leading/trailing spaces before matching: the compiled $command patterns are anchored
+		// at both ends (^...$), so a command typed (or queued) with surrounding whitespace — e.g.
+		// " test" — would otherwise fail to match and produce a "Huh?". PennMUSH strips this whitespace
+		// before command matching. Trim the MString itself (not just the plain text) so the argument
+		// capture indices below stay aligned with the string the regex actually matched against.
+		var trimmedCommandString = MModule.trim(commandString, " ", global::MarkupString.TrimType.TrimBoth);
+		var plainCommandString = MModule.plainText(trimmedCommandString);
 		var matchedCommandPatternAttributes = await commandPatternAttributes
 			.Where(x => x.Regex.IsMatch(plainCommandString))
 			.ToArrayAsync();
@@ -57,14 +63,14 @@ public partial class CommandDiscoveryService(IMediator mediator) : ICommandDisco
 					match.IsRegex
 						// For regex patterns: generate both numeric index key and named capture group key
 						? [
-							new KeyValuePair<string, MString>(x.groupIndex.ToString(), MModule.substring(x.group.Index, x.group.Length, commandString)),
-							new KeyValuePair<string, MString>(x.group.Name, MModule.substring(x.group.Index, x.group.Length, commandString))
+							new KeyValuePair<string, MString>(x.groupIndex.ToString(), MModule.substring(x.group.Index, x.group.Length, trimmedCommandString)),
+							new KeyValuePair<string, MString>(x.group.Name, MModule.substring(x.group.Index, x.group.Length, trimmedCommandString))
 						  ]
 						// For wildcard patterns: generate only numeric index key (0-based) to avoid key
 						// collisions between a group's auto-generated name (e.g. "1") and the next
 						// group's 0-based index key (also "1"), which would cause wrong %1, %2 values.
 						: [
-							new KeyValuePair<string, MString>((x.groupIndex - 1).ToString(), MModule.substring(x.group.Index, x.group.Length, commandString))
+							new KeyValuePair<string, MString>((x.groupIndex - 1).ToString(), MModule.substring(x.group.Index, x.group.Length, trimmedCommandString))
 						  ])
 				.GroupBy(kv => kv.Key)
 				.ToDictionary(kv => kv.Key, kv => new CallState(kv.First().Value, 0))

--- a/SharpMUSH.Tests/Commands/UserDefinedCommandsTests.cs
+++ b/SharpMUSH.Tests/Commands/UserDefinedCommandsTests.cs
@@ -444,4 +444,186 @@ public class UserDefinedCommandsTests
 				Arg.Is<OneOf<MString, string>>(s => TestHelpers.MessagePlainTextEquals(s, $"Leaf {token}")),
 				Arg.Any<AnySharpObject>(), INotifyService.NotificationType.Announce);
 	}
+
+	// ── Leading-space $command matching (bug repro) ───────────────────────────
+	// Reported bug: a $command like `$test:@emit ...` does NOT match when the
+	// player types " test" (a leading space before the command). PennMUSH strips
+	// leading whitespace from a command before matching, so this SHOULD fire.
+	// These tests assert the expected (PennMUSH-compatible) behavior; if the bug
+	// is present they fail with a "Huh?" (zero notifications received).
+
+	/// <summary>
+	/// Control: an exact-match $command with NO leading space fires (baseline for the leading-space tests).
+	/// </summary>
+	[Test]
+	public async ValueTask NoLeadingSpace_TerminalEntry_Matches()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var obj = await TestIsolationHelpers.CreateTestThingAsync(Parser, ConnectionService, "UdcNoLeadSpace");
+		var token = TestIsolationHelpers.GenerateUniqueName("uc");
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"&UTEST_NOLEAD {obj}=${token}:@emit {token} Matched"));
+
+		// No leading space — the control case.
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"{token}"));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf<MString, string>>(s => TestHelpers.MessagePlainTextEquals(s, $"{token} Matched")),
+				TestHelpers.MatchingObject(obj), INotifyService.NotificationType.Emit);
+	}
+
+	/// <summary>
+	/// Terminal entry (direct player input): typing " {token}" (leading space) should still match the $command.
+	/// This is the exact scenario from the bug report.
+	/// </summary>
+	[Test]
+	public async ValueTask LeadingSpace_TerminalEntry_StillMatches()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var obj = await TestIsolationHelpers.CreateTestThingAsync(Parser, ConnectionService, "UdcLeadSpaceTerm");
+		var token = TestIsolationHelpers.GenerateUniqueName("uc");
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"&UTEST_LEAD_TERM {obj}=${token}:@emit {token} Matched"));
+
+		// Leading space before the command (player typed " test").
+		await Parser.CommandParse(1, ConnectionService, MModule.single($" {token}"));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf<MString, string>>(s => TestHelpers.MessagePlainTextEquals(s, $"{token} Matched")),
+				TestHelpers.MatchingObject(obj), INotifyService.NotificationType.Emit);
+	}
+
+	/// <summary>
+	/// Command-list path (queued/callback, e.g. softcode action lists): a single command with a
+	/// leading space run via CommandListParse should still match the $command.
+	/// </summary>
+	[Test]
+	public async ValueTask LeadingSpace_CommandList_StillMatches()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var listParser = WebAppFactoryArg.CommandParser;
+		var obj = await TestIsolationHelpers.CreateTestThingAsync(Parser, ConnectionService, "UdcLeadSpaceList");
+		var token = TestIsolationHelpers.GenerateUniqueName("uc");
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"&UTEST_LEAD_LIST {obj}=${token}:@emit {token} Matched"));
+
+		// Command-list entry point with a leading space before the command.
+		await listParser.CommandListParse(MModule.single($" {token}"));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf<MString, string>>(s => TestHelpers.MessagePlainTextEquals(s, $"{token} Matched")),
+				TestHelpers.MatchingObject(obj), INotifyService.NotificationType.Emit);
+	}
+
+	/// <summary>
+	/// SCOPED OUT: command-list path with a space after a ';' separator ("@@ comment;  {token}").
+	/// Fails for the same reason as <see cref="SemicolonList_SecondCommand_NoLeadingSpace_Match"/> — the
+	/// whole-list-source matching, not the leading space. See the note above that test.
+	/// </summary>
+	[Test]
+	[Skip("Scoped out: $command matching in ';' command-lists uses the whole list source (SharpMUSHParserVisitor.cs:907). Separate from the fixed leading/trailing-space bug.")]
+	public async ValueTask LeadingSpace_AfterSemicolonInCommandList_StillMatches()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var listParser = WebAppFactoryArg.CommandParser;
+		var obj = await TestIsolationHelpers.CreateTestThingAsync(Parser, ConnectionService, "UdcLeadSpaceSemi");
+		var token = TestIsolationHelpers.GenerateUniqueName("uc");
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"&UTEST_LEAD_SEMI {obj}=${token}:@emit {token} Matched"));
+
+		// A null command followed by a space-prefixed $command in the same list.
+		await listParser.CommandListParse(MModule.single($"@@ ignore;  {token}"));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf<MString, string>>(s => TestHelpers.MessagePlainTextEquals(s, $"{token} Matched")),
+				TestHelpers.MatchingObject(obj), INotifyService.NotificationType.Emit);
+	}
+
+	// ── SCOPED-OUT: separate command-list bug (tracked, to be fixed later) ─────
+	// A $command that is part of a multi-command ';' list does not match, because $command
+	// matching runs against the WHOLE list source (SharpMUSHParserVisitor.cs:907 passes the
+	// visitor's full `source`), not the individual command — so its ^...$ pattern never matches
+	// ("token;@emit X"). Proven independent of whitespace and of command position: with plain
+	// @emit in the same positions the command fires; ';' splitting itself works for built-ins.
+	// This is NOT the leading/trailing-space bug (that one is fixed); these two tests are Skipped
+	// until the command-list $command-matching path is addressed.
+
+	/// <summary>
+	/// SCOPED OUT: a $command that is the SECOND command in a list, with NO leading space
+	/// ("@@ ignore;{token}"). Fails because matching runs against the whole list source. See note above.
+	/// </summary>
+	[Test]
+	[Skip("Scoped out: $command matching in ';' command-lists uses the whole list source (SharpMUSHParserVisitor.cs:907). Separate from the fixed leading/trailing-space bug.")]
+	public async ValueTask SemicolonList_SecondCommand_NoLeadingSpace_Match()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var listParser = WebAppFactoryArg.CommandParser;
+		var obj = await TestIsolationHelpers.CreateTestThingAsync(Parser, ConnectionService, "UdcSemiNoSpace");
+		var token = TestIsolationHelpers.GenerateUniqueName("uc");
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"&UTEST_SEMI_NOSPACE {obj}=${token}:@emit {token} Matched"));
+
+		// Second command in the list, NO leading space.
+		await listParser.CommandListParse(MModule.single($"@@ ignore;{token}"));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf<MString, string>>(s => TestHelpers.MessagePlainTextEquals(s, $"{token} Matched")),
+				TestHelpers.MatchingObject(obj), INotifyService.NotificationType.Emit);
+	}
+
+	/// <summary>
+	/// Terminal entry: a trailing space after the command (" {token} ") should still match an exact $command.
+	/// The wildcard patterns are anchored at the end (^...$), so a trailing space breaks an exact match.
+	/// </summary>
+	[Test]
+	public async ValueTask TrailingSpace_TerminalEntry_StillMatches()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var obj = await TestIsolationHelpers.CreateTestThingAsync(Parser, ConnectionService, "UdcTrailSpaceTerm");
+		var token = TestIsolationHelpers.GenerateUniqueName("uc");
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"&UTEST_TRAIL_TERM {obj}=${token}:@emit {token} Matched"));
+
+		// Trailing space after the command.
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"{token} "));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf<MString, string>>(s => TestHelpers.MessagePlainTextEquals(s, $"{token} Matched")),
+				TestHelpers.MatchingObject(obj), INotifyService.NotificationType.Emit);
+	}
+
+	/// <summary>
+	/// Command-list path: a trailing space after the command run via CommandListParse should still match.
+	/// </summary>
+	[Test]
+	public async ValueTask TrailingSpace_CommandList_StillMatches()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var listParser = WebAppFactoryArg.CommandParser;
+		var obj = await TestIsolationHelpers.CreateTestThingAsync(Parser, ConnectionService, "UdcTrailSpaceList");
+		var token = TestIsolationHelpers.GenerateUniqueName("uc");
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"&UTEST_TRAIL_LIST {obj}=${token}:@emit {token} Matched"));
+
+		// Command-list entry point with a trailing space after the command.
+		await listParser.CommandListParse(MModule.single($"{token} "));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf<MString, string>>(s => TestHelpers.MessagePlainTextEquals(s, $"{token} Matched")),
+				TestHelpers.MatchingObject(obj), INotifyService.NotificationType.Emit);
+	}
 }

--- a/SharpMUSH.Tests/Commands/UserDefinedCommandsTests.cs
+++ b/SharpMUSH.Tests/Commands/UserDefinedCommandsTests.cs
@@ -522,12 +522,10 @@ public class UserDefinedCommandsTests
 	}
 
 	/// <summary>
-	/// SCOPED OUT: command-list path with a space after a ';' separator ("@@ comment;  {token}").
-	/// Fails for the same reason as <see cref="SemicolonList_SecondCommand_NoLeadingSpace_Match"/> — the
-	/// whole-list-source matching, not the leading space. See the note above that test.
+	/// Command-list path with a space after a ';' separator ("@@ comment;  {token}"). The $command is the
+	/// second command in the list; it must match its own per-command slice, not the whole list source.
 	/// </summary>
 	[Test]
-	[Skip("Scoped out: $command matching in ';' command-lists uses the whole list source (SharpMUSHParserVisitor.cs:907). Separate from the fixed leading/trailing-space bug.")]
 	public async ValueTask LeadingSpace_AfterSemicolonInCommandList_StillMatches()
 	{
 		var executor = WebAppFactoryArg.ExecutorDBRef;
@@ -547,21 +545,16 @@ public class UserDefinedCommandsTests
 				TestHelpers.MatchingObject(obj), INotifyService.NotificationType.Emit);
 	}
 
-	// ── SCOPED-OUT: separate command-list bug (tracked, to be fixed later) ─────
-	// A $command that is part of a multi-command ';' list does not match, because $command
-	// matching runs against the WHOLE list source (SharpMUSHParserVisitor.cs:907 passes the
-	// visitor's full `source`), not the individual command — so its ^...$ pattern never matches
-	// ("token;@emit X"). Proven independent of whitespace and of command position: with plain
-	// @emit in the same positions the command fires; ';' splitting itself works for built-ins.
-	// This is NOT the leading/trailing-space bug (that one is fixed); these two tests are Skipped
-	// until the command-list $command-matching path is addressed.
+	// ── Command-list per-command $command matching ────────────────────────────
+	// A $command that is part of a multi-command ';' list must match against its own per-command
+	// slice (EvaluateCommands computes `commandText` via the command's evaluationString span), NOT
+	// the whole list source. Otherwise its ^...$ pattern would be tested against "alpha;beta" and
+	// never match. Built-in commands already slice this way (ArgumentSplit's realSubtext).
 
 	/// <summary>
-	/// SCOPED OUT: a $command that is the SECOND command in a list, with NO leading space
-	/// ("@@ ignore;{token}"). Fails because matching runs against the whole list source. See note above.
+	/// A $command that is the SECOND command in a list, with NO leading space ("@@ ignore;{token}").
 	/// </summary>
 	[Test]
-	[Skip("Scoped out: $command matching in ';' command-lists uses the whole list source (SharpMUSHParserVisitor.cs:907). Separate from the fixed leading/trailing-space bug.")]
 	public async ValueTask SemicolonList_SecondCommand_NoLeadingSpace_Match()
 	{
 		var executor = WebAppFactoryArg.ExecutorDBRef;
@@ -624,6 +617,108 @@ public class UserDefinedCommandsTests
 			.Received(1)
 			.Notify(TestHelpers.MatchingObject(executor),
 				Arg.Is<OneOf<MString, string>>(s => TestHelpers.MessagePlainTextEquals(s, $"{token} Matched")),
+				TestHelpers.MatchingObject(obj), INotifyService.NotificationType.Emit);
+	}
+
+	/// <summary>
+	/// A $command that is the FIRST command in a list with a trailing built-in ("{token};@emit X").
+	/// It must match its own slice, not "token;@emit X".
+	/// </summary>
+	[Test]
+	public async ValueTask SemicolonList_FirstCommand_WithTail_Match()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var listParser = WebAppFactoryArg.CommandParser;
+		var obj = await TestIsolationHelpers.CreateTestThingAsync(Parser, ConnectionService, "UdcSemiFirst");
+		var token = TestIsolationHelpers.GenerateUniqueName("uc");
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"&UTEST_SEMI_FIRST {obj}=${token}:@emit {token} Matched"));
+
+		await listParser.CommandListParse(MModule.single($"{token};@emit TAIL"));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf<MString, string>>(s => TestHelpers.MessagePlainTextEquals(s, $"{token} Matched")),
+				TestHelpers.MatchingObject(obj), INotifyService.NotificationType.Emit);
+	}
+
+	/// <summary>
+	/// Three-command list: a $command in the MIDDLE and at the END both match. Guards the
+	/// Stop.StopIndex arithmetic for the final list element.
+	/// </summary>
+	[Test]
+	public async ValueTask SemicolonList_MiddleAndLastCommands_Match()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var listParser = WebAppFactoryArg.CommandParser;
+		var obj = await TestIsolationHelpers.CreateTestThingAsync(Parser, ConnectionService, "UdcSemiThree");
+		var mid = TestIsolationHelpers.GenerateUniqueName("ucmid");
+		var last = TestIsolationHelpers.GenerateUniqueName("uclast");
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"&UTEST_SEMI_MID {obj}=${mid}:@emit {mid} MidMatched"));
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"&UTEST_SEMI_LAST {obj}=${last}:@emit {last} LastMatched"));
+
+		await listParser.CommandListParse(MModule.single($"@emit HEAD;{mid};{last}"));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf<MString, string>>(s => TestHelpers.MessagePlainTextEquals(s, $"{mid} MidMatched")),
+				TestHelpers.MatchingObject(obj), INotifyService.NotificationType.Emit);
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf<MString, string>>(s => TestHelpers.MessagePlainTextEquals(s, $"{last} LastMatched")),
+				TestHelpers.MatchingObject(obj), INotifyService.NotificationType.Emit);
+	}
+
+	/// <summary>
+	/// Per-command argument capture in a list (the "funky indexes" guard). A wildcard $command as the
+	/// SECOND command must capture %0 from its OWN slice — "Bob" — not leak the first command's text or a
+	/// wrong offset. The first command is deliberately a different length than the second.
+	/// </summary>
+	[Test]
+	public async ValueTask SemicolonList_WildcardArg_CapturesPerCommandSlice()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var listParser = WebAppFactoryArg.CommandParser;
+		var obj = await TestIsolationHelpers.CreateTestThingAsync(Parser, ConnectionService, "UdcSemiArg");
+		var token = TestIsolationHelpers.GenerateUniqueName("uc");
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"&UTEST_SEMI_ARG {obj}=${token} *:@emit GREET=<%0>"));
+
+		// First command is a longer @emit; second is the wildcard $command with arg "Bob".
+		await listParser.CommandListParse(MModule.single($"@emit AAAAAAAAAA;{token} Bob"));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf<MString, string>>(s => TestHelpers.MessagePlainTextEquals(s, "GREET=<Bob>")),
+				TestHelpers.MatchingObject(obj), INotifyService.NotificationType.Emit);
+	}
+
+	/// <summary>
+	/// Two-wildcard $command as the second command in a list: %0 and %1 each capture from the
+	/// per-command slice. Further guards capture-group index alignment after slicing.
+	/// </summary>
+	[Test]
+	public async ValueTask SemicolonList_TwoWildcardArgs_CapturePerCommandSlice()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var listParser = WebAppFactoryArg.CommandParser;
+		var obj = await TestIsolationHelpers.CreateTestThingAsync(Parser, ConnectionService, "UdcSemiArg2");
+		var token = TestIsolationHelpers.GenerateUniqueName("uc");
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"&UTEST_SEMI_ARG2 {obj}=${token} * to *:@emit MSG=<%0>-<%1>"));
+
+		await listParser.CommandListParse(MModule.single($"@emit IGNORE;{token} Alice to Bob"));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf<MString, string>>(s => TestHelpers.MessagePlainTextEquals(s, "MSG=<Alice>-<Bob>")),
 				TestHelpers.MatchingObject(obj), INotifyService.NotificationType.Emit);
 	}
 }


### PR DESCRIPTION
Two related fixes to `$command` matching, both proven by tests in `UserDefinedCommandsTests`.

## Fix 1 — surrounding whitespace (terminal + command-list)

`$test:@emit ...` did not match when a player typed `" test"` (leading space) → `Huh?`. The compiled `$command` patterns are anchored (`^...$`), and `MatchUserDefinedCommand` matched the **raw, untrimmed** command string, so leading/trailing whitespace broke the anchors. PennMUSH strips this before matching.

**Fix:** trim the command `MString` (both ends) before matching in `CommandDiscoveryService.MatchUserDefinedCommand`, reusing the trimmed `MString` for argument capture so regex group indices stay aligned.

## Fix 2 — per-command matching in `;` command-lists

A `$command` that was part of a multi-command `;` list never matched. `EvaluateCommands` passed the visitor's whole `source` (the entire list, e.g. `"alpha;beta"`) to `MatchUserDefinedCommand`, so every command's `^...$` pattern was tested against the whole list and failed — at any position, not just the second.

Proven by instrumentation: the grammar splits the list into separate `CommandContext` nodes correctly (built-ins resolve per-command), but `$command` matching alone used the whole `source`. Built-in commands already re-slice `src` down to the current command via the command's `evaluationString` span (`ArgumentSplit`'s `realSubtext`).

**Fix:** `EvaluateCommands` now computes the same per-command, markup-preserving slice (`commandText`) and uses it for all five scope lookups (nearby, ZMR, location, personal zone, global). The slice is plain-text-indexed from `source`, so regex capture-group indices stay aligned (`MModule.substring` clips markup runs); the whitespace trim from Fix 1 now trims the per-command slice.

## Tests

`UserDefinedCommandsTests` — 26 tests, 25 pass, 1 pre-existing skip:
- Leading/trailing-space match — terminal and command-list paths + no-space control
- `;`-list `$command` matching: second command (with/without leading space after `;`), first command with a trailing built-in, and a 3-command list (middle + last, guarding the final element's `Stop` index)
- Per-command argument capture (single and double wildcard) proving `%0`/`%1` come from the command's own slice — not a leaked offset into the whole list (the markup-index concern)

No regressions across CommandFlow / ControlFlow / Attribute / General / Command / Zone / Semaphore command suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)