### PR TITLE
chore(deps): consolidate outstanding Dependabot version bumps + fix Scriban vuln

### DIFF
--- a/SharpMUSH.Benchmarks/SharpMUSH.Benchmarks.csproj
+++ b/SharpMUSH.Benchmarks/SharpMUSH.Benchmarks.csproj
@@ -11,7 +11,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
 		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />

--- a/SharpMUSH.Client/SharpMUSH.Client.csproj
+++ b/SharpMUSH.Client/SharpMUSH.Client.csproj
@@ -15,10 +15,10 @@
 	<ItemGroup>
 		<PackageReference Include="AutoBogus" Version="2.13.1" />
 		<PackageReference Include="BlazorMonaco" Version="3.4.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.7" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.7" />
 		<PackageReference Include="MudBlazor" Version="9.4.0" />
 		<PackageReference Include="OneOf" Version="3.0.271" />

--- a/SharpMUSH.Configuration/SharpMUSH.Configuration.csproj
+++ b/SharpMUSH.Configuration/SharpMUSH.Configuration.csproj
@@ -16,8 +16,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/SharpMUSH.Database/SharpMUSH.Database.csproj
+++ b/SharpMUSH.Database/SharpMUSH.Database.csproj
@@ -12,14 +12,14 @@
   <ItemGroup>
     <PackageReference Include="Core.Arango" Version="3.12.2" />
     <PackageReference Include="Core.Arango.Migration" Version="3.12.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNext" Version="6.2.0" />
