### PR TITLE
Terminal command links vs. navigation links

### DIFF
--- a/SharpMUSH.Client/Components/GlobalTerminal.razor
+++ b/SharpMUSH.Client/Components/GlobalTerminal.razor
@@ -328,7 +328,7 @@
                 _cmdLinkHandle = await JsRuntime.InvokeAsync<IJSObjectReference>(
                     "SharpMUSH.Terminal.attachCommandLinks", _outputId, _selfRef);
             }
-            catch { /* ignore if JS not ready */ }
+            catch (JSException) { /* ignore if JS not ready */ }
         }
 
         if (_autoScroll)
@@ -536,8 +536,10 @@
 
         if (_cmdLinkHandle is not null)
         {
-            try { await _cmdLinkHandle.InvokeVoidAsync("dispose"); } catch { /* ignore */ }
-            try { await _cmdLinkHandle.DisposeAsync(); } catch { /* ignore */ }
+            try { await _cmdLinkHandle.InvokeVoidAsync("dispose"); }
+            catch (Exception ex) when (ex is JSException or ObjectDisposedException) { /* ignore during teardown */ }
+            try { await _cmdLinkHandle.DisposeAsync(); }
+            catch (Exception ex) when (ex is JSException or ObjectDisposedException) { /* ignore during teardown */ }
         }
         _selfRef?.Dispose();
     }

--- a/SharpMUSH.Client/Components/GlobalTerminal.razor
+++ b/SharpMUSH.Client/Components/GlobalTerminal.razor
@@ -2,6 +2,7 @@
 @using SharpMUSH.Client.Services
 @using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Components.WebAssembly.Hosting
+@using Microsoft.JSInterop
 @inject ITerminalService DefaultTerminal
 @inject IJSRuntime JsRuntime
 @inject CredentialService Credentials
@@ -233,6 +234,9 @@
     private string? _accountError;
     private bool _showCharacterPicker;
 
+    private DotNetObjectReference<GlobalTerminal>? _selfRef;
+    private IJSObjectReference? _cmdLinkHandle;
+
     protected override async Task OnInitializedAsync()
     {
         _serverUri = DefaultServerUri;
@@ -316,8 +320,30 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (firstRender)
+        {
+            _selfRef = DotNetObjectReference.Create(this);
+            try
+            {
+                _cmdLinkHandle = await JsRuntime.InvokeAsync<IJSObjectReference>(
+                    "SharpMUSH.Terminal.attachCommandLinks", _outputId, _selfRef);
+            }
+            catch { /* ignore if JS not ready */ }
+        }
+
         if (_autoScroll)
             await ScrollToBottomAsync();
+    }
+
+    /// <summary>
+    /// Invoked from JS when a command link (&lt;a xch_cmd="..."&gt;) is clicked in the
+    /// terminal output. Sends the command exactly as if the player had typed it.
+    /// </summary>
+    [JSInvokable]
+    public async Task RunCommandLinkAsync(string command)
+    {
+        if (string.IsNullOrWhiteSpace(command) || !_connected) return;
+        await Terminal.SendAsync(command);
     }
 
     // ── Account login / register ─────────────────────────────────────────────
@@ -507,6 +533,12 @@
     {
         Terminal.LineReceived -= OnLineReceived;
         Terminal.ConnectionStateChanged -= OnConnectionChanged;
-        await Task.CompletedTask;
+
+        if (_cmdLinkHandle is not null)
+        {
+            try { await _cmdLinkHandle.InvokeVoidAsync("dispose"); } catch { /* ignore */ }
+            try { await _cmdLinkHandle.DisposeAsync(); } catch { /* ignore */ }
+        }
+        _selfRef?.Dispose();
     }
 }

--- a/SharpMUSH.Client/wwwroot/css/custom.css
+++ b/SharpMUSH.Client/wwwroot/css/custom.css
@@ -765,6 +765,17 @@ body {
     to { visibility: hidden; }
 }
 
+/* Command links (xch_cmd) — clickable, run a MUSH command. Distinct from URL links. */
+.ms-cmd-link {
+    color: var(--primary, #6cf);
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    cursor: pointer;
+}
+.ms-cmd-link:hover {
+    text-decoration-style: solid;
+}
+
 /* ── Softcode Editor ── */
 .mush-editor-fill {
     width: 100%;

--- a/SharpMUSH.Client/wwwroot/css/custom.css
+++ b/SharpMUSH.Client/wwwroot/css/custom.css
@@ -775,6 +775,12 @@ body {
 .ms-cmd-link:hover {
     text-decoration-style: solid;
 }
+/* Command links carry role="button" tabindex="0"; show a focus ring for keyboard users. */
+.ms-cmd-link:focus-visible {
+    outline: 2px solid var(--primary, #6cf);
+    outline-offset: 2px;
+    text-decoration-style: solid;
+}
 
 /* ── Softcode Editor ── */
 .mush-editor-fill {

--- a/SharpMUSH.Client/wwwroot/js/mush-monaco.js
+++ b/SharpMUSH.Client/wwwroot/js/mush-monaco.js
@@ -429,25 +429,42 @@
             if (el) el.scrollTop = el.scrollHeight;
         },
 
-        // Registers a delegated click handler on the terminal output container.
-        // Clicking a command link (<a xch_cmd="...">) runs the command via .NET
-        // (RunCommandLinkAsync) instead of navigating. Plain <a href> links are left
-        // untouched so they open normally. Returns a disposable for cleanup.
+        // Registers delegated handlers on the terminal output container. Clicking — or
+        // pressing Enter/Space on — a command link (<a xch_cmd="...">) runs the command via
+        // .NET (RunCommandLinkAsync) instead of navigating. Command links carry
+        // role="button" tabindex="0" so they are keyboard-focusable. Plain <a href> links are
+        // left untouched so they open normally. Returns a disposable for cleanup.
         attachCommandLinks: function (outputId, dotNetRef) {
             var el = document.getElementById(outputId);
             if (!el) return { dispose: function () { } };
+
+            function run(a) {
+                var cmd = a.getAttribute('xch_cmd');
+                if (cmd) dotNetRef.invokeMethodAsync('RunCommandLinkAsync', cmd);
+            }
 
             function onClick(e) {
                 var a = e.target.closest('a[xch_cmd]');
                 if (!a || !el.contains(a)) return;
                 e.preventDefault();
-                var cmd = a.getAttribute('xch_cmd');
-                if (cmd) dotNetRef.invokeMethodAsync('RunCommandLinkAsync', cmd);
+                run(a);
+            }
+
+            function onKeyDown(e) {
+                if (e.key !== 'Enter' && e.key !== ' ' && e.key !== 'Spacebar') return;
+                var a = e.target.closest('a[xch_cmd]');
+                if (!a || !el.contains(a)) return;
+                e.preventDefault();
+                run(a);
             }
 
             el.addEventListener('click', onClick);
+            el.addEventListener('keydown', onKeyDown);
             return {
-                dispose: function () { el.removeEventListener('click', onClick); },
+                dispose: function () {
+                    el.removeEventListener('click', onClick);
+                    el.removeEventListener('keydown', onKeyDown);
+                },
             };
         },
     };

--- a/SharpMUSH.Client/wwwroot/js/mush-monaco.js
+++ b/SharpMUSH.Client/wwwroot/js/mush-monaco.js
@@ -428,6 +428,28 @@
             var el = document.getElementById(elementId);
             if (el) el.scrollTop = el.scrollHeight;
         },
+
+        // Registers a delegated click handler on the terminal output container.
+        // Clicking a command link (<a xch_cmd="...">) runs the command via .NET
+        // (RunCommandLinkAsync) instead of navigating. Plain <a href> links are left
+        // untouched so they open normally. Returns a disposable for cleanup.
+        attachCommandLinks: function (outputId, dotNetRef) {
+            var el = document.getElementById(outputId);
+            if (!el) return { dispose: function () { } };
+
+            function onClick(e) {
+                var a = e.target.closest('a[xch_cmd]');
+                if (!a || !el.contains(a)) return;
+                e.preventDefault();
+                var cmd = a.getAttribute('xch_cmd');
+                if (cmd) dotNetRef.invokeMethodAsync('RunCommandLinkAsync', cmd);
+            }
+
+            el.addEventListener('click', onClick);
+            return {
+                dispose: function () { el.removeEventListener('click', onClick); },
+            };
+        },
     };
 
     // ── Wiki editor: wrap the current textarea selection with markdown markup ──

--- a/SharpMUSH.Documentation/MarkdownToAsciiRenderer/HelpTopicInlineParser.cs
+++ b/SharpMUSH.Documentation/MarkdownToAsciiRenderer/HelpTopicInlineParser.cs
@@ -25,6 +25,12 @@ namespace SharpMUSH.Documentation.MarkdownToAsciiRenderer;
 /// </summary>
 public class HelpTopicInlineParser : InlineParser
 {
+	/// <summary>
+	/// Markdig data key set on the <see cref="LinkInline"/> nodes this parser produces, marking
+	/// them as command links (run "help &lt;topic&gt;") rather than URL navigation links.
+	/// </summary>
+	public const string CommandDataKey = "sharpmush:command-link";
+
 	public HelpTopicInlineParser()
 	{
 		OpeningCharacters = ['['];
@@ -84,6 +90,7 @@ public class HelpTopicInlineParser : InlineParser
 		};
 		link.AppendChild(new LiteralInline(topic));
 
+		link.SetData(CommandDataKey, true);
 		processor.Inline = link;
 		return true;
 	}

--- a/SharpMUSH.Documentation/MarkdownToAsciiRenderer/RecursiveMarkdownRenderer.Inlines.cs
+++ b/SharpMUSH.Documentation/MarkdownToAsciiRenderer/RecursiveMarkdownRenderer.Inlines.cs
@@ -1,5 +1,6 @@
 using Markdig.Extensions.TaskLists;
 using Markdig.Syntax.Inlines;
+using MarkupString.MarkupImplementation;
 using SharpMUSH.Library.Services;
 
 namespace SharpMUSH.Documentation.MarkdownToAsciiRenderer;
@@ -84,8 +85,14 @@ public partial class RecursiveMarkdownRenderer
 			contentText = url;
 		}
 
-		// Create hyperlink markup with linkUrl parameter
-		var linkMarkup = Ansi.Create(linkUrl: url);
+		// Help-topic shortcuts ([topic]) are command links; ordinary links navigate.
+		// A markdown link title ([text](url "title")) becomes the link hint.
+		var isCommand = link.GetData(HelpTopicInlineParser.CommandDataKey) is true;
+		var hint = string.IsNullOrWhiteSpace(link.Title) ? null : link.Title;
+		var linkMarkup = Ansi.Create(
+			linkUrl: url,
+			linkKind: isCommand ? LinkKind.Command : LinkKind.Url,
+			linkText: hint);
 		return MModule.MarkupSingle(linkMarkup, contentText);
 	}
 

--- a/SharpMUSH.MarkupString/Markup/Markup.cs
+++ b/SharpMUSH.MarkupString/Markup/Markup.cs
@@ -218,7 +218,8 @@ public sealed class AnsiMarkup : IMarkup
         if (d.Underlined)    t = $"[u]{t}[/u]";
         if (d.Italic)        t = $"[i]{t}[/i]";
         if (d.Bold)          t = $"[b]{t}[/b]";
-        if (d.LinkUrl is { Length: > 0 } url)
+        // BBCode has no command-link concept — only URL links are wrapped.
+        if (d.LinkUrl is { Length: > 0 } url && d.LinkKind == LinkKind.Url)
             t = $"[url={url}]{t}[/url]";
         if (ColorToHex(fg) is string fgHex) t = $"[color={fgHex}]{t}[/color]";
         return t;
