### PR TITLE
chore(deps): collate Dependabot NuGet bumps + prune redundant references

### DIFF
--- a/SharpMUSH.Benchmarks/SharpMUSH.Benchmarks.csproj
+++ b/SharpMUSH.Benchmarks/SharpMUSH.Benchmarks.csproj
@@ -13,11 +13,9 @@
 		<PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-		<PackageReference Include="Testcontainers" Version="4.11.0" />
 		<PackageReference Include="Testcontainers.ArangoDb" Version="4.11.0" />
 		<PackageReference Include="Testcontainers.Nats" Version="4.11.0" />
 	</ItemGroup>

--- a/SharpMUSH.Documentation/SharpMUSH.Documentation.csproj
+++ b/SharpMUSH.Documentation/SharpMUSH.Documentation.csproj
@@ -10,7 +10,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="ColorCode.Core" Version="2.0.15" />
-		<PackageReference Include="Markdig" Version="1.2.0" />
+		<PackageReference Include="Markdig" Version="1.3.2" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
 		<PackageReference Include="OneOf" Version="3.0.271" />
 	</ItemGroup>

--- a/SharpMUSH.Library/SharpMUSH.Library.csproj
+++ b/SharpMUSH.Library/SharpMUSH.Library.csproj
@@ -64,11 +64,11 @@
 
   <ItemGroup>
     <PackageReference Include="DotNext" Version="6.3.0" />
-    <PackageReference Include="Markdig" Version="0.40.0" />
+    <PackageReference Include="Markdig" Version="1.3.2" />
     <PackageReference Include="DotNext.Threading" Version="6.4.0" />
     <PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.8" />
     <PackageReference Include="morelinq" Version="4.4.0" />
     <PackageReference Include="MySqlConnector" Version="2.5.0" />

--- a/SharpMUSH.Messaging/SharpMUSH.Messaging.csproj
+++ b/SharpMUSH.Messaging/SharpMUSH.Messaging.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageReference Include="NATS.Net" Version="2.7.3" />

--- a/SharpMUSH.Messaging/SharpMUSH.Messaging.csproj
+++ b/SharpMUSH.Messaging/SharpMUSH.Messaging.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageReference Include="NATS.Net" Version="2.7.3" />

--- a/SharpMUSH.Server/SharpMUSH.Server.csproj
+++ b/SharpMUSH.Server/SharpMUSH.Server.csproj
@@ -41,7 +41,7 @@
 		     normally trimmed from output. The McMaster plugin loader eagerly walks the shared SharpMUSH.Library
 		     reference closure and resolves each referenced assembly against the host's default load context,
 		     so FSharp.Core must be present beside the host binary for plugin loading to succeed. -->
-		<PackageReference Include="FSharp.Core" Version="10.1.203" />
+		<PackageReference Include="FSharp.Core" Version="10.1.301" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.7" />
 		<PackageReference Include="Testcontainers" Version="4.11.0" />
 		<PackageReference Include="Testcontainers.ArangoDb" Version="4.11.0" />

--- a/SharpMUSH.Server/SharpMUSH.Server.csproj
+++ b/SharpMUSH.Server/SharpMUSH.Server.csproj
@@ -43,7 +43,6 @@
 		     so FSharp.Core must be present beside the host binary for plugin loading to succeed. -->
 		<PackageReference Include="FSharp.Core" Version="10.1.301" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.7" />
-		<PackageReference Include="Testcontainers" Version="4.11.0" />
 		<PackageReference Include="Testcontainers.ArangoDb" Version="4.11.0" />
 
 	</ItemGroup>
@@ -92,7 +91,6 @@
     <PackageReference Include="Asp.Versioning.Mvc" Version="10.0.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
     <None Include="..\SharpMUSH.Documentation\Helpfiles\SharpMUSH\*.md">
       <Link>TextFiles\help\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/SharpMUSH.Tests.Infrastructure/SharpMUSH.Tests.Infrastructure.csproj
+++ b/SharpMUSH.Tests.Infrastructure/SharpMUSH.Tests.Infrastructure.csproj
@@ -12,11 +12,9 @@
 
 	<ItemGroup>
 		<!-- TUnit types for IAsyncInitializer, ClassDataSource, TestWebApplicationFactory, etc. -->
-		<PackageReference Include="TUnit" Version="1.19.16" />
 		<PackageReference Include="TUnit.AspNetCore" Version="1.19.16" />
 		<!-- ASP.NET Core test host -->
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
 		<!-- Mocking and assertions -->
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<!-- Test containers -->

--- a/SharpMUSH.Tests.Integration/SharpMUSH.Tests.Integration.csproj
+++ b/SharpMUSH.Tests.Integration/SharpMUSH.Tests.Integration.csproj
@@ -14,7 +14,6 @@
 
 	<ItemGroup>
 		<!-- TUnit test framework -->