+    <PackageReference Include="DotNext" Version="6.3.0" />
     <ProjectReference Include="..\SharpMUSH.Library\SharpMUSH.Library.csproj" />
     <!-- MarkupString used directly across the providers. Referenced explicitly because SharpMUSH.Library
          marks its SharpMUSH.* ProjectReferences PrivateAssets="all" (to keep them out of its NuGet

--- a/SharpMUSH.Documentation/SharpMUSH.Documentation.csproj
+++ b/SharpMUSH.Documentation/SharpMUSH.Documentation.csproj
@@ -11,7 +11,7 @@
 	<ItemGroup>
 		<PackageReference Include="ColorCode.Core" Version="2.0.15" />
 		<PackageReference Include="Markdig" Version="1.2.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
 		<PackageReference Include="OneOf" Version="3.0.271" />
 	</ItemGroup>
 

--- a/SharpMUSH.Implementation/SharpMUSH.Implementation.csproj
+++ b/SharpMUSH.Implementation/SharpMUSH.Implementation.csproj
@@ -25,8 +25,8 @@
 		<PackageReference Include="JsonPath.Net" Version="3.0.2" />
 		<PackageReference Include="McMaster.NETCore.Plugins" Version="2.0.0" />
 		<PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.7" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
 		<PackageReference Include="morelinq" Version="4.4.0" />
 		<PackageReference Include="OneOf" Version="3.0.271" />
 		<PackageReference Include="Serilog" Version="4.3.1" />

--- a/SharpMUSH.LanguageServer/SharpMUSH.LanguageServer.csproj
+++ b/SharpMUSH.LanguageServer/SharpMUSH.LanguageServer.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/SharpMUSH.Library/SharpMUSH.Library.csproj
+++ b/SharpMUSH.Library/SharpMUSH.Library.csproj
@@ -63,13 +63,13 @@
 	</Target>
 
   <ItemGroup>
-    <PackageReference Include="DotNext" Version="6.2.0" />
+    <PackageReference Include="DotNext" Version="6.3.0" />
     <PackageReference Include="Markdig" Version="0.40.0" />
-    <PackageReference Include="DotNext.Threading" Version="6.2.0" />
+    <PackageReference Include="DotNext.Threading" Version="6.3.0" />
     <PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.8" />
     <PackageReference Include="morelinq" Version="4.4.0" />
     <PackageReference Include="MySqlConnector" Version="2.5.0" />
     <PackageReference Include="NATS.Net" Version="2.7.3" />

--- a/SharpMUSH.MarkupString/SharpMUSH.MarkupString.csproj
+++ b/SharpMUSH.MarkupString/SharpMUSH.MarkupString.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.8" />
   </ItemGroup>
 
 </Project>

--- a/SharpMUSH.Messaging/SharpMUSH.Messaging.csproj
+++ b/SharpMUSH.Messaging/SharpMUSH.Messaging.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageReference Include="NATS.Net" Version="2.7.3" />
     <PackageReference Include="Testcontainers.Nats" Version="4.11.0" />
   </ItemGroup>

--- a/SharpMUSH.Server/SharpMUSH.Server.csproj
+++ b/SharpMUSH.Server/SharpMUSH.Server.csproj
@@ -17,12 +17,12 @@
 		<PackageReference Include="Core.Arango" Version="3.12.2" />
 		<PackageReference Include="Core.Arango.Serilog" Version="3.12.3" />
     <PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
-    <PackageReference Include="Scriban" Version="7.2.0" />
+    <PackageReference Include="Scriban" Version="7.2.5" />
     <PackageReference Include="Mediator.SourceGenerator" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.8" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.11.0-beta.1" />
@@ -89,10 +89,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
+    <PackageReference Include="Asp.Versioning.Mvc" Version="10.0.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
     <None Include="..\SharpMUSH.Documentation\Helpfiles\SharpMUSH\*.md">
       <Link>TextFiles\help\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/SharpMUSH.Tests.Infrastructure/SharpMUSH.Tests.Infrastructure.csproj
+++ b/SharpMUSH.Tests.Infrastructure/SharpMUSH.Tests.Infrastructure.csproj
@@ -26,7 +26,7 @@
 		<PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
 		<PackageReference Include="MySqlConnector" Version="2.5.0" />
 		<!-- Logging -->
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
 		<PackageReference Include="Serilog" Version="4.3.1" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" ExcludeAssets="compile" />

--- a/SharpMUSH.Tests.ScenePlugin/SharpMUSH.Tests.ScenePlugin.csproj
+++ b/SharpMUSH.Tests.ScenePlugin/SharpMUSH.Tests.ScenePlugin.csproj
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="TUnit" Version="1.19.16" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
     <!-- The fake IArangoStorageAccessor references Core.Arango types at runtime. -->
     <PackageReference Include="Core.Arango" Version="3.12.2" />
   </ItemGroup>


### PR DESCRIPTION
## What

Consolidates the five open **automated (Dependabot) version-up PRs** into one coordinated bump that actually builds, and fixes the Scriban security advisory that is currently failing the build on `main` itself.

Dependabot opens one PR per project, bumping a single package at a time. Under this solution's `TreatWarningsAsErrors`, that trips **NU1605 package-downgrade errors** the moment a sibling project still pins the old version transitively — which is why every one of these PRs was red in CI. Bumping them together resolves the whole graph.

## Captured PRs

| PR | Bump | Status |
|----|------|--------|
| #646 | `Asp.Versioning.Mvc` 8.1.0 → 10.0.0 | included |
| #629 | `Microsoft.AspNetCore.Components.WebAssembly` (+ `.Server`) 10.0.7 → 10.0.8 | included |
| #617 | `Microsoft.AspNetCore.Components.WebAssembly.Authentication` 10.0.7 → 10.0.8 | included |
| #628 | `DotNext` / `DotNext.Threading` 6.2.0 → 6.3.0 | included |
| #619 | `DotNext` 6.2.1 / `DotNext.Threading` 6.2.3 | **superseded** by #628 (newer, same packages) |

## Coordination changes (required for a green graph)

- `DotNext` bumped in **SharpMUSH.Database** to match SharpMUSH.Library.
- `Components.WebAssembly` bumped in **SharpMUSH.Benchmarks** to match Server.
- The whole **`Microsoft.Extensions.*` family** aligned `10.0.7 → 10.0.8`. This matches the 10.0.8 shared framework and the packages already on 10.0.8 (`JwtBearer`, `DevServer`), and stops a transitive `Logging.Abstractions → DependencyInjection.Abstractions` downgrade cascade.

## Security

- `Scriban` **7.2.0 → 7.2.5** — patches `GHSA-6q7j-xr26-3h2c` and `GHSA-q6rr-fm2g-g5x8` (both fixed in 7.2.1; 7.2.5 is latest). This advisory is failing the build on `main` today via NuGetAudit, independent of the dependency PRs, so it had to be fixed for this branch to be green.

## Verification

- ✅ `dotnet build` — **0 errors**
- ✅ `SharpMUSH.Tests` (DB-backed) — **4395 passed / 0 failed** / 198 skipped (pre-existing "Not Yet Implemented")
- ✅ `SharpMUSH.Tests.BUnit` — **112 passed / 0 failed**
- CI runs the 3-DB integration matrix; #646 already passed it with Asp.Versioning.Mvc 10.

## Follow-up

Once merged, the five source Dependabot PRs (#646, #629, #628, #619, #617) can be closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several app, server, library, and test dependencies to newer versions.
  * Included refreshes for Blazor WebAssembly, Microsoft.Extensions, DotNext, Scriban, and API versioning packages.
  * No user-facing features or public APIs were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->