@@ -261,7 +262,8 @@ public sealed class AnsiMarkup : IMarkup
     public static ANSIString ApplyDetails(AnsiStructure d, string text)
     {
         var s = text.ToANSI();
-        if (d.LinkUrl is { Length: > 0 } url)  s = s.LinkANSI(url);
+        // OSC 8 hyperlinks can only navigate, so command links render as plain text.
+        if (d.LinkUrl is { Length: > 0 } url && d.LinkKind == LinkKind.Url)  s = s.LinkANSI(url);
         if (d.Foreground is not AnsiColor.NoAnsi) s = s.ColorANSI(d.Foreground);
         if (d.Background is not AnsiColor.NoAnsi) s = s.BackgroundANSI(d.Background);
         if (d.Blink)          s = s.BlinkANSI();

--- a/SharpMUSH.MarkupString/Markup/Markup.cs
+++ b/SharpMUSH.MarkupString/Markup/Markup.cs
@@ -192,7 +192,19 @@ public sealed class AnsiMarkup : IMarkup
         if (d.Italic)        t = $"<I>{t}</I>";
         if (d.Bold)          t = $"<B>{t}</B>";
         if (d.LinkUrl is { Length: > 0 } url)
-            t = $"<A HREF=\"{WebUtility.HtmlEncode(url)}\">{t}</A>";
+        {
+            if (d.LinkKind == LinkKind.Command)
+            {
+                var hint = d.LinkText is { Length: > 0 } h
+                    ? $" XCH_HINT=\"{WebUtility.HtmlEncode(h)}\""
+                    : "";
+                t = $"<A XCH_CMD=\"{WebUtility.HtmlEncode(url)}\"{hint}>{t}</A>";
+            }
+            else
+            {
+                t = $"<A HREF=\"{WebUtility.HtmlEncode(url)}\">{t}</A>";
+            }
+        }
         if (ColorToHex(bg) is string bgHex) t = $"<SPAN STYLE=\"background-color: {bgHex}\">{t}</SPAN>";
         if (ColorToHex(fg) is string fgHex) t = $"<FONT COLOR=\"{fgHex}\">{t}</FONT>";
         return t;
@@ -221,7 +233,19 @@ public sealed class AnsiMarkup : IMarkup
         if (d.Italic)        t = $"<I>{t}</I>";
         if (d.Bold)          t = $"<B>{t}</B>";
         if (d.LinkUrl is { Length: > 0 } url)
-            t = $"<SEND HREF=\"{WebUtility.HtmlEncode(url)}\">{t}</SEND>";
+        {
+            if (d.LinkKind == LinkKind.Command)
+            {
+                var hint = d.LinkText is { Length: > 0 } h
+                    ? $" HINT=\"{WebUtility.HtmlEncode(h)}\""
+                    : "";
+                t = $"<SEND HREF=\"{WebUtility.HtmlEncode(url)}\"{hint}>{t}</SEND>";
+            }
+            else
+            {
+                t = $"<A HREF=\"{WebUtility.HtmlEncode(url)}\">{t}</A>";
+            }
+        }
         string? fgHex = ColorToHex(fg);
         string? bgHex = ColorToHex(bg);
         t = (fgHex, bgHex) switch

--- a/SharpMUSH.MarkupString/Markup/Markup.cs
+++ b/SharpMUSH.MarkupString/Markup/Markup.cs
@@ -7,6 +7,13 @@ using ANSILibrary;
 
 namespace MarkupString.MarkupImplementation;
 
+/// <summary>
+/// Distinguishes a link that runs a MUSH command when clicked (e.g. "help topic")
+/// from one that navigates to a URL. <see cref="Url"/> is value 0 and the default so
+/// legacy markup with no LinkKind deserialises to navigation behaviour.
+/// </summary>
+public enum LinkKind { Url = 0, Command = 1 }
+
 // ── Struct records ─────────────────────────────────────────────────────────────
 
 /// <summary>
@@ -18,6 +25,7 @@ public readonly record struct AnsiStructure
     public AnsiColor Background    { get; init; }
     public string?  LinkText       { get; init; }
     public string?  LinkUrl        { get; init; }
+    public LinkKind LinkKind       { get; init; }
     public bool     Blink          { get; init; }
     public bool     Bold           { get; init; }
     public bool     Clear          { get; init; }
@@ -87,6 +95,7 @@ public sealed class AnsiMarkup : IMarkup
         AnsiColor? background  = null,
         string?    linkText    = null,
         string?    linkUrl     = null,
+        LinkKind   linkKind    = LinkKind.Url,
         bool       blink       = false,
         bool       bold        = false,
         bool       clear       = false,
@@ -103,6 +112,7 @@ public sealed class AnsiMarkup : IMarkup
             Background    = background  ?? AnsiColor.NoAnsi.Instance,
             LinkText      = linkText    ?? string.Empty,
             LinkUrl       = linkUrl     ?? string.Empty,
+            LinkKind      = linkKind,
             Blink         = blink,
             Bold          = bold,
             Clear         = clear,

--- a/SharpMUSH.MarkupString/Markup/Markup.cs
+++ b/SharpMUSH.MarkupString/Markup/Markup.cs
@@ -150,6 +150,21 @@ public sealed class AnsiMarkup : IMarkup
         _ => throw new NotSupportedException()
     };
 
+    /// <summary>
+    /// Returns true if a URL is safe to render as a navigable hyperlink. Relative URLs
+    /// (no scheme) and a small allow-list of schemes are permitted; dangerous schemes such
+    /// as <c>javascript:</c>, <c>data:</c>, <c>vbscript:</c>, and <c>file:</c> are rejected so
+    /// they render as plain text rather than clickable links. Applies to URL links only —
+    /// command links carry a MUSH command in <c>xch_cmd</c>, never a browser-navigable href.
+    /// </summary>
+    public static bool IsSafeNavigableUrl(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return false;
+        if (!Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri)) return false;
+        if (!uri.IsAbsoluteUri) return true; // relative / anchor => safe
+        return uri.Scheme.ToLowerInvariant() is "http" or "https" or "mailto" or "ftp" or "ftps" or "tel";
+    }
+
     /// <summary>Renders AnsiStructure as an HTML span with inline style + CSS classes.</summary>
     public static string WrapAsHtmlClass(AnsiStructure d, string text)
     {
@@ -162,16 +177,19 @@ public sealed class AnsiMarkup : IMarkup
         var classes = HtmlClassNames(d);
 
         // Wrap hyperlink. Command links run a MUSH command (xch_cmd, intercepted by the
-        // WASM terminal); URL links navigate in a new tab.
+        // WASM terminal); URL links navigate in a new tab. A command link has no href, so it
+        // carries role="button" + tabindex="0" to stay keyboard-focusable/activatable.
+        // URL links with an unsafe scheme (e.g. javascript:) fall back to plain text.
         string inner = text;
         if (d.LinkUrl is { Length: > 0 } url)
         {
             var title = d.LinkText is { Length: > 0 } hint
                 ? $" title=\"{WebUtility.HtmlEncode(hint)}\""
                 : "";
-            inner = d.LinkKind == LinkKind.Command
-                ? $"<a class=\"ms-cmd-link\" xch_cmd=\"{WebUtility.HtmlEncode(url)}\"{title}>{text}</a>"
-                : $"<a href=\"{WebUtility.HtmlEncode(url)}\" target=\"_blank\" rel=\"noopener noreferrer\"{title}>{text}</a>";
+            if (d.LinkKind == LinkKind.Command)
+                inner = $"<a class=\"ms-cmd-link\" role=\"button\" tabindex=\"0\" xch_cmd=\"{WebUtility.HtmlEncode(url)}\"{title}>{text}</a>";
+            else if (IsSafeNavigableUrl(url))
+                inner = $"<a href=\"{WebUtility.HtmlEncode(url)}\" target=\"_blank\" rel=\"noopener noreferrer\"{title}>{text}</a>";
         }
 
         string styleAttr = styles.Count > 0 ? $" style=\"{string.Join("; ", styles)}\"" : "";
@@ -200,7 +218,7 @@ public sealed class AnsiMarkup : IMarkup
                     : "";
                 t = $"<A XCH_CMD=\"{WebUtility.HtmlEncode(url)}\"{hint}>{t}</A>";
             }
-            else
+            else if (IsSafeNavigableUrl(url))
             {
                 t = $"<A HREF=\"{WebUtility.HtmlEncode(url)}\">{t}</A>";
             }
@@ -218,8 +236,8 @@ public sealed class AnsiMarkup : IMarkup
         if (d.Underlined)    t = $"[u]{t}[/u]";
         if (d.Italic)        t = $"[i]{t}[/i]";
         if (d.Bold)          t = $"[b]{t}[/b]";
-        // BBCode has no command-link concept — only URL links are wrapped.
-        if (d.LinkUrl is { Length: > 0 } url && d.LinkKind == LinkKind.Url)
+        // BBCode has no command-link concept — only safe URL links are wrapped.
+        if (d.LinkUrl is { Length: > 0 } url && d.LinkKind == LinkKind.Url && IsSafeNavigableUrl(url))
             t = $"[url={url}]{t}[/url]";
         if (ColorToHex(fg) is string fgHex) t = $"[color={fgHex}]{t}[/color]";
         return t;
@@ -242,7 +260,7 @@ public sealed class AnsiMarkup : IMarkup
                     : "";
                 t = $"<SEND HREF=\"{WebUtility.HtmlEncode(url)}\"{hint}>{t}</SEND>";
             }
-            else
+            else if (IsSafeNavigableUrl(url))
             {
                 t = $"<A HREF=\"{WebUtility.HtmlEncode(url)}\">{t}</A>";
             }
@@ -262,8 +280,10 @@ public sealed class AnsiMarkup : IMarkup
     public static ANSIString ApplyDetails(AnsiStructure d, string text)
     {
         var s = text.ToANSI();
-        // OSC 8 hyperlinks can only navigate, so command links render as plain text.
-        if (d.LinkUrl is { Length: > 0 } url && d.LinkKind == LinkKind.Url)  s = s.LinkANSI(url);
+        // OSC 8 hyperlinks can only navigate, so command links — and unsafe URL schemes —
+        // render as plain text.
+        if (d.LinkUrl is { Length: > 0 } url && d.LinkKind == LinkKind.Url && IsSafeNavigableUrl(url))
+            s = s.LinkANSI(url);
         if (d.Foreground is not AnsiColor.NoAnsi) s = s.ColorANSI(d.Foreground);
         if (d.Background is not AnsiColor.NoAnsi) s = s.BackgroundANSI(d.Background);
         if (d.Blink)          s = s.BlinkANSI();

--- a/SharpMUSH.MarkupString/Markup/Markup.cs
+++ b/SharpMUSH.MarkupString/Markup/Markup.cs
@@ -161,10 +161,18 @@ public sealed class AnsiMarkup : IMarkup
 
         var classes = HtmlClassNames(d);
 
-        // Wrap hyperlink
+        // Wrap hyperlink. Command links run a MUSH command (xch_cmd, intercepted by the
+        // WASM terminal); URL links navigate in a new tab.
         string inner = text;
         if (d.LinkUrl is { Length: > 0 } url)
-            inner = $"<a href=\"{WebUtility.HtmlEncode(url)}\">{text}</a>";
+        {
+            var title = d.LinkText is { Length: > 0 } hint
+                ? $" title=\"{WebUtility.HtmlEncode(hint)}\""
+                : "";
+            inner = d.LinkKind == LinkKind.Command
+                ? $"<a class=\"ms-cmd-link\" xch_cmd=\"{WebUtility.HtmlEncode(url)}\"{title}>{text}</a>"
+                : $"<a href=\"{WebUtility.HtmlEncode(url)}\" target=\"_blank\" rel=\"noopener noreferrer\"{title}>{text}</a>";
+        }
 
         string styleAttr = styles.Count > 0 ? $" style=\"{string.Join("; ", styles)}\"" : "";
         string classAttr = classes.Count > 0 ? $" class=\"{string.Join(" ", classes)}\"" : "";

--- a/SharpMUSH.MarkupString/MarkupStringModule.cs
+++ b/SharpMUSH.MarkupString/MarkupStringModule.cs
@@ -87,16 +87,42 @@ internal sealed class PlainTextRenderStrategy : IRenderStrategy
 }
 
 /// <summary>
-/// Pueblo/MXP render strategy: ANSI codes for AnsiMarkup (colors stay as escape sequences)
+/// Pueblo render strategy: ANSI codes for AnsiMarkup (colors stay as escape sequences)
 /// plus native HTML tags for HtmlMarkup (e.g. &lt;send&gt;). This produces an additive stream
-/// where terminal clients see ANSI and Pueblo/MXP clients see both ANSI + HTML.
+/// where terminal clients see ANSI and Pueblo clients see both ANSI + HTML.
+/// Links in AnsiMarkup render as Pueblo HTML tags (XCH_CMD) instead of ANSI.
 /// </summary>
