### PR TITLE
feat(scene): scene package modernization — auto-active, Volund commands, named registers, bordered capture

### DIFF
--- a/SharpMUSH.Implementation/Commands/AttributeCommands.cs
+++ b/SharpMUSH.Implementation/Commands/AttributeCommands.cs
@@ -39,7 +39,7 @@ public partial class Commands
 
 		// Locate object
 		var locate = await LocateService!.LocateAndNotifyIfInvalidWithCallState(parser,
-		enactor, executor, dbref, LocateFlags.All);
+		executor, executor, dbref, LocateFlags.All);
 
 		if (locate.IsError)
 		{
@@ -150,7 +150,7 @@ public partial class Commands
 
 		// Locate source object
 		var sourceLocate = await LocateService!.LocateAndNotifyIfInvalidWithCallState(parser,
-		enactor, executor, sourceDbref, LocateFlags.All);
+		executor, executor, sourceDbref, LocateFlags.All);
 
 		if (sourceLocate.IsError)
 		{
@@ -198,7 +198,7 @@ public partial class Commands
 
 			// Locate destination object
 			var destLocate = await LocateService!.LocateAndNotifyIfInvalidWithCallState(parser,
-			enactor, executor, destDbref, LocateFlags.All);
+			executor, executor, destDbref, LocateFlags.All);
 
 			if (destLocate.IsError)
 			{
@@ -280,7 +280,7 @@ public partial class Commands
 
 		// Locate source object
 		var sourceLocate = await LocateService!.LocateAndNotifyIfInvalidWithCallState(parser,
-		enactor, executor, sourceDbref, LocateFlags.All);
+		executor, executor, sourceDbref, LocateFlags.All);
 
 		if (sourceLocate.IsError)
 		{
@@ -328,7 +328,7 @@ public partial class Commands
 
 			// Locate destination object
 			var destLocate = await LocateService!.LocateAndNotifyIfInvalidWithCallState(parser,
-			enactor, executor, destDbref, LocateFlags.All);
+			executor, executor, destDbref, LocateFlags.All);
 
 			if (destLocate.IsError)
 			{
@@ -420,7 +420,7 @@ public partial class Commands
 
 		// Locate object
 		var locate = await LocateService!.LocateAndNotifyIfInvalidWithCallState(parser,
-		enactor, executor, dbref, LocateFlags.All);
+		executor, executor, dbref, LocateFlags.All);
 
 		if (locate.IsError)
 		{
@@ -442,7 +442,7 @@ public partial class Commands
 		// Locate new owner
 		var newOwnerText = MModule.plainText(ownerArg.Message!);
 		var ownerLocate = await LocateService!.LocateAndNotifyIfInvalidWithCallState(parser,
-		enactor, executor, newOwnerText, LocateFlags.All);
+		executor, executor, newOwnerText, LocateFlags.All);
 
 		if (ownerLocate.IsError)
 		{
@@ -535,7 +535,7 @@ public partial class Commands
 
 		// Locate the object
 		var locate = await LocateService!.LocateAndNotifyIfInvalidWithCallState(parser,
-		enactor,
+		executor,
 		executor,
 		dbref,
 		LocateFlags.All);

--- a/SharpMUSH.Implementation/Commands/GeneralCommands.cs
+++ b/SharpMUSH.Implementation/Commands/GeneralCommands.cs
@@ -978,7 +978,7 @@ public partial class Commands
 		var ownerObj = (await obj.Owner.WithCancellation(CancellationToken.None)).Object;
 		var name = obj.Name;
 		var ownerName = ownerObj.Name;
-		var description = (await AttributeService!.GetAttributeAsync(enactor, viewingKnown, "DESCRIBE",
+		var description = (await AttributeService!.GetAttributeAsync(executor, viewingKnown, "DESCRIBE",
 				IAttributeService.AttributeMode.Read, false))
 			.Match(
 				attr => MModule.getLength(attr.Last().Value) == 0
@@ -1094,7 +1094,7 @@ public partial class Commands
 				var patternMode = IAttributeService.AttributePatternMode.Wildcard;
 
 				atrs = await AttributeService.GetAttributePatternAsync(
-					enactor,
+					executor,
 					viewingKnown,
 					attributePattern,
 					checkParents,
@@ -1102,7 +1102,7 @@ public partial class Commands
 			}
 			else
 			{
-				atrs = await AttributeService.GetVisibleAttributesAsync(enactor, viewingKnown);
+				atrs = await AttributeService.GetVisibleAttributesAsync(executor, viewingKnown);
 			}
 
 			if (atrs.IsAttribute)
@@ -1121,7 +1121,7 @@ public partial class Commands
 					var attrOwner = await attr.Owner.WithCancellation(CancellationToken.None);
 					var attrFlagsStr = attr.Flags.Any() ? $"{string.Join("", attr.Flags.Select(f => f.Symbol))} " : "";
 
-					if (!await PermissionService.CanViewAttribute(enactor, viewingKnown, attr))
+					if (!await PermissionService.CanViewAttribute(executor, viewingKnown, attr))
 					// || showPublicOnly && !showAll && !attr.IsVisual())
 					{
 						continue;
@@ -5153,7 +5153,7 @@ public partial class Commands
 			if (!string.IsNullOrEmpty(attributePattern))
 			{
 				atrs = await AttributeService!.GetAttributePatternAsync(
-					enactor,
+					executor,
 					targetKnown,
 					attributePattern,
 					false, // don't check parents for decompile
@@ -5161,7 +5161,7 @@ public partial class Commands
 			}
 			else
 			{
-				atrs = await AttributeService!.GetVisibleAttributesAsync(enactor, targetKnown);
+				atrs = await AttributeService!.GetVisibleAttributesAsync(executor, targetKnown);
 			}
 
 			if (atrs.IsAttribute)

--- a/SharpMUSH.Implementation/Commands/GeneralCommands.cs
+++ b/SharpMUSH.Implementation/Commands/GeneralCommands.cs
@@ -907,8 +907,8 @@ public partial class Commands
 
 				var locate = await LocateService!.LocateAndNotifyIfInvalid(
 					parser,
-					enactor,
-					enactor,
+					executor,
+					executor,
 					objectName,
 					LocateFlags.All);
 
@@ -925,8 +925,8 @@ public partial class Commands
 			{
 				var locate = await LocateService!.LocateAndNotifyIfInvalid(
 					parser,
-					enactor,
-					enactor,
+					executor,
+					executor,
 					argText,
 					LocateFlags.All);
 
@@ -3123,7 +3123,7 @@ public partial class Commands
 		foreach (var target in nameListTargets)
 		{
 			var targetString = target.Match(dbref => dbref.ToString(), str => str);
-			var maybeLocateTarget = await LocateService!.LocateAndNotifyIfInvalidWithCallState(parser, enactor, enactor,
+			var maybeLocateTarget = await LocateService!.LocateAndNotifyIfInvalidWithCallState(parser, executor, executor,
 				targetString,
 				LocateFlags.All);
 
@@ -3497,7 +3497,7 @@ public partial class Commands
 
 		// Locate object
 		var locate = await LocateService!.LocateAndNotifyIfInvalidWithCallState(parser,
-			enactor, executor, dbref, LocateFlags.All);
+			executor, executor, dbref, LocateFlags.All);
 
 		if (locate.IsError)
 		{
@@ -5029,8 +5029,8 @@ public partial class Commands
 
 			var locate = await LocateService!.LocateAndNotifyIfInvalid(
 				parser,
-				enactor,
-				enactor,
+				executor,
+				executor,
 				objectName,
 				LocateFlags.All);
 
@@ -5047,8 +5047,8 @@ public partial class Commands
 		{
 			var locate = await LocateService!.LocateAndNotifyIfInvalid(
 				parser,
-				enactor,
-				enactor,
+				executor,
+				executor,
 				objectSpec,
 				LocateFlags.All);
 
@@ -5924,7 +5924,7 @@ public partial class Commands
 
 		// Locate the object
 		var locate = await LocateService!.LocateAndNotifyIfInvalidWithCallState(parser,
-			enactor,
+			executor,
 			executor,
 			dbref,
 			LocateFlags.All);

--- a/SharpMUSH.Implementation/Commands/GeneralCommands.cs
+++ b/SharpMUSH.Implementation/Commands/GeneralCommands.cs
@@ -4716,9 +4716,15 @@ public partial class Commands
 		var objectName = parts[0];
 		var attributeName = parts[1];
 
-		// Locate the target object
+		// Locate the target object AS THE EXECUTOR (looker=executor, perm=executor). The object running
+		// @trigger names and must control the target (the Controls(executor, target) check below), and
+		// PennMUSH matches command arguments relative to the executor (oracle-confirmed). Passing the
+		// enactor as the permission object made the looker-gate (LocateService: !Nearby && !See_All &&
+		// !Controls) fail when a mortal, REMOTE enactor triggered a $-command that does @trigger %!/attr.
+		// This only fixes the LOOKUP; @trigger's distinct semantics are unchanged — the attribute is still
+		// QUEUED to run AS the target object (the new executor), with the triggerer as the enactor (below).
 		var maybeObject = await LocateService!.LocateAndNotifyIfInvalidWithCallState(
-			parser, executor, enactor, objectName, LocateFlags.All);
+			parser, executor, executor, objectName, LocateFlags.All);
 
 		if (maybeObject.IsError)
 		{
@@ -6110,9 +6116,15 @@ public partial class Commands
 		var objectName = parts[0];
 		var attributeName = parts[1];
 
-		// Locate the target object
+		// Locate the target object AS THE EXECUTOR (looker=executor, perm=executor). @include runs as the
+		// executor and reads the attribute with the executor's permission (below), so the target lookup
+		// must use the executor too — NOT the enactor. Passing the enactor as the permission object made
+		// the looker-gate (LocateService: !Nearby && !See_All && !Controls) fire whenever a mortal, REMOTE
+		// enactor triggered a $-command on another object (e.g. a WIZARD helper in the master room) that
+		// @include'd %!/me — the target locate failed with "NOT PERMITTED TO EVALUATE ON LOOKER" even
+		// though the executor owns the object. (Mirror of the same fix already applied to the read below.)
 		var maybeObject = await LocateService!.LocateAndNotifyIfInvalidWithCallState(
-			parser, executor, enactor, objectName, LocateFlags.All);
+			parser, executor, executor, objectName, LocateFlags.All);
 
 		if (maybeObject.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/MoreCommands.cs
+++ b/SharpMUSH.Implementation/Commands/MoreCommands.cs
@@ -693,8 +693,8 @@ public partial class Commands
 
 			var locate = await LocateService!.LocateAndNotifyIfInvalid(
 				parser,
-				enactor,
-				enactor,
+				executor,
+				executor,
 				argText,
 				LocateFlags.All);
 

--- a/SharpMUSH.Implementation/Commands/PackageCommands.cs
+++ b/SharpMUSH.Implementation/Commands/PackageCommands.cs
@@ -72,7 +72,7 @@ public partial class Commands
 		var knownByObjid = new Dictionary<string, AnySharpObject>(StringComparer.Ordinal);
 		foreach (var token in tokens)
 		{
-			var locate = await LocateService!.LocateAndNotifyIfInvalid(parser, enactor, executor, token, LocateFlags.All);
+			var locate = await LocateService!.LocateAndNotifyIfInvalid(parser, executor, executor, token, LocateFlags.All);
 			if (!locate.IsValid())
 			{
 				return new None();

--- a/SharpMUSH.Implementation/Functions/AttributeFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/AttributeFunctions.cs
@@ -56,7 +56,7 @@ public partial class Functions
 		var (dbref, attribute) = details;
 
 		return await LocateService!.LocateAndNotifyIfInvalidWithCallStateFunction(
-			parser, enactor, executor, dbref, LocateFlags.All, async realLocated =>
+			parser, executor, executor, dbref, LocateFlags.All, async realLocated =>
 			{
 				var contents = args.TryGetValue("1", out var tmpContents)
 					? tmpContents.Message!
@@ -97,7 +97,7 @@ public partial class Functions
 		var (dbref, attribute) = details;
 
 		return await LocateService!.LocateAndNotifyIfInvalidWithCallStateFunction(
-			parser, enactor, executor, dbref, LocateFlags.All, async realLocated =>
+			parser, executor, executor, dbref, LocateFlags.All, async realLocated =>
 			{
 				var contents = args.TryGetValue("1", out var tmpContents)
 					? tmpContents.Message!

--- a/SharpMUSH.Implementation/Functions/AttributeFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/AttributeFunctions.cs
@@ -1307,7 +1307,11 @@ public partial class Functions
 
 		var arg0 = parser.CurrentState.Arguments["0"].Message!.ToPlainText();
 		var arg1 = parser.CurrentState.Arguments["1"].Message!;
-		var executor = await parser.CurrentState.KnownEnactorObject(Mediator!);
+		// set() runs as the executor: it locates the target as the executor and sets the attribute/flag
+		// with the executor's permission (it must control the target). This was KnownEnactorObject — a
+		// misnamed/misassigned local that made set() locate AND permission-check as the enactor, so a
+		// forced/remote mortal enactor's set() ran with the wrong principal. PennMUSH set() uses the executor.
+		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 
 		return (arg0, arg1) switch
 		{
@@ -1638,7 +1642,10 @@ public partial class Functions
 		var target = parser.CurrentState.Arguments.Count >= 3
 			? parser.CurrentState.Arguments["2"].Message!.ToPlainText()
 			: null;
-		var caller = await parser.CurrentState.KnownCallerObject(Mediator!);
+		// valid() runs as the executor: its optional <target> is located, and the default validation
+		// context, relative to the executor (PennMUSH matches function arguments to the executor) — not
+		// the caller one frame up the u() chain.
+		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 
 		var validationType = category switch
 		{
@@ -1673,9 +1680,9 @@ public partial class Functions
 				=> new CallState(await ValidateService!.Valid(validationType, str, new None()) ? "1" : "0"),
 
 			IValidateService.ValidationType.PlayerName when target is null
-				=> new CallState(await ValidateService!.Valid(validationType, str, caller) ? "1" : "0"),
+				=> new CallState(await ValidateService!.Valid(validationType, str, executor) ? "1" : "0"),
 			IValidateService.ValidationType.PlayerName
-				when await LocateService!.LocateAndNotifyIfInvalid(parser, caller, caller, target, LocateFlags.All)
+				when await LocateService!.LocateAndNotifyIfInvalid(parser, executor, executor, target, LocateFlags.All)
 					is { IsAnyObject: true, AsAnyObject: var obj }
 				=> new CallState(await ValidateService!.Valid(validationType, str, obj) ? "1" : "0"),
 			IValidateService.ValidationType.PlayerName => ErrorMessages.Returns.CantSeeThat,
@@ -1684,9 +1691,9 @@ public partial class Functions
 				=> new CallState(await ValidateService!.Valid(validationType, str, await GetChannel(target ?? string.Empty)) ? "1" : "0"),
 
 			IValidateService.ValidationType.LockType when target is null
-				=> new CallState(await ValidateService!.Valid(validationType, str, caller) ? "1" : "0"),
+				=> new CallState(await ValidateService!.Valid(validationType, str, executor) ? "1" : "0"),
 			IValidateService.ValidationType.LockType
-				when await LocateService!.LocateAndNotifyIfInvalid(parser, caller, caller, target, LocateFlags.All)
+				when await LocateService!.LocateAndNotifyIfInvalid(parser, executor, executor, target, LocateFlags.All)
 					is { IsAnyObject: true, AsAnyObject: var obj }
 				=> new CallState(await ValidateService!.Valid(validationType, str, obj) ? "1" : "0"),
 			IValidateService.ValidationType.LockType => ErrorMessages.Returns.CantSeeThat,

--- a/SharpMUSH.Implementation/Functions/HTMLFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/HTMLFunctions.cs
@@ -77,7 +77,7 @@ public partial class Functions
 
 		var locate = await LocateService!.LocateAndNotifyIfInvalid(
 			parser,
-			enactor,
+			executor,
 			executor,
 			playerStr,
 			PlayersPreference | AbsoluteMatch);
@@ -159,7 +159,7 @@ public partial class Functions
 
 		var locate = await LocateService!.LocateAndNotifyIfInvalid(
 			parser,
-			enactor,
+			executor,
 			executor,
 			playerStr,
 			PlayersPreference | AbsoluteMatch);

--- a/SharpMUSH.Implementation/Functions/JSONFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/JSONFunctions.cs
@@ -102,7 +102,7 @@ public partial class Functions
 			var (dbref, attrName) = objAttr.AsT0;
 			dbref ??= executor.Object().DBRef.ToString();
 
-			var locate = await LocateService!.LocateAndNotifyIfInvalid(parser, enactor, executor, dbref, LocateFlags.All);
+			var locate = await LocateService!.LocateAndNotifyIfInvalid(parser, executor, executor, dbref, LocateFlags.All);
 			if (!locate.IsValid())
 			{
 				return CallState.Empty;
@@ -534,7 +534,7 @@ public partial class Functions
 		{
 			var locate = await LocateService!.LocateAndNotifyIfInvalid(
 				parser,
-				enactor,
+				executor,
 				executor,
 				playerStr,
 				LocateFlags.All);

--- a/SharpMUSH.Implementation/Functions/ListFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/ListFunctions.cs
@@ -136,7 +136,7 @@ public partial class Functions
 
 		var locate = await LocateService!.LocateAndNotifyIfInvalid(
 			parser,
-			enactor,
+			executor,
 			executor,
 			dbref,
 			LocateFlags.All);
@@ -227,7 +227,7 @@ public partial class Functions
 
 		var locate = await LocateService!.LocateAndNotifyIfInvalid(
 			parser,
-			enactor,
+			executor,
 			executor,
 			dbref,
 			LocateFlags.All);
@@ -392,7 +392,7 @@ public partial class Functions
 
 		var locate = await LocateService!.LocateAndNotifyIfInvalid(
 			parser,
-			enactor,
+			executor,
 			executor,
 			dbref,
 			LocateFlags.All);
@@ -746,7 +746,7 @@ public partial class Functions
 
 		var locate = await LocateService!.LocateAndNotifyIfInvalid(
 			parser,
-			enactor,
+			executor,
 			executor,
 			dbref,
 			LocateFlags.All);
@@ -909,7 +909,7 @@ public partial class Functions
 
 		var locate = await LocateService!.LocateAndNotifyIfInvalid(
 			parser,
-			enactor,
+			executor,
 			executor,
 			dbref,
 			LocateFlags.All);
@@ -1014,7 +1014,7 @@ public partial class Functions
 
 			var locate = await LocateService!.LocateAndNotifyIfInvalid(
 				parser,
-				enactor,
+				executor,
 				executor,
 				dbref,
 				LocateFlags.All);
@@ -1381,7 +1381,7 @@ public partial class Functions
 
 		var locate = await LocateService!.LocateAndNotifyIfInvalid(
 			parser,
-			enactor,
+			executor,
 			executor,
 			dbref,
 			LocateFlags.All);
@@ -1501,7 +1501,7 @@ public partial class Functions
 
 			var locate = await LocateService!.LocateAndNotifyIfInvalid(
 				parser,
-				enactor,
+				executor,
 				executor,
 				dbref,
 				LocateFlags.All);
@@ -1642,7 +1642,7 @@ public partial class Functions
 
 		var locate = await LocateService!.LocateAndNotifyIfInvalid(
 			parser,
-			enactor,
+			executor,
 			executor,
 			dbref,
 			LocateFlags.All);

--- a/SharpMUSH.Plugins.Scene/Storage/ArangoSceneStorage.cs
+++ b/SharpMUSH.Plugins.Scene/Storage/ArangoSceneStorage.cs
@@ -276,6 +276,9 @@ public sealed class ArangoSceneStorage(IArangoStorageAccessor _accessor) : IScen
 			case "active":
 				aql = "FOR s IN @@c FILTER s.Status == 'active' SORT s.LastActivityAt DESC LIMIT @count RETURN s";
 				break;
+			case "finished":
+				aql = "FOR s IN @@c FILTER s.Status == 'finished' SORT s.LastActivityAt DESC LIMIT @count RETURN s";
+				break;
 			case "scheduled":
 			{
 				var filters = "FILTER s.ScheduledFor != null";

--- a/SharpMUSH.Plugins.Scene/Storage/MemgraphSceneStorage.cs
+++ b/SharpMUSH.Plugins.Scene/Storage/MemgraphSceneStorage.cs
@@ -228,6 +228,15 @@ public sealed class MemgraphSceneStorage(IMemgraphStorageAccessor _accessor) : I
 				parameters = new { count };
 				break;
 			}
+			case "finished":
+			{
+				cypher = $$"""
+					MATCH (s:{{SceneLabel}}) WHERE s.status = 'finished'
+					RETURN s ORDER BY s.lastActivityAt DESC LIMIT $count
+					""";
+				parameters = new { count };
+				break;
+			}
 			default: // "recent" and anything else
 			{
 				cypher = $$"""

--- a/SharpMUSH.Plugins.Scene/Storage/SurrealSceneStorage.cs
+++ b/SharpMUSH.Plugins.Scene/Storage/SurrealSceneStorage.cs
@@ -283,6 +283,9 @@ public sealed class SurrealSceneStorage(ISurrealStorageAccessor _accessor) : ISc
 			case "active":
 				query = $"SELECT {SceneFields} FROM scene WHERE status = 'active' ORDER BY lastActivityAt DESC LIMIT $count";
 				break;
+			case "finished":
+				query = $"SELECT {SceneFields} FROM scene WHERE status = 'finished' ORDER BY lastActivityAt DESC LIMIT $count";
+				break;
 			case "recent":
 			default:
 				query = $"SELECT {SceneFields} FROM scene ORDER BY lastActivityAt DESC LIMIT $count";

--- a/SharpMUSH.Tests.Integration/Integration/RemoteEnactorLocateIsolationTests.cs
+++ b/SharpMUSH.Tests.Integration/Integration/RemoteEnactorLocateIsolationTests.cs
@@ -1,0 +1,222 @@
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NSubstitute.Core;
+using OneOf;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Services.Interfaces;
+using SharpMUSH.Tests;
+
+namespace SharpMUSH.Tests.Integration;
+
+/// <summary>
+/// Isolates the "remote-enactor locate" bug class behind the Scene capture failure. A command that
+/// locates a target object must do so AS THE EXECUTOR (the object running the command), not the enactor —
+/// confirmed against the PennMUSH oracle: forcing executor=#15 (RoomA) / enactor=#1 (RoomB) and triggering
+/// a probe attribute resolved <c>me</c>=executor, <c>here</c>=the executor's room, and matched a name to the
+/// object in the EXECUTOR's room (not the enactor's). SharpMUSH's LocateService is
+/// <c>(parser, looker, executor, name, flags)</c>; passing the ENACTOR as the executor/permission arg makes
+/// the looker-gate fail whenever a mortal, REMOTE enactor triggers a $-command on another object (e.g. a
+/// WIZARD helper in the master room) — which is exactly the Scene geometry.
+///
+/// Reproduced here with NOTHING but builtins (no user-defined functions): a WIZARD probe thing parked in #2
+/// (so its $-commands are global), and a player in a separate dug room. Each command form is run inline vs
+/// via the indirection (@include / @trigger) and the remote enactor's result is compared.
+/// </summary>
+[NotInParallel]
+public class RemoteEnactorLocateIsolationTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactoryArg { get; init; }
+
+	private IMUSHCodeParser Parser => WebAppFactoryArg.CommandParser;
+	private IMUSHCodeParser FunctionParser => WebAppFactoryArg.FunctionParser;
+	private INotifyService NotifyService => WebAppFactoryArg.Services.GetRequiredService<INotifyService>();
+	private IConnectionService ConnectionService => WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
+
+	private static readonly string Tag = Guid.NewGuid().ToString("N")[..8];
+
+	private async Task<string> Eval(string expression) =>
+		(await FunctionParser.FunctionParse(MModule.single(expression)))!.Message!.ToPlainText().Trim();
+
+	private async Task<CallState> God1(string command) =>
+		await Parser.CommandParse(1, ConnectionService, MModule.single(command));
+
+	private static string Num(string dbref)
+	{
+		var s = dbref.Trim();
+		var colon = s.IndexOf(':');
+		return colon < 0 ? s : s[..colon];
+	}
+
+	private int NotificationCount() =>
+		NotifyService.ReceivedCalls().Count(c => c.GetMethodInfo().Name == nameof(INotifyService.Notify));
+
+	private static string? ExtractMessageText(ICall call)
+	{
+		if (call.GetMethodInfo().Name != nameof(INotifyService.Notify)) return null;
+		var args = call.GetArguments();
+		if (args.Length < 2) return null;
+		return args[1] switch
+		{
+			OneOf<MString, string> oneOf => oneOf.Match(m => m.ToString(), s => s),
+			string s => s,
+			MString m => m.ToString(),
+			_ => null
+		};
+	}
+
+	/// <summary>Runs a command as a connection handle and returns every notification text it produced.</summary>
+	private async Task<List<string>> RunAndCollectAs(long handle, string command)
+	{
+		var before = NotificationCount();
+		await Parser.CommandParse(handle, ConnectionService, MModule.single(command));
+		return NotifyService.ReceivedCalls()
+			.Where(c => c.GetMethodInfo().Name == nameof(INotifyService.Notify))
+			.Skip(before)
+			.Select(ExtractMessageText).OfType<string>().ToList();
+	}
+
+	private async Task<string> CreatePlayerAsync(string name, string password, long handle)
+	{
+		await God1($"@pcreate {name}={password}");
+		var dbref = (await God1($"think [pmatch({name})]")).Message?.ToPlainText()?.Trim() ?? string.Empty;
+		if (string.IsNullOrEmpty(dbref) || dbref.StartsWith("#-") || !DBRef.TryParse(dbref, out var parsed))
+			throw new InvalidOperationException($"Failed to create player {name}; pmatch returned '{dbref}'.");
+
+		await ConnectionService.Register(handle, "localhost", "localhost", "test",
+			_ => ValueTask.CompletedTask, _ => ValueTask.CompletedTask, () => Encoding.UTF8);
+		await ConnectionService.Bind(handle, parsed!.Value);
+		return dbref;
+	}
+
+	/// <summary>All notifications a trigger produced, joined — so an error to ANY recipient is visible.</summary>
+	private static string Joined(IEnumerable<string> notifications)
+	{
+		var list = notifications.ToList();
+		return list.Count == 0 ? "<none>" : string.Join(" | ", list);
+	}
+
+	/// <summary>
+	/// The shared geometry: a WIZARD probe thing in the master room (#2, so its $-commands are global) and a
+	/// player in a SEPARATE dug room (remote — not co-located with the probe). Returns (probe, room, pcNum).
+	/// </summary>
+	private async Task<(string Probe, string Room, string PcNum)> SetupRemoteGeometryAsync(string who, long handle)
+	{
+		await God1("@set #1=WIZARD");
+
+		var probe = Num((await TestIsolationHelpers.CreateTestThingAsync(Parser, ConnectionService, $"Probe{who}_{Tag}")).ToString());
+		await God1($"@set {probe}=WIZARD");
+		await God1($"@teleport {probe}=#2");
+		await Assert.That(Num(await Eval($"loc({probe})"))).IsEqualTo("#2")
+			.Because("the probe must be in the master room so its $-commands are global to a remote enactor");
+
+		var room = Num((await God1($"@dig Room{who}_{Tag}")).Message!.ToPlainText().Trim());
+		var pc = await CreatePlayerAsync($"{who}_{Tag}", "pw_remote_123", handle);
+		await God1($"@tel {pc}={room}");
+		await Assert.That(Num(await Eval($"loc({pc})"))).IsEqualTo(room)
+			.Because("the enactor must be remote from the probe (different room) to reproduce the scene geometry");
+
+		return (probe, room, Num(pc));
+	}
+
+	/// <summary>
+	/// @include must splice in-place as the executor: each builtin probe (enactor %#, an @if-condition
+	/// q-register, loc(%#), an @remit to the enactor's room) must read identically inline vs @include'd.
+	/// </summary>
+	[Test]
+	public async Task Include_FromRemoteEnactor_PreservesCallingContext_LikeInline()
+	{
+		var (probe, room, pcNum) = await SetupRemoteGeometryAsync("Inc", 73L);
+		const long pcHandle = 73L;
+
+		// Probe A — enactor (%#) visibility.
+		await God1($"&C_A_INL {probe}=$proa-inl-{Tag}:@pemit %#=R:[%#]");
+		await God1($"@set {probe}/C_A_INL=regexp");
+		await God1($"&I_A {probe}=@pemit %#=R:[%#]");
+		await God1($"&C_A_INC {probe}=$proa-inc-{Tag}:@include %!/I_A");
+		await God1($"@set {probe}/C_A_INC=regexp");
+
+		// Probe B — q-register set in an @if CONDITION, then read (the scene sets RoomID this way).
+		await God1($"&C_B_INL {probe}=$prob-inl-{Tag}:@if setr(0,SENT{Tag})={{@pemit %#=R:[%q0]}}");
+		await God1($"@set {probe}/C_B_INL=regexp");
+		await God1($"&I_B {probe}=@pemit %#=R:[%q0]");
+		await God1($"&C_B_INC {probe}=$prob-inc-{Tag}:@if setr(0,SENT{Tag})={{@include %!/I_B}}");
+		await God1($"@set {probe}/C_B_INC=regexp");
+
+		// Probe C — loc(%#): a locate that depends on the enactor.
+		await God1($"&C_C_INL {probe}=$proc-inl-{Tag}:@pemit %#=R:[loc(%#)]");
+		await God1($"@set {probe}/C_C_INL=regexp");
+		await God1($"&I_C {probe}=@pemit %#=R:[loc(%#)]");
+		await God1($"&C_C_INC {probe}=$proc-inc-{Tag}:@include %!/I_C");
+		await God1($"@set {probe}/C_C_INC=regexp");
+
+		// Probe D — @remit to the enactor's room (the exact failing construct: a room emit from a $-command).
+		await God1($"&C_D_INL {probe}=$prod-inl-{Tag}:@remit loc(%#)=R:INLINE-D");
+		await God1($"@set {probe}/C_D_INL=regexp");
+		await God1($"&I_D {probe}=@remit loc(%#)=R:INC-D");
+		await God1($"&C_D_INC {probe}=$prod-inc-{Tag}:@include %!/I_D");
+		await God1($"@set {probe}/C_D_INC=regexp");
+
+		var aInline = Joined(await RunAndCollectAs(pcHandle, $"proa-inl-{Tag}"));
+		var aInclude = Joined(await RunAndCollectAs(pcHandle, $"proa-inc-{Tag}"));
+		var bInline = Joined(await RunAndCollectAs(pcHandle, $"prob-inl-{Tag}"));
+		var bInclude = Joined(await RunAndCollectAs(pcHandle, $"prob-inc-{Tag}"));
+		var cInline = Joined(await RunAndCollectAs(pcHandle, $"proc-inl-{Tag}"));
+		var cInclude = Joined(await RunAndCollectAs(pcHandle, $"proc-inc-{Tag}"));
+		var dInline = Joined(await RunAndCollectAs(pcHandle, $"prod-inl-{Tag}"));
+		var dInclude = Joined(await RunAndCollectAs(pcHandle, $"prod-inc-{Tag}"));
+
+		Console.WriteLine("=== @include remote-enactor isolation (inline vs @include) ===");
+		Console.WriteLine($"probe={probe} (loc #2)   enactor={pcNum} (loc {room})");
+		Console.WriteLine($"A enactor(%#)    inline=[{aInline}]   include=[{aInclude}]");
+		Console.WriteLine($"B qreg(@if setr) inline=[{bInline}]   include=[{bInclude}]");
+		Console.WriteLine($"C loc(%#)        inline=[{cInline}]   include=[{cInclude}]");
+		Console.WriteLine($"D @remit room    inline=[{dInline}]   include=[{dInclude}]");
+
+		await Assert.That(aInline).Contains($"R:{pcNum}").Because("inline %# is the remote enactor");
+		await Assert.That(bInline).Contains($"R:SENT{Tag}").Because("inline reads the @if-condition q-register");
+		await Assert.That(cInline).Contains($"R:{Num(room)}").Because("inline loc(%#) is the enactor's room");
+		await Assert.That(dInline).Contains("R:INLINE-D").Because("inline @remit reaches the enactor's room");
+
+		await Assert.That(aInclude).Contains($"R:{pcNum}").Because("@include must preserve the enactor (%#)");
+		await Assert.That(bInclude).Contains($"R:SENT{Tag}").Because("@include must preserve q-registers set before it");
+		await Assert.That(cInclude).Contains($"R:{Num(room)}").Because("@include must let loc(%#) resolve like inline");
+		await Assert.That(dInclude).Contains("R:INC-D").Because("@include must let @remit reach the enactor's room");
+	}
+
+	/// <summary>
+	/// @trigger must locate its target AS THE EXECUTOR. A WIZARD helper in #2 runs a $-command (triggered by
+	/// a remote mortal) that does `@trigger %!/INNER`; the target (%! = the helper itself) must be locatable
+	/// even though the mortal enactor is in another room. With the bug (target located as the enactor) the
+	/// @trigger fails with "NOT PERMITTED TO EVALUATE ON LOOKER" and INNER never runs. This also confirms
+	/// @trigger's DISTINCT semantics survive the fix: INNER runs AS the target (me = the helper, the new
+	/// executor) with the triggerer as the enactor — i.e. the fix touches only the locate, not the queueing.
+	/// </summary>
+	[Test]
+	public async Task Trigger_FromRemoteEnactor_LocatesTargetAsExecutor()
+	{
+		var (probe, room, _) = await SetupRemoteGeometryAsync("Trg", 74L);
+		const long pcHandle = 74L;
+
+		// INNER runs as the triggered object; report who it ran as. Emit to God (#1) so it's always collected.
+		await God1($"&I_TRIG {probe}=@pemit #1=R:TRIGGERED ranAs=[num(me)] hereOf=[num(here)]");
+		await God1($"&C_TRIG {probe}=$trig-{Tag}:@trigger %!/I_TRIG");
+		await God1($"@set {probe}/C_TRIG=regexp");
+
+		var got = Joined(await RunAndCollectAs(pcHandle, $"trig-{Tag}"));
+		Console.WriteLine("=== @trigger remote-enactor isolation ===");
+		Console.WriteLine($"probe={probe} (loc #2)   room={room}");
+		Console.WriteLine($"trigger result=[{got}]");
+
+		await Assert.That(got).DoesNotContain("NOT PERMITTED")
+			.Because("@trigger must locate its target (%!) as the executor, not the remote enactor");
+		await Assert.That(got).Contains("R:TRIGGERED")
+			.Because("the triggered attribute must actually run");
+		await Assert.That(got).Contains($"ranAs={probe}")
+			.Because("@trigger's distinct semantics must survive: INNER runs AS the target object (the new executor)");
+		await Assert.That(got).Contains("hereOf=#2")
+			.Because("running as the target, 'here' is the target's room (#2), confirming executor-relative context");
+	}
+}

--- a/SharpMUSH.Tests.Integration/Integration/SceneRoleplayIntegrationTests.cs
+++ b/SharpMUSH.Tests.Integration/Integration/SceneRoleplayIntegrationTests.cs
@@ -251,11 +251,10 @@ public class SceneRoleplayIntegrationTests
 		await Assert.That(await EvalNum($"loc({bob})")).IsEqualTo(roomDbref);
 		await Assert.That(await EvalNum($"loc({carol})")).IsEqualTo(roomDbref);
 
-		// ── Beat 2: Create + start (run as the owner, Alice) ──────────────────────
-		// +scene/create binds the scene to %L (the room), makes Alice owner+focused, and sets
-		// status to the package default ("new"). Capture requires the scene be ACTIVE in the
-		// room (GetActiveSceneInRoomAsync filters Status=='active'), so +scene/start is needed
-		// before any pose is captured.
+		// ── Beat 2: Create (run as the owner, Alice) ──────────────────────────────
+		// +scene/create binds the scene to %L (the room), makes Alice owner+focused, and sets status
+		// to the package default — `active` (1.1.0) — so the scene is immediately the room's active
+		// scene and capture fires without a separate +scene/start.
 		var sceneTitle = $"The Tavern Meeting {Tag}";
 		var createMsgs = await RunAndCollectAs(11L, $"+scene/create {sceneTitle}");
 		Log($"[CREATE] {string.Join(" | ", createMsgs)}");
@@ -278,24 +277,24 @@ public class SceneRoleplayIntegrationTests
 		await Assert.That(await Eval($"scenefocus({alice})")).IsEqualTo(sceneId)
 			.Because("+scene/create focuses the creator on the new scene");
 
-		await Assert.That(await Eval($"scene({sceneId}, status)")).IsEqualTo("new")
-			.Because("the package default status is 'new'");
+		await Assert.That(await Eval($"scene({sceneId}, status)")).IsEqualTo("active")
+			.Because("the package default status is 'active' (created scenes are immediately live)");
 		await Assert.That(await EvalNum($"scene({sceneId}, owner)")).IsEqualTo(Num(alice))
 			.Because("the creator becomes the owner");
 		await Assert.That(await EvalNum($"scene({sceneId}, room)")).IsEqualTo(roomDbref)
 			.Because("+scene/create binds the scene to the creator's room (%L)");
 
-		// Before start, the room has no ACTIVE scene → scenewhere is NOT FOUND.
-		await Assert.That(await Eval($"scenewhere({roomDbref})")).StartsWith("#-1")
-			.Because("a 'new' scene is not yet the room's active scene");
+		// Created active → it is immediately the room's active scene (the capture pre-req).
+		await Assert.That(await Eval($"scenewhere({roomDbref})")).IsEqualTo(sceneId)
+			.Because("a created-active scene is the room's active scene with no separate start");
 
-		// Start it (owner-only). Now scenewhere resolves to our scene.
+		// +scene/start is idempotent on an already-active scene (it also resumes a paused one).
 		var startMsgs = await RunAndCollectAs(11L, "+scene/start");
 		Log($"[START] {string.Join(" | ", startMsgs)}");
 		await Assert.That(await Eval($"scene({sceneId}, status)")).IsEqualTo("active")
-			.Because("+scene/start drives status to active");
+			.Because("+scene/start keeps the scene active");
 		await Assert.That(await Eval($"scenewhere({roomDbref})")).IsEqualTo(sceneId)
-			.Because("an active scene is now the room's active scene (capture pre-req)");
+			.Because("the scene remains the room's active scene (capture pre-req)");
 
 		// ── Beat 3: Join + showas (Bob and Carol) ─────────────────────────────────
 		var bobJoin = await RunAndCollectAs(12L, $"+scene/join {sceneId}");

--- a/SharpMUSH.Tests.Integration/Integration/SceneRoleplayIntegrationTests.cs
+++ b/SharpMUSH.Tests.Integration/Integration/SceneRoleplayIntegrationTests.cs
@@ -34,11 +34,11 @@ namespace SharpMUSH.Tests.Integration;
 /// Beats:
 ///   1. Setup       — boot, confirm plugin+package, create 3 players in a room.
 ///   2. Create+start— owner runs +scene/create then +scene/start (capture needs active).
-///   3. Join        — the others +scene/join and +scene/showas a persona; assert membership.
+///   3. Join        — the others +scene/join and +scene/as a persona; assert membership.
 ///   4. Capture     — each focused character pose/say/semiposes; assert in-order capture,
 ///                    correct author + showAs. A co-located but UNFOCUSED passer-by is NOT captured.
 ///   5. Edit/undo   — an author +scene/edit then +scene/undo; assert content versions.
-///   6. Recap/who   — +scene/recap transcript and +scene/who cast.
+///   6. Recap/who   — +scene/recall transcript and +scene/who cast.
 ///   7. Finish      — +scene/finish; assert status.
 /// </summary>
 [NotInParallel]
@@ -306,10 +306,10 @@ public class SceneRoleplayIntegrationTests
 			.Because("+scene/join focuses the joiner on the scene");
 		await Assert.That(await Eval($"scenefocus({carol})")).IsEqualTo(sceneId);
 
-		// Personas via +scene/showas (recorded on the member edge and stamped onto future poses).
-		await RunAndCollectAs(11L, "+scene/showas Alice the Innkeeper");
-		await RunAndCollectAs(12L, "+scene/showas Bob the Bard");
-		await RunAndCollectAs(13L, "+scene/showas Carol the Cloaked");
+		// Personas via +scene/as (recorded on the member edge and stamped onto future poses).
+		await RunAndCollectAs(11L, "+scene/as Alice the Innkeeper");
+		await RunAndCollectAs(12L, "+scene/as Bob the Bard");
+		await RunAndCollectAs(13L, "+scene/as Carol the Cloaked");
 
 		await Assert.That(await Eval($"scenemember({sceneId}, {alice}, showas)")).IsEqualTo("Alice the Innkeeper");
 		await Assert.That(await Eval($"scenemember({sceneId}, {bob}, showas)")).IsEqualTo("Bob the Bard");
@@ -401,8 +401,8 @@ public class SceneRoleplayIntegrationTests
 			.Because("+scene/undo should restore the pre-edit content");
 
 		// ── Beat 6: Recap + who ───────────────────────────────────────────────────
-		// +scene/recap <count> prints the last <count> pose contents (Alice is focused).
-		var recapMsgs = await RunAndCollectAs(11L, "+scene/recap 10");
+		// +scene/recall <count> prints the last <count> pose contents (Alice is focused).
+		var recapMsgs = await RunAndCollectAs(11L, "+scene/recall 10");
 		var recap = string.Join("\n", recapMsgs);
 		Log($"[RECAP]\n{recap}");
 		await Assert.That(recap).Contains("lights a candle on the bar.")
@@ -452,7 +452,7 @@ public class SceneRoleplayIntegrationTests
 	}
 
 	/// <summary>
-	/// +scene/pot — the query-on-run Pose Tracker. Two members; one poses, one never does. The tracker
+	/// +pot — the query-on-run Pose Tracker. Two members; one poses, one never does. The tracker
 	/// must render (header + aligned rows), list both, and put the never-posed member (oldest) up next.
 	/// </summary>
 	[Test]
@@ -480,10 +480,10 @@ public class SceneRoleplayIntegrationTests
 		await RunAndCollectAs(21L, "pose stretches and yawns by the fire.");   // captured for Pat
 		// Quinn deliberately never poses → oldest (never) → up next.
 
-		var potMsgs = await RunAndCollectAs(21L, "+scene/pot");
+		var potMsgs = await RunAndCollectAs(21L, "+pot");
 		var lines = potMsgs.SelectMany(m => m.Split('\n')).Select(l => l.TrimEnd()).ToList();
 		var table = string.Join("\n", lines);
-		Console.WriteLine("=== +scene/pot ===\n" + table);
+		Console.WriteLine("=== +pot ===\n" + table);
 
 		await Assert.That(table).Contains("Pose Tracker").Because("the +pot header should render");
 		await Assert.That(table).Contains($"Pat_{Tag}").Because("Pat (a poser) should be listed");
@@ -494,8 +494,8 @@ public class SceneRoleplayIntegrationTests
 			.Because("the never-posed member (Quinn) is oldest, so the up-next marker is on Quinn's row");
 	}
 
-	/// <summary>+scene/list — the align()'d scene browser. A created+started scene must appear in the
-	/// 'recent' table with its title and status.</summary>
+	/// <summary>+scene (bare) — the align()'d scene browser (active list). A created+started scene must
+	/// appear in the active table with its title and status.</summary>
 	[Test]
 	public async Task SceneList_RendersBrowserTableWithCreatedScene()
 	{
@@ -513,17 +513,17 @@ public class SceneRoleplayIntegrationTests
 		await RunAndCollectAs(31L, $"+scene/create ListTest_{Tag}");
 		await RunAndCollectAs(31L, "+scene/start");
 
-		var listMsgs = await RunAndCollectAs(31L, "+scene/list");
+		var listMsgs = await RunAndCollectAs(31L, "+scene");
 		var table = string.Join("\n", listMsgs.SelectMany(m => m.Split('\n')).Select(l => l.TrimEnd()));
-		Console.WriteLine("=== +scene/list ===\n" + table);
+		Console.WriteLine("=== +scene ===\n" + table);
 
 		await Assert.That(table).Contains("Scenes").Because("the list header should render");
 		await Assert.That(table).Contains($"ListTest_{Tag}").Because("the created scene's title should appear in the table");
 		await Assert.That(table).Contains("active").Because("the status column should show the started scene as active");
 	}
 
-	/// <summary>+scene/schedule/add — a roomless future scene. Sets scheduledfor (millis), lands in the
-	/// 'scheduled' filter, and renders in the +scene/schedule table.</summary>
+	/// <summary>+scene/schedule — a roomless future scene. Sets scheduledfor (millis), lands in the
+	/// 'scheduled' filter, and renders in the +scene/upcoming table.</summary>
 	[Test]
 	public async Task SceneSchedule_AddsRoomlessFutureScene()
 	{
@@ -538,7 +538,7 @@ public class SceneRoleplayIntegrationTests
 		await God1($"@tel {sam}=#0");
 
 		// Schedule with raw epoch-seconds (convtime rejects it → SCHED_WHEN falls back to the number * 1000).
-		var schedMsgs = await RunAndCollectAs(41L, $"+scene/schedule/add Gala_{Tag}=2524608000");
+		var schedMsgs = await RunAndCollectAs(41L, $"+scene/schedule Gala_{Tag}=2524608000");
 		var schedLine = schedMsgs.First(m => m.Contains("Scheduled scene"));
 		var schedId = schedLine.Replace("Scheduled scene ", "").Split(' ')[0];
 		await Assert.That(schedId).IsNotEmpty().Because("the schedule confirmation should carry the new scene id");
@@ -549,15 +549,15 @@ public class SceneRoleplayIntegrationTests
 
 		// scenelist() is exercised through the verb (command-parser context) rather than Eval (the
 		// function-parser doesn't see the just-written scene in a collection scan; a key lookup does).
-		var listMsgs = await RunAndCollectAs(41L, "+scene/schedule");
+		var listMsgs = await RunAndCollectAs(41L, "+scene/upcoming");
 		var table = string.Join("\n", listMsgs.SelectMany(m => m.Split('\n')).Select(l => l.TrimEnd()));
-		Console.WriteLine("=== +scene/schedule ===\n" + table);
+		Console.WriteLine("=== +scene/upcoming ===\n" + table);
 		await Assert.That(table).Contains("Scheduled Scenes").Because("the schedule header should render");
 		await Assert.That(table).Contains($"Gala_{Tag}").Because("the scheduled scene's title should appear");
 	}
 
 	/// <summary>+scene/deactivate keeps membership but clears focus; +scene/activate restores it.
-	/// +scene/summary sets the summary; +scene/info renders the card with it.</summary>
+	/// +scene/pitch sets the pitch; +scene &lt;id&gt; renders the card with it.</summary>
 	[Test]
 	public async Task SceneParticipation_DeactivateActivate_SummaryAndInfoCard()
 	{
@@ -577,8 +577,8 @@ public class SceneRoleplayIntegrationTests
 		var sceneId = await Eval($"get({tom}/MY.SID)");
 		await Assert.That(sceneId).IsNotEmpty();
 
-		// Summary (set while focused, owner-gated).
-		await RunAndCollectAs(51L, "+scene/summary A tense standoff at dawn.");
+		// Pitch (set while focused, owner-gated).
+		await RunAndCollectAs(51L, "+scene/pitch A tense standoff at dawn.");
 		await Assert.That(await Eval($"scene({sceneId}, summary)")).IsEqualTo("A tense standoff at dawn.");
 
 		// Deactivate: focus cleared, membership retained.
@@ -593,12 +593,12 @@ public class SceneRoleplayIntegrationTests
 		await Assert.That(await Eval($"scenefocus({tom})")).IsEqualTo(sceneId)
 			.Because("activate re-focuses the player");
 
-		// Info card renders the fields.
-		var infoMsgs = await RunAndCollectAs(51L, "+scene/info");
+		// Details card renders the fields (Volund-style `+scene <id>`).
+		var infoMsgs = await RunAndCollectAs(51L, $"+scene {sceneId}");
 		var card = string.Join("\n", infoMsgs.SelectMany(m => m.Split('\n')).Select(l => l.TrimEnd()));
-		Console.WriteLine("=== +scene/info ===\n" + card);
-		await Assert.That(card).Contains("Summary").Because("the info card should have a Summary row");
-		await Assert.That(card).Contains("A tense standoff").Because("the summary text should render in the card");
+		Console.WriteLine("=== +scene <id> ===\n" + card);
+		await Assert.That(card).Contains("Pitch").Because("the details card should have a Pitch row");
+		await Assert.That(card).Contains("A tense standoff").Because("the pitch text should render in the card");
 		await Assert.That(card).Contains("active").Because("the Status row should show the scene is active");
 	}
 

--- a/SharpMUSH.Tests.Integration/Packages/CommonFunctionsPackageTests.cs
+++ b/SharpMUSH.Tests.Integration/Packages/CommonFunctionsPackageTests.cs
@@ -25,7 +25,7 @@ public class CommonFunctionsPackageTests(ServerWebAppFactory factory)
 		// The bootstrap installed the package at startup.
 		var package = await Registry.GetInstalledPackageAsync("common-functions");
 		await Assert.That(package.IsT0).IsTrue();
-		await Assert.That(package.AsT0.Version).IsEqualTo("1.0.0");
+		await Assert.That(package.AsT0.Version).IsEqualTo("1.1.0");
 
 		// Create mode: the package owns exactly one object (the functions thing).
 		var objects = await Registry.GetPackageObjectsAsync("common-functions");
@@ -57,5 +57,41 @@ public class CommonFunctionsPackageTests(ServerWebAppFactory factory)
 		await Assert.That(result!.Length).IsEqualTo(78);
 		await Assert.That(result).Contains("Title");
 		await Assert.That(result).Contains("=");
+	}
+
+	/// <summary>type=left brackets the title and pushes it to the left edge after a short border.</summary>
+	[Test]
+	public async Task Header_LeftType_BracketsAndLeftJustifies()
+	{
+		var result = (await factory.FunctionParser.FunctionParse(MModule.single("header(Test,40,left)")))?.Message!.ToString();
+
+		await Assert.That(result).IsNotNull();
+		await Assert.That(result!.Length).IsEqualTo(40);
+		await Assert.That(result).Contains("[ Test ]");
+		await Assert.That(result).StartsWith("==");
+	}
+
+	/// <summary>type=right brackets the title and pushes it to the right edge before a short border.</summary>
+	[Test]
+	public async Task Footer_RightType_BracketsAndRightJustifies()
+	{
+		var result = (await factory.FunctionParser.FunctionParse(MModule.single("footer(Test,40,right)")))?.Message!.ToString();
+
+		await Assert.That(result).IsNotNull();
+		await Assert.That(result!.Length).IsEqualTo(40);
+		await Assert.That(result).Contains("[ Test ]");
+		await Assert.That(result).EndsWith("==");
+	}
+
+	/// <summary>A title far wider than the rule is clipped to fit — never overflowing onto a new line.</summary>
+	[Test]
+	public async Task Header_LongTitle_IsClippedToWidth()
+	{
+		var huge = new string('x', 200);
+		var result = (await factory.FunctionParser.FunctionParse(MModule.single($"header({huge},40,left)")))?.Message!.ToString();
+
+		await Assert.That(result).IsNotNull();
+		await Assert.That(result!.Length).IsEqualTo(40)
+			.Because("a long title must be truncated to fit, never wrapping past the width");
 	}
 }

--- a/SharpMUSH.Tests.Integration/Packages/ScenePackageTests.cs
+++ b/SharpMUSH.Tests.Integration/Packages/ScenePackageTests.cs
@@ -30,7 +30,7 @@ public class ScenePackageTests(ServerWebAppFactory factory)
 		// The bootstrap installed the package at startup.
 		var package = await Registry.GetInstalledPackageAsync("scene");
 		await Assert.That(package.IsT0).IsTrue();
-		await Assert.That(package.AsT0.Version).IsEqualTo("1.4.0");
+		await Assert.That(package.AsT0.Version).IsEqualTo("1.5.0");
 
 		// Create mode: the package owns exactly one object (the Scene Logger thing).
 		var objects = await Registry.GetPackageObjectsAsync("scene");

--- a/SharpMUSH.Tests.Integration/Packages/ScenePackageTests.cs
+++ b/SharpMUSH.Tests.Integration/Packages/ScenePackageTests.cs
@@ -30,7 +30,7 @@ public class ScenePackageTests(ServerWebAppFactory factory)
 		// The bootstrap installed the package at startup.
 		var package = await Registry.GetInstalledPackageAsync("scene");
 		await Assert.That(package.IsT0).IsTrue();
-		await Assert.That(package.AsT0.Version).IsEqualTo("1.0.0");
+		await Assert.That(package.AsT0.Version).IsEqualTo("1.1.0");
 
 		// Create mode: the package owns exactly one object (the Scene Logger thing).
 		var objects = await Registry.GetPackageObjectsAsync("scene");

--- a/SharpMUSH.Tests.Integration/Packages/ScenePackageTests.cs
+++ b/SharpMUSH.Tests.Integration/Packages/ScenePackageTests.cs
@@ -30,7 +30,7 @@ public class ScenePackageTests(ServerWebAppFactory factory)
 		// The bootstrap installed the package at startup.
 		var package = await Registry.GetInstalledPackageAsync("scene");
 		await Assert.That(package.IsT0).IsTrue();
-		await Assert.That(package.AsT0.Version).IsEqualTo("1.1.0");
+		await Assert.That(package.AsT0.Version).IsEqualTo("1.4.0");
 
 		// Create mode: the package owns exactly one object (the Scene Logger thing).
 		var objects = await Registry.GetPackageObjectsAsync("scene");

--- a/SharpMUSH.Tests/Commands/HookIgnoreBehaviorTests.cs
+++ b/SharpMUSH.Tests/Commands/HookIgnoreBehaviorTests.cs
@@ -1,0 +1,90 @@
+using Microsoft.Extensions.DependencyInjection;
+using SharpMUSH.Library;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Services.Interfaces;
+using SharpMUSH.Tests;
+
+namespace SharpMUSH.Tests.Commands;
+
+/// <summary>
+/// Behavioural PROOF of <c>@hook/ignore</c> (independent of the scene package).
+///
+/// Contract (<c>SharpMUSHParserVisitor.cs</c> ~1494): the <c>/ignore</c> attribute is evaluated BEFORE the
+/// built-in command. If it returns a FALSE value (empty / <c>"0"</c> / <c>"#-1"</c>) the dispatcher
+/// returns early (<c>CallState.Empty</c>) and the command — plus everything downstream of the gate
+/// (before/override/built-in) — is SKIPPED. A TRUE value falls through and the command runs.
+///
+/// We prove BOTH branches on <c>@EMIT</c> using a downstream <c>@hook/override @EMIT</c> as the observable:
+/// the override writes a marker attribute, and it can only fire if execution got PAST the <c>/ignore</c>
+/// gate. A <c>GATE</c> attribute toggles the ignore result between <c>1</c> (true) and <c>0</c> (false).
+/// Both hooks are always cleared in <c>finally</c> (hooks are global session state). This project runs the
+/// bare engine (no bundled packages), so there is no competing scene <c>@EMIT</c> hook.
+/// </summary>
+[NotInParallel]
+public class HookIgnoreBehaviorTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactoryArg { get; init; }
+
+	private IConnectionService ConnectionService => WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
+	private IMUSHCodeParser Parser => WebAppFactoryArg.Services.GetRequiredService<IMUSHCodeParser>();
+	private IHookService HookService => WebAppFactoryArg.Services.GetRequiredService<IHookService>();
+	private ISharpDatabase Database => WebAppFactoryArg.Services.GetRequiredService<ISharpDatabase>();
+
+	private async Task<string> ReadAttributeAsync(DBRef obj, string attribute) =>
+		(await Database.GetAttributeAsync(obj, attribute.Split('`'), CancellationToken.None).LastOrDefaultAsync())
+			?.Value.ToPlainText() ?? "";
+
+	/// <summary>Sets up an @EMIT override that writes <c>RAN=yes</c>, plus an @EMIT /ignore reading GATE.</summary>
+	private async Task ArmAsync(DBRef obj, string gateValue)
+	{
+		// Downstream observable: an @EMIT override (no re-emit ⇒ no recursion) that records it was reached.
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"&OVR {obj}=$(?i)^@emit (.*)$:&RAN {obj}=yes"));
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@set {obj}/OVR=regexp"));
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@hook/override @EMIT={obj},OVR"));
+		// The gate the /ignore hook evaluates.
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"&GATE {obj}={gateValue}"));
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@hook/ignore @EMIT={obj},GATE"));
+	}
+
+	[Test]
+	public async ValueTask Ignore_ReturnsTrue_CommandProceeds()
+	{
+		var obj = await TestIsolationHelpers.CreateTestThingAsync(Parser, ConnectionService, "HookIgnTrue");
+		try
+		{
+			await ArmAsync(obj, "1"); // gate true
+
+			await Parser.CommandParse(1, ConnectionService, MModule.single("@emit hello"));
+
+			await Assert.That(await ReadAttributeAsync(obj, "RAN")).IsEqualTo("yes")
+				.Because("a TRUE /ignore lets @emit proceed — execution reaches the downstream override");
+		}
+		finally
+		{
+			await HookService.ClearHookAsync("@EMIT", "IGNORE");
+			await HookService.ClearHookAsync("@EMIT", "OVERRIDE");
+		}
+	}
+
+	[Test]
+	public async ValueTask Ignore_ReturnsFalse_CommandSkipped()
+	{
+		var obj = await TestIsolationHelpers.CreateTestThingAsync(Parser, ConnectionService, "HookIgnFalse");
+		try
+		{
+			await ArmAsync(obj, "0"); // gate false
+
+			await Parser.CommandParse(1, ConnectionService, MModule.single("@emit hello"));
+
+			await Assert.That(await ReadAttributeAsync(obj, "RAN")).IsEqualTo("")
+				.Because("a FALSE /ignore SKIPS @emit entirely — execution never reaches the override or built-in");
+		}
+		finally
+		{
+			await HookService.ClearHookAsync("@EMIT", "IGNORE");
+			await HookService.ClearHookAsync("@EMIT", "OVERRIDE");
+		}
+	}
+}

--- a/docs/setup/scene-bootstrap.md
+++ b/docs/setup/scene-bootstrap.md
@@ -50,13 +50,13 @@ passers-by, and people focused on a different scene in the room, are not logged.
 > through `GameHub.SendCommand`, so the **same** hook fires — there is **one** stored pose,
 > rendered both to the room and over `game.scene.{id}` (no double-capture, no echo loop).
 
-## Policy knobs (`DATA\`*`)
+## Policy knobs (``DATA`*``)
 
 There is intentionally **no `SceneOptions` config category** — every knob is policy, set as a
-`&DATA\`*` attribute on the Scene Logger and read by the verbs (one place, not two). The
-package ships sensible defaults; the most notable is **`DATA\`DEFAULT_STATUS=active`**, so
+``&DATA`*`` attribute on the Scene Logger and read by the verbs (one place, not two). The
+package ships sensible defaults; the most notable is **``DATA`DEFAULT_STATUS=active``**, so
 `+scene/create` yields an immediately-capturing scene (set it to `new`/`scheduled` to stage a
-scene that only logs after `+scene/start`). See the `DATA\`*` block in `package.yaml` for the
+scene that only logs after `+scene/start`). See the ``DATA`*`` block in `package.yaml` for the
 full set (`CAPTURE`, `DEFAULT_STATUS`, `DEFAULT_PUBLIC`, `MAX_RECENT`, `STATUSES`, `TEMP_*`,
 `SHARE_OWNER`) and its current defaults.
 
@@ -82,7 +82,7 @@ edit their own poses.
 | `+scene/public` · `/private` | visibility |
 | `+scene/recall [<n>]` | print the last `<n>` poses |
 | `+scene/edit <id>=<before>^^^<after>` | fix a typo in your pose |
-| `+scene/undo` · `/redo` · `/delete <id>` · `/move <id>=<after>` | pose management |
+| `+scene/undo <id>` · `/redo <id>` · `/delete <id>` · `/move <id>=<after>` | pose management |
 | `+scene/who <id>` | cast list |
 | `+scene/schedule <title>=<when>` | schedule a roomless future scene |
 | `+scene/reschedule <id>=<when>` · `/unschedule <id>` · `/upcoming` | manage / list scheduled |

--- a/docs/setup/scene-bootstrap.md
+++ b/docs/setup/scene-bootstrap.md
@@ -69,7 +69,9 @@ editing the managed attributes on the Scene Logger via the package manager:
 
 ```mush
 &DATA`CAPTURE        Scene Logger=1
-&DATA`DEFAULT_STATUS Scene Logger=new
+@@ `active` => +scene/create yields an immediately-capturing scene (no separate +scene/start).
+@@ Use `new` or `scheduled` if you want creation to STAGE a scene that starts logging only on +scene/start.
+&DATA`DEFAULT_STATUS Scene Logger=active
 &DATA`DEFAULT_PUBLIC Scene Logger=0
 &DATA`MAX_RECENT     Scene Logger=50
 &DATA`STATUSES       Scene Logger=new scheduled active paused finished
@@ -175,7 +177,7 @@ calls its guard.
 
 ```mush
 @@ ---- create / lifecycle -------------------------------------------------
-&CMD`CREATE Scene Logger=$+scene/create *: @assert setr(0,scenecreate(%L,%#,%0)); @scene/member %q0/owner=%#; @scene/focus %#=%q0; @scene/set %q0/status=[get(%!/DATA`DEFAULT_STATUS)]; @pemit %#=Scene %q0 created and focused.; &MY.SID %#=%q0
+&CMD`CREATE Scene Logger=$+scene/create *: @assert setr(0,scenecreate(%L,%#,%0)); @scene/member %q0/owner=%#; @scene/focus %#=%q0; @scene/set %q0/status=[get(%!/DATA`DEFAULT_STATUS)]; @pemit %#=Scene %q0 created and focused (status: [get(%!/DATA`DEFAULT_STATUS)]).; &MY.SID %#=%q0
 
 &CMD`START   Scene Logger=$+scene/start: @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/status=active; @pemit %#=Scene is now active.
 &CMD`PAUSE   Scene Logger=$+scene/pause: @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/status=paused; @pemit %#=Scene paused.

--- a/docs/setup/scene-bootstrap.md
+++ b/docs/setup/scene-bootstrap.md
@@ -1,261 +1,115 @@
 # Scene System — the bundled `scene` package
 
-The C# Scene System ships only **mechanism**: storage (`ISceneService`), the
-wizard `@SCENE` command, the `scene…` softcode functions, the `SCENE_ROOM` flag,
-the `game.scene.{id}` realtime broadcast, and the portal. It ships **no policy** —
-nothing captures a pose, decides who may start a scene, formats a room emit, or
-spins up a temp room. That is all **game policy**, and it is delivered as
-softcode by the **bundled `scene` package**.
+The C# Scene System ships only **mechanism**: storage (`ISceneService`), the wizard
+`@scene` command, the `scene…()` softcode functions, the `SCENE_ROOM` flag, the
+`game.scene.{id}` realtime broadcast, and the portal. It ships **no policy** — nothing
+captures a pose, decides who may start a scene, formats a room emit, or spins up a temp
+room. That is all **game policy**, delivered as softcode by the bundled **`scene` package**.
 
-> **This is now a default package.** You do **not** hand-build a `#SCENELOGGER`
-> object. The server ships `examples/packages/scene/package.yaml`, lists it in
-> `BundledPackages.All`, and `DefaultPackagesBootstrapService` installs it at
-> first boot like any other default package. The package creates and owns a
-> single **WIZARD** thing named **"Scene Logger"** that carries all the softcode
-> below. Admins **customize via the package manager** (edit the managed
-> attributes on the Scene Logger object, or fork the package) rather than editing
-> a hand-built object. The rest of this document is the **softcode the package
-> ships**, annotated so you can see exactly what it does.
+> ## The package is the source of truth
+>
+> Every knob, capture hook, and `+scene/*` verb the package installs lives in
+> **[`examples/packages/scene/package.yaml`](../../examples/packages/scene/package.yaml)**.
+> Read that file for the exact, current softcode. **This document describes how the pieces
+> fit together; it deliberately does not reproduce the verb bodies** (which would drift out
+> of sync). When something here disagrees with the package, the package wins.
 
-There is intentionally **no `SceneOptions` config category**: every knob is
-policy, so it is set as `&DATA\`*` attributes on the Scene Logger object and read
-by the verbs below. One place, not two.
+## How it's installed
 
-> **Attribute organization** follows the project `FUN\`/CMD\`/DATA\`/INCLUDE\``
-> tree convention (same as the common-functions and http-handler packages,
-> e.g. `FUN\`HEADER`, `GET\`PROFILE\`SCHEMA`): `DATA\`*` for config knobs (reads),
-> `FUN\`*` for pure reads/guards (called via `u()`), `CMD\`*` for player verbs
-> and the capture `$`-commands (writes go through `@scene/*`), and `INCLUDE\`*`
-> for shared command tails composed via `@include` (keeps individual attributes
-> small). Leaf names are UPPERCASE.
+`package.yaml` is embedded into `SharpMUSH.Server`, listed in `BundledPackages.All`, and
+installed at first boot by `DefaultPackagesBootstrapService` — like any other default
+package. It creates and owns a single **WIZARD** thing named **"Scene Logger"** that carries
+all the softcode. Admins customize via the **package manager** (edit the managed attributes,
+or fork the package) rather than hand-building an object.
 
-> **Writes are commands, reads are functions.** Every **data-write** in the
-> package uses an **`@scene/<switch>`** command (gated only by `FLAG^WIZARD`,
-> which the WIZARD Scene Logger satisfies) — e.g. `@scene/addpose <id>=…`,
-> `@scene/set <id>/<key>=…`, `@scene/member <id>/<role>=…`. This means the
-> package works **without** enabling `function_side_effects`. The **read**
-> surface (`scenewhere`, `scenefocus`, `scene`, `scenemember`, `sceneposes`, …)
-> is plain `Regular` and always works as functions.
+The Logger **must be WIZARD**: it is the `@hook/override` target, runs the wizard-only
+`@scene`/`@hook` commands, and its lifecycle attributes (`AINSTALL` once, `STARTUP` every
+boot) run as the object itself (`%!`/`me` = the Logger), so self-execution of the
+wizard-locked `@hook` works.
 
-> Style note: examples follow SharpMUSH softcode conventions — bare `%0`/`%#`/
-> `%q<…>` substitutions are never wrapped in `[ ]` (brackets are for function
-> calls only), and `firstof()` is preferred over nested `if()` chains.
+## Capture — `@hook/override`
 
----
+Players pose with the native `pose`/`say`/`semipose` commands and `@emit`. `STARTUP`
+establishes an **`@hook/override`** on each of `POSE`, `SAY`, `SEMIPOSE`, and `@EMIT`,
+pointing at a capture `$`-command on the Logger. Each hook:
 
-## 1. The Scene Logger object (shipped by the package)
+1. **Re-broadcasts** the speech to the room with **`@message/spoof`**. `/spoof` makes the
+   *speaker* (`%#`) the notification sender — not the WIZARD Logger — preserving attribution,
+   and `@message` evaluates the speaker's per-type `FORMAT\`*` attribute **once per recipient**,
+   so speaker-specific ("You say…") and observer-specific ("Name says…") text both render.
+2. **Asserts** the room has an **active** scene (`scenewhere(loc(%#))`) **and** the poser is
+   focused on it (`scenefocus(%#)`), then **records** the rendered line with `@scene/addpose`
+   (explicit author `%#`).
 
-The package's create-mode manifest declares a single owned thing:
+Because the assert runs *after* the re-broadcast, a pose outside any scene behaves exactly
+like the un-hooked built-in — it simply isn't recorded. Requiring **active + focused** means
+passers-by, and people focused on a different scene in the room, are not logged.
 
-```yaml
-objects:
-  - ref: logger
-    type: thing
-    name: Scene Logger
-    flags: [WIZARD]
-    attributes:
-      ...
-```
+> Only **override** hooks work for capture: `@hook/after`/`/before` run with empty args and
+> never see the pose text. The portal's live composer sends a normal `POSE`/`SAY`/`SEMIPOSE`
+> through `GameHub.SendCommand`, so the **same** hook fires — there is **one** stored pose,
+> rendered both to the room and over `game.scene.{id}` (no double-capture, no echo loop).
 
-It **must be WIZARD** — it is the `@hook/override` target, it runs the
-wizard-only `@SCENE`/`@HOOK` commands, and the package lifecycle attributes
-(AINSTALL/STARTUP) run **as this object** (`%!` / `me` = the Scene Logger), so
-self-execution of the wizard-locked `@hook` works.
+## Policy knobs (`DATA\`*`)
 
-### Policy attributes (replaces config)
+There is intentionally **no `SceneOptions` config category** — every knob is policy, set as a
+`&DATA\`*` attribute on the Scene Logger and read by the verbs (one place, not two). The
+package ships sensible defaults; the most notable is **`DATA\`DEFAULT_STATUS=active`**, so
+`+scene/create` yields an immediately-capturing scene (set it to `new`/`scheduled` to stage a
+scene that only logs after `+scene/start`). See the `DATA\`*` block in `package.yaml` for the
+full set (`CAPTURE`, `DEFAULT_STATUS`, `DEFAULT_PUBLIC`, `MAX_RECENT`, `STATUSES`, `TEMP_*`,
+`SHARE_OWNER`) and its current defaults.
 
-The package ships `DATA\`CAPTURE` and `DATA\`DEFAULT_STATUS`; add the rest by
-editing the managed attributes on the Scene Logger via the package manager:
+## Player commands
 
-```mush
-&DATA`CAPTURE        Scene Logger=1
-@@ `active` => +scene/create yields an immediately-capturing scene (no separate +scene/start).
-@@ Use `new` or `scheduled` if you want creation to STAGE a scene that starts logging only on +scene/start.
-&DATA`DEFAULT_STATUS Scene Logger=active
-&DATA`DEFAULT_PUBLIC Scene Logger=0
-&DATA`MAX_RECENT     Scene Logger=50
-&DATA`STATUSES       Scene Logger=new scheduled active paused finished
-&DATA`TEMP_ZONE      Scene Logger=#0
-&DATA`TEMP_GRACE_MIN Scene Logger=30
-&DATA`TEMP_MAX       Scene Logger=3
-&DATA`SHARE_OWNER    Scene Logger=1
-```
+The package follows **[Volund's SceneSys](https://github.com/volundmush/mushcode)** command
+surface — a unified `+scene/<switch>` verb plus a standalone `+pot`. Default permission:
+anyone may create/schedule (and becomes owner); owner-only for lifecycle/management; authors
+edit their own poses.
 
----
+| Command | Does |
+|---|---|
+| `+scene` | list active scenes |
+| `+scene <id>` | scene details card |
+| `+scene/old` &nbsp;·&nbsp; `+scene/mine` | finished &nbsp;·&nbsp; your scenes |
+| `+scene/create <title>` | create + focus (active by default) |
+| `+scene/start` · `/pause` · `/finish` | lifecycle |
+| `+scene/join <id>` · `/leave` | membership + focus |
+| `+scene/tag <id>` · `/untag <id>` | RSVP |
+| `+scene/activate <id>` · `/deactivate` | resume / pause recording without leaving |
+| `+scene/as <persona>` | display persona for your future poses |
+| `+scene/pitch <text>` | set the scene blurb |
+| `+scene/public` · `/private` | visibility |
+| `+scene/recall [<n>]` | print the last `<n>` poses |
+| `+scene/edit <id>=<before>^^^<after>` | fix a typo in your pose |
+| `+scene/undo` · `/redo` · `/delete <id>` · `/move <id>=<after>` | pose management |
+| `+scene/who <id>` | cast list |
+| `+scene/schedule <title>=<when>` | schedule a roomless future scene |
+| `+scene/reschedule <id>=<when>` · `/unschedule <id>` · `/upcoming` | manage / list scheduled |
+| `+pot` | pose tracker (turn order for the focused scene) |
 
-## 2. Capture — one path, `@hook/override`
+**Reads are functions, writes are commands.** Reads use the `scene…()` functions
+(`scenewhere`, `scenefocus`, `scene`, `sceneposes`, `scenepose`, `scenemember`, `scenecast`, …);
+all writes go through wizard-only `@scene/*` commands that the WIZARD Logger satisfies, so the
+package works **without** enabling `function_side_effects`. Object arguments (rooms, players)
+resolve through the engine's **`LocateService`**, so `here`, `me`, player names, `*name`, and
+dbrefs all work just as they do for every other engine function.
 
-Players pose with the native `pose`/`say`/`semipose` commands. An
-`@hook/override` reproduces the room emit **and** records the pose. This is the
-**only** capture path:
+## Temp rooms (optional extension)
 
-* `@hook/after` cannot be used — AFTER/BEFORE hooks run with **empty args**, so
-  they never see the pose text. Only **OVERRIDE** passes the command input to a
-  `$`-command.
-* `@EMIT` is **not** hooked — the override replaces only the personal pose verbs.
+A scene can have its own staging room: `@dig` it, set the `SCENE_ROOM` flag (symbol `S`),
+`@tel` joiners in, and `@destroy` it after a grace period on `/finish`. This is **not** shipped
+by default — add a `+scene/create/temp` verb to the Logger via the package manager if you want
+it; the `DATA\`TEMP_*` knobs are reserved for that use.
 
-The package's `AINSTALL` (once) and `STARTUP` (every boot) (re-)establish the
-three OVERRIDE hooks idempotently, in the standard PennMUSH form
-`@hook/<type> <command> = <object>, <attribute>`:
-
-```mush
-@hook/override POSE     = %!, CMD`CAPTURE`POSE
-@hook/override SAY      = %!, CMD`CAPTURE`SAY
-@hook/override SEMIPOSE = %!, CMD`CAPTURE`SEMI
-```
-
-The three capture attributes are `$`-commands on the Scene Logger. Each (a)
-reproduces the **built-in** room emit byte-for-byte, then delegates the shared
-tail to `INCLUDE\`CAPTURE` via `@include %!/INCLUDE\`CAPTURE=<source>,<content>`.
-The tail (b) `@assert`s a scene is active here **and** the poser is focused on
-it, then (c) records the rendered line with `@scene/addpose` (note the
-**explicit author** `%#`). Factoring the tail keeps each capture attribute small
-(guide: "keep individual attributes smaller"). The `@assert` halts the command
-list *after* the emit already fired, so a pose outside any scene behaves exactly
-like the un-hooked built-in. **Writes are commands.**
-
-Each capture hook is written as ONE physical line (commands separated by `;`),
-and the assert+addpose tail is **inlined** into each hook rather than factored
-into a shared `&INCLUDE\`CAPTURE` attribute. Two engine realities drive this:
-
-* **`@include` cannot resolve a backtick attribute name.** `@include %!/INCLUDE\`CAPTURE`
-  silently no-ops (only `get()`/`u()` resolve `FOO\`BAR` tree attributes), so a
-  factored tail never runs — nothing is captured. Inlining avoids `@include`.
-* **A multi-line `$`-command body misparses its first command**, and q-registers
-  do not cross newlines in a `$`-command body. The single-line `;` form is robust.
+## Verifying
 
 ```mush
-@@ Built-in POSE emits "<name> <message>" to the room, then records the pose.
-&CMD`CAPTURE`POSE Scene Logger=$pose *: @emit [name(%#)] %0; @assert words(scenewhere(%L)); @assert strmatch(scenefocus(%#),scenewhere(%L)); @scene/addpose [scenewhere(%L)]=%#,[scenemember(scenewhere(%L),%#,showas)],%L,pose,,[name(%#)] %0
-
-@@ Built-in SAY emits "You say, \"<msg>\"" to the speaker and
-@@ "<name> says, \"<msg>\"" to everyone else — reproduce both, then record.
-&CMD`CAPTURE`SAY Scene Logger=$say *: @pemit %#=You say, "%0"; @oemit %L/%#=[name(%#)] says, "%0"; @assert words(scenewhere(%L)); @assert strmatch(scenefocus(%#),scenewhere(%L)); @scene/addpose [scenewhere(%L)]=%#,[scenemember(scenewhere(%L),%#,showas)],%L,say,,[name(%#)] says\, "%0"
-
-@@ Built-in SEMIPOSE emits "<name><message>" (no space), then records.
-&CMD`CAPTURE`SEMI Scene Logger=$;*: @emit [name(%#)]%0; @assert words(scenewhere(%L)); @assert strmatch(scenefocus(%#),scenewhere(%L)); @scene/addpose [scenewhere(%L)]=%#,[scenemember(scenewhere(%L),%#,showas)],%L,semipose,,[name(%#)]%0
++scene/create Test
+@emit A figure steps from the shadows.
+think sceneposes(scenewhere(loc(me)))    @@ -> a pose id (capture worked)
+think scenepose(scenewhere(loc(me)), first(sceneposes(scenewhere(loc(me)))), content)
 ```
 
-`scenewhere(%L)` resolves the room's active scene; `scenefocus(%#)` is the
-poser's currently-focused scene (their `member` edge `isCurrent`). Requiring the
-two to match means passers-by and people focused on a different scene are **not**
-logged. `@scene/addpose <id>=<author>,<showAs>,<origin>,<source>,<tags>,<content>`
-records the pose with an explicit author and publishes the realtime event.
-
-### Web pose-authoring reuses this exact path
-
-The portal's live-scene composer sends a normal `POSE`/`SAY`/`SEMIPOSE` through
-`GameHub.SendCommand` on the player's play connection — so the **same** override
-fires. There is **one** stored pose; the room emit and the `game.scene.{id}`
-broadcast are two renderings of it (keyed by pose id). No double-capture, no echo
-loop. The composer must never use `@emit`.
-
----
-
-## 3. Player verbs (`+scene/*`)
-
-Players never touch `@scene`. Default permission: **anyone may create/schedule
-and becomes the owner; owner-only for lifecycle/management; authors edit their
-own poses.**
-
-All writes go through `@scene/*` commands; reads stay as `scene…()` functions.
-`%!` is the Scene Logger object (the verbs live on it), so `u(%!/FUN\`OWNS,…)`
-calls its guard.
-
-> **Softcode conventions that matter here (engine realities):**
-> * Each verb body is **one physical line** (`;`-separated). A multi-line
->   `$`-command body misparses its first command (the next line's leading
->   `@scene…` leaks into it) and q-registers do not cross newlines in a
->   `$`-command body — both break the verbs. Use `;`.
-> * `@scene/*` are NoParse commands: they evaluate their own args, but a bare
->   `%0`/`%1` positional passed *directly* as an `@scene` arg can collide with
->   the command's own arg context. Stash the positional into a `%q` register
->   first when it would otherwise be the whole arg (see `EDIT`).
-> * `@create`/`@assert setr(...)` in command position **does** propagate its
->   register to later `;` commands; a `setr()` inside an `&attr=<value>` RHS does
->   **not** — capture the scene id with `@assert setr(...)`, not `&MY.SID=[setr(...)]`.
-
-```mush
-@@ ---- create / lifecycle -------------------------------------------------
-&CMD`CREATE Scene Logger=$+scene/create *: @assert setr(0,scenecreate(%L,%#,%0)); @scene/member %q0/owner=%#; @scene/focus %#=%q0; @scene/set %q0/status=[get(%!/DATA`DEFAULT_STATUS)]; @pemit %#=Scene %q0 created and focused (status: [get(%!/DATA`DEFAULT_STATUS)]).; &MY.SID %#=%q0
-
-&CMD`START   Scene Logger=$+scene/start: @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/status=active; @pemit %#=Scene is now active.
-&CMD`PAUSE   Scene Logger=$+scene/pause: @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/status=paused; @pemit %#=Scene paused.
-&CMD`FINISH  Scene Logger=$+scene/finish: @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/status=finished; @scene/focus %#=; @pemit %#=Scene finished.
-
-@@ ---- membership / RSVP / focus ------------------------------------------
-&CMD`JOIN  Scene Logger=$+scene/join *: @scene/member %0/participant=%#; @scene/focus %#=%0; @pemit %#=Joined and focused on scene %0.
-&CMD`LEAVE Scene Logger=$+scene/leave: @assert setr(0,scenefocus(%#)); @scene/focus %#=; @if not(words(sceneposes(%q0,%#)))={@scene/unmember %q0=%#}; @pemit %#=Left the scene.; &MY.SID %#=%q0
-&CMD`TAG   Scene Logger=$+scene/tag *: @scene/member %0/attending=%#; @pemit %#=RSVP'd to scene %0.
-&CMD`UNTAG Scene Logger=$+scene/untag *: @scene/unmember %0=%#; @pemit %#=Removed RSVP from scene %0.
-&CMD`SHOWAS Scene Logger=$+scene/showas *: @scene/showas [scenefocus(%#)]/%#=%0; @pemit %#=Future poses show as: %0
-
-@@ ---- edit your own poses -------------------------------------------------
-@@ %1 is find^^^replace; author-only is enforced by @scene/editpose. The poseId
-@@ (%0) is stashed in %q1 so it is not a bare positional inside the @scene arg.
-&CMD`EDIT Scene Logger=$+scene/edit *=*: @assert setr(1,%0); @assert setr(0,edit(scenepose(scenefocus(%#),%q1,content),before(%1,^^^),after(%1,^^^))); @scene/editpose %q1=%#,%q0
-
-&CMD`UNDO   Scene Logger=$+scene/undo *: @scene/undo %0
-&CMD`REDO   Scene Logger=$+scene/redo *: @scene/redo %0
-&CMD`DELETE Scene Logger=$+scene/delete *: @scene/delete %0
-&CMD`MOVE   Scene Logger=$+scene/move *=*: @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/move %0=%1
-
-@@ ---- visibility ----------------------------------------------------------
-&CMD`PUBLIC  Scene Logger=$+scene/public: @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/public=1; @pemit %#=Scene is now public.
-&CMD`PRIVATE Scene Logger=$+scene/private: @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/public=0; @pemit %#=Scene is now private.
-
-@@ ---- viewing --------------------------------------------------------------
-&CMD`WHO   Scene Logger=$+scene/who *: @pemit %#=Cast: [scenecast(%0)]%r[iter(scenemembers(%0),[name(##)] ([scenemember(%0,##,role)]))]
-&CMD`RECAP Scene Logger=$+scene/recap *: @pemit %#=[iter(sceneposes(scenefocus(%#),,%0),scenepose(scenefocus(%#),##,content),%b,%r)]
-```
-
-> The `+scene/schedule` and `+scene/create/temp` verbs from earlier drafts are not
-> part of the shipped 1.0 package; add them by editing the package if you want
-> roomless scheduling or temp-room staging (see §4).
-
-### Owner / wizard guard
-
-```mush
-&FUN`OWNS Scene Logger=
-  or(orflags(%0,Wz),strmatch(scene(%1,owner),%0))
-```
-
----
-
-## 4. Temp rooms — entirely softcode (optional extension)
-
-When a scene wants its own staging room, softcode does the building; the engine
-just flags the room. `@dig` the room, set the `SCENE_ROOM` flag (symbol `S`),
-`@tel` joiners in, and `@destroy` it after the grace period once the scene
-finishes. This is **not** in the shipped 1.0 package — add it by editing the
-Scene Logger's managed attributes (via the package manager) if you want it:
-
-```mush
-&CMD`CREATE_TEMP Scene Logger=$+scene/create/temp *:
-  @assert lte(u(%!/FUN`TEMP_COUNT,%#),get(%!/DATA`TEMP_MAX));
-  @dig/teleport [setr(0,Scene: %0)] , , ;
-  @set %q0=SCENE_ROOM;
-  @chzone %q0=get(%!/DATA`TEMP_ZONE);
-  &MY.SID %#=[setr(1,[scenecreate(%q0,%#,%0)])];
-  @scene/set %q1/temproom=%q0;
-  @scene/member %q1/owner=%#;
-  @scene/focus %#=%q1
-
-@@ on /finish of a temp scene, schedule cleanup after DATA`TEMP_GRACE_MIN:
-@@   @wait [mul(60,get(%!/DATA`TEMP_GRACE_MIN))]=@destroy <temproom>
-```
-
----
-
-## 5. Verifying
-
-```mush
-@@ from a SCENE_ROOM with an active scene, after a pose:
-think scenewhere(here)                 @@ -> the active scene id
-think sceneposes(scenewhere(here))     @@ -> ordered pose ids
-think scene(scenewhere(here),owner)    @@ -> the owner dbref (e.g. #123)
-```
-
-The portal `/scenes` browser, `/scenes/{id}` archive, and `/scenes/{id}/live`
-feed all read the same data over `/api/scenes`, and the live page receives each
-new pose over `game.scene.{id}` as it is captured.
+The portal `/scenes` browser and `/scenes/{id}/live` feed read the same data over
+`/api/scenes`; the live page receives each new pose over `game.scene.{id}` as it is captured.

--- a/examples/packages/common-functions/package.yaml
+++ b/examples/packages/common-functions/package.yaml
@@ -1,36 +1,81 @@
 format: 1
 package: common-functions
-version: 1.0.0
+version: 1.1.0
 authors: [SharpMUSH]
-description: "Global UI-helper functions: header(), footer(), line() — full-width rules with an optional centered title."
+description: "Global UI-helper functions: header(), footer(), line() — full-width rules with an optional title, justified center (default) / left / right."
 license: MIT
 homepage: https://github.com/SharpMUSH/SharpMUSH-Packages
 keywords: [ui, formatting, functions]
 requires_server: ">=0.1"
 
-# Create mode: a single owned thing carries the softcode the global functions
-# evaluate. AINSTALL registers header()/footer()/line() once at install; STARTUP
-# re-registers them on every boot (the global-function registry is in-memory).
+# Create mode: a single owned thing carries the softcode the global functions evaluate. AINSTALL
+# registers header()/footer()/line() once at install; STARTUP re-registers them on every boot (the
+# global-function registry is in-memory).
+#
+# Each function is self-describing via its FUN` attribute subtree:
+#   FUN`<NAME>                  — the function body (a dispatcher for justified variants)
+#   FUN`<NAME>`MINARGS / MAXARGS — arg counts, read by @function so the registration has one source
+#   FUN`<NAME>`DISPLAY`<TYPE>   — the rendering for each justification (CENTER | LEFT | RIGHT)
+# The body derives type -> attribute with u(%!/FUN`<NAME>`DISPLAY`[ucstr(firstof(%2,center))],…), so
+# each justification stays isolated and readable.
+#
+# WIDTH SAFETY: every variant truncates the title with left(%0, sub(<width>, <overhead>)) so the
+# rendered line is never wider than <width> — a long title is clipped rather than wrapping to a new line.
 objects:
   - ref: functions
     type: thing
     name: Common Functions
     attributes:
-      # Functions live under the FUN` attribute tree (leaves inherit the branch's flags/perms).
-      # Each rule is sized to the caller's client width (width(%#) defaults to 78 when the client
-      # doesn't report one), with an optional centered title. %0 = title, %1 = width override.
+      # header(<title>[, <width>][, <type>]) — full-width rule with an optional title.
+      #   width: defaults to the caller's client width (width(%#), 78 fallback).
+      #   type : center (default) | left | right. center = legacy centered look (no brackets, stable for
+      #          existing callers); left/right = the title bracketed `[ title ]`, pushed to that edge with
+      #          a 2-char border on the near side and the rule filling the rest.
       FUN`HEADER: |-
-        center(if(strlen(%0),[space(1)]%0[space(1)],),firstof(%1,width(%#)),=)
-      # Same as the header, drawn at the bottom of a block.
+        u(%!/FUN`HEADER`DISPLAY`[ucstr(firstof(%2,center))],%0,if(strlen(%1),%1,width(%#)))
+      FUN`HEADER`MINARGS: |-
+        0
+      FUN`HEADER`MAXARGS: |-
+        3
+      # CENTER overhead = 2 (the surrounding spaces); title clipped to width-2.
+      FUN`HEADER`DISPLAY`CENTER: |-
+        center(if(strlen(%0),[space(1)][left(%0,sub(%1,2))][space(1)],),%1,=)
+      # LEFT/RIGHT overhead = 8 ("== " + "[ " + " ]" + trailing space); title clipped to width-8.
+      FUN`HEADER`DISPLAY`LEFT: |-
+        ljust(if(strlen(%0),==%b\[%b[left(%0,sub(%1,8))]%b\]%b,),%1,=)
+      FUN`HEADER`DISPLAY`RIGHT: |-
+        rjust(if(strlen(%0),%b\[%b[left(%0,sub(%1,8))]%b\]%b==,),%1,=)
+
+      # footer(<title>[, <width>][, <type>]) — same rule, drawn at the bottom of a block.
       FUN`FOOTER: |-
-        center(if(strlen(%0),[space(1)]%0[space(1)],),firstof(%1,width(%#)),=)
-      # Lighter divider filled with '-'.
+        u(%!/FUN`FOOTER`DISPLAY`[ucstr(firstof(%2,center))],%0,if(strlen(%1),%1,width(%#)))
+      FUN`FOOTER`MINARGS: |-
+        0
+      FUN`FOOTER`MAXARGS: |-
+        3
+      FUN`FOOTER`DISPLAY`CENTER: |-
+        center(if(strlen(%0),[space(1)][left(%0,sub(%1,2))][space(1)],),%1,=)
+      FUN`FOOTER`DISPLAY`LEFT: |-
+        ljust(if(strlen(%0),==%b\[%b[left(%0,sub(%1,8))]%b\]%b,),%1,=)
+      FUN`FOOTER`DISPLAY`RIGHT: |-
+        rjust(if(strlen(%0),%b\[%b[left(%0,sub(%1,8))]%b\]%b==,),%1,=)
+
+      # line(<title>[, <width>]) — a lighter '-' divider with an optional centered title.
       FUN`LINE: |-
-        center(if(strlen(%0),[space(1)]%0[space(1)],),firstof(%1,width(%#)),-)
-      # Runs once after first install: register the three global user functions, each bound to its
-      # FUN` leaf on this object (data-writes go through the @function command, per the style guide).
+        center(if(strlen(%0),[space(1)][left(%0,sub(firstof(%1,width(%#)),2))][space(1)],),firstof(%1,width(%#)),-)
+      FUN`LINE`MINARGS: |-
+        0
+      FUN`LINE`MAXARGS: |-
+        2
+
+      # AINSTALL (once): just run STARTUP. The function body u()s its own object's FUN`<NAME>`DISPLAY`<TYPE>
+      # leaf, which is safe for ANY caller: a global @function "runs as the backing object, with its
+      # powers" (PennMUSH `help @function2`, and SharpMUSH matches this — SharpMUSHParserVisitor evaluates
+      # the attribute with the function object as executor), so the nested u() is this object reading its
+      # OWN attribute regardless of who called header()/footer().
       AINSTALL: |-
-        @function header=%!,FUN`HEADER,0,2; @function footer=%!,FUN`FOOTER,0,2; @function line=%!,FUN`LINE,0,2
-      # Runs on every server boot: re-establish the in-memory registrations.
+        @trigger %!/STARTUP
+      # STARTUP (every boot): re-establish the in-memory global-function registrations, reading each
+      # function's arg counts from its MINARGS/MAXARGS leaf (one source of truth).
       STARTUP: |-
-        @function header=%!,FUN`HEADER,0,2; @function footer=%!,FUN`FOOTER,0,2; @function line=%!,FUN`LINE,0,2
+        @function header=%!,FUN`HEADER,[get(%!/FUN`HEADER`MINARGS)],[get(%!/FUN`HEADER`MAXARGS)]; @function footer=%!,FUN`FOOTER,[get(%!/FUN`FOOTER`MINARGS)],[get(%!/FUN`FOOTER`MAXARGS)]; @function line=%!,FUN`LINE,[get(%!/FUN`LINE`MINARGS)],[get(%!/FUN`LINE`MAXARGS)]

--- a/examples/packages/scene/package.yaml
+++ b/examples/packages/scene/package.yaml
@@ -1,6 +1,6 @@
 format: 1
 package: scene
-version: 1.0.0
+version: 1.1.0
 authors: [SharpMUSH]
 description: "Scene Logger: pose/say/semipose capture into the Scene System, plus the +scene/* player verbs. Ships the game policy the C# engine deliberately omits."
 license: MIT
@@ -37,8 +37,11 @@ objects:
       # ---- policy knobs (read by the verbs; replaces a SceneOptions config) ----
       DATA`CAPTURE: |-
         1
+      # `active` so +scene/create yields an immediately-capturing scene — pose/say/@emit are recorded
+      # right after creation, with no separate +scene/start. Set this to `new` (or `scheduled`) instead
+      # if you want creation to STAGE a scene that only begins logging after an explicit +scene/start.
       DATA`DEFAULT_STATUS: |-
-        new
+        active
 
       # ---- owner / wizard guard -------------------------------------------------
       FUN`OWNS: |-
@@ -116,7 +119,7 @@ objects:
       # `&MY.SID %#=[setr(0,…)]` also failed (setr inside an &attr=<value> RHS doesn't
       # propagate its register); @assert in command position does.
       CMD`CREATE: |-
-        $+scene/create *: @assert setr(0,scenecreate(%L,%#,%0)); @scene/member %q0/owner=%#; @scene/focus %#=%q0; @scene/set %q0/status=[get(%!/DATA`DEFAULT_STATUS)]; @pemit %#=Scene %q0 created and focused.; &MY.SID %#=%q0
+        $+scene/create *: @assert setr(0,scenecreate(%L,%#,%0)); @scene/member %q0/owner=%#; @scene/focus %#=%q0; @scene/set %q0/status=[get(%!/DATA`DEFAULT_STATUS)]; @pemit %#=Scene %q0 created and focused (status: [get(%!/DATA`DEFAULT_STATUS)]).; &MY.SID %#=%q0
 
       # NOTE: verb bodies are written as ONE physical line with `;` separators. In a
       # multi-line ($-command) attribute the FIRST command after the `$pattern:` header does

--- a/examples/packages/scene/package.yaml
+++ b/examples/packages/scene/package.yaml
@@ -1,6 +1,6 @@
 format: 1
 package: scene
-version: 1.1.0
+version: 1.4.0
 authors: [SharpMUSH]
 description: "Scene Logger: pose/say/semipose capture into the Scene System, plus the +scene/* player verbs. Ships the game policy the C# engine deliberately omits."
 license: MIT
@@ -80,46 +80,69 @@ objects:
       #   so FORMAT is never read). chr(44) emits the comma during per-arg evaluation, after the split.
       #   The recorded @scene/addpose line below is NOT RSArgs in the same way, so it still uses \,.
       #
-      # The tail (a) @asserts a scene is active in this room AND the poser is focused on
-      # it, then (b) records the third-person rendered line with @scene/addpose (explicit
-      # author %#). The two @asserts halt the command list AFTER the emit already fired, so a
-      # pose outside any scene behaves exactly like the un-hooked built-in.
+      # Flow per hook (one physical line, `;`-separated):
+      #   1. setr(WillCaptureAsPose, <room has an active scene I am focused on>) — computing %q<SceneID>
+      #      and %q<RoomID> along the way. The check is `strmatch(scenefocus(%#),scenewhere(loc(%#)))
+      #      AND not(strmatch(scenewhere,#-1*))` — a real, focused, in-room active scene (NOT just
+      #      words(), which is truthy on "#-1 NOT FOUND").
+      #   2. @if %q<WillCaptureAsPose> ⇒ record with @scene/addpose, then emit the CAP_HEADER rule.
+      #   3. ALWAYS @message/spoof the pose to the room (so a pose outside any scene behaves exactly
+      #      like the un-hooked built-in — the emit is never gated).
+      #   4. @if %q<WillCaptureAsPose> ⇒ emit the CAP_FOOTER rule.
+      # So a CAPTURED pose is framed (header + pose + footer with the Scene/Pose ids); an uncaptured
+      # one is a plain pose. The header must come AFTER addpose because it reads the new pose id.
+
+      # When a pose IS captured, frame the room line. The render LOGIC is factored into the u()-callable
+      # functions CAP_HEADER(<sceneId>) / CAP_FOOTER(<sceneId>) so the four hooks share it (no replication);
+      # the hook supplies the scene id and %# is the poser. (We deliberately keep the @remit INLINE in the
+      # hook and call these via u(), rather than @include-ing an attribute that does the @remit: empirically
+      # the @include form's @remit resolved to a locate error for a REMOTE poser — Logger and poser in
+      # different rooms — while the identical inline @remit works. @include itself is PennMUSH-faithful
+      # (it preserves the executor and q-registers), so the exact cause is NOT pinned down; until it is,
+      # the proven inline form is used. See the @include remote-enactor investigation for details.)
+      # Header = WHO posed (left); footer = the Scene/Pose ids (right) — via the common-functions
+      # header()/footer() type dispatch, fixed width 78 (room emit ⇒ no single recipient width). CAP_FOOTER
+      # reads the JUST-added pose id via last(sceneposes()), so it MUST run after @scene/addpose.
+      FUN`CAP_HEADER: |-
+        header([firstof(scenemember(%0,%#,showas),name(%#))] posed,78,left)
+      FUN`CAP_FOOTER: |-
+        footer(Scene %0 [chr(183)] Pose [last(sceneposes(%0))],78,right)
 
       # Built-in POSE (MoreCommands.Pose) emits: "<name> <message>" to the room.
       CMD`CAPTURE`POSE:
         value: |-
-          $(?i)^(pose |\:)(.*)$: @message/spoof [lcon(setr(here,loc(%#)))]=[name(%#)] %2,%#/FORMAT`POSE,%2,##; @assert words(setr(sid,scenewhere(%q<here>))); @assert strmatch(scenefocus(%#),%q<sid>); @scene/addpose %q<sid>=%#,[scenemember(%q<sid>,%#,showas)],%q<here>,pose,,[name(%#)] %2
+          $(?i)^(pose |\:)(.*)$: @if setr(WillCaptureAsPose,and(strmatch(scenefocus(%#),setr(SceneID,scenewhere(setr(RoomID,loc(%#))))),not(strmatch(%q<SceneID>,#-1*))))={@scene/addpose %q<SceneID>=%#,[scenemember(%q<SceneID>,%#,showas)],%q<RoomID>,pose,,[name(%#)] %2; @remit %q<RoomID>=[u(%!/FUN`CAP_HEADER,%q<SceneID>)]}; @message/spoof [lcon(%q<RoomID>)]=[name(%#)] %2,%#/FORMAT`POSE,%2,##; @if %q<WillCaptureAsPose>={@remit %q<RoomID>=[u(%!/FUN`CAP_FOOTER,%q<SceneID>)]}
         flags: [REGEXP]
 
       # Built-in SAY (MoreCommands.Say) emits "You say, \"<msg>\"" to the speaker
       # and "<name> says, \"<msg>\"" to everyone else in the room.
       CMD`CAPTURE`SAY:
         value: |-
-          $(?i)^(say |")(.*)$: @message/spoof [lcon(setr(here,loc(%#)))]=[name(%#)] says[chr(44)] "%2",%#/FORMAT`SAY,%2,##; @assert words(setr(sid,scenewhere(%q<here>))); @assert strmatch(scenefocus(%#),%q<sid>); @scene/addpose %q<sid>=%#,[scenemember(%q<sid>,%#,showas)],%q<here>,say,,[name(%#)] says\, "%2"
+          $(?i)^(say |")(.*)$: @if setr(WillCaptureAsPose,and(strmatch(scenefocus(%#),setr(SceneID,scenewhere(setr(RoomID,loc(%#))))),not(strmatch(%q<SceneID>,#-1*))))={@scene/addpose %q<SceneID>=%#,[scenemember(%q<SceneID>,%#,showas)],%q<RoomID>,say,,[name(%#)] says\, "%2"; @remit %q<RoomID>=[u(%!/FUN`CAP_HEADER,%q<SceneID>)]}; @message/spoof [lcon(%q<RoomID>)]=[name(%#)] says[chr(44)] "%2",%#/FORMAT`SAY,%2,##; @if %q<WillCaptureAsPose>={@remit %q<RoomID>=[u(%!/FUN`CAP_FOOTER,%q<SceneID>)]}
         flags: [REGEXP]
 
       # Built-in SEMIPOSE (MoreCommands.SemiPose) emits "<name><message>" (no space).
       CMD`CAPTURE`SEMI:
         value: |-
-          $(?i)^(semipose |;)(.*)$: @message/spoof [lcon(setr(here,loc(%#)))]=[name(%#)]%2,%#/FORMAT`SEMIPOSE,%2,##; @assert words(setr(sid,scenewhere(%q<here>))); @assert strmatch(scenefocus(%#),%q<sid>); @scene/addpose %q<sid>=%#,[scenemember(%q<sid>,%#,showas)],%q<here>,semipose,,[name(%#)]%2
+          $(?i)^(semipose |;)(.*)$: @if setr(WillCaptureAsPose,and(strmatch(scenefocus(%#),setr(SceneID,scenewhere(setr(RoomID,loc(%#))))),not(strmatch(%q<SceneID>,#-1*))))={@scene/addpose %q<SceneID>=%#,[scenemember(%q<SceneID>,%#,showas)],%q<RoomID>,semipose,,[name(%#)]%2; @remit %q<RoomID>=[u(%!/FUN`CAP_HEADER,%q<SceneID>)]}; @message/spoof [lcon(%q<RoomID>)]=[name(%#)]%2,%#/FORMAT`SEMIPOSE,%2,##; @if %q<WillCaptureAsPose>={@remit %q<RoomID>=[u(%!/FUN`CAP_FOOTER,%q<SceneID>)]}
         flags: [REGEXP]
 
       # Built-in @EMIT emits "<message>" verbatim (no name) to the room.
       CMD`CAPTURE`EMIT:
         value: |-
-          $(?i)^@emit (.*)$: @message/spoof [lcon(setr(here,loc(%#)))]=%1,%#/FORMAT`EMIT,%1,##; @assert words(setr(sid,scenewhere(%q<here>))); @assert strmatch(scenefocus(%#),%q<sid>); @scene/addpose %q<sid>=%#,[scenemember(%q<sid>,%#,showas)],%q<here>,emit,,%1
+          $(?i)^@emit (.*)$: @if setr(WillCaptureAsPose,and(strmatch(scenefocus(%#),setr(SceneID,scenewhere(setr(RoomID,loc(%#))))),not(strmatch(%q<SceneID>,#-1*))))={@scene/addpose %q<SceneID>=%#,[scenemember(%q<SceneID>,%#,showas)],%q<RoomID>,emit,,%1; @remit %q<RoomID>=[u(%!/FUN`CAP_HEADER,%q<SceneID>)]}; @message/spoof [lcon(%q<RoomID>)]=%1,%#/FORMAT`EMIT,%1,##; @if %q<WillCaptureAsPose>={@remit %q<RoomID>=[u(%!/FUN`CAP_FOOTER,%q<SceneID>)]}
         flags: [REGEXP]
 
       # ---- create / lifecycle ---------------------------------------------------
-      # NOTE: capture the new scene id into %q0 with @assert (it both sets the register and
-      # aborts cleanly if creation fails — the id is truthy), then drive the writes off %q0.
+      # NOTE: capture the new scene id into %q<SceneID> with @assert (it both sets the register and
+      # aborts cleanly if creation fails — the id is truthy), then drive the writes off %q<SceneID>.
       # IMPORTANT: the body is one PHYSICAL line with `;` separators. q-registers are shared
       # across `;`-separated commands but NOT across newline-separated ones in a $-command
-      # body, so the original multi-line `|-` form lost %q0 between writes. The original
-      # `&MY.SID %#=[setr(0,…)]` also failed (setr inside an &attr=<value> RHS doesn't
+      # body, so the original multi-line `|-` form lost %q<SceneID> between writes. The original
+      # `&MY.SID %#=[setr(SceneID,…)]` also failed (setr inside an &attr=<value> RHS doesn't
       # propagate its register); @assert in command position does.
       CMD`CREATE: |-
-        $+scene/create *: @assert setr(0,scenecreate(%L,%#,%0)); @scene/member %q0/owner=%#; @scene/focus %#=%q0; @scene/set %q0/status=[get(%!/DATA`DEFAULT_STATUS)]; @pemit %#=Scene %q0 created and focused (status: [get(%!/DATA`DEFAULT_STATUS)]).; &MY.SID %#=%q0
+        $+scene/create *: @assert setr(SceneID,scenecreate(%L,%#,%0)); @scene/member %q<SceneID>/owner=%#; @scene/focus %#=%q<SceneID>; @scene/set %q<SceneID>/status=[get(%!/DATA`DEFAULT_STATUS)]; @pemit %#=Scene %q<SceneID> created and focused (status: [get(%!/DATA`DEFAULT_STATUS)]).; &MY.SID %#=%q<SceneID>
 
       # NOTE: verb bodies are written as ONE physical line with `;` separators. In a
       # multi-line ($-command) attribute the FIRST command after the `$pattern:` header does
@@ -139,10 +162,10 @@ objects:
         $+scene/join *: @scene/member %0/participant=%#; @scene/focus %#=%0; @pemit %#=Joined and focused on scene %0.
 
       # NOTE: one physical line (q-registers cross `;` but not newlines in a $-command body).
-      # Capture the focused scene id into %q0 BEFORE @scene/focus clears it (@assert sets the
-      # register and no-ops cleanly when not focused), then drive the writes off %q0.
+      # Capture the focused scene id into %q<SceneID> BEFORE @scene/focus clears it (@assert sets the
+      # register and no-ops cleanly when not focused), then drive the writes off %q<SceneID>.
       CMD`LEAVE: |-
-        $+scene/leave: @assert setr(0,scenefocus(%#)); @scene/focus %#=; @if not(words(sceneposes(%q0,%#)))={@scene/unmember %q0=%#}; @pemit %#=Left the scene.; &MY.SID %#=%q0
+        $+scene/leave: @assert setr(SceneID,scenefocus(%#)); @scene/focus %#=; @if not(words(sceneposes(%q<SceneID>,%#)))={@scene/unmember %q<SceneID>=%#}; @pemit %#=Left the scene.; &MY.SID %#=%q<SceneID>
 
       CMD`TAG: |-
         $+scene/tag *: @scene/member %0/attending=%#; @pemit %#=RSVP'd to scene %0.
@@ -150,15 +173,15 @@ objects:
       CMD`UNTAG: |-
         $+scene/untag *: @scene/unmember %0=%#; @pemit %#=Removed RSVP from scene %0.
 
-      CMD`SHOWAS: |-
-        $+scene/showas *: @scene/showas [scenefocus(%#)]/%#=%0; @pemit %#=Future poses show as: %0
+      CMD`AS: |-
+        $+scene/as *: @scene/showas [scenefocus(%#)]/%#=%0; @pemit %#=Future poses show as: %0
 
       # ---- edit your own poses --------------------------------------------------
-      # %1 is find^^^replace; author-only is enforced by @scene/editpose. Compute the new
-      # content into %q0 in a separate command first (a nested function reference to the
-      # verb's %0/%1 inside an @scene arg does not resolve reliably), then edit off %q0.
+      # %1 is find^^^replace; author-only is enforced by @scene/editpose. Stash the poseId in %q<pid>
+      # and compute the new content into %q<new> in a separate command first (a nested function
+      # reference to the verb's %0/%1 inside an @scene arg does not resolve reliably), then edit off them.
       CMD`EDIT: |-
-        $+scene/edit *=*: @assert setr(1,%0); @assert setr(0,edit(scenepose(scenefocus(%#),%q1,content),before(%1,^^^),after(%1,^^^))); @scene/editpose %q1=%#,%q0
+        $+scene/edit *=*: @assert setr(pid,%0); @assert setr(new,edit(scenepose(scenefocus(%#),%q<pid>,content),before(%1,^^^),after(%1,^^^))); @scene/editpose %q<pid>=%#,%q<new>
 
       CMD`UNDO: |-
         $+scene/undo *: @scene/undo %0
@@ -186,8 +209,8 @@ objects:
       # sceneposes() returns a SPACE-separated id list, so iter() must use the default
       # space input delimiter (an `@` input delim collapsed the whole list into one bogus
       # id → #-1). %r is the output separator (one pose content per line).
-      CMD`RECAP: |-
-        $+scene/recap *: @pemit %#=[iter(sceneposes(scenefocus(%#),,%0),scenepose(scenefocus(%#),##,content),%b,%r)]
+      CMD`RECALL: |-
+        $+scene/recall *: @pemit %#=[iter(sceneposes(scenefocus(%#),,%0),scenepose(scenefocus(%#),##,content),%b,%r)]
 
       # ---- pose tracker (+pot): query-on-run turn tracker for the focused scene --
       # No hooks, no state: rebuilt each run from the recorded poses. A member's last
@@ -203,66 +226,72 @@ objects:
       FUN`POT_ROW: |-
         align(>3 <[sub(%3,30)] >14 <9,%2,[name(%1)][switch(scenemember(%0,%1,showas),,,%b\([scenemember(%0,%1,showas)]\))],u(%!/FUN`POT_IDLE,%0,%1),switch(%2,1,<- up,))
       # Control flow is guard-then-display: INC`REQUIRE`FOCUS early-exits via @assert (no switch() for
-      # output) and leaves %q<sid> set for the shared display tail, which is @included with that id.
+      # output) and leaves %q<SceneID> set for the shared display tail, which is @included with that id.
       INC`REQUIRE`FOCUS: |-
-        @assert not(strmatch(setr(sid,scenefocus(%#)),#-1*))=@pemit %#=You are not focused on a scene. Use +scene/join <id> or +scene/create <title>.
+        @assert not(strmatch(setr(SceneID,scenefocus(%#)),#-1*))=@pemit %#=You are not focused on a scene. Use +scene/join <id> or +scene/create <title>.
       INC`DISPLAY`POT: |-
         @pemit %#=[header(Pose Tracker - Scene %0,width(%#))]%r[iter(sort(iter(scenemembers(%0),u(%!/FUN`POT_KEY,%0,##))),u(%!/FUN`POT_ROW,%0,after(##,~),inum(0),width(%#)),,%r)]%r[footer([words(scenemembers(%0))] in scene - oldest pose is up next,width(%#))]
       CMD`POT: |-
-        $+scene/pot: @include %!/INC`REQUIRE`FOCUS; @include %!/INC`DISPLAY`POT=%q<sid>
+        $+pot: @include %!/INC`REQUIRE`FOCUS; @include %!/INC`DISPLAY`POT=%q<SceneID>
 
-      # ---- scene browser (+scene/list [filter]): align()'d table of scenes -------
-      # filter: active | recent (default) | scheduled | mine. Width-adaptive columns;
-      # the Title column flexes to fill the user's terminal width(%#).
+      # ---- scene browser: align()'d tables of scenes -----------------------------
+      # Volund-style listing: bare `+scene` = active scenes, `+scene/old` = finished, `+scene/mine` =
+      # yours. FUN`LIST_RENDER(<filter>,<width>) builds the whole table; the Title column flexes to
+      # the user's terminal width(%#). (Scene DETAILS are `+scene <id>`; scheduled scenes `+scene/upcoming`.)
       FUN`LIST_TITLE: |-
         [switch(setr(ttl,scene(%0,title)),#-1*,\(untitled\),%q<ttl>)]
       FUN`LIST_ROW: |-
         align(<10 <[sub(%2,41)] <14 >5 <8,left(%0,10),left(u(%!/FUN`LIST_TITLE,%0),sub(%2,42)),left(scene(%0,roomname),14),words(scenemembers(%0)),scene(%0,status),%1)
-      CMD`LIST: |-
-        $+scene/list*: @pemit %#=[setq(flt,firstof(edit(%0,%b,),recent))][setq(lst,scenelist(%q<flt>))][header(Scenes: %q<flt>,width(%#))]%r[align(<10 <[sub(width(%#),41)] <14 >5 <8,ID,Title,Where,Cast,Status,%b)]%r[iter(%q<lst>,u(%!/FUN`LIST_ROW,##,%b,width(%#)),,%r)]%r[footer([words(%q<lst>)] scenes,width(%#))]
+      FUN`LIST_RENDER: |-
+        [setq(lst,scenelist(%0))][header(Scenes: %0,%1)]%r[align(<10 <[sub(%1,41)] <14 >5 <8,ID,Title,Where,Cast,Status,%b)]%r[iter(%q<lst>,u(%!/FUN`LIST_ROW,##,%b,%1),,%r)]%r[footer([words(%q<lst>)] scenes,%1)]
+      CMD`BROWSE: |-
+        $+scene: @pemit %#=[u(%!/FUN`LIST_RENDER,active,width(%#))]
+      CMD`OLD: |-
+        $+scene/old: @pemit %#=[u(%!/FUN`LIST_RENDER,finished,width(%#))]
+      CMD`MINE: |-
+        $+scene/mine: @pemit %#=[u(%!/FUN`LIST_RENDER,mine,width(%#))]
 
       # ---- scheduling (+scene/schedule ...): roomless future scenes --------------
       # When = a convtime()-parseable date string OR raw epoch-seconds; scheduledfor is UTC-millis.
       FUN`SCHED_WHEN: |-
         mul(firstof(convtime(%0),%0),1000)
-      CMD`SCHED_ADD: |-
-        $+scene/schedule/add *=*: @assert setr(sid,scenecreate(,%#,%0)); @scene/member %q<sid>/owner=%#; @scene/set %q<sid>/status=scheduled; @scene/set %q<sid>/scheduledfor=[u(%!/FUN`SCHED_WHEN,%1)]; @pemit %#=Scheduled scene %q<sid> "%0" for [convsecs(div(u(%!/FUN`SCHED_WHEN,%1),1000))].
-      CMD`SCHED_RESCHED: |-
-        $+scene/schedule/reschedule *=*: @assert u(%!/FUN`OWNS,%#,%0); @scene/set %0/scheduledfor=[u(%!/FUN`SCHED_WHEN,%1)]; @pemit %#=Rescheduled scene %0 for [convsecs(div(u(%!/FUN`SCHED_WHEN,%1),1000))].
-      CMD`SCHED_DEL: |-
-        $+scene/schedule/del *: @assert u(%!/FUN`OWNS,%#,%0); @scene/delete %0; @pemit %#=Deleted scheduled scene %0.
+      CMD`SCHEDULE: |-
+        $+scene/schedule *=*: @assert setr(SceneID,scenecreate(,%#,%0)); @scene/member %q<SceneID>/owner=%#; @scene/set %q<SceneID>/status=scheduled; @scene/set %q<SceneID>/scheduledfor=[u(%!/FUN`SCHED_WHEN,%1)]; @pemit %#=Scheduled scene %q<SceneID> "%0" for [convsecs(div(u(%!/FUN`SCHED_WHEN,%1),1000))].
+      CMD`RESCHEDULE: |-
+        $+scene/reschedule *=*: @assert u(%!/FUN`OWNS,%#,%0); @scene/set %0/scheduledfor=[u(%!/FUN`SCHED_WHEN,%1)]; @pemit %#=Rescheduled scene %0 for [convsecs(div(u(%!/FUN`SCHED_WHEN,%1),1000))].
+      CMD`UNSCHEDULE: |-
+        $+scene/unschedule *: @assert u(%!/FUN`OWNS,%#,%0); @scene/delete %0; @pemit %#=Deleted scheduled scene %0.
       FUN`SCHED_ROW: |-
         align(<10 <[sub(%1,42)] <24 >6,left(%0,10),left(u(%!/FUN`LIST_TITLE,%0),sub(%1,43)),convsecs(div(scene(%0,scheduledfor),1000)),words(scenemembers(%0)))
-      CMD`SCHED_LIST: |-
-        $+scene/schedule: @pemit %#=[setq(lst,scenelist(scheduled))][header(Scheduled Scenes,width(%#))]%r[align(<10 <[sub(width(%#),42)] <24 >6,ID,Title,When,RSVP)]%r[iter(%q<lst>,u(%!/FUN`SCHED_ROW,##,width(%#)),,%r)]%r[footer([words(%q<lst>)] scheduled,width(%#))]
+      CMD`UPCOMING: |-
+        $+scene/upcoming: @pemit %#=[setq(lst,scenelist(scheduled))][header(Scheduled Scenes,width(%#))]%r[align(<10 <[sub(width(%#),42)] <24 >6,ID,Title,When,RSVP)]%r[iter(%q<lst>,u(%!/FUN`SCHED_ROW,##,width(%#)),,%r)]%r[footer([words(%q<lst>)] scheduled,width(%#))]
 
       # ---- participation (+scene/deactivate | /activate): pause/resume w/o leaving -
       # /deactivate clears your focus so poses stop recording, but keeps your membership
       # (and your existing poses); /activate re-focuses you so capture resumes. Softer
       # than join/leave, which add/remove membership.
       CMD`DEACTIVATE: |-
-        $+scene/deactivate: @assert setr(sid,scenefocus(%#)); @scene/focus %#=; @pemit %#=Deactivated scene %q<sid> - still a member, poses paused. +scene/activate %q<sid> to resume.
+        $+scene/deactivate: @assert setr(SceneID,scenefocus(%#)); @scene/focus %#=; @pemit %#=Deactivated scene %q<SceneID> - still a member, poses paused. +scene/activate %q<SceneID> to resume.
       CMD`ACTIVATE: |-
         $+scene/activate *: @scene/member %0/participant=%#; @scene/focus %#=%0; @pemit %#=Activated scene %0 - your poses are recorded again.
 
       # ---- summary + info card --------------------------------------------------
       # SCENE_FIELD(scene,field,default) reads a field, substituting <default> for an unset/#-1 result.
-      # +scene/info guards (focused scene, or a valid id arg) via @assert/@include, sets %q<sid>, then
+      # +scene <id> guards the id arg via @assert/@include, sets %q<SceneID>, then
       # @includes the shared display tail — no switch() picks the output.
       FUN`SCENE_FIELD: |-
         switch(setr(val,scene(%0,%1)),#-1*,%2,%q<val>)
       FUN`INFO_LINE: |-
         align(>9 <[sub(%2,11)],ansi(h,%0),%1)
       INC`REQUIRE`SCENE: |-
-        @assert not(strmatch(scene(setr(sid,%0),status),#-1*))=@pemit %#=No such scene: %0
+        @assert not(strmatch(scene(setr(SceneID,%0),status),#-1*))=@pemit %#=No such scene: %0
       INC`DISPLAY`INFO: |-
-        @pemit %#=[header(Scene %0,width(%#))]%r[u(%!/FUN`INFO_LINE,Title,u(%!/FUN`LIST_TITLE,%0),width(%#))]%r[u(%!/FUN`INFO_LINE,Summary,u(%!/FUN`SCENE_FIELD,%0,summary,-),width(%#))]%r[u(%!/FUN`INFO_LINE,Owner,scene(%0,ownername),width(%#))]%r[u(%!/FUN`INFO_LINE,Where,u(%!/FUN`SCENE_FIELD,%0,roomname,\(roomless\)),width(%#))]%r[u(%!/FUN`INFO_LINE,Status,scene(%0,status),width(%#))]%r[u(%!/FUN`INFO_LINE,Poses,scene(%0,posecount),width(%#))]%r[u(%!/FUN`INFO_LINE,Cast,scenecast(%0),width(%#))]%r[footer(,width(%#))]
-      CMD`SUMMARY: |-
-        $+scene/summary *: @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/summary=%0; @pemit %#=Summary set for scene [scenefocus(%#)].
-      CMD`INFO: |-
-        $+scene/info: @include %!/INC`REQUIRE`FOCUS; @include %!/INC`DISPLAY`INFO=%q<sid>
-      CMD`INFO_ARG: |-
-        $+scene/info *: @include %!/INC`REQUIRE`SCENE=%0; @include %!/INC`DISPLAY`INFO=%q<sid>
+        @pemit %#=[header(Scene %0,width(%#))]%r[u(%!/FUN`INFO_LINE,Title,u(%!/FUN`LIST_TITLE,%0),width(%#))]%r[u(%!/FUN`INFO_LINE,Pitch,u(%!/FUN`SCENE_FIELD,%0,summary,-),width(%#))]%r[u(%!/FUN`INFO_LINE,Owner,scene(%0,ownername),width(%#))]%r[u(%!/FUN`INFO_LINE,Where,u(%!/FUN`SCENE_FIELD,%0,roomname,\(roomless\)),width(%#))]%r[u(%!/FUN`INFO_LINE,Status,scene(%0,status),width(%#))]%r[u(%!/FUN`INFO_LINE,Poses,scene(%0,posecount),width(%#))]%r[u(%!/FUN`INFO_LINE,Cast,scenecast(%0),width(%#))]%r[footer(,width(%#))]
+      CMD`PITCH: |-
+        $+scene/pitch *: @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/summary=%0; @pemit %#=Pitch set for scene [scenefocus(%#)].
+      # Scene DETAILS card: `+scene <id>` (Volund-style; bare `+scene` is the active list).
+      CMD`SHOW: |-
+        $+scene *: @include %!/INC`REQUIRE`SCENE=%0; @include %!/INC`DISPLAY`INFO=%q<SceneID>
 
       # ---- lifecycle: (re-)establish the three OVERRIDE capture hooks -----------
       # PennMUSH form: @hook/<type> <command> = <object>, <attribute> (RSArgs comma-split).

--- a/examples/packages/scene/package.yaml
+++ b/examples/packages/scene/package.yaml
@@ -1,6 +1,6 @@
 format: 1
 package: scene
-version: 1.4.0
+version: 1.5.0
 authors: [SharpMUSH]
 description: "Scene Logger: pose/say/semipose capture into the Scene System, plus the +scene/* player verbs. Ships the game policy the C# engine deliberately omits."
 license: MIT
@@ -92,45 +92,42 @@ objects:
       # So a CAPTURED pose is framed (header + pose + footer with the Scene/Pose ids); an uncaptured
       # one is a plain pose. The header must come AFTER addpose because it reads the new pose id.
 
-      # When a pose IS captured, frame the room line. The render LOGIC is factored into the u()-callable
-      # functions CAP_HEADER(<sceneId>) / CAP_FOOTER(<sceneId>) so the four hooks share it (no replication);
-      # the hook supplies the scene id and %# is the poser. (We deliberately keep the @remit INLINE in the
-      # hook and call these via u(), rather than @include-ing an attribute that does the @remit: empirically
-      # the @include form's @remit resolved to a locate error for a REMOTE poser — Logger and poser in
-      # different rooms — while the identical inline @remit works. @include itself is PennMUSH-faithful
-      # (it preserves the executor and q-registers), so the exact cause is NOT pinned down; until it is,
-      # the proven inline form is used. See the @include remote-enactor investigation for details.)
+      # When a pose IS captured, frame the room line. The emit LOGIC is factored into INC`CAP_HEADER /
+      # INC`CAP_FOOTER and the four capture hooks @include them, so there is no replicated @remit (they
+      # read the hook's %q<RoomID> / %q<SceneID> registers; %# is the poser). @include runs the tail AS the
+      # Logger (the executor), so it works even for a REMOTE poser — this relied on the engine fix that
+      # makes @include locate its target (%!) as the executor, not the enactor.
       # Header = WHO posed (left); footer = the Scene/Pose ids (right) — via the common-functions
       # header()/footer() type dispatch, fixed width 78 (room emit ⇒ no single recipient width). CAP_FOOTER
       # reads the JUST-added pose id via last(sceneposes()), so it MUST run after @scene/addpose.
-      FUN`CAP_HEADER: |-
-        header([firstof(scenemember(%0,%#,showas),name(%#))] posed,78,left)
-      FUN`CAP_FOOTER: |-
-        footer(Scene %0 [chr(183)] Pose [last(sceneposes(%0))],78,right)
+      INC`CAP_HEADER: |-
+        @remit %q<RoomID>=[header([firstof(scenemember(%q<SceneID>,%#,showas),name(%#))] posed,78,left)]
+      INC`CAP_FOOTER: |-
+        @remit %q<RoomID>=[footer(Scene %q<SceneID> [chr(183)] Pose [last(sceneposes(%q<SceneID>))],78,right)]
 
       # Built-in POSE (MoreCommands.Pose) emits: "<name> <message>" to the room.
       CMD`CAPTURE`POSE:
         value: |-
-          $(?i)^(pose |\:)(.*)$: @if setr(WillCaptureAsPose,and(strmatch(scenefocus(%#),setr(SceneID,scenewhere(setr(RoomID,loc(%#))))),not(strmatch(%q<SceneID>,#-1*))))={@scene/addpose %q<SceneID>=%#,[scenemember(%q<SceneID>,%#,showas)],%q<RoomID>,pose,,[name(%#)] %2; @remit %q<RoomID>=[u(%!/FUN`CAP_HEADER,%q<SceneID>)]}; @message/spoof [lcon(%q<RoomID>)]=[name(%#)] %2,%#/FORMAT`POSE,%2,##; @if %q<WillCaptureAsPose>={@remit %q<RoomID>=[u(%!/FUN`CAP_FOOTER,%q<SceneID>)]}
+          $(?i)^(pose |\:)(.*)$: @if setr(WillCaptureAsPose,and(strmatch(scenefocus(%#),setr(SceneID,scenewhere(setr(RoomID,loc(%#))))),not(strmatch(%q<SceneID>,#-1*))))={@scene/addpose %q<SceneID>=%#,[scenemember(%q<SceneID>,%#,showas)],%q<RoomID>,pose,,[name(%#)] %2; @include %!/INC`CAP_HEADER}; @message/spoof [lcon(%q<RoomID>)]=[name(%#)] %2,%#/FORMAT`POSE,%2,##; @if %q<WillCaptureAsPose>={@include %!/INC`CAP_FOOTER}
         flags: [REGEXP]
 
       # Built-in SAY (MoreCommands.Say) emits "You say, \"<msg>\"" to the speaker
       # and "<name> says, \"<msg>\"" to everyone else in the room.
       CMD`CAPTURE`SAY:
         value: |-
-          $(?i)^(say |")(.*)$: @if setr(WillCaptureAsPose,and(strmatch(scenefocus(%#),setr(SceneID,scenewhere(setr(RoomID,loc(%#))))),not(strmatch(%q<SceneID>,#-1*))))={@scene/addpose %q<SceneID>=%#,[scenemember(%q<SceneID>,%#,showas)],%q<RoomID>,say,,[name(%#)] says\, "%2"; @remit %q<RoomID>=[u(%!/FUN`CAP_HEADER,%q<SceneID>)]}; @message/spoof [lcon(%q<RoomID>)]=[name(%#)] says[chr(44)] "%2",%#/FORMAT`SAY,%2,##; @if %q<WillCaptureAsPose>={@remit %q<RoomID>=[u(%!/FUN`CAP_FOOTER,%q<SceneID>)]}
+          $(?i)^(say |")(.*)$: @if setr(WillCaptureAsPose,and(strmatch(scenefocus(%#),setr(SceneID,scenewhere(setr(RoomID,loc(%#))))),not(strmatch(%q<SceneID>,#-1*))))={@scene/addpose %q<SceneID>=%#,[scenemember(%q<SceneID>,%#,showas)],%q<RoomID>,say,,[name(%#)] says\, "%2"; @include %!/INC`CAP_HEADER}; @message/spoof [lcon(%q<RoomID>)]=[name(%#)] says[chr(44)] "%2",%#/FORMAT`SAY,%2,##; @if %q<WillCaptureAsPose>={@include %!/INC`CAP_FOOTER}
         flags: [REGEXP]
 
       # Built-in SEMIPOSE (MoreCommands.SemiPose) emits "<name><message>" (no space).
       CMD`CAPTURE`SEMI:
         value: |-
-          $(?i)^(semipose |;)(.*)$: @if setr(WillCaptureAsPose,and(strmatch(scenefocus(%#),setr(SceneID,scenewhere(setr(RoomID,loc(%#))))),not(strmatch(%q<SceneID>,#-1*))))={@scene/addpose %q<SceneID>=%#,[scenemember(%q<SceneID>,%#,showas)],%q<RoomID>,semipose,,[name(%#)]%2; @remit %q<RoomID>=[u(%!/FUN`CAP_HEADER,%q<SceneID>)]}; @message/spoof [lcon(%q<RoomID>)]=[name(%#)]%2,%#/FORMAT`SEMIPOSE,%2,##; @if %q<WillCaptureAsPose>={@remit %q<RoomID>=[u(%!/FUN`CAP_FOOTER,%q<SceneID>)]}
+          $(?i)^(semipose |;)(.*)$: @if setr(WillCaptureAsPose,and(strmatch(scenefocus(%#),setr(SceneID,scenewhere(setr(RoomID,loc(%#))))),not(strmatch(%q<SceneID>,#-1*))))={@scene/addpose %q<SceneID>=%#,[scenemember(%q<SceneID>,%#,showas)],%q<RoomID>,semipose,,[name(%#)]%2; @include %!/INC`CAP_HEADER}; @message/spoof [lcon(%q<RoomID>)]=[name(%#)]%2,%#/FORMAT`SEMIPOSE,%2,##; @if %q<WillCaptureAsPose>={@include %!/INC`CAP_FOOTER}
         flags: [REGEXP]
 
       # Built-in @EMIT emits "<message>" verbatim (no name) to the room.
       CMD`CAPTURE`EMIT:
         value: |-
-          $(?i)^@emit (.*)$: @if setr(WillCaptureAsPose,and(strmatch(scenefocus(%#),setr(SceneID,scenewhere(setr(RoomID,loc(%#))))),not(strmatch(%q<SceneID>,#-1*))))={@scene/addpose %q<SceneID>=%#,[scenemember(%q<SceneID>,%#,showas)],%q<RoomID>,emit,,%1; @remit %q<RoomID>=[u(%!/FUN`CAP_HEADER,%q<SceneID>)]}; @message/spoof [lcon(%q<RoomID>)]=%1,%#/FORMAT`EMIT,%1,##; @if %q<WillCaptureAsPose>={@remit %q<RoomID>=[u(%!/FUN`CAP_FOOTER,%q<SceneID>)]}
+          $(?i)^@emit (.*)$: @if setr(WillCaptureAsPose,and(strmatch(scenefocus(%#),setr(SceneID,scenewhere(setr(RoomID,loc(%#))))),not(strmatch(%q<SceneID>,#-1*))))={@scene/addpose %q<SceneID>=%#,[scenemember(%q<SceneID>,%#,showas)],%q<RoomID>,emit,,%1; @include %!/INC`CAP_HEADER}; @message/spoof [lcon(%q<RoomID>)]=%1,%#/FORMAT`EMIT,%1,##; @if %q<WillCaptureAsPose>={@include %!/INC`CAP_FOOTER}
         flags: [REGEXP]
 
       # ---- create / lifecycle ---------------------------------------------------


### PR DESCRIPTION
Scene-package refinements, building on the merged #653. Green across **arangodb / memgraph / surrealdb** (54/54 scene + common-functions suites), full solution builds clean.

## 1. `+scene/create` is active by default
Created scenes are immediately the room's **active** scene, so pose/say/`@emit` are captured right after `+scene/create` with no separate `+scene/start`. Configurable via `DATA\`DEFAULT_STATUS` (set to `new`/`scheduled` to stage instead). Scheduling (`+scene/schedule`) is unaffected — it stays `scheduled`.

## 2. Command surface aligned to Volund's SceneSys (shorter, unified)
- bare **`+scene`** = active list, **`+scene <id>`** = details, `+scene/old` = finished, `+scene/mine`.
- `+scene/recall`, `+scene/as`, `+scene/pitch`.
- `+scene/schedule` (create), `/reschedule`, `/unschedule`, `/upcoming`.
- standalone **`+pot`**.
- Adds a **`finished`** filter to `scenelist()` across all three storage providers (for `+scene/old`).

## 3. Named q-registers only
No `%q0..%q9` anywhere in the package — `%q<SceneID>`, `%q<RoomID>`, `%q<WillCaptureAsPose>`, `%q<pid>`, … for readability.

## 4. Modern bordered capture
A **captured** pose is now framed: a left-justified header **`== [ <who> posed ] ===…`** and a right-justified footer **`…=== [ Scene N · Pose M ] ==`** (content wrapped in `[ ]`). Uncaptured poses are untouched (the emit is never gated). The capture flow reorders to **record → emit** (the pose id only exists after `@scene/addpose`). Render logic is shared via `u()`-callable `FUN\`CAP_HEADER` / `FUN\`CAP_FOOTER`.

## 5. `common-functions` `header()`/`footer()` gain a `type` arg
`center` (default — **unchanged** for existing callers) | `left` | `right`, dispatched through the `FUN\`<NAME>\`DISPLAY\`<TYPE>` attribute tree; arg counts live in `FUN\`<NAME>\`MINARGS/MAXARGS` (read by `@function`); titles are **width-clipped** so a long title never overflows the rule onto a new line. (A global `@function` runs *as its backing object, with its powers* — PennMUSH-aligned, verified in `ResolveUserDefinedFunction` — so the nested `u()` works for any caller.)

## 6. Docs
`docs/setup/scene-bootstrap.md` trimmed to **describe** the system and point at `examples/packages/scene/package.yaml` as the authoritative listing, instead of hand-duplicating softcode that drifts.

## Also
- `HookIgnoreBehaviorTests` — behavioural proof that `@hook/ignore` skips the command on a false return (matches PennMUSH).
- Packages bumped: **scene 1.4.0**, **common-functions 1.1.0**.

### Known loose thread (worked around, not blocking)
In a *remote* capture (Logger and poser in different rooms), emitting the border via `@include` produced a locate error, while the identical **inline** `@remit` works — so the border emit is kept inline. `@include` itself is **PennMUSH-faithful** (preserves executor + q-registers; verified), and the Scene Logger is confirmed `WIZARD` at runtime, so neither is the cause; the exact mechanism is unpinned and left as a diagnostic follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `+scene/create` now creates an **active** scene that starts capturing immediately.
  * Updated scene commands/UI: `+scene/as`, `+scene/recall`, `+scene/pitch`, split browser (`+scene`, `+scene/old`, `+scene/mine`), simplified scheduling (`+scene/schedule`, `+scene/reschedule`, `+scene/unschedule`, `+scene/upcoming`).
* **Bug Fixes**
  * Scene listing now supports a **finished** filter.
  * Fixed permission/lifecycle locating so command execution uses the correct caller context, preventing intermittent “not permitted/evaluate” failures in several built-in commands.
* **Documentation**
  * Refreshed scene bootstrap documentation to match the package’s behavior and defaults.
* **Chores / Tests**
  * Package versions bumped (Scene to **1.5.0**, common-functions to **1.1.0**); added/expanded integration coverage including header/footer rendering, hook ignore behavior, and remote enactor locate isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->