-		<PackageReference Include="TUnit" Version="1.19.16" />
 		<PackageReference Include="TUnit.AspNetCore" Version="1.19.16" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" ExcludeAssets="compile" />
 		<!-- FSharp.Core is a runtime transitive of SharpMUSH.Library (via TelnetNegotiationCore) that the

--- a/SharpMUSH.Tests.Integration/SharpMUSH.Tests.Integration.csproj
+++ b/SharpMUSH.Tests.Integration/SharpMUSH.Tests.Integration.csproj
@@ -23,7 +23,7 @@
 		     assembly against the host's default load context — so FSharp.Core must be present beside the
 		     host binary for plugin loading to succeed. A host that loads plugins must carry its full
 		     dependency closure; this reference materializes FSharp.Core into the test host output. -->
-		<PackageReference Include="FSharp.Core" Version="10.1.203" />
+		<PackageReference Include="FSharp.Core" Version="10.1.301" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/SharpMUSH.Tests.ScenePlugin/SharpMUSH.Tests.ScenePlugin.csproj
+++ b/SharpMUSH.Tests.ScenePlugin/SharpMUSH.Tests.ScenePlugin.csproj
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="TUnit" Version="1.19.16" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
     <!-- The fake IArangoStorageAccessor references Core.Arango types at runtime. -->
     <PackageReference Include="Core.Arango" Version="3.12.2" />
   </ItemGroup>

--- a/SharpMUSH.Tests/SharpMUSH.Tests.csproj
+++ b/SharpMUSH.Tests/SharpMUSH.Tests.csproj
@@ -22,7 +22,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
-		<PackageReference Include="TUnit" Version="1.19.16" />
 		<PackageReference Include="TUnit.AspNetCore" Version="1.19.16" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" ExcludeAssets="compile" />
   </ItemGroup>


### PR DESCRIPTION
Dependency housekeeping in two independent commits.

## Commit 1 — collate Dependabot NuGet bumps
Combines the five open Dependabot PRs onto the latest `main`, plus the sibling alignment bumps needed so the solution builds without NU1605 downgrade errors.

| PR | Package | From → To | Project |
|----|---------|-----------|---------|
| #662 | FSharp.Core | 10.1.203 → 10.1.301 | Server |
| #663 | Markdig | 0.40.0 → 1.3.2 | Library |
| #666 | Microsoft.Extensions.Caching.Memory | 10.0.8 → 10.0.9 | Library |
| #667 | Microsoft.Extensions.Configuration | 10.0.8 → 10.0.9 | Tests.ScenePlugin |
| #668 | Microsoft.Extensions.DependencyInjection[.Abstractions] | 10.0.8 → 10.0.9 | Messaging |

Alignment bumps surfaced only once combined (transitive NU1605 downgrades):
- Documentation: Markdig 1.2.0 → 1.3.2 (matches Library)
- Tests.ScenePlugin: M.E.DependencyInjection 10.0.8 → 10.0.9 (matches Messaging)
- Tests.Integration: FSharp.Core 10.1.203 → 10.1.301 (matches Server)

## Commit 2 — prune 9 redundant direct references
A build-graph scan (`project.assets.json`) found direct `PackageReference`s already provided at an equal-or-higher version by a sibling package that supersedes them. Removed (verified no NU1605 downgrade):

| Project | Removed | Already provided by |
|---------|---------|--------------------|
| Benchmarks | Microsoft.AspNetCore.TestHost | Microsoft.AspNetCore.Mvc.Testing |
| Benchmarks | Testcontainers | Testcontainers.ArangoDb / .Nats |
| Server | Testcontainers | Testcontainers.ArangoDb |
| Server | Microsoft.AspNetCore.Components.WebAssembly | …Components.WebAssembly.Server |
| Messaging | Microsoft.Extensions.DependencyInjection.Abstractions | Microsoft.Extensions.DependencyInjection |
| Tests | TUnit | TUnit.AspNetCore |
| Tests.Infrastructure | TUnit | TUnit.AspNetCore |
| Tests.Infrastructure | Microsoft.AspNetCore.TestHost | Mvc.Testing / TUnit.AspNetCore |
| Tests.Integration | TUnit | TUnit.AspNetCore |

## Verification
`dotnet build SharpMUSH.sln` — **Build succeeded, 0 errors** (remaining warnings pre-existing: NU1603 CodeAnalysis.Analyzers, ANTLR grammar).

Closes #662, closes #663, closes #666, closes #667, closes #668.

🤖 Generated with [Claude Code](https://claude.com/claude-code)