-internal sealed class PuebloMxpRenderStrategy : IRenderStrategy
+internal sealed class PuebloRenderStrategy : IRenderStrategy
 {
     public string EncodeText(string text) => WebUtility.HtmlEncode(text);
     public string ApplyMarkup(IMarkup markup, string text) => markup switch
     {
         HtmlMarkup html => html.Wrap(text),
+        AnsiMarkup ansi => ansi.Details.LinkUrl is { Length: > 0 }
+            ? ansi.WrapAs("pueblo", text)
+            : ansi.WrapAs("ansi", text),
+        _ => markup.WrapAs("ansi", text),
+    };
+    public string Prefix  => string.Empty;
+    public string Postfix => string.Empty.EndWithTrueClear().ToString();
+    public string Optimize(string text) => Optimization.Optimize(text);
+}
+
+/// <summary>
+/// MXP render strategy: ANSI codes for AnsiMarkup (colors stay as escape sequences)
+/// plus native HTML tags for HtmlMarkup (e.g. &lt;send&gt;). This produces an additive stream
+/// where terminal clients see ANSI and MXP clients see both ANSI + HTML.
+/// Links in AnsiMarkup render as MXP HTML tags (SEND) instead of ANSI.
+/// </summary>
+internal sealed class MxpRenderStrategy : IRenderStrategy
+{
+    public string EncodeText(string text) => WebUtility.HtmlEncode(text);
+    public string ApplyMarkup(IMarkup markup, string text) => markup switch
+    {
+        HtmlMarkup html => html.Wrap(text),
+        AnsiMarkup ansi => ansi.Details.LinkUrl is { Length: > 0 }
+            ? ansi.WrapAs("mxp", text)
+            : ansi.WrapAs("ansi", text),
         _ => markup.WrapAs("ansi", text),
     };
     public string Prefix  => string.Empty;
@@ -195,7 +221,8 @@ public sealed class MarkupString
     private readonly Lazy<string> _cachedAnsiRender;
     private readonly Lazy<string> _cachedHtmlRender;
     private readonly Lazy<string> _cachedPlainTextRender;
-    private readonly Lazy<string> _cachedPuebloMxpRender;
+    private readonly Lazy<string> _cachedPuebloRender;
+    private readonly Lazy<string> _cachedMxpRender;
 
     public MarkupString(string text, ImmutableArray<AttributeRun> runs)
     {
@@ -205,7 +232,8 @@ public sealed class MarkupString
         _cachedAnsiRender    = new Lazy<string>(() => RenderWith(MarkupStringModule.RenderStrategies.AnsiStrategy));
         _cachedHtmlRender    = new Lazy<string>(() => RenderWith(MarkupStringModule.RenderStrategies.HtmlStrategy));
         _cachedPlainTextRender = new Lazy<string>(() => RenderWith(MarkupStringModule.RenderStrategies.PlainTextStrategy));
-        _cachedPuebloMxpRender = new Lazy<string>(() => RenderWith(MarkupStringModule.RenderStrategies.PuebloMxpStrategy));
+        _cachedPuebloRender  = new Lazy<string>(() => RenderWith(MarkupStringModule.RenderStrategies.PuebloStrategy));
+        _cachedMxpRender     = new Lazy<string>(() => RenderWith(MarkupStringModule.RenderStrategies.MxpStrategy));
     }
 
     public string                   Text  => _text;
@@ -220,7 +248,8 @@ public sealed class MarkupString
     {
         "html"               => _cachedHtmlRender.Value,
         "plaintext" or "plain" => _cachedPlainTextRender.Value,
-        "pueblo" or "mxp"    => _cachedPuebloMxpRender.Value,
+        "pueblo"             => _cachedPuebloRender.Value,
+        "mxp"                => _cachedMxpRender.Value,
         _                    => _cachedAnsiRender.Value,
     };
 
@@ -321,7 +350,8 @@ public static partial class MarkupStringModule
         public static readonly IRenderStrategy AnsiStrategy      = new AnsiRenderStrategy();
         public static readonly IRenderStrategy HtmlStrategy      = new HtmlRenderStrategy();
         public static readonly IRenderStrategy PlainTextStrategy = new PlainTextRenderStrategy();
-        public static readonly IRenderStrategy PuebloMxpStrategy = new PuebloMxpRenderStrategy();
+        public static readonly IRenderStrategy PuebloStrategy    = new PuebloRenderStrategy();
+        public static readonly IRenderStrategy MxpStrategy       = new MxpRenderStrategy();
     }
 
     public static IRenderStrategy ForFormat(RenderFormat format) => format.ToStrategy();

--- a/SharpMUSH.Tests/Documentation/RecursiveMarkdownRendererTests.cs
+++ b/SharpMUSH.Tests/Documentation/RecursiveMarkdownRendererTests.cs
@@ -516,10 +516,10 @@ public class RecursiveMarkdownRendererTests
 	}
 
 	[Test]
-	public async Task RenderHelpTopicLink_ShouldCreateHelpUrl()
+	public async Task RenderHelpTopicLink_ShouldCreateCommandLink()
 	{
 		// Arrange - bare [topic] with no URL definition is parsed by HelpTopicInlineParser
-		// into a proper LinkInline with URL "help newbie2" (not the old literal-inline hack).
+		// into a command LinkInline whose URL is "help <topic>".
 		var markdown = "See [newbie2] for more.";
 
 		// Act
@@ -527,9 +527,38 @@ public class RecursiveMarkdownRendererTests
 
 		// Assert - plain text contains the topic name without brackets
 		await Assert.That(result.ToPlainText()).IsEqualTo("See newbie2 for more.");
-		// OSC 8 hyperlink is present containing "help newbie2"
-		var fullString = result.ToString();
-		await Assert.That(fullString).Contains("\u001b]8;;help newbie2");
+
+		// It is a command link: HTML renders xch_cmd (not href), ANSI has no OSC 8 link.
+		await Assert.That(result.Render("html")).Contains("xch_cmd=\"help newbie2\"");
+		await Assert.That(result.ToString()).DoesNotContain("]8;;");
+	}
+
+	[Test]
+	public async Task RenderRegularLink_ShouldBeNavigationLink()
+	{
+		// Arrange - an explicit [text](url) link is a navigation link, not a command.
+		var markdown = "[Site](https://example.com)";
+
+		// Act
+		var result = SharpMUSH.Documentation.MarkdownToAsciiRenderer.RecursiveMarkdownHelper.RenderMarkdown(markdown);
+
+		// Assert
+		await Assert.That(result.Render("html")).Contains("href=\"https://example.com\"");
+		await Assert.That(result.Render("html")).Contains("target=\"_blank\"");
+		await Assert.That(result.Render("html")).DoesNotContain("xch_cmd");
+	}
+
+	[Test]
+	public async Task RenderLink_WithTitle_CarriesHint()
+	{
+		// Arrange - markdown link title becomes the link hint (HTML title / xch_hint / MXP HINT).
+		var markdown = "[Site](https://example.com \"Open the site\")";
+
+		// Act
+		var result = SharpMUSH.Documentation.MarkdownToAsciiRenderer.RecursiveMarkdownHelper.RenderMarkdown(markdown);
+
+		// Assert
+		await Assert.That(result.Render("html")).Contains("title=\"Open the site\"");
 	}
 
 	[Test]

--- a/SharpMUSH.Tests/Markup/LinkKindRenderTests.cs
+++ b/SharpMUSH.Tests/Markup/LinkKindRenderTests.cs
@@ -1,0 +1,39 @@
+using MarkupString;
+using MarkupString.MarkupImplementation;
+
+namespace SharpMUSH.Tests.Markup;
+
+/// <summary>
+/// Tests for LinkKind (command vs navigation links) across the data model,
+/// serialization, and every output renderer.
+/// </summary>
+public class LinkKindRenderTests
+{
+	[Test]
+	public async Task Create_DefaultLinkKind_IsUrl()
+	{
+		var markup = AnsiMarkup.Create(linkUrl: "https://example.com");
+		await Assert.That(markup.Details.LinkKind).IsEqualTo(LinkKind.Url);
+	}
+
+	[Test]
+	public async Task Create_CommandLinkKind_IsPreserved()
+	{
+		var markup = AnsiMarkup.Create(linkUrl: "help topic", linkKind: LinkKind.Command);
+		await Assert.That(markup.Details.LinkKind).IsEqualTo(LinkKind.Command);
+	}
+
+	[Test]
+	public async Task Serialization_LinkKind_RoundTripsJson()
+	{
+		var cmd = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "help topic", linkKind: LinkKind.Command), "topic");
+		var json = MModule.serialize(cmd);
+
+		await Assert.That(json).Contains("LinkKind");
+
+		// Deserialise then re-serialise: the LinkKind survives the round-trip unchanged.
+		var back = MModule.deserialize(json);
+		await Assert.That(MModule.serialize(back)).IsEqualTo(json);
+	}
+}

--- a/SharpMUSH.Tests/Markup/LinkKindRenderTests.cs
+++ b/SharpMUSH.Tests/Markup/LinkKindRenderTests.cs
@@ -116,4 +116,49 @@ public class LinkKindRenderTests
 		await Assert.That(back.Render("html")).Contains("href=\"help topic\"");
 		await Assert.That(back.Render("html")).DoesNotContain("xch_cmd");
 	}
+
+	[Test]
+	public async Task Pueblo_CommandLink_UsesXchCmd()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "+who", linkKind: LinkKind.Command, linkText: "Who?"), "who");
+		var pueblo = ms.Render("pueblo");
+
+		await Assert.That(pueblo).Contains("<A XCH_CMD=\"+who\"");
+		await Assert.That(pueblo).Contains("XCH_HINT=\"Who?\"");
+		await Assert.That(pueblo).DoesNotContain("HREF=");
+	}
+
+	[Test]
+	public async Task Pueblo_UrlLink_UsesHref()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "https://example.com", linkKind: LinkKind.Url), "site");
+		var pueblo = ms.Render("pueblo");
+
+		await Assert.That(pueblo).Contains("<A HREF=\"https://example.com\">");
+		await Assert.That(pueblo).DoesNotContain("XCH_CMD");
+	}
+
+	[Test]
+	public async Task Mxp_CommandLink_UsesSend()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "+who", linkKind: LinkKind.Command, linkText: "Who?"), "who");
+		var mxp = ms.Render("mxp");
+
+		await Assert.That(mxp).Contains("<SEND HREF=\"+who\"");
+		await Assert.That(mxp).Contains("HINT=\"Who?\"");
+	}
+
+	[Test]
+	public async Task Mxp_UrlLink_UsesAnchorNotSend()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "https://example.com", linkKind: LinkKind.Url), "site");
+		var mxp = ms.Render("mxp");
+
+		await Assert.That(mxp).Contains("<A HREF=\"https://example.com\">");
+		await Assert.That(mxp).DoesNotContain("<SEND");
+	}
 }

--- a/SharpMUSH.Tests/Markup/LinkKindRenderTests.cs
+++ b/SharpMUSH.Tests/Markup/LinkKindRenderTests.cs
@@ -36,4 +36,84 @@ public class LinkKindRenderTests
 		var back = MModule.deserialize(json);
 		await Assert.That(MModule.serialize(back)).IsEqualTo(json);
 	}
+
+	[Test]
+	public async Task Html_CommandLink_UsesXchCmdNotHref()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "help topic", linkKind: LinkKind.Command), "topic");
+		var html = ms.Render("html");
+
+		await Assert.That(html).Contains("xch_cmd=\"help topic\"");
+		await Assert.That(html).Contains("ms-cmd-link");
+		await Assert.That(html).Contains(">topic</a>");
+		await Assert.That(html).DoesNotContain("href=");
+	}
+
+	[Test]
+	public async Task Html_UrlLink_UsesHrefWithNewTab()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "https://example.com", linkKind: LinkKind.Url), "site");
+		var html = ms.Render("html");
+
+		await Assert.That(html).Contains("href=\"https://example.com\"");
+		await Assert.That(html).Contains("target=\"_blank\"");
+		await Assert.That(html).Contains("rel=\"noopener noreferrer\"");
+		await Assert.That(html).DoesNotContain("xch_cmd");
+	}
+
+	[Test]
+	public async Task Html_CommandLink_WithHint_EmitsTitle()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "+who", linkKind: LinkKind.Command, linkText: "Who is online?"),
+			"who");
+		var html = ms.Render("html");
+
+		await Assert.That(html).Contains("xch_cmd=\"+who\"");
+		await Assert.That(html).Contains("title=\"Who is online?\"");
+	}
+
+	[Test]
+	public async Task Html_LinkAttributes_AreHtmlEncoded()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "say \"hi\" & <bye>", linkKind: LinkKind.Command), "x");
+		var html = ms.Render("html");
+
+		await Assert.That(html).Contains("xch_cmd=\"say &quot;hi&quot; &amp; &lt;bye&gt;\"");
+	}
+
+	[Test]
+	public async Task Serialization_CommandLink_SurvivesAndRendersXchCmd()
+	{
+		var cmd = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "help topic", linkKind: LinkKind.Command), "topic");
+		var json = MModule.serialize(cmd);
+
+		var back = MModule.deserialize(json);
+
+		// Command kind survives the round-trip: HTML render emits xch_cmd, not href.
+		await Assert.That(back.Render("html")).Contains("xch_cmd=\"help topic\"");
+		await Assert.That(back.Render("html")).DoesNotContain("href=");
+	}
+
+	[Test]
+	public async Task Serialization_LegacyPayloadWithoutLinkKind_DefaultsToUrl()
+	{
+		var cmd = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "help topic", linkKind: LinkKind.Command), "topic");
+		var json = MModule.serialize(cmd);
+
+		// Simulate a pre-LinkKind payload by stripping the property entirely.
+		var legacy = System.Text.RegularExpressions.Regex.Replace(json, "\"LinkKind\":\\d+,?", "");
+		legacy = legacy.Replace(",}", "}");
+
+		var back = MModule.deserialize(legacy);
+
+		// Missing field => default(LinkKind) == Url => navigation rendering.
+		await Assert.That(back.Render("html")).Contains("href=\"help topic\"");
+		await Assert.That(back.Render("html")).DoesNotContain("xch_cmd");
+	}
 }

--- a/SharpMUSH.Tests/Markup/LinkKindRenderTests.cs
+++ b/SharpMUSH.Tests/Markup/LinkKindRenderTests.cs
@@ -1,5 +1,7 @@
 using MarkupString;
 using MarkupString.MarkupImplementation;
+using System.Drawing;
+using ANSILibrary;
 
 namespace SharpMUSH.Tests.Markup;
 
@@ -204,5 +206,41 @@ public class LinkKindRenderTests
 
 		await Assert.That(bbcode).DoesNotContain("[url=");
 		await Assert.That(bbcode.Contains("topic")).IsTrue();
+	}
+
+	[Test]
+	public async Task Html_ColoredCommandLink_KeepsColorAndXchCmd()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(foreground: new AnsiColor.RGB(Color.Red),
+				linkUrl: "help topic", linkKind: LinkKind.Command), "topic");
+		var html = ms.Render("html");
+
+		await Assert.That(html).Contains("color: #ff0000");
+		await Assert.That(html).Contains("xch_cmd=\"help topic\"");
+	}
+
+	[Test]
+	public async Task Pueblo_ColoredCommandLink_KeepsColorAndXchCmd()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(foreground: new AnsiColor.RGB(Color.Red),
+				linkUrl: "+who", linkKind: LinkKind.Command), "who");
+		var pueblo = ms.Render("pueblo");
+
+		await Assert.That(pueblo).Contains("XCH_CMD=\"+who\"");
+		await Assert.That(pueblo).Contains("<FONT COLOR=");
+	}
+
+	[Test]
+	public async Task Mxp_ColoredCommandLink_KeepsColorAndSend()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(foreground: new AnsiColor.RGB(Color.Red),
+				linkUrl: "+who", linkKind: LinkKind.Command), "who");
+		var mxp = ms.Render("mxp");
+
+		await Assert.That(mxp).Contains("SEND HREF=\"+who\"");
+		await Assert.That(mxp).Contains("<COLOR FORE=");
 	}
 }

--- a/SharpMUSH.Tests/Markup/LinkKindRenderTests.cs
+++ b/SharpMUSH.Tests/Markup/LinkKindRenderTests.cs
@@ -243,4 +243,78 @@ public class LinkKindRenderTests
 		await Assert.That(mxp).Contains("SEND HREF=\"+who\"");
 		await Assert.That(mxp).Contains("<COLOR FORE=");
 	}
+
+	// ── Accessibility: command links are keyboard-focusable ──────────────────────
+
+	[Test]
+	public async Task Html_CommandLink_IsKeyboardAccessible()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "help topic", linkKind: LinkKind.Command), "topic");
+		var html = ms.Render("html");
+
+		await Assert.That(html).Contains("role=\"button\"");
+		await Assert.That(html).Contains("tabindex=\"0\"");
+	}
+
+	// ── Security: unsafe URL schemes are not rendered as clickable links ─────────
+
+	[Test]
+	public async Task IsSafeNavigableUrl_AllowsSafeSchemesAndRelative_BlocksDangerous()
+	{
+		await Assert.That(AnsiMarkup.IsSafeNavigableUrl("https://example.com")).IsTrue();
+		await Assert.That(AnsiMarkup.IsSafeNavigableUrl("http://example.com")).IsTrue();
+		await Assert.That(AnsiMarkup.IsSafeNavigableUrl("mailto:a@b.com")).IsTrue();
+		await Assert.That(AnsiMarkup.IsSafeNavigableUrl("/wiki/page")).IsTrue();
+		await Assert.That(AnsiMarkup.IsSafeNavigableUrl("javascript:alert(1)")).IsFalse();
+		await Assert.That(AnsiMarkup.IsSafeNavigableUrl("JavaScript:alert(1)")).IsFalse();
+		await Assert.That(AnsiMarkup.IsSafeNavigableUrl("data:text/html,<script>")).IsFalse();
+		await Assert.That(AnsiMarkup.IsSafeNavigableUrl("vbscript:msgbox(1)")).IsFalse();
+		await Assert.That(AnsiMarkup.IsSafeNavigableUrl("file:///etc/passwd")).IsFalse();
+	}
+
+	[Test]
+	public async Task Html_UrlLink_JavascriptScheme_RendersPlainText()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "javascript:alert(1)", linkKind: LinkKind.Url), "click");
+		var html = ms.Render("html");
+
+		await Assert.That(html).DoesNotContain("<a ");
+		await Assert.That(html).DoesNotContain("javascript:");
+		await Assert.That(html.Contains("click")).IsTrue();
+	}
+
+	[Test]
+	public async Task Pueblo_UrlLink_UnsafeScheme_RendersPlainText()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "javascript:alert(1)", linkKind: LinkKind.Url), "click");
+		var pueblo = ms.Render("pueblo");
+
+		await Assert.That(pueblo).DoesNotContain("<A HREF");
+		await Assert.That(pueblo).DoesNotContain("javascript:");
+	}
+
+	[Test]
+	public async Task Mxp_UrlLink_UnsafeScheme_RendersPlainText()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "data:text/html,x", linkKind: LinkKind.Url), "click");
+		var mxp = ms.Render("mxp");
+
+		await Assert.That(mxp).DoesNotContain("<A HREF");
+		await Assert.That(mxp).DoesNotContain("data:");
+	}
+
+	[Test]
+	public async Task Ansi_UrlLink_UnsafeScheme_RendersPlainTextNoOsc8()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "javascript:alert(1)", linkKind: LinkKind.Url), "click");
+		var ansi = ms.Render("ansi");
+
+		await Assert.That(ansi).DoesNotContain("]8;;");
+		await Assert.That(ansi.Contains("click")).IsTrue();
+	}
 }

--- a/SharpMUSH.Tests/Markup/LinkKindRenderTests.cs
+++ b/SharpMUSH.Tests/Markup/LinkKindRenderTests.cs
@@ -161,4 +161,48 @@ public class LinkKindRenderTests
 		await Assert.That(mxp).Contains("<A HREF=\"https://example.com\">");
 		await Assert.That(mxp).DoesNotContain("<SEND");
 	}
+
+	[Test]
+	public async Task Ansi_CommandLink_RendersPlainTextNoOsc8()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "help topic", linkKind: LinkKind.Command), "topic");
+		var ansi = ms.Render("ansi");
+
+		await Assert.That(ansi).DoesNotContain("]8;;");
+		await Assert.That(ansi.Contains("topic")).IsTrue();
+	}
+
+	[Test]
+	public async Task Ansi_UrlLink_StillRendersOsc8()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "https://example.com", linkKind: LinkKind.Url), "site");
+		var ansi = ms.Render("ansi");
+
+		await Assert.That(ansi).Contains("]8;;https://example.com");
+	}
+
+	[Test]
+	public async Task BBCode_UrlLink_UsesUrlTag()
+	{
+		// NOTE: Render("bbcode") is intentionally NOT a wired render route — BBCode has no
+		// production consumer (the string Render switch falls through to ANSI, and the only
+		// "bbcode" usage is a test-local custom strategy). Wiring a full BBCode strategy/cache
+		// for an unused format would be YAGNI, so we test the public static WrapAsBBCode directly.
+		var details = AnsiMarkup.Create(linkUrl: "https://example.com", linkKind: LinkKind.Url).Details;
+		var bbcode = AnsiMarkup.WrapAsBBCode(details, "site");
+
+		await Assert.That(bbcode).Contains("[url=https://example.com]");
+	}
+
+	[Test]
+	public async Task BBCode_CommandLink_RendersPlainText()
+	{
+		var details = AnsiMarkup.Create(linkUrl: "help topic", linkKind: LinkKind.Command).Details;
+		var bbcode = AnsiMarkup.WrapAsBBCode(details, "topic");
+
+		await Assert.That(bbcode).DoesNotContain("[url=");
+		await Assert.That(bbcode.Contains("topic")).IsTrue();
+	}
 }

--- a/docs/superpowers/plans/2026-06-20-terminal-command-links.md
+++ b/docs/superpowers/plans/2026-06-20-terminal-command-links.md
@@ -76,38 +76,22 @@ public class LinkKindRenderTests
 	}
 
 	[Test]
-	public async Task Serialization_CommandLink_RoundTrips()
+	public async Task Serialization_LinkKind_RoundTripsJson()
 	{
 		var cmd = MModule.MarkupSingle(
 			AnsiMarkup.Create(linkUrl: "help topic", linkKind: LinkKind.Command), "topic");
 		var json = MModule.serialize(cmd);
 
+		await Assert.That(json).Contains("LinkKind");
+
+		// Deserialise then re-serialise: the LinkKind survives the round-trip unchanged.
 		var back = MModule.deserialize(json);
-
-		// Command kind survives the round-trip: HTML render emits xch_cmd, not href.
-		await Assert.That(back.Render("html")).Contains("xch_cmd=\"help topic\"");
-		await Assert.That(back.Render("html")).DoesNotContain("href=");
-	}
-
-	[Test]
-	public async Task Serialization_LegacyPayloadWithoutLinkKind_DefaultsToUrl()
-	{
-		var cmd = MModule.MarkupSingle(
-			AnsiMarkup.Create(linkUrl: "help topic", linkKind: LinkKind.Command), "topic");
-		var json = MModule.serialize(cmd);
-
-		// Simulate a pre-LinkKind payload by stripping the property entirely.
-		var legacy = System.Text.RegularExpressions.Regex.Replace(json, "\"LinkKind\":\\d+,?", "");
-		legacy = legacy.Replace(",}", "}");
-
-		var back = MModule.deserialize(legacy);
-
-		// Missing field => default(LinkKind) == Url => navigation rendering.
-		await Assert.That(back.Render("html")).Contains("href=\"help topic\"");
-		await Assert.That(back.Render("html")).DoesNotContain("xch_cmd");
+		await Assert.That(MModule.serialize(back)).IsEqualTo(json);
 	}
 }
 ```
+
+> These three tests are rendering-independent, so Task 1's suite is fully green at commit time. The serialization tests whose assertions depend on the HTML renderer (command→`xch_cmd`, legacy→`href`) live in Task 2, where that renderer distinguishes the kinds.
 
 - [ ] **Step 2: Run tests to verify they fail (compile error)**
 
@@ -152,9 +136,7 @@ and in the returned `new AnsiStructure { ... }`, after the `LinkUrl = linkUrl ??
 - [ ] **Step 6: Run tests**
 
 Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/LinkKindRenderTests/*"`
-Expected: PASS — all 4 tests pass. (The two render tests rely on the existing `WrapAsHtmlClass`, which still emits `href` for everything; the command round-trip test passes because legacy/Url path renders `href` and the command test... )
-
-> NOTE: `Serialization_CommandLink_RoundTrips` asserts `xch_cmd`, which the HTML renderer does NOT emit until Task 2. Expect that ONE test to FAIL here; the other 3 pass. It turns green at the end of Task 2. This is the intended TDD ordering — the failing assertion is the spec for Task 2.
+Expected: PASS — all 3 tests pass (they assert on the data model and JSON round-trip, not on rendering).
 
 - [ ] **Step 7: Commit**
 
@@ -229,12 +211,44 @@ Add to `LinkKindRenderTests.cs` (inside the class):
 
 		await Assert.That(html).Contains("xch_cmd=\"say &quot;hi&quot; &amp; &lt;bye&gt;\"");
 	}
+
+	[Test]
+	public async Task Serialization_CommandLink_SurvivesAndRendersXchCmd()
+	{
+		var cmd = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "help topic", linkKind: LinkKind.Command), "topic");
+		var json = MModule.serialize(cmd);
+
+		var back = MModule.deserialize(json);
+
+		// Command kind survives the round-trip: HTML render emits xch_cmd, not href.
+		await Assert.That(back.Render("html")).Contains("xch_cmd=\"help topic\"");
+		await Assert.That(back.Render("html")).DoesNotContain("href=");
+	}
+
+	[Test]
+	public async Task Serialization_LegacyPayloadWithoutLinkKind_DefaultsToUrl()
+	{
+		var cmd = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "help topic", linkKind: LinkKind.Command), "topic");
+		var json = MModule.serialize(cmd);
+
+		// Simulate a pre-LinkKind payload by stripping the property entirely.
+		var legacy = System.Text.RegularExpressions.Regex.Replace(json, "\"LinkKind\":\\d+,?", "");
+		legacy = legacy.Replace(",}", "}");
+
+		var back = MModule.deserialize(legacy);
+
+		// Missing field => default(LinkKind) == Url => navigation rendering.
+		await Assert.That(back.Render("html")).Contains("href=\"help topic\"");
+		await Assert.That(back.Render("html")).DoesNotContain("xch_cmd");
+	}
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/LinkKindRenderTests/Html_*"`
-Expected: FAIL — current renderer emits `<a href="help topic">` for everything (no `xch_cmd`, no `target`).
+Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/LinkKindRenderTests/*"`
+Expected: the four `Html_*` tests and the two `Serialization_*` tests added in this step FAIL (current renderer emits `<a href="help topic">` for everything — no `xch_cmd`, no `target`); the three Task 1 tests still PASS.
 
 - [ ] **Step 3: Implement the renderer change**
 

--- a/docs/superpowers/plans/2026-06-20-terminal-command-links.md
+++ b/docs/superpowers/plans/2026-06-20-terminal-command-links.md
@@ -481,9 +481,12 @@ Add to `LinkKindRenderTests.cs`:
 	[Test]
 	public async Task BBCode_UrlLink_UsesUrlTag()
 	{
-		var ms = MModule.MarkupSingle(
-			AnsiMarkup.Create(linkUrl: "https://example.com", linkKind: LinkKind.Url), "site");
-		var bbcode = ms.Render("bbcode");
+		// NOTE: Render("bbcode") is intentionally NOT a wired render route — BBCode has no
+		// production consumer (the string Render switch falls through to ANSI, and the only
+		// "bbcode" usage is a test-local custom strategy). Wiring a full BBCode strategy/cache
+		// for an unused format would be YAGNI, so we test the public static WrapAsBBCode directly.
+		var details = AnsiMarkup.Create(linkUrl: "https://example.com", linkKind: LinkKind.Url).Details;
+		var bbcode = AnsiMarkup.WrapAsBBCode(details, "site");
 
 		await Assert.That(bbcode).Contains("[url=https://example.com]");
 	}
@@ -491,9 +494,8 @@ Add to `LinkKindRenderTests.cs`:
 	[Test]
 	public async Task BBCode_CommandLink_RendersPlainText()
 	{
-		var ms = MModule.MarkupSingle(
-			AnsiMarkup.Create(linkUrl: "help topic", linkKind: LinkKind.Command), "topic");
-		var bbcode = ms.Render("bbcode");
+		var details = AnsiMarkup.Create(linkUrl: "help topic", linkKind: LinkKind.Command).Details;
+		var bbcode = AnsiMarkup.WrapAsBBCode(details, "topic");
 
 		await Assert.That(bbcode).DoesNotContain("[url=");
 		await Assert.That(bbcode.Contains("topic")).IsTrue();
@@ -503,7 +505,7 @@ Add to `LinkKindRenderTests.cs`:
 - [ ] **Step 2: Run tests to verify they fail**
 
 Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/LinkKindRenderTests/Ansi_*"` then `BBCode_*`.
-Expected: FAIL — ANSI currently emits OSC8 for command links; BBCode currently emits `[url=]` for command links.
+Expected: FAIL — `Ansi_CommandLink_RendersPlainTextNoOsc8` fails (ANSI currently emits OSC8 for command links) and `BBCode_CommandLink_RendersPlainText` fails (WrapAsBBCode currently emits `[url=]` for any link). `Ansi_UrlLink_StillRendersOsc8` and `BBCode_UrlLink_UsesUrlTag` already pass.
 
 - [ ] **Step 3: Implement WrapAsBBCode**
 

--- a/docs/superpowers/plans/2026-06-20-terminal-command-links.md
+++ b/docs/superpowers/plans/2026-06-20-terminal-command-links.md
@@ -1,0 +1,910 @@
+# Terminal Command Links Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render markup links in the terminal as command-invocation links (click runs a MUSH command, e.g. `help topic`) distinct from navigation links (click opens a URL), across HTML/Pueblo/MXP/BBCode/ANSI.
+
+**Architecture:** Add an explicit `LinkKind` (Url/Command) to the shared markup layer (`AnsiStructure`). Each format renderer branches on it (HTML `xch_cmd` vs `href`; Pueblo `XCH_CMD` vs `HREF`; MXP `SEND` vs `A`; BBCode/ANSI command→plain text). The markdown renderer tags help-topic `[topic]` links as commands and ordinary links/autolinks as URLs, carrying markdown link titles as hints. The WASM terminal intercepts clicks on `a[xch_cmd]` via a JS delegate that calls back into Blazor to send the command.
+
+**Tech Stack:** .NET 10, C# (tabs, indent size 2), Blazor WASM, MudBlazor, Markdig, System.Text.Json, TUnit tests, JS interop.
+
+## Global Constraints
+
+- C# files: tabs, indent size 2. Razor files: spaces, indent size 4.
+- `TreatWarningsAsErrors` is enabled in every project — code must compile clean.
+- Prefer `var`; no `this.` qualifier.
+- Test framework is TUnit. Run tests with: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/<Class>/<Method>"`.
+- Markup link attribute values are HTML-encoded with `System.Net.WebUtility.HtmlEncode` (existing convention — keep it).
+- `LinkKind.Url` MUST be enum value `0` so legacy serialized markup (no field) deserializes to navigation behavior.
+- Branch: `feature/terminal-command-links` (already created off `origin/main`).
+
+---
+
+## File Structure
+
+- `SharpMUSH.MarkupString/Markup/Markup.cs` — owns `LinkKind`, the `AnsiStructure.LinkKind` field, the `AnsiMarkup.Create` parameter, and all format renderers (`WrapAsHtmlClass`, `WrapAsPueblo`, `WrapAsMxp`, `WrapAsBBCode`, `ApplyDetails`).
+- `SharpMUSH.Documentation/MarkdownToAsciiRenderer/HelpTopicInlineParser.cs` — tags `[topic]` links with a command-marker data key.
+- `SharpMUSH.Documentation/MarkdownToAsciiRenderer/RecursiveMarkdownRenderer.Inlines.cs` — maps the marker + markdown title to `LinkKind`/hint.
+- `SharpMUSH.Client/wwwroot/js/mush-monaco.js` — `SharpMUSH.Terminal.attachCommandLinks`.
+- `SharpMUSH.Client/Components/GlobalTerminal.razor` — DotNetObjectReference + `[JSInvokable] RunCommandLinkAsync` + lifecycle.
+- `SharpMUSH.Client/wwwroot/css/custom.css` — `.ms-cmd-link` style.
+- `SharpMUSH.Tests/Markup/LinkKindRenderTests.cs` — new test file (data model + serialization + all renderers).
+- `SharpMUSH.Tests/Documentation/RecursiveMarkdownRendererTests.cs` — add producer tests; update one existing test.
+
+---
+
+## Task 1: LinkKind data model + serialization
+
+**Files:**
+- Modify: `SharpMUSH.MarkupString/Markup/Markup.cs` (add enum ~line 10; field in `AnsiStructure` ~line 20; param in `Create` ~line 85-116)
+- Test: `SharpMUSH.Tests/Markup/LinkKindRenderTests.cs` (create)
+
+**Interfaces:**
+- Produces:
+  - `enum MarkupString.MarkupImplementation.LinkKind { Url = 0, Command = 1 }`
+  - `AnsiStructure.LinkKind { get; init; }` (type `LinkKind`)
+  - `AnsiMarkup.Create(..., LinkKind linkKind = LinkKind.Url, ...)` — new optional parameter (added after the existing `linkUrl` parameter)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `SharpMUSH.Tests/Markup/LinkKindRenderTests.cs`:
+
+```csharp
+using MarkupString;
+using MarkupString.MarkupImplementation;
+
+namespace SharpMUSH.Tests.Markup;
+
+/// <summary>
+/// Tests for LinkKind (command vs navigation links) across the data model,
+/// serialization, and every output renderer.
+/// </summary>
+public class LinkKindRenderTests
+{
+	[Test]
+	public async Task Create_DefaultLinkKind_IsUrl()
+	{
+		var markup = AnsiMarkup.Create(linkUrl: "https://example.com");
+		await Assert.That(markup.Details.LinkKind).IsEqualTo(LinkKind.Url);
+	}
+
+	[Test]
+	public async Task Create_CommandLinkKind_IsPreserved()
+	{
+		var markup = AnsiMarkup.Create(linkUrl: "help topic", linkKind: LinkKind.Command);
+		await Assert.That(markup.Details.LinkKind).IsEqualTo(LinkKind.Command);
+	}
+
+	[Test]
+	public async Task Serialization_CommandLink_RoundTrips()
+	{
+		var cmd = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "help topic", linkKind: LinkKind.Command), "topic");
+		var json = MModule.serialize(cmd);
+
+		var back = MModule.deserialize(json);
+
+		// Command kind survives the round-trip: HTML render emits xch_cmd, not href.
+		await Assert.That(back.Render("html")).Contains("xch_cmd=\"help topic\"");
+		await Assert.That(back.Render("html")).DoesNotContain("href=");
+	}
+
+	[Test]
+	public async Task Serialization_LegacyPayloadWithoutLinkKind_DefaultsToUrl()
+	{
+		var cmd = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "help topic", linkKind: LinkKind.Command), "topic");
+		var json = MModule.serialize(cmd);
+
+		// Simulate a pre-LinkKind payload by stripping the property entirely.
+		var legacy = System.Text.RegularExpressions.Regex.Replace(json, "\"LinkKind\":\\d+,?", "");
+		legacy = legacy.Replace(",}", "}");
+
+		var back = MModule.deserialize(legacy);
+
+		// Missing field => default(LinkKind) == Url => navigation rendering.
+		await Assert.That(back.Render("html")).Contains("href=\"help topic\"");
+		await Assert.That(back.Render("html")).DoesNotContain("xch_cmd");
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail (compile error)**
+
+Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/LinkKindRenderTests/*"`
+Expected: FAIL — does not compile (`LinkKind` type and `linkKind` parameter do not exist yet).
+
+- [ ] **Step 3: Add the enum**
+
+In `SharpMUSH.MarkupString/Markup/Markup.cs`, immediately after the `namespace MarkupString.MarkupImplementation;` line (line 8) and before the `AnsiStructure` doc comment, add:
+
+```csharp
+/// <summary>
+/// Distinguishes a link that runs a MUSH command when clicked (e.g. "help topic")
+/// from one that navigates to a URL. <see cref="Url"/> is value 0 and the default so
+/// legacy markup with no LinkKind deserialises to navigation behaviour.
+/// </summary>
+public enum LinkKind { Url = 0, Command = 1 }
+```
+
+- [ ] **Step 4: Add the field to AnsiStructure**
+
+In the `AnsiStructure` record (after the `LinkUrl` line, currently line 20), add:
+
+```csharp
+    public LinkKind LinkKind       { get; init; }
+```
+
+- [ ] **Step 5: Add the parameter to AnsiMarkup.Create**
+
+In `AnsiMarkup.Create` (lines 85-116), add a parameter after `string? linkUrl = null,`:
+
+```csharp
+        LinkKind   linkKind    = LinkKind.Url,
+```
+
+and in the returned `new AnsiStructure { ... }`, after the `LinkUrl = linkUrl ?? string.Empty,` line, add:
+
+```csharp
+            LinkKind      = linkKind,
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/LinkKindRenderTests/*"`
+Expected: PASS — all 4 tests pass. (The two render tests rely on the existing `WrapAsHtmlClass`, which still emits `href` for everything; the command round-trip test passes because legacy/Url path renders `href` and the command test... )
+
+> NOTE: `Serialization_CommandLink_RoundTrips` asserts `xch_cmd`, which the HTML renderer does NOT emit until Task 2. Expect that ONE test to FAIL here; the other 3 pass. It turns green at the end of Task 2. This is the intended TDD ordering — the failing assertion is the spec for Task 2.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add SharpMUSH.MarkupString/Markup/Markup.cs SharpMUSH.Tests/Markup/LinkKindRenderTests.cs
+git commit -m "feat(markup): add LinkKind to AnsiStructure for command vs navigation links
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: HTML renderer (command vs URL + hint)
+
+**Files:**
+- Modify: `SharpMUSH.MarkupString/Markup/Markup.cs` — `WrapAsHtmlClass` (lines 144-165)
+- Test: `SharpMUSH.Tests/Markup/LinkKindRenderTests.cs` (add methods)
+
+**Interfaces:**
+- Consumes: `LinkKind`, `AnsiStructure.LinkKind`, `AnsiStructure.LinkText` (hint), `AnsiMarkup.Create(..., linkKind, linkText)`.
+- Produces: HTML output — command → `<a class="ms-cmd-link" xch_cmd="{enc}"[ title="{enc}"]>text</a>`; url → `<a href="{enc}" target="_blank" rel="noopener noreferrer"[ title="{enc}"]>text</a>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `LinkKindRenderTests.cs` (inside the class):
+
+```csharp
+	[Test]
+	public async Task Html_CommandLink_UsesXchCmdNotHref()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "help topic", linkKind: LinkKind.Command), "topic");
+		var html = ms.Render("html");
+
+		await Assert.That(html).Contains("xch_cmd=\"help topic\"");
+		await Assert.That(html).Contains("ms-cmd-link");
+		await Assert.That(html).Contains(">topic</a>");
+		await Assert.That(html).DoesNotContain("href=");
+	}
+
+	[Test]
+	public async Task Html_UrlLink_UsesHrefWithNewTab()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "https://example.com", linkKind: LinkKind.Url), "site");
+		var html = ms.Render("html");
+
+		await Assert.That(html).Contains("href=\"https://example.com\"");
+		await Assert.That(html).Contains("target=\"_blank\"");
+		await Assert.That(html).Contains("rel=\"noopener noreferrer\"");
+		await Assert.That(html).DoesNotContain("xch_cmd");
+	}
+
+	[Test]
+	public async Task Html_CommandLink_WithHint_EmitsTitle()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "+who", linkKind: LinkKind.Command, linkText: "Who is online?"),
+			"who");
+		var html = ms.Render("html");
+
+		await Assert.That(html).Contains("xch_cmd=\"+who\"");
+		await Assert.That(html).Contains("title=\"Who is online?\"");
+	}
+
+	[Test]
+	public async Task Html_LinkAttributes_AreHtmlEncoded()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "say \"hi\" & <bye>", linkKind: LinkKind.Command), "x");
+		var html = ms.Render("html");
+
+		await Assert.That(html).Contains("xch_cmd=\"say &quot;hi&quot; &amp; &lt;bye&gt;\"");
+	}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/LinkKindRenderTests/Html_*"`
+Expected: FAIL — current renderer emits `<a href="help topic">` for everything (no `xch_cmd`, no `target`).
+
+- [ ] **Step 3: Implement the renderer change**
+
+In `WrapAsHtmlClass` (lines 154-157), replace the hyperlink block:
+
+```csharp
+        // Wrap hyperlink
+        string inner = text;
+        if (d.LinkUrl is { Length: > 0 } url)
+            inner = $"<a href=\"{WebUtility.HtmlEncode(url)}\">{text}</a>";
+```
+
+with:
+
+```csharp
+        // Wrap hyperlink. Command links run a MUSH command (xch_cmd, intercepted by the
+        // WASM terminal); URL links navigate in a new tab.
+        string inner = text;
+        if (d.LinkUrl is { Length: > 0 } url)
+        {
+            var title = d.LinkText is { Length: > 0 } hint
+                ? $" title=\"{WebUtility.HtmlEncode(hint)}\""
+                : "";
+            inner = d.LinkKind == LinkKind.Command
+                ? $"<a class=\"ms-cmd-link\" xch_cmd=\"{WebUtility.HtmlEncode(url)}\"{title}>{text}</a>"
+                : $"<a href=\"{WebUtility.HtmlEncode(url)}\" target=\"_blank\" rel=\"noopener noreferrer\"{title}>{text}</a>";
+        }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/LinkKindRenderTests/*"`
+Expected: PASS — all Task 1 + Task 2 tests pass (including `Serialization_CommandLink_RoundTrips`).
+
+- [ ] **Step 5: Run the broader HTML render suite for regressions**
+
+Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/RenderFormatTests/*"`
+Expected: PASS — no existing HTML render test asserts link markup, so adding `target`/`rel` does not break them.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add SharpMUSH.MarkupString/Markup/Markup.cs SharpMUSH.Tests/Markup/LinkKindRenderTests.cs
+git commit -m "feat(markup): render HTML command links as xch_cmd, URL links as href target=_blank
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Pueblo + MXP renderers
+
+**Files:**
+- Modify: `SharpMUSH.MarkupString/Markup/Markup.cs` — `WrapAsPueblo` (lines 176-177), `WrapAsMxp` (lines 205-206)
+- Test: `SharpMUSH.Tests/Markup/LinkKindRenderTests.cs` (add methods)
+
+**Interfaces:**
+- Consumes: `LinkKind`, `AnsiStructure.LinkText`.
+- Produces: Pueblo — command → `<A XCH_CMD="{enc}"[ XCH_HINT="{enc}"]>`, url → `<A HREF="{enc}">`. MXP — command → `<SEND HREF="{enc}"[ HINT="{enc}"]>`, url → `<A HREF="{enc}">`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `LinkKindRenderTests.cs`:
+
+```csharp
+	[Test]
+	public async Task Pueblo_CommandLink_UsesXchCmd()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "+who", linkKind: LinkKind.Command, linkText: "Who?"), "who");
+		var pueblo = ms.Render("pueblo");
+
+		await Assert.That(pueblo).Contains("<A XCH_CMD=\"+who\"");
+		await Assert.That(pueblo).Contains("XCH_HINT=\"Who?\"");
+		await Assert.That(pueblo).DoesNotContain("HREF=");
+	}
+
+	[Test]
+	public async Task Pueblo_UrlLink_UsesHref()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "https://example.com", linkKind: LinkKind.Url), "site");
+		var pueblo = ms.Render("pueblo");
+
+		await Assert.That(pueblo).Contains("<A HREF=\"https://example.com\">");
+		await Assert.That(pueblo).DoesNotContain("XCH_CMD");
+	}
+
+	[Test]
+	public async Task Mxp_CommandLink_UsesSend()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "+who", linkKind: LinkKind.Command, linkText: "Who?"), "who");
+		var mxp = ms.Render("mxp");
+
+		await Assert.That(mxp).Contains("<SEND HREF=\"+who\"");
+		await Assert.That(mxp).Contains("HINT=\"Who?\"");
+	}
+
+	[Test]
+	public async Task Mxp_UrlLink_UsesAnchorNotSend()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "https://example.com", linkKind: LinkKind.Url), "site");
+		var mxp = ms.Render("mxp");
+
+		await Assert.That(mxp).Contains("<A HREF=\"https://example.com\">");
+		await Assert.That(mxp).DoesNotContain("<SEND");
+	}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/LinkKindRenderTests/Pueblo_*"` then the `Mxp_*` filter.
+Expected: FAIL — Pueblo currently always emits `<A HREF>`; MXP currently always emits `<SEND HREF>`.
+
+- [ ] **Step 3: Implement WrapAsPueblo**
+
+In `WrapAsPueblo`, replace lines 176-177:
+
+```csharp
+        if (d.LinkUrl is { Length: > 0 } url)
+            t = $"<A HREF=\"{WebUtility.HtmlEncode(url)}\">{t}</A>";
+```
+
+with:
+
+```csharp
+        if (d.LinkUrl is { Length: > 0 } url)
+        {
+            if (d.LinkKind == LinkKind.Command)
+            {
+                var hint = d.LinkText is { Length: > 0 } h
+                    ? $" XCH_HINT=\"{WebUtility.HtmlEncode(h)}\""
+                    : "";
+                t = $"<A XCH_CMD=\"{WebUtility.HtmlEncode(url)}\"{hint}>{t}</A>";
+            }
+            else
+            {
+                t = $"<A HREF=\"{WebUtility.HtmlEncode(url)}\">{t}</A>";
+            }
+        }
+```
+
+- [ ] **Step 4: Implement WrapAsMxp**
+
+In `WrapAsMxp`, replace lines 205-206:
+
+```csharp
+        if (d.LinkUrl is { Length: > 0 } url)
+            t = $"<SEND HREF=\"{WebUtility.HtmlEncode(url)}\">{t}</SEND>";
+```
+
+with:
+
+```csharp
+        if (d.LinkUrl is { Length: > 0 } url)
+        {
+            if (d.LinkKind == LinkKind.Command)
+            {
+                var hint = d.LinkText is { Length: > 0 } h
+                    ? $" HINT=\"{WebUtility.HtmlEncode(h)}\""
+                    : "";
+                t = $"<SEND HREF=\"{WebUtility.HtmlEncode(url)}\"{hint}>{t}</SEND>";
+            }
+            else
+            {
+                t = $"<A HREF=\"{WebUtility.HtmlEncode(url)}\">{t}</A>";
+            }
+        }
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/LinkKindRenderTests/*"`
+Expected: PASS — all LinkKind tests pass.
+
+- [ ] **Step 6: Run existing Pueblo/MXP suite for regressions**
+
+Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/PuebloMxpRenderTests/*"`
+Expected: PASS — existing tests use `HtmlMarkup.Create("send", ...)` (raw HTML markup), not `AnsiStructure.LinkUrl`, so they are unaffected.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add SharpMUSH.MarkupString/Markup/Markup.cs SharpMUSH.Tests/Markup/LinkKindRenderTests.cs
+git commit -m "feat(markup): Pueblo XCH_CMD and MXP SEND for command links vs anchors for URLs
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: BBCode + ANSI/OSC8 renderers
+
+**Files:**
+- Modify: `SharpMUSH.MarkupString/Markup/Markup.cs` — `WrapAsBBCode` (lines 191-192), `ApplyDetails` (line 222)
+- Test: `SharpMUSH.Tests/Markup/LinkKindRenderTests.cs` (add methods)
+
+**Interfaces:**
+- Consumes: `LinkKind`.
+- Produces: BBCode — url → `[url={url}]text[/url]`, command → plain `text` (no wrap). ANSI — url → OSC8 link (unchanged), command → plain `text` (no OSC8).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `LinkKindRenderTests.cs`:
+
+```csharp
+	[Test]
+	public async Task Ansi_CommandLink_RendersPlainTextNoOsc8()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "help topic", linkKind: LinkKind.Command), "topic");
+		var ansi = ms.Render("ansi");
+
+		await Assert.That(ansi).DoesNotContain("]8;;");
+		await Assert.That(ansi.Contains("topic")).IsTrue();
+	}
+
+	[Test]
+	public async Task Ansi_UrlLink_StillRendersOsc8()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "https://example.com", linkKind: LinkKind.Url), "site");
+		var ansi = ms.Render("ansi");
+
+		await Assert.That(ansi).Contains("]8;;https://example.com");
+	}
+
+	[Test]
+	public async Task BBCode_UrlLink_UsesUrlTag()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "https://example.com", linkKind: LinkKind.Url), "site");
+		var bbcode = ms.Render("bbcode");
+
+		await Assert.That(bbcode).Contains("[url=https://example.com]");
+	}
+
+	[Test]
+	public async Task BBCode_CommandLink_RendersPlainText()
+	{
+		var ms = MModule.MarkupSingle(
+			AnsiMarkup.Create(linkUrl: "help topic", linkKind: LinkKind.Command), "topic");
+		var bbcode = ms.Render("bbcode");
+
+		await Assert.That(bbcode).DoesNotContain("[url=");
+		await Assert.That(bbcode.Contains("topic")).IsTrue();
+	}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/LinkKindRenderTests/Ansi_*"` then `BBCode_*`.
+Expected: FAIL — ANSI currently emits OSC8 for command links; BBCode currently emits `[url=]` for command links.
+
+- [ ] **Step 3: Implement WrapAsBBCode**
+
+In `WrapAsBBCode`, replace lines 191-192:
+
+```csharp
+        if (d.LinkUrl is { Length: > 0 } url)
+            t = $"[url={url}]{t}[/url]";
+```
+
+with:
+
+```csharp
+        // BBCode has no command-link concept — only URL links are wrapped.
+        if (d.LinkUrl is { Length: > 0 } url && d.LinkKind == LinkKind.Url)
+            t = $"[url={url}]{t}[/url]";
+```
+
+- [ ] **Step 4: Implement ApplyDetails (ANSI/OSC8)**
+
+In `ApplyDetails`, replace line 222:
+
+```csharp
+        if (d.LinkUrl is { Length: > 0 } url)  s = s.LinkANSI(url);
+```
+
+with:
+
+```csharp
+        // OSC 8 hyperlinks can only navigate, so command links render as plain text.
+        if (d.LinkUrl is { Length: > 0 } url && d.LinkKind == LinkKind.Url)  s = s.LinkANSI(url);
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/LinkKindRenderTests/*"`
+Expected: PASS — all LinkKind tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add SharpMUSH.MarkupString/Markup/Markup.cs SharpMUSH.Tests/Markup/LinkKindRenderTests.cs
+git commit -m "feat(markup): command links render as plain text in BBCode and ANSI/OSC8
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Markdown producer — tag help-topic links as commands, carry titles as hints
+
+**Files:**
+- Modify: `SharpMUSH.Documentation/MarkdownToAsciiRenderer/HelpTopicInlineParser.cs` (add const + `SetData`)
+- Modify: `SharpMUSH.Documentation/MarkdownToAsciiRenderer/RecursiveMarkdownRenderer.Inlines.cs` — `RenderLink` (lines 63-90)
+- Test: `SharpMUSH.Tests/Documentation/RecursiveMarkdownRendererTests.cs` (add methods; update one existing test)
+
+**Interfaces:**
+- Consumes: `LinkKind` (from `MarkupString.MarkupImplementation`), `Ansi.Create(linkUrl, linkKind, linkText)`.
+- Produces: `HelpTopicInlineParser.CommandDataKey` (public const string); help-topic links → `LinkKind.Command`; ordinary links/autolinks → `LinkKind.Url`; markdown link title → hint.
+
+- [ ] **Step 1: Update the one existing test that changes behavior, and write new tests**
+
+In `SharpMUSH.Tests/Documentation/RecursiveMarkdownRendererTests.cs`, REPLACE the body of `RenderHelpTopicLink_ShouldCreateHelpUrl` (lines ~519-533) with:
+
+```csharp
+	[Test]
+	public async Task RenderHelpTopicLink_ShouldCreateCommandLink()
+	{
+		// Arrange - bare [topic] with no URL definition is parsed by HelpTopicInlineParser
+		// into a command LinkInline whose URL is "help <topic>".
+		var markdown = "See [newbie2] for more.";
+
+		// Act
+		var result = SharpMUSH.Documentation.MarkdownToAsciiRenderer.RecursiveMarkdownHelper.RenderMarkdown(markdown);
+
+		// Assert - plain text contains the topic name without brackets
+		await Assert.That(result.ToPlainText()).IsEqualTo("See newbie2 for more.");
+
+		// It is a command link: HTML renders xch_cmd (not href), ANSI has no OSC 8 link.
+		await Assert.That(result.Render("html")).Contains("xch_cmd=\"help newbie2\"");
+		await Assert.That(result.ToString()).DoesNotContain("]8;;");
+	}
+
+	[Test]
+	public async Task RenderRegularLink_ShouldBeNavigationLink()
+	{
+		// Arrange - an explicit [text](url) link is a navigation link, not a command.
+		var markdown = "[Site](https://example.com)";
+
+		// Act
+		var result = SharpMUSH.Documentation.MarkdownToAsciiRenderer.RecursiveMarkdownHelper.RenderMarkdown(markdown);
+
+		// Assert
+		await Assert.That(result.Render("html")).Contains("href=\"https://example.com\"");
+		await Assert.That(result.Render("html")).Contains("target=\"_blank\"");
+		await Assert.That(result.Render("html")).DoesNotContain("xch_cmd");
+	}
+
+	[Test]
+	public async Task RenderLink_WithTitle_CarriesHint()
+	{
+		// Arrange - markdown link title becomes the link hint (HTML title / xch_hint / MXP HINT).
+		var markdown = "[Site](https://example.com \"Open the site\")";
+
+		// Act
+		var result = SharpMUSH.Documentation.MarkdownToAsciiRenderer.RecursiveMarkdownHelper.RenderMarkdown(markdown);
+
+		// Assert
+		await Assert.That(result.Render("html")).Contains("title=\"Open the site\"");
+	}
+```
+
+Note: `RenderLink_ShouldShowTextAndUrl` (line ~285, uses `[Link Text](https://example.com)`) is a regular URL link and stays OSC8 — leave it unchanged.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/RecursiveMarkdownRendererTests/RenderHelpTopicLink_ShouldCreateCommandLink"`
+Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/RecursiveMarkdownRendererTests/RenderRegularLink_ShouldBeNavigationLink"`
+Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/RecursiveMarkdownRendererTests/RenderLink_WithTitle_CarriesHint"`
+Expected: FAIL — the renderer currently produces `Ansi.Create(linkUrl: url)` with default `LinkKind.Url` for everything and ignores titles, so help links still render OSC8/`href` and no `title` is emitted.
+
+- [ ] **Step 3: Add the command-marker key and tag help-topic links**
+
+In `SharpMUSH.Documentation/MarkdownToAsciiRenderer/HelpTopicInlineParser.cs`, add a public const inside the class (after the `OpeningCharacters` constructor, before `Match`):
+
+```csharp
+	/// <summary>
+	/// Markdig data key set on the <see cref="LinkInline"/> nodes this parser produces, marking
+	/// them as command links (run "help &lt;topic&gt;") rather than URL navigation links.
+	/// </summary>
+	public const string CommandDataKey = "sharpmush:command-link";
+```
+
+Then, in `Match`, right before `processor.Inline = link;` (line 87), add:
+
+```csharp
+		link.SetData(CommandDataKey, true);
+```
+
+- [ ] **Step 4: Map marker + title to LinkKind/hint in RenderLink**
+
+In `SharpMUSH.Documentation/MarkdownToAsciiRenderer/RecursiveMarkdownRenderer.Inlines.cs`:
+
+First, add a using at the top (after the existing `using SharpMUSH.Library.Services;`, line 3):
+
+```csharp
+using MarkupString.MarkupImplementation;
+```
+
+Then replace the link-creation block in `RenderLink` (lines 87-89):
+
+```csharp
+		// Create hyperlink markup with linkUrl parameter
+		var linkMarkup = Ansi.Create(linkUrl: url);
+		return MModule.MarkupSingle(linkMarkup, contentText);
+```
+
+with:
+
+```csharp
+		// Help-topic shortcuts ([topic]) are command links; ordinary links navigate.
+		// A markdown link title ([text](url "title")) becomes the link hint.
+		var isCommand = link.GetData(HelpTopicInlineParser.CommandDataKey) is true;
+		var hint = string.IsNullOrWhiteSpace(link.Title) ? null : link.Title;
+		var linkMarkup = Ansi.Create(
+			linkUrl: url,
+			linkKind: isCommand ? LinkKind.Command : LinkKind.Url,
+			linkText: hint);
+		return MModule.MarkupSingle(linkMarkup, contentText);
+```
+
+(`RenderAutolink` already calls `Ansi.Create(linkUrl: ...)` with the default `LinkKind.Url` — no change needed.)
+
+- [ ] **Step 5: Run the new/updated tests**
+
+Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/RecursiveMarkdownRendererTests/RenderHelpTopicLink_ShouldCreateCommandLink"`
+Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/RecursiveMarkdownRendererTests/RenderRegularLink_ShouldBeNavigationLink"`
+Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/RecursiveMarkdownRendererTests/RenderLink_WithTitle_CarriesHint"`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full markdown + markdown-function suites for regressions**
+
+Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/RecursiveMarkdownRendererTests/*"`
+Run: `dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/MarkdownFunctionUnitTests/*"`
+Expected: PASS — the URL-link and autolink tests (`RenderLink_ShouldShowTextAndUrl`, `RenderMarkdown_Link_*`) stay `LinkKind.Url` and keep their OSC8 assertions.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add SharpMUSH.Documentation/MarkdownToAsciiRenderer/HelpTopicInlineParser.cs \
+        SharpMUSH.Documentation/MarkdownToAsciiRenderer/RecursiveMarkdownRenderer.Inlines.cs \
+        SharpMUSH.Tests/Documentation/RecursiveMarkdownRendererTests.cs
+git commit -m "feat(docs): help-topic markdown links become command links; titles become hints
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: WASM terminal — intercept command-link clicks and send the command
+
+**Files:**
+- Modify: `SharpMUSH.Client/wwwroot/js/mush-monaco.js` — extend `SharpMUSH.Terminal` (lines 426-431)
+- Modify: `SharpMUSH.Client/Components/GlobalTerminal.razor` — usings, fields, `OnAfterRenderAsync`, `[JSInvokable]`, `DisposeAsync`
+- Modify: `SharpMUSH.Client/wwwroot/css/custom.css` — add `.ms-cmd-link` rule (after line 762)
+
+**Interfaces:**
+- Consumes: `ITerminalService.SendAsync(string)`; rendered HTML `<a class="ms-cmd-link" xch_cmd="...">` from Task 2.
+- Produces: `SharpMUSH.Terminal.attachCommandLinks(outputId, dotNetRef)` (JS, returns `{ dispose() }`); `GlobalTerminal.RunCommandLinkAsync(string)` (`[JSInvokable]`).
+
+- [ ] **Step 1: Add the JS click delegate**
+
+In `SharpMUSH.Client/wwwroot/js/mush-monaco.js`, replace the `window.SharpMUSH.Terminal = { ... };` block (lines 426-431) with:
+
+```javascript
+    window.SharpMUSH.Terminal = {
+        scrollToBottom: function (elementId) {
+            var el = document.getElementById(elementId);
+            if (el) el.scrollTop = el.scrollHeight;
+        },
+
+        // Registers a delegated click handler on the terminal output container.
+        // Clicking a command link (<a xch_cmd="...">) runs the command via .NET
+        // (RunCommandLinkAsync) instead of navigating. Plain <a href> links are left
+        // untouched so they open normally. Returns a disposable for cleanup.
+        attachCommandLinks: function (outputId, dotNetRef) {
+            var el = document.getElementById(outputId);
+            if (!el) return { dispose: function () { } };
+
+            function onClick(e) {
+                var a = e.target.closest('a[xch_cmd]');
+                if (!a || !el.contains(a)) return;
+                e.preventDefault();
+                var cmd = a.getAttribute('xch_cmd');
+                if (cmd) dotNetRef.invokeMethodAsync('RunCommandLinkAsync', cmd);
+            }
+
+            el.addEventListener('click', onClick);
+            return {
+                dispose: function () { el.removeEventListener('click', onClick); },
+            };
+        },
+    };
+```
+
+- [ ] **Step 2: Add the CSS for command links**
+
+In `SharpMUSH.Client/wwwroot/css/custom.css`, after the `.ms-blink` rule and its `@keyframes` (after line 766), add:
+
+```css
+/* Command links (xch_cmd) — clickable, run a MUSH command. Distinct from URL links. */
+.ms-cmd-link {
+    color: var(--primary, #6cf);
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    cursor: pointer;
+}
+.ms-cmd-link:hover {
+    text-decoration-style: solid;
+}
+```
+
+- [ ] **Step 3: Wire up the component**
+
+In `SharpMUSH.Client/Components/GlobalTerminal.razor`:
+
+(a) After the existing `@using` lines (after line 4 `@using Microsoft.AspNetCore.Components.WebAssembly.Hosting`), add:
+
+```razor
+@using Microsoft.JSInterop
+```
+
+(b) In `@code`, add fields next to the other private fields (after line 234 `private bool _showCharacterPicker;`):
+
+```csharp
+    private DotNetObjectReference<GlobalTerminal>? _selfRef;
+    private IJSObjectReference? _cmdLinkHandle;
+```
+
+(c) Replace `OnAfterRenderAsync` (lines 317-321):
+
+```csharp
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_autoScroll)
+            await ScrollToBottomAsync();
+    }
+```
+
+with:
+
+```csharp
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _selfRef = DotNetObjectReference.Create(this);
+            try
+            {
+                _cmdLinkHandle = await JsRuntime.InvokeAsync<IJSObjectReference>(
+                    "SharpMUSH.Terminal.attachCommandLinks", _outputId, _selfRef);
+            }
+            catch { /* ignore if JS not ready */ }
+        }
+
+        if (_autoScroll)
+            await ScrollToBottomAsync();
+    }
+
+    /// <summary>
+    /// Invoked from JS when a command link (&lt;a xch_cmd="..."&gt;) is clicked in the
+    /// terminal output. Sends the command exactly as if the player had typed it.
+    /// </summary>
+    [JSInvokable]
+    public async Task RunCommandLinkAsync(string command)
+    {
+        if (string.IsNullOrWhiteSpace(command) || !_connected) return;
+        await Terminal.SendAsync(command);
+    }
+```
+
+(d) Replace `DisposeAsync` (lines 506-511):
+
+```csharp
+    public async ValueTask DisposeAsync()
+    {
+        Terminal.LineReceived -= OnLineReceived;
+        Terminal.ConnectionStateChanged -= OnConnectionChanged;
+        await Task.CompletedTask;
+    }
+```
+
+with:
+
+```csharp
+    public async ValueTask DisposeAsync()
+    {
+        Terminal.LineReceived -= OnLineReceived;
+        Terminal.ConnectionStateChanged -= OnConnectionChanged;
+
+        if (_cmdLinkHandle is not null)
+        {
+            try { await _cmdLinkHandle.InvokeVoidAsync("dispose"); } catch { /* ignore */ }
+            try { await _cmdLinkHandle.DisposeAsync(); } catch { /* ignore */ }
+        }
+        _selfRef?.Dispose();
+    }
+```
+
+- [ ] **Step 4: Build the client to verify it compiles**
+
+Run: `dotnet build SharpMUSH.Client`
+Expected: Build succeeded, 0 warnings (warnings are errors).
+
+- [ ] **Step 5: Manual end-to-end verification (JS interop cannot be unit-tested here)**
+
+Start infrastructure and both servers, then the client:
+
+```bash
+docker compose up -d
+dotnet run --project SharpMUSH.Server &
+dotnet run --project SharpMUSH.ConnectionServer &
+dotnet run --project SharpMUSH.Client
+```
+
+In the browser terminal (dev auto-connects as the wizard):
+1. Type `help` and press Enter.
+2. Confirm topic links (e.g. `[ATTRIBUTES]`) render underlined-dotted (`.ms-cmd-link`) and have NO normal-link cursor behavior of navigating.
+3. Click a topic link → the terminal runs `help <topic>` (new help page appears) and the browser does NOT navigate/refresh.
+4. Hover a link that has a hint → tooltip shows.
+5. If any help text contains a real `[text](https://…)` link, clicking it opens a new browser tab (does not run a command).
+
+Document the observed result (pass/fail per step) in the task notes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add SharpMUSH.Client/wwwroot/js/mush-monaco.js \
+        SharpMUSH.Client/wwwroot/css/custom.css \
+        SharpMUSH.Client/Components/GlobalTerminal.razor
+git commit -m "feat(client): intercept terminal command-link clicks and send the command
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full markup + documentation test suites:**
+
+```bash
+dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/LinkKindRenderTests/*"
+dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/RenderFormatTests/*"
+dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/PuebloMxpRenderTests/*"
+dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/RecursiveMarkdownRendererTests/*"
+dotnet run --project SharpMUSH.Tests -- --treenode-filter "/*/*/MarkdownFunctionUnitTests/*"
+```
+
+Expected: all PASS.
+
+- [ ] **Build the whole solution (warnings are errors):**
+
+```bash
+dotnet build
+```
+
+Expected: Build succeeded.
+
+---
+
+## Self-Review Notes (coverage vs. spec)
+
+- Data model (`LinkKind` enum, `AnsiStructure` field, `Create` param, serialization + legacy default) → Task 1.
+- Render matrix: HTML → Task 2; Pueblo + MXP → Task 3; BBCode + ANSI/OSC8 → Task 4. Hint (`LinkText` → `title`/`XCH_HINT`/`HINT`) covered in Tasks 2-3.
+- Markdown producer (help-topic marker, title→hint, autolink stays URL) → Task 5, including the one existing behavior-changing test update (`RenderHelpTopicLink`).
+- Client (JS delegate, `RunCommandLinkAsync`, lifecycle, CSS) → Task 6, verified by running the app.
+- Out-of-scope items (softcode functions, MXP line-security prefixes, wiki links) intentionally untouched.

--- a/docs/superpowers/specs/2026-06-20-terminal-command-links-design.md
+++ b/docs/superpowers/specs/2026-06-20-terminal-command-links-design.md
@@ -127,6 +127,7 @@ the server, or softcode that already requires the `PUEBLO_SEND`/`Send_OOB` power
 protocol tags (per `sharppueb.md`). The client simply sends back whatever the server placed
 in `xch_cmd`; it introduces no new trust boundary beyond what typing the same command would.
 Attribute values remain HTML-encoded.
+Any future code path that turns *player-supplied* text into command-kind links (none exists today — help-topic links are doc-authored) would let one player craft a command another could click, so such a path must not be added without escaping/gating.
 
 ## Components & Boundaries
 

--- a/docs/superpowers/specs/2026-06-20-terminal-command-links-design.md
+++ b/docs/superpowers/specs/2026-06-20-terminal-command-links-design.md
@@ -1,0 +1,170 @@
+# Terminal Command Links vs. Navigation Links — Design
+
+**Date:** 2026-06-20
+**Branch:** `feature/terminal-command-links`
+**Status:** Approved design, pending spec review
+
+## Problem
+
+In the SharpMUSH.Client WebSocket terminal (Blazor WASM), markdown links render as
+real navigation links (`<a href="…">`) regardless of what they represent. The `help`
+command's markdown contains bare `[topic]` shortcuts that are converted to a *command*
+(`help <topic>`), not a URL — yet they render as `<a href="help topic">`, so clicking
+makes the browser try to navigate to a bogus route instead of running the command.
+
+These command links are conceptually distinct from ordinary `<https://…>` navigation
+links, but the markup layer flattens both into a single ambiguous `LinkUrl` string and
+the HTML renderer emits `<a href>` for everything.
+
+The canonical convention (documented in
+`SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharppueb.md`, lines 189–206, matching the
+grapenut `websockclient`) is:
+
+- **Command link:** `<a xch_cmd="+who">Who is online?</a>` (+ optional `xch_hint` tooltip)
+- **Navigation link:** `<a href="url">text</a>`
+
+MXP (`Markup.cs` `WrapAsMxp`) uses `<SEND HREF="cmd">` for commands vs `<A HREF="url">`
+for navigation; Pueblo uses `XCH_CMD` vs `HREF`.
+
+## Root Cause
+
+`AnsiStructure.LinkUrl` (`SharpMUSH.MarkupString/Markup/Markup.cs:20`) is a single string
+with no type information. The distinction between "command" and "URL" exists only
+implicitly at *production* time (the `HelpTopicInlineParser` knows it built a command;
+ordinary links know they carry a URL) and is lost before *render* time.
+
+## Design Decisions
+
+1. **Explicit link kind in the markup** (not a render-time URL heuristic). The producer
+   declares intent; renderers act on it. Chosen for correctness and future-proofing.
+2. **Fix all output formats consistently** in one pass, since `LinkKind` lives in the
+   shared markup layer used by HTML (WASM), Pueblo, MXP, BBCode, and ANSI/OSC8.
+3. **Preserve the hint/tooltip path** (`xch_hint` / MXP `HINT` / HTML `title`).
+
+## Architecture
+
+### 1. Data model — `SharpMUSH.MarkupString/Markup/Markup.cs`
+
+- New enum:
+
+  ```csharp
+  public enum LinkKind { Url = 0, Command = 1 }
+  ```
+
+  `Url` is value `0` and the default, so existing serialized markup (which has no field)
+  deserializes to `Url` and keeps today's navigation behavior for ordinary links.
+
+- Add to `AnsiStructure`:
+
+  ```csharp
+  public LinkKind LinkKind { get; init; }
+  ```
+
+- Add a `linkKind` parameter (default `LinkKind.Url`) to `AnsiMarkup.Create(...)`.
+
+- `LinkText` (already present on `AnsiStructure`, currently set but never read) becomes the
+  **hint**: rendered as `xch_hint` (Pueblo), `HINT` (MXP), and `title` (HTML) when non-empty.
+
+**Serialization:** `AnsiStructure` is serialized via `System.Text.Json` in
+`MarkupStringModule`. The new property round-trips automatically. A round-trip test plus a
+legacy-payload (no `LinkKind` field → `Url`) test lock this down.
+
+### 2. Renderers — same file, switched on `LinkKind`
+
+`LinkUrl` empty → no link wrapper (unchanged). When `LinkUrl` is non-empty:
+
+| Format | `Command` | `Url` |
+|---|---|---|
+| HTML (`WrapAsHtmlClass`) | `<a class="ms-cmd-link" xch_cmd="{enc}"[ title="{hint}"]>` | `<a href="{enc}" target="_blank" rel="noopener noreferrer">` |
+| Pueblo (`WrapAsPueblo`) | `<A XCH_CMD="{enc}"[ XCH_HINT="{hint}"]>` | `<A HREF="{enc}">` |
+| MXP (`WrapAsMxp`) | `<SEND HREF="{enc}"[ HINT="{hint}"]>` | `<A HREF="{enc}">` |
+| BBCode (`WrapAsBBCode`) | plain text (no command concept) | `[url={…}]` |
+| ANSI/OSC8 (`ApplyDetails`) | plain text (OSC8 cannot run a command) | OSC8 link (unchanged) |
+
+All attribute values are HTML-encoded with `WebUtility.HtmlEncode` (as today). The hint
+attribute is emitted only when `LinkText` is non-empty.
+
+### 3. Markdown producer — `SharpMUSH.Documentation`
+
+- `HelpTopicInlineParser.Match` tags the `LinkInline` it builds:
+  `link.SetData(HelpTopicLink.CommandMarkerKey, true)` (a shared constant key). The URL it
+  already sets (`"help " + topic`) becomes the command string.
+- `RecursiveMarkdownRenderer.RenderLink`:
+  - reads the marker: `link.GetData(HelpTopicLink.CommandMarkerKey) is true` → `LinkKind.Command`, else `LinkKind.Url`;
+  - maps `link.Title` (markdown `[text](url "title")`) → `linkText` (hint) when non-empty;
+  - calls `Ansi.Create(linkUrl: url, linkKind: kind, linkText: hint)`.
+- `RecursiveMarkdownRenderer.RenderAutolink` is always `LinkKind.Url`.
+
+Result: `help` output renders `[ATTRIBUTES]` as a `help ATTRIBUTES` command link, while
+`[SharpMUSH](https://sharpmush.com)` stays a real navigation link that opens in a new tab.
+
+### 4. Client — `SharpMUSH.Client`
+
+Terminal lines are injected as raw HTML via `@((MarkupString)line.Html)`
+(`GlobalTerminal.razor:20`), so Blazor cannot bind `@onclick` to those anchors. Use JS
+event delegation bridged to .NET:
+
+- `wwwroot/js/mush-monaco.js`: add to `SharpMUSH.Terminal`:
+  - `attachCommandLinks(outputId, dotNetRef)` — registers a single delegated `click`
+    listener on the output container. On click, walk up from `event.target` to find an
+    ancestor `a[xch_cmd]`; if found, `preventDefault()` and
+    `dotNetRef.invokeMethodAsync('RunCommandLinkAsync', el.getAttribute('xch_cmd'))`.
+    Plain `a[href]` links are left alone (default new-tab navigation via the rendered
+    `target="_blank"`).
+  - `detachCommandLinks(outputId)` — removes the listener (idempotent).
+- `GlobalTerminal.razor`:
+  - hold a `DotNetObjectReference<GlobalTerminal>`;
+  - in `OnAfterRenderAsync(firstRender)` call `attachCommandLinks(_outputId, _selfRef)`;
+  - add `[JSInvokable] public Task RunCommandLinkAsync(string command)` →
+    `await Terminal.SendAsync(command)` (identical to the user typing the command, so echo
+    and history behave the same);
+  - in `DisposeAsync`, call `detachCommandLinks` and dispose the reference.
+
+### Security note
+
+Command strings in `xch_cmd` come from server-rendered markup — help content shipped with
+the server, or softcode that already requires the `PUEBLO_SEND`/`Send_OOB` power to emit
+protocol tags (per `sharppueb.md`). The client simply sends back whatever the server placed
+in `xch_cmd`; it introduces no new trust boundary beyond what typing the same command would.
+Attribute values remain HTML-encoded.
+
+## Components & Boundaries
+
+- **`SharpMUSH.MarkupString`** — owns the `LinkKind` type and all format rendering. Pure,
+  unit-testable, no I/O.
+- **`SharpMUSH.Documentation`** — owns markdown→markup mapping (which links are commands).
+- **`SharpMUSH.Client`** — owns terminal click handling and command dispatch.
+
+Each boundary is testable in isolation: markup renderers via TUnit string assertions; the
+markdown mapping via TUnit on rendered markup; the client callback via its forwarding to
+`ITerminalService`.
+
+## Testing
+
+- **MarkupString unit tests (TUnit):** each renderer (HTML/Pueblo/MXP/BBCode/ANSI) for
+  `Command` vs `Url`; hint present vs absent; attribute encoding.
+- **Serialization tests:** `AnsiStructure` with `LinkKind` round-trips; a legacy payload
+  with no `LinkKind` field deserializes to `Url`.
+- **Markdown renderer tests:** `[topic]` → command markup whose HTML is
+  `xch_cmd="help topic"` with no `href`; `[text](http://x)` → `href` + `target="_blank"`;
+  `[text](http://x "tip")` → hint present; `<http://x>` autolink → `href`.
+- **Client:** a test that `RunCommandLinkAsync` forwards the command to
+  `ITerminalService.SendAsync`. The JS event delegation itself is verified by running the
+  app against the help command.
+
+## Out of Scope
+
+- Changing softcode functions (`tag`/`tagwrap`/`wshtml`/`html`) — they already let
+  privileged players emit raw `xch_cmd`/`SEND`.
+- Reworking MXP line-security mode prefixes (`ESC[0z`/`ESC[1z`) — tracked separately.
+- Wiki `[[links]]` (already rendered as underlined non-links in the terminal).
+
+## Files Touched (anticipated)
+
+- `SharpMUSH.MarkupString/Markup/Markup.cs` — enum, `AnsiStructure`, `Create`, all `WrapAs*`/`ApplyDetails`.
+- `SharpMUSH.Documentation/MarkdownToAsciiRenderer/HelpTopicInlineParser.cs` — set command marker.
+- `SharpMUSH.Documentation/MarkdownToAsciiRenderer/HelpTopicLinkExtension.cs` (or a small shared type) — marker key constant.
+- `SharpMUSH.Documentation/MarkdownToAsciiRenderer/RecursiveMarkdownRenderer.Inlines.cs` — `RenderLink`/`RenderAutolink`.
+- `SharpMUSH.Client/wwwroot/js/mush-monaco.js` — `attachCommandLinks`/`detachCommandLinks`.
+- `SharpMUSH.Client/Components/GlobalTerminal.razor` — DotNetObjectReference, JSInvokable, lifecycle.
+- Tests across `SharpMUSH.Tests` (markup + markdown + serialization) and client.


### PR DESCRIPTION
## What & why

In the WebSocket terminal (Blazor WASM), markup links rendered as plain navigation links (`<a href>`) regardless of intent. Help output's bare `[topic]` shortcuts are *commands* (`help <topic>`), so clicking them made the browser navigate to a bogus route instead of running the command.

This adds an explicit `LinkKind` (`Url` / `Command`) to the shared markup layer and renders each kind correctly across **all** formats, matching the canonical grapenut/Pueblo convention documented in `sharppueb.md`.

## Render matrix

| Format | `Command` | `Url` |
|---|---|---|
| HTML | `<a class="ms-cmd-link" xch_cmd="…">` | `<a href="…" target="_blank" rel="noopener noreferrer">` |
| Pueblo | `<A XCH_CMD="…">` | `<A HREF="…">` |
| MXP | `<SEND HREF="…">` | `<A HREF="…">` |
| BBCode | plain text | `[url=…]` |
| ANSI/OSC8 | plain text | OSC8 link (unchanged) |

Hints flow through uniformly: markdown link title → `xch_hint` (Pueblo) / `HINT` (MXP) / `title` (HTML).

## How it works

- **Data model** (`Markup.cs`): `enum LinkKind { Url = 0, Command = 1 }` + `AnsiStructure.LinkKind` + `AnsiMarkup.Create(linkKind:)`. `Url = 0` keeps legacy serialized markup (no field) rendering as navigation.
- **Renderers** branch on `LinkKind`; all attribute values stay `WebUtility.HtmlEncode`d.
- **Render-strategy split** (`MarkupStringModule.cs`): the old shared Pueblo/MXP strategy routed `AnsiMarkup` links through `WrapAs("ansi")`, so the Pueblo/MXP tag paths were unreachable for links. Split into `PuebloRenderStrategy`/`MxpRenderStrategy`: colour-only spans still render as ANSI escapes (no regression); links route to the tag renderer. This also makes MXP correctly use `<A HREF>` for URLs vs `<SEND>` for commands.
- **Markdown producer**: `HelpTopicInlineParser` tags `[topic]` shortcuts; `RenderLink` maps tagged links → `Command`, ordinary links/autolinks → `Url`, and markdown titles → hints.
- **Client**: terminal lines are raw-HTML-injected, so a delegated JS click handler (`SharpMUSH.Terminal.attachCommandLinks`) catches `a[xch_cmd]`, `preventDefault()`s, and bridges to `[JSInvokable] RunCommandLinkAsync` → `Terminal.SendAsync` (identical to typing). Plain `href` links navigate normally. `DotNetObjectReference` + `IJSObjectReference` both disposed.

## Deliberate scope decisions

- `Render("bbcode")` is intentionally **not** wired (no production consumer; falls through to ANSI). `WrapAsBBCode` still got the `LinkKind` guard and is unit-tested via its `public static` method — wiring a full BBCode strategy would be YAGNI.

## Testing

- New `LinkKindRenderTests` cover all 5 renderers (command vs url, hint present/absent, attribute encoding, **colored** command links keeping colour + command tag), plus serialization round-trip and legacy-default-to-`Url`.
- Markdown producer tests: `[topic]` → `xch_cmd="help topic"` (no `href`, no OSC8); `[text](url)` → `href`+`target=_blank`; titles → hints; autolinks → `href`. Existing URL-link/autolink OSC8 tests unchanged.
- Suites green: LinkKindRenderTests, RecursiveMarkdownRendererTests, MarkdownFunctionUnitTests, PuebloMxpRenderTests, RenderFormatTests. Full `dotnet build` clean (`TreatWarningsAsErrors`).

## Not yet done

Live browser click-through (full stack: Arango+NATS+Server+ConnectionServer+WASM) was not run; the click wiring is verified by unit tests + code review only.

Design: `docs/superpowers/specs/2026-06-20-terminal-command-links-design.md` · Plan: `docs/superpowers/plans/2026-06-20-terminal-command-links.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Terminal output now supports clickable command links for help topics and other commands, enabling direct execution via clicking rather than manual typing.

* **Tests**
  * Added comprehensive test coverage validating command link functionality across all supported output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->