### PR TITLE
fix(connection): address #664 session-resilience review items

### DIFF
--- a/SharpMUSH.Client/Services/WebSocketClientService.cs
+++ b/SharpMUSH.Client/Services/WebSocketClientService.cs
@@ -1,7 +1,6 @@
 using System.Collections.Concurrent;
 using System.Net.WebSockets;
 using System.Text;
-using System.Text.Json;
 
 namespace SharpMUSH.Client.Services;
 

--- a/SharpMUSH.ConnectionServer/ProtocolHandlers/ConnectionPump.cs
+++ b/SharpMUSH.ConnectionServer/ProtocolHandlers/ConnectionPump.cs
@@ -88,18 +88,26 @@ public sealed class ConnectionPump(
 		}
 		finally
 		{
-			// Detach (hold the session) instead of disconnecting; the grace timer does the real
-			// disconnect if the client does not come back.
-			sinkRegistry.Get(handle)?.Detach();
-			detachedTracker.Detach(handle, async () =>
+			// Only tear down if THIS pump's transport is still the sink's active one. If a newer pump
+			// rebound this handle while we were exiting (connection-steal), it has already Attached its own
+			// transport and cancelled the grace timer — so our exit must not detach its transport or
+			// schedule a disconnect for the live session it now owns. Ownership is "I am sink.Current".
+			var sink = sinkRegistry.Get(handle);
+			if (sink is not null && ReferenceEquals(sink.Current, transport))
 			{
-				await connectionService.DisconnectAsync(handle);
-				descriptorGenerator.ReleaseWebSocketDescriptor(handle);
-				sinkRegistry.Remove(handle);
-				// The session is over for good — release its replay bookkeeping (the durable buffer itself
-				// ages out via the store's retention, so a late resume-to-dead still works).
-				await replayStore.DropAsync(session, CancellationToken.None);
-			}, grace);
+				// Detach (hold the session) instead of disconnecting; the grace timer does the real
+				// disconnect if the client does not come back.
+				sink.Detach();
+				detachedTracker.Detach(handle, async () =>
+				{
+					await connectionService.DisconnectAsync(handle);
+					descriptorGenerator.ReleaseWebSocketDescriptor(handle);
+					sinkRegistry.Remove(handle);
+					// The session is over for good — release its replay bookkeeping (the durable buffer itself
+					// ages out via the store's retention, so a late resume-to-dead still works).
+					await replayStore.DropAsync(session, CancellationToken.None);
+				}, grace);
+			}
 		}
 	}
 
@@ -129,7 +137,7 @@ public sealed class ConnectionPump(
 		var newToken = await resumeTokens.MintAsync(oldHandle, oldSession, ct);
 		await transport.SendAsync(SeqEnvelope.ResumeToken(newToken), ct);
 
-		logger.LogInformation("Reattached to session {Handle}", oldHandle);
+		logger.LogInformation("Reattached handle {Handle} to session {Session}", oldHandle, oldSession);
 		return (oldHandle, oldSession);
 	}
 

--- a/SharpMUSH.ConnectionServer/ProtocolHandlers/ConnectionPump.cs
+++ b/SharpMUSH.ConnectionServer/ProtocolHandlers/ConnectionPump.cs
@@ -25,6 +25,7 @@ public sealed class ConnectionPump(
 	public async Task RunAsync(IDuplexTransport transport, long candidateHandle, CancellationToken ct)
 	{
 		long handle;
+		string session;
 
 		var firstFrame = await transport.ReceiveTextAsync(ct);
 		if (firstFrame is null)
@@ -37,12 +38,12 @@ public sealed class ConnectionPump(
 			&& await TryRebindAsync(transport, token, lastSeq, ct) is { } rebound)
 		{
 			descriptorGenerator.ReleaseWebSocketDescriptor(candidateHandle);
-			handle = rebound;
+			(handle, session) = rebound;
 		}
 		else
 		{
 			handle = candidateHandle;
-			await RegisterFreshAsync(transport, handle, ct);
+			session = await RegisterFreshAsync(transport, handle, ct);
 
 			if (SeqEnvelope.TryReadResume(firstFrame, out var deadToken, out var deadLastSeq))
 			{
@@ -53,7 +54,7 @@ public sealed class ConnectionPump(
 					foreach (var f in await replayStore.AfterAsync(oldSession, deadLastSeq, ct))
 						await transport.SendAsync(f, ct);
 			}
-			else if (!IsHello(firstFrame))
+			else if (!SeqEnvelope.IsHello(firstFrame))
 			{
 				// Not hello and not resume — a real command arrived first; don't drop it.
 				await PublishInputAsync(handle, firstFrame, ct);
@@ -90,12 +91,15 @@ public sealed class ConnectionPump(
 				await connectionService.DisconnectAsync(handle);
 				descriptorGenerator.ReleaseWebSocketDescriptor(handle);
 				sinkRegistry.Remove(handle);
+				// The session is over for good — release its replay bookkeeping (the durable buffer itself
+				// ages out via the store's retention, so a late resume-to-dead still works).
+				await replayStore.DropAsync(session, CancellationToken.None);
 			}, grace);
 		}
 	}
 
-	/// <summary>Rebind to a live handle; returns the handle, or null to fall back to the fresh path.</summary>
-	private async Task<long?> TryRebindAsync(IDuplexTransport transport, string token, long lastSeq, CancellationToken ct)
+	/// <summary>Rebind to a live handle; returns the (handle, session), or null to fall back to the fresh path.</summary>
+	private async Task<(long Handle, string Session)?> TryRebindAsync(IDuplexTransport transport, string token, long lastSeq, CancellationToken ct)
 	{
 		var (found, oldHandle, oldSession) = await resumeTokens.TryResolveAsync(token, ct);
 		if (!found) return null;
@@ -121,10 +125,11 @@ public sealed class ConnectionPump(
 		await transport.SendAsync(SeqEnvelope.ResumeToken(newToken), ct);
 
 		logger.LogInformation("Reattached to session {Handle}", oldHandle);
-		return oldHandle;
+		return (oldHandle, oldSession);
 	}
 
-	private async Task RegisterFreshAsync(IDuplexTransport transport, long handle, CancellationToken ct)
+	/// <summary>Registers a fresh session and returns its per-incarnation session id.</summary>
+	private async Task<string> RegisterFreshAsync(IDuplexTransport transport, long handle, CancellationToken ct)
 	{
 		// A fresh incarnation gets a unique session id. Replay is keyed by it (never by the reusable
 		// handle), so a recycled handle's new occupant can never read this session's buffer, and vice
@@ -152,6 +157,7 @@ public sealed class ConnectionPump(
 
 		var token = await resumeTokens.MintAsync(handle, session, ct);
 		await transport.SendAsync(SeqEnvelope.ResumeToken(token), ct);
+		return session;
 	}
 
 	private async Task PublishInputAsync(long handle, string message, CancellationToken ct)
@@ -161,6 +167,4 @@ public sealed class ConnectionPump(
 		else
 			await publishEndpoint.Publish(new WebSocketInputMessage(handle, message), ct);
 	}
-
-	private static bool IsHello(string frame) => SeqEnvelope.IsHello(frame);
 }

--- a/SharpMUSH.ConnectionServer/ProtocolHandlers/ConnectionPump.cs
+++ b/SharpMUSH.ConnectionServer/ProtocolHandlers/ConnectionPump.cs
@@ -56,7 +56,9 @@ public sealed class ConnectionPump(
 						await transport.SendAsync(f, ct);
 					// Spend the token, as the rebind path does — it is single-use, so a retry can't re-fetch
 					// this buffer. The fresh registration above already issued this connection a new token.
-					await resumeTokens.InvalidateAsync(deadToken, ct);
+					// Use CancellationToken.None: this single-use invalidation must still run even if the
+					// connection token cancels mid-replay, or a retry could re-fetch the same buffer.
+					await resumeTokens.InvalidateAsync(deadToken, CancellationToken.None);
 				}
 			}
 			else if (!SeqEnvelope.IsHello(firstFrame))
@@ -133,7 +135,8 @@ public sealed class ConnectionPump(
 
 		// Rotate the resume token: the one just used is now spent (single-use / forward-secure), and the
 		// client needs a fresh one so a *subsequent* drop can resume too. Same incarnation → same session id.
-		await resumeTokens.InvalidateAsync(token, ct);
+		// CancellationToken.None: spending the used token must not be skipped if the connection token cancels.
+		await resumeTokens.InvalidateAsync(token, CancellationToken.None);
 		var newToken = await resumeTokens.MintAsync(oldHandle, oldSession, ct);
 		await transport.SendAsync(SeqEnvelope.ResumeToken(newToken), ct);
 
@@ -176,7 +179,12 @@ public sealed class ConnectionPump(
 
 		await connectionService.RegisterAsync(
 			handle, transport.RemoteIp, transport.Hostname, transport.Kind,
-			output, output, () => Encoding.UTF8, () => _ = sink.Current?.CloseAsync());
+			// Close the current transport on forced disconnect, observing the fault instead of dropping it
+			// into TaskScheduler.UnobservedTaskException — same pattern as the grace-timer path.
+			output, output, () => Encoding.UTF8,
+			() => TimerGraceScheduler.Fire(
+				() => sink.Current?.CloseAsync() ?? Task.CompletedTask,
+				ex => logger.LogError(ex, "Error closing transport on forced disconnect for handle {Handle}", handle)));
 
 		var token = await resumeTokens.MintAsync(handle, session, ct);
 		await transport.SendAsync(SeqEnvelope.ResumeToken(token), ct);

--- a/SharpMUSH.ConnectionServer/ProtocolHandlers/ConnectionPump.cs
+++ b/SharpMUSH.ConnectionServer/ProtocolHandlers/ConnectionPump.cs
@@ -51,8 +51,13 @@ public sealed class ConnectionPump(
 				// by the token's session id, so it never picks up a later occupant of the same (reused) handle.
 				var (found, _, oldSession) = await resumeTokens.TryResolveAsync(deadToken, ct);
 				if (found)
+				{
 					foreach (var f in await replayStore.AfterAsync(oldSession, deadLastSeq, ct))
 						await transport.SendAsync(f, ct);
+					// Spend the token, as the rebind path does — it is single-use, so a retry can't re-fetch
+					// this buffer. The fresh registration above already issued this connection a new token.
+					await resumeTokens.InvalidateAsync(deadToken, ct);
+				}
 			}
 			else if (!SeqEnvelope.IsHello(firstFrame))
 			{
@@ -145,10 +150,20 @@ public sealed class ConnectionPump(
 		// on drop and would abort buffering exactly when replay matters most.
 		Func<byte[], ValueTask> output = async data =>
 		{
-			var (_, wrapped) = await replayStore.AppendAsync(session, data, CancellationToken.None);
-			var current = sink.Current;
-			if (current is not null)
-				await current.SendAsync(wrapped, CancellationToken.None);
+			try
+			{
+				var (_, wrapped) = await replayStore.AppendAsync(session, data, CancellationToken.None);
+				var current = sink.Current;
+				if (current is not null)
+					await current.SendAsync(wrapped, CancellationToken.None);
+			}
+			catch (Exception ex)
+			{
+				// A transient replay-store / transport failure must not propagate back into the engine's
+				// output path and tear down higher-level workflows; swallow-and-log, as the other output
+				// handlers do (e.g. OutputMessageConsumers).
+				logger.LogError(ex, "Error writing output on handle {Handle}", handle);
+			}
 		};
 
 		await connectionService.RegisterAsync(

--- a/SharpMUSH.ConnectionServer/ProtocolHandlers/ConnectionPump.cs
+++ b/SharpMUSH.ConnectionServer/ProtocolHandlers/ConnectionPump.cs
@@ -46,10 +46,11 @@ public sealed class ConnectionPump(
 
 			if (SeqEnvelope.TryReadResume(firstFrame, out var deadToken, out var deadLastSeq))
 			{
-				// resume-to-dead: still replay the old handle's durable buffer, then continue fresh.
-				var (found, oldHandle) = await resumeTokens.TryResolveAsync(deadToken, ct);
+				// resume-to-dead: still replay the old session's durable buffer, then continue fresh. Keyed
+				// by the token's session id, so it never picks up a later occupant of the same (reused) handle.
+				var (found, _, oldSession) = await resumeTokens.TryResolveAsync(deadToken, ct);
 				if (found)
-					foreach (var f in await replayStore.AfterAsync(oldHandle, deadLastSeq, ct))
+					foreach (var f in await replayStore.AfterAsync(oldSession, deadLastSeq, ct))
 						await transport.SendAsync(f, ct);
 			}
 			else if (!IsHello(firstFrame))
@@ -96,7 +97,7 @@ public sealed class ConnectionPump(
 	/// <summary>Rebind to a live handle; returns the handle, or null to fall back to the fresh path.</summary>
 	private async Task<long?> TryRebindAsync(IDuplexTransport transport, string token, long lastSeq, CancellationToken ct)
 	{
-		var (found, oldHandle) = await resumeTokens.TryResolveAsync(token, ct);
+		var (found, oldHandle, oldSession) = await resumeTokens.TryResolveAsync(token, ct);
 		if (!found) return null;
 
 		var sink = sinkRegistry.Get(oldHandle);
@@ -110,13 +111,13 @@ public sealed class ConnectionPump(
 			await previous.CloseAsync();               // connection-steal: last write wins
 
 		await transport.SendAsync(SeqEnvelope.Reattached(), ct);
-		foreach (var f in await replayStore.AfterAsync(oldHandle, lastSeq, ct))
+		foreach (var f in await replayStore.AfterAsync(oldSession, lastSeq, ct))
 			await transport.SendAsync(f, ct);
 
 		// Rotate the resume token: the one just used is now spent (single-use / forward-secure), and the
-		// client needs a fresh one so a *subsequent* drop can resume too.
+		// client needs a fresh one so a *subsequent* drop can resume too. Same incarnation → same session id.
 		await resumeTokens.InvalidateAsync(token, ct);
-		var newToken = await resumeTokens.MintAsync(oldHandle, ct);
+		var newToken = await resumeTokens.MintAsync(oldHandle, oldSession, ct);
 		await transport.SendAsync(SeqEnvelope.ResumeToken(newToken), ct);
 
 		logger.LogInformation("Reattached to session {Handle}", oldHandle);
@@ -125,22 +126,31 @@ public sealed class ConnectionPump(
 
 	private async Task RegisterFreshAsync(IDuplexTransport transport, long handle, CancellationToken ct)
 	{
+		// A fresh incarnation gets a unique session id. Replay is keyed by it (never by the reusable
+		// handle), so a recycled handle's new occupant can never read this session's buffer, and vice
+		// versa — closing the cross-session replay leak at its root rather than relying on purge timing.
+		var session = Guid.NewGuid().ToString("N");
+
 		var sink = sinkRegistry.GetOrCreate(handle);
 		sink.Attach(transport);
 
+		// The output path outlives this socket: after a drop the session is DETACHED and engine output
+		// must keep buffering to the replay store (and flow to a reattached transport) during the grace
+		// window. So it must NOT capture the per-connection token — that is RequestAborted, which cancels
+		// on drop and would abort buffering exactly when replay matters most.
 		Func<byte[], ValueTask> output = async data =>
 		{
-			var (_, wrapped) = await replayStore.AppendAsync(handle, data, ct);
+			var (_, wrapped) = await replayStore.AppendAsync(session, data, CancellationToken.None);
 			var current = sink.Current;
 			if (current is not null)
-				await current.SendAsync(wrapped, ct);
+				await current.SendAsync(wrapped, CancellationToken.None);
 		};
 
 		await connectionService.RegisterAsync(
 			handle, transport.RemoteIp, transport.Hostname, transport.Kind,
 			output, output, () => Encoding.UTF8, () => _ = sink.Current?.CloseAsync());
 
-		var token = await resumeTokens.MintAsync(handle, ct);
+		var token = await resumeTokens.MintAsync(handle, session, ct);
 		await transport.SendAsync(SeqEnvelope.ResumeToken(token), ct);
 	}
 
@@ -152,5 +162,5 @@ public sealed class ConnectionPump(
 			await publishEndpoint.Publish(new WebSocketInputMessage(handle, message), ct);
 	}
 
-	private static bool IsHello(string frame) => frame.Contains("\"hello\"");
+	private static bool IsHello(string frame) => SeqEnvelope.IsHello(frame);
 }

--- a/SharpMUSH.ConnectionServer/Services/DetachedSessionTracker.cs
+++ b/SharpMUSH.ConnectionServer/Services/DetachedSessionTracker.cs
@@ -9,10 +9,43 @@ public interface IGraceScheduler
 }
 
 /// <summary>Production scheduler backed by a one-shot <see cref="Timer"/>.</summary>
-public sealed class TimerGraceScheduler : IGraceScheduler
+public sealed class TimerGraceScheduler(ILogger<TimerGraceScheduler>? logger = null) : IGraceScheduler
 {
 	public IDisposable Schedule(TimeSpan delay, Func<Task> action)
-		=> new Timer(_ => _ = action(), null, delay, Timeout.InfiniteTimeSpan);
+		=> new Timer(
+			_ => Fire(action, ex => logger?.LogError(ex, "Grace-expiry action faulted")),
+			null, delay, Timeout.InfiniteTimeSpan);
+
+	/// <summary>
+	/// Fires <paramref name="action"/> and observes its faults — synchronous throws and faulted Tasks
+	/// alike — routing any exception to <paramref name="onFault"/>. Firing via a bare <c>_ = action()</c>
+	/// would drop an async fault, leaving it to surface later as an unobserved
+	/// <see cref="TaskScheduler.UnobservedTaskException"/> (hard to trace, policy-dependent crash).
+	/// </summary>
+	internal static void Fire(Func<Task> action, Action<Exception>? onFault)
+	{
+		Task task;
+		try
+		{
+			task = action();
+		}
+		catch (Exception ex)
+		{
+			onFault?.Invoke(ex);
+			return;
+		}
+
+		task.ContinueWith(
+			t =>
+			{
+				// Accessing t.Exception observes the fault; unwrap the AggregateException to the real cause.
+				var ex = t.Exception!.InnerException ?? t.Exception!;
+				onFault?.Invoke(ex);
+			},
+			CancellationToken.None,
+			TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+			TaskScheduler.Default);
+	}
 }
 
 /// <summary>

--- a/SharpMUSH.ConnectionServer/Services/IResumeTokenStore.cs
+++ b/SharpMUSH.ConnectionServer/Services/IResumeTokenStore.cs
@@ -1,16 +1,18 @@
 namespace SharpMUSH.ConnectionServer.Services;
 
 /// <summary>
-/// Mints and resolves opaque resume tokens binding a fresh reconnect back to a prior handle within a
-/// short grace window. Implementations: in-memory, and a NATS KV-backed store that survives a
-/// ConnectionServer restart / instance change (so replay works after the server bounces).
+/// Mints and resolves opaque resume tokens binding a fresh reconnect back to a prior connection within a
+/// short grace window. A token carries both the <c>handle</c> (to rebind the live session) and its
+/// per-incarnation <c>session</c> id (to replay that incarnation's buffered output — never a later
+/// occupant's, even when the handle has since been recycled). Implementations: in-memory, and a NATS
+/// KV-backed store that survives a ConnectionServer restart / instance change.
 /// </summary>
 public interface IResumeTokenStore
 {
-	ValueTask<string> MintAsync(long handle, CancellationToken ct = default);
+	ValueTask<string> MintAsync(long handle, string session, CancellationToken ct = default);
 
-	/// <summary>Resolves a token to its handle if present and unexpired.</summary>
-	ValueTask<(bool Found, long Handle)> TryResolveAsync(string token, CancellationToken ct = default);
+	/// <summary>Resolves a token to its handle and session id if present and unexpired.</summary>
+	ValueTask<(bool Found, long Handle, string Session)> TryResolveAsync(string token, CancellationToken ct = default);
 
 	ValueTask InvalidateAsync(string token, CancellationToken ct = default);
 }

--- a/SharpMUSH.ConnectionServer/Services/ITerminalReplayStore.cs
+++ b/SharpMUSH.ConnectionServer/Services/ITerminalReplayStore.cs
@@ -19,6 +19,6 @@ public interface ITerminalReplayStore
 	/// <summary>Wrapped frames with seq greater than <paramref name="lastSeq"/>, oldest first.</summary>
 	ValueTask<IReadOnlyList<byte[]>> AfterAsync(string session, long lastSeq, CancellationToken ct = default);
 
-	/// <summary>Discards a session's buffered history.</summary>
+	/// <summary>Releases a session's replay resources once it has ended for good.</summary>
 	ValueTask DropAsync(string session, CancellationToken ct = default);
 }

--- a/SharpMUSH.ConnectionServer/Services/ITerminalReplayStore.cs
+++ b/SharpMUSH.ConnectionServer/Services/ITerminalReplayStore.cs
@@ -1,20 +1,24 @@
 namespace SharpMUSH.ConnectionServer.Services;
 
 /// <summary>
-/// Per-handle terminal output history for reconnect replay. Each append assigns a monotonic
-/// per-handle sequence, wraps the frame in a <see cref="SeqEnvelope"/>, and records it; on a fresh
+/// Per-session terminal output history for reconnect replay. Each append assigns a monotonic
+/// per-session sequence, wraps the frame in a <see cref="SeqEnvelope"/>, and records it; on a fresh
 /// reconnect the server replays frames after the client's acked sequence.
 /// Implementations: an in-memory bounded buffer, and a NATS JetStream-backed store that survives a
 /// ConnectionServer restart / instance change.
+///
+/// The key is a per-incarnation <c>session</c> id, NOT the connection handle: handles are reused
+/// (recycled by <c>DescriptorGeneratorService</c>), so keying replay on the handle would let a new
+/// occupant replay a prior session's output — a cross-session leak. A fresh session mints a new id.
 /// </summary>
 public interface ITerminalReplayStore
 {
-	/// <summary>Assigns the next seq for the handle, wraps + records the frame, returns both.</summary>
-	ValueTask<(long Seq, byte[] Wrapped)> AppendAsync(long handle, byte[] rawUtf8, CancellationToken ct = default);
+	/// <summary>Assigns the next seq for the session, wraps + records the frame, returns both.</summary>
+	ValueTask<(long Seq, byte[] Wrapped)> AppendAsync(string session, byte[] rawUtf8, CancellationToken ct = default);
 
 	/// <summary>Wrapped frames with seq greater than <paramref name="lastSeq"/>, oldest first.</summary>
-	ValueTask<IReadOnlyList<byte[]>> AfterAsync(long handle, long lastSeq, CancellationToken ct = default);
+	ValueTask<IReadOnlyList<byte[]>> AfterAsync(string session, long lastSeq, CancellationToken ct = default);
 
-	/// <summary>Discards a handle's buffered history (after a successful resume).</summary>
-	ValueTask DropAsync(long handle, CancellationToken ct = default);
+	/// <summary>Discards a session's buffered history.</summary>
+	ValueTask DropAsync(string session, CancellationToken ct = default);
 }

--- a/SharpMUSH.ConnectionServer/Services/JetStreamTerminalReplayStore.cs
+++ b/SharpMUSH.ConnectionServer/Services/JetStreamTerminalReplayStore.cs
@@ -89,21 +89,14 @@ public sealed class JetStreamTerminalReplayStore : ITerminalReplayStore, IAsyncD
 	}
 
 	/// <summary>
-	/// Purges a session's buffered frames from the stream and drops its seq counter. Session ids are
-	/// unique per incarnation, so isolation does not depend on this — but purging reclaims stream storage
-	/// that MaxAge would otherwise hold for the full retention window.
+	/// Releases the ended session's in-memory seq bookkeeping so it does not accumulate for the process
+	/// lifetime. The durable buffer is left to age out via the stream's MaxAge (so a late resume-to-dead
+	/// still works); session ids are unique per incarnation, so nothing depends on an explicit purge.
 	/// </summary>
-	public async ValueTask DropAsync(string session, CancellationToken ct = default)
+	public ValueTask DropAsync(string session, CancellationToken ct = default)
 	{
 		_seq.TryRemove(session, out _);
-		try
-		{
-			await _js.PurgeStreamAsync(StreamName, new StreamPurgeRequest { Filter = Subject(session) }, ct);
-		}
-		catch (NatsJSApiException ex)
-		{
-			_logger.LogWarning(ex, "Replay purge failed for session {Session}", session);
-		}
+		return ValueTask.CompletedTask;
 	}
 
 	public async ValueTask DisposeAsync()

--- a/SharpMUSH.ConnectionServer/Services/JetStreamTerminalReplayStore.cs
+++ b/SharpMUSH.ConnectionServer/Services/JetStreamTerminalReplayStore.cs
@@ -6,11 +6,12 @@ using NATS.Client.JetStream.Models;
 namespace SharpMUSH.ConnectionServer.Services;
 
 /// <summary>
-/// NATS JetStream-backed <see cref="ITerminalReplayStore"/>. Each handle's output is published to
-/// <c>terminal.replay.&lt;handle&gt;</c> in a short-<see cref="StreamConfig.MaxAge"/> stream, so buffered
+/// NATS JetStream-backed <see cref="ITerminalReplayStore"/>. Each session's output is published to
+/// <c>terminal.replay.&lt;session&gt;</c> in a short-<see cref="StreamConfig.MaxAge"/> stream, so buffered
 /// output survives a ConnectionServer restart / instance change and can be replayed on reconnect.
-/// The per-handle sequence counter is in-memory (a handle is owned by one connection for its life);
-/// durability of the buffer itself is what enables replay after a restart into a new handle.
+/// The subject is keyed by a per-incarnation session id (not the reusable handle), so a recycled handle's
+/// new occupant can never read a prior session's frames, and a restart that loses the in-memory seq
+/// counter cannot collide two sessions onto one subject.
 /// </summary>
 public sealed class JetStreamTerminalReplayStore : ITerminalReplayStore, IAsyncDisposable
 {
@@ -21,7 +22,7 @@ public sealed class JetStreamTerminalReplayStore : ITerminalReplayStore, IAsyncD
 	private readonly NatsConnection _nats;
 	private readonly NatsJSContext _js;
 	private readonly ILogger<JetStreamTerminalReplayStore> _logger;
-	private readonly ConcurrentDictionary<long, long> _seq = new();
+	private readonly ConcurrentDictionary<string, long> _seq = new();
 
 	private JetStreamTerminalReplayStore(NatsConnection nats, NatsJSContext js, ILogger<JetStreamTerminalReplayStore> logger)
 	{
@@ -44,27 +45,27 @@ public sealed class JetStreamTerminalReplayStore : ITerminalReplayStore, IAsyncD
 		return new JetStreamTerminalReplayStore(nats, js, logger);
 	}
 
-	private static string Subject(long handle) => $"{SubjectPrefix}.{handle}";
+	private static string Subject(string session) => $"{SubjectPrefix}.{session}";
 
-	public async ValueTask<(long Seq, byte[] Wrapped)> AppendAsync(long handle, byte[] rawUtf8, CancellationToken ct = default)
+	public async ValueTask<(long Seq, byte[] Wrapped)> AppendAsync(string session, byte[] rawUtf8, CancellationToken ct = default)
 	{
-		var seq = _seq.AddOrUpdate(handle, 1, (_, v) => v + 1);
+		var seq = _seq.AddOrUpdate(session, 1, (_, v) => v + 1);
 		var wrapped = SeqEnvelope.Wrap(seq, rawUtf8);
-		await _js.PublishAsync(Subject(handle), wrapped, cancellationToken: ct);
+		await _js.PublishAsync(Subject(session), wrapped, cancellationToken: ct);
 		return (seq, wrapped);
 	}
 
-	public async ValueTask<IReadOnlyList<byte[]>> AfterAsync(long handle, long lastSeq, CancellationToken ct = default)
+	public async ValueTask<IReadOnlyList<byte[]>> AfterAsync(string session, long lastSeq, CancellationToken ct = default)
 	{
 		var result = new List<byte[]>();
 		INatsJSConsumer consumer;
 		try
 		{
-			// Ephemeral, no-ack consumer over just this handle's subject; auto-cleaned after inactivity.
+			// Ephemeral, no-ack consumer over just this session's subject; auto-cleaned after inactivity.
 			consumer = await _js.CreateOrUpdateConsumerAsync(StreamName, new ConsumerConfig
 			{
-				Name = $"replay-read-{handle}-{Guid.NewGuid():N}",
-				FilterSubject = Subject(handle),
+				Name = $"replay-read-{Guid.NewGuid():N}",
+				FilterSubject = Subject(session),
 				DeliverPolicy = ConsumerConfigDeliverPolicy.All,
 				AckPolicy = ConsumerConfigAckPolicy.None,
 				InactiveThreshold = TimeSpan.FromSeconds(10),
@@ -72,7 +73,7 @@ public sealed class JetStreamTerminalReplayStore : ITerminalReplayStore, IAsyncD
 		}
 		catch (NatsJSApiException ex)
 		{
-			_logger.LogWarning(ex, "Replay consumer creation failed for handle {Handle}", handle);
+			_logger.LogWarning(ex, "Replay consumer creation failed for session {Session}", session);
 			return result;
 		}
 
@@ -87,8 +88,23 @@ public sealed class JetStreamTerminalReplayStore : ITerminalReplayStore, IAsyncD
 		return result;
 	}
 
-	// MaxAge bounds the stream; explicit purge is unnecessary for the minimal safety net.
-	public ValueTask DropAsync(long handle, CancellationToken ct = default) => ValueTask.CompletedTask;
+	/// <summary>
+	/// Purges a session's buffered frames from the stream and drops its seq counter. Session ids are
+	/// unique per incarnation, so isolation does not depend on this — but purging reclaims stream storage
+	/// that MaxAge would otherwise hold for the full retention window.
+	/// </summary>
+	public async ValueTask DropAsync(string session, CancellationToken ct = default)
+	{
+		_seq.TryRemove(session, out _);
+		try
+		{
+			await _js.PurgeStreamAsync(StreamName, new StreamPurgeRequest { Filter = Subject(session) }, ct);
+		}
+		catch (NatsJSApiException ex)
+		{
+			_logger.LogWarning(ex, "Replay purge failed for session {Session}", session);
+		}
+	}
 
 	public async ValueTask DisposeAsync()
 	{

--- a/SharpMUSH.ConnectionServer/Services/NatsKvResumeTokenStore.cs
+++ b/SharpMUSH.ConnectionServer/Services/NatsKvResumeTokenStore.cs
@@ -39,19 +39,26 @@ public sealed class NatsKvResumeTokenStore : IResumeTokenStore, IAsyncDisposable
 		return new NatsKvResumeTokenStore(nats, store, logger);
 	}
 
-	public async ValueTask<string> MintAsync(long handle, CancellationToken ct = default)
+	public async ValueTask<string> MintAsync(long handle, string session, CancellationToken ct = default)
 	{
 		var token = Convert.ToHexString(RandomNumberGenerator.GetBytes(16));
-		await _store.PutAsync(token, handle.ToString(), cancellationToken: ct);
+		// Value is "<handle>:<session>" — handle is numeric and the session id is a hex GUID, so ':' is an
+		// unambiguous separator.
+		await _store.PutAsync(token, $"{handle}:{session}", cancellationToken: ct);
 		return token;
 	}
 
-	public async ValueTask<(bool Found, long Handle)> TryResolveAsync(string token, CancellationToken ct = default)
+	public async ValueTask<(bool Found, long Handle, string Session)> TryResolveAsync(string token, CancellationToken ct = default)
 	{
 		var result = await _store.TryGetEntryAsync<string>(token, cancellationToken: ct);
 		if (!result.Success || result.Value.Value is null)
-			return (false, 0L);
-		return long.TryParse(result.Value.Value, out var handle) ? (true, handle) : (false, 0L);
+			return (false, 0L, string.Empty);
+
+		var value = result.Value.Value;
+		var sep = value.IndexOf(':');
+		if (sep <= 0 || !long.TryParse(value.AsSpan(0, sep), out var handle))
+			return (false, 0L, string.Empty);
+		return (true, handle, value[(sep + 1)..]);
 	}
 
 	public async ValueTask InvalidateAsync(string token, CancellationToken ct = default)

--- a/SharpMUSH.ConnectionServer/Services/NatsKvResumeTokenStore.cs
+++ b/SharpMUSH.ConnectionServer/Services/NatsKvResumeTokenStore.cs
@@ -56,7 +56,10 @@ public sealed class NatsKvResumeTokenStore : IResumeTokenStore, IAsyncDisposable
 
 		var value = result.Value.Value;
 		var sep = value.IndexOf(':');
-		if (sep <= 0 || !long.TryParse(value.AsSpan(0, sep), out var handle))
+		// Require a non-empty handle AND session: the session is part of the security boundary (it scopes
+		// replay to one incarnation), so a malformed/corrupt entry with an empty session is rejected rather
+		// than resolved to session "".
+		if (sep <= 0 || sep == value.Length - 1 || !long.TryParse(value.AsSpan(0, sep), out var handle))
 			return (false, 0L, string.Empty);
 		return (true, handle, value[(sep + 1)..]);
 	}

--- a/SharpMUSH.ConnectionServer/Services/NatsKvResumeTokenStore.cs
+++ b/SharpMUSH.ConnectionServer/Services/NatsKvResumeTokenStore.cs
@@ -39,12 +39,20 @@ public sealed class NatsKvResumeTokenStore : IResumeTokenStore, IAsyncDisposable
 		return new NatsKvResumeTokenStore(nats, store, logger);
 	}
 
+	// Serialized resume-token value format, versioned so the layout can evolve deliberately. A token
+	// stored under a different version — or the pre-versioned legacy layout, or a corrupt entry — fails
+	// to resolve, and the caller falls back to a fresh session (which still replays via the durable
+	// store). That is safe because resume tokens are single-use and short-lived (re-minted on every
+	// connect/reattach), so a format change only costs a brief, self-healing loss of seamless reattach
+	// across the one deploy that introduces it — never a correctness or security problem.
+	private const string TokenFormatVersion = "1";
+
 	public async ValueTask<string> MintAsync(long handle, string session, CancellationToken ct = default)
 	{
 		var token = Convert.ToHexString(RandomNumberGenerator.GetBytes(16));
-		// Value is "<handle>:<session>" — handle is numeric and the session id is a hex GUID, so ':' is an
-		// unambiguous separator.
-		await _store.PutAsync(token, $"{handle}:{session}", cancellationToken: ct);
+		// "<version>:<handle>:<session>" — handle is numeric and the session id is a hex GUID (no ':'),
+		// so ':' is an unambiguous separator.
+		await _store.PutAsync(token, $"{TokenFormatVersion}:{handle}:{session}", cancellationToken: ct);
 		return token;
 	}
 
@@ -54,14 +62,16 @@ public sealed class NatsKvResumeTokenStore : IResumeTokenStore, IAsyncDisposable
 		if (!result.Success || result.Value.Value is null)
 			return (false, 0L, string.Empty);
 
-		var value = result.Value.Value;
-		var sep = value.IndexOf(':');
-		// Require a non-empty handle AND session: the session is part of the security boundary (it scopes
-		// replay to one incarnation), so a malformed/corrupt entry with an empty session is rejected rather
-		// than resolved to session "".
-		if (sep <= 0 || sep == value.Length - 1 || !long.TryParse(value.AsSpan(0, sep), out var handle))
+		// Expect exactly "<version>:<handle>:<session>". Require the current version, a parseable handle, and
+		// a non-empty session: the session is part of the security boundary (it scopes replay to one
+		// incarnation), so anything else is rejected rather than resolved to a guessed or empty session.
+		var parts = result.Value.Value.Split(':', 3);
+		if (parts.Length != 3
+		    || parts[0] != TokenFormatVersion
+		    || !long.TryParse(parts[1], out var handle)
+		    || parts[2].Length == 0)
 			return (false, 0L, string.Empty);
-		return (true, handle, value[(sep + 1)..]);
+		return (true, handle, parts[2]);
 	}
 
 	public async ValueTask InvalidateAsync(string token, CancellationToken ct = default)

--- a/SharpMUSH.ConnectionServer/Services/ResumeTokenService.cs
+++ b/SharpMUSH.ConnectionServer/Services/ResumeTokenService.cs
@@ -19,24 +19,24 @@ public sealed class ResumeTokenService : IResumeTokenStore
 	// Test seam: inject a clock so TTL expiry is deterministic.
 	public ResumeTokenService(Func<DateTimeOffset> now) => _now = now;
 
-	public ValueTask<string> MintAsync(long handle, CancellationToken ct = default)
+	public ValueTask<string> MintAsync(long handle, string session, CancellationToken ct = default)
 	{
 		var token = Convert.ToHexString(RandomNumberGenerator.GetBytes(16));
-		_tokens[token] = new Entry(handle, _now() + Ttl);
+		_tokens[token] = new Entry(handle, session, _now() + Ttl);
 		return ValueTask.FromResult(token);
 	}
 
-	public ValueTask<(bool Found, long Handle)> TryResolveAsync(string token, CancellationToken ct = default)
+	public ValueTask<(bool Found, long Handle, string Session)> TryResolveAsync(string token, CancellationToken ct = default)
 	{
 		if (!_tokens.TryGetValue(token, out var entry))
-			return ValueTask.FromResult((false, 0L));
+			return ValueTask.FromResult((false, 0L, string.Empty));
 		if (_now() > entry.Expires)
 		{
 			_tokens.TryRemove(token, out _);
-			return ValueTask.FromResult((false, 0L));
+			return ValueTask.FromResult((false, 0L, string.Empty));
 		}
 
-		return ValueTask.FromResult((true, entry.Handle));
+		return ValueTask.FromResult((true, entry.Handle, entry.Session));
 	}
 
 	public ValueTask InvalidateAsync(string token, CancellationToken ct = default)
@@ -45,5 +45,5 @@ public sealed class ResumeTokenService : IResumeTokenStore
 		return ValueTask.CompletedTask;
 	}
 
-	private sealed record Entry(long Handle, DateTimeOffset Expires);
+	private sealed record Entry(long Handle, string Session, DateTimeOffset Expires);
 }

--- a/SharpMUSH.ConnectionServer/Services/SeqEnvelope.cs
+++ b/SharpMUSH.ConnectionServer/Services/SeqEnvelope.cs
@@ -53,6 +53,22 @@ public static class SeqEnvelope
 		}
 	}
 
+	/// <summary>
+	/// True only if the frame is the structured <c>{"hello":n}</c> handshake. A substring test would
+	/// misclassify a real first command like <c>say "hello"</c> as the handshake and drop it.
+	/// </summary>
+	public static bool IsHello(string frame)
+	{
+		try
+		{
+			return JsonSerializer.Deserialize<HelloFrame>(frame, Json)?.Hello is not null;
+		}
+		catch (JsonException)
+		{
+			return false;
+		}
+	}
+
 	public static bool TryReadResume(string frame, out string token, out long lastSeq)
 	{
 		token = string.Empty;
@@ -74,6 +90,8 @@ public static class SeqEnvelope
 	private sealed record SeqFrame(long? Seq, string Data);
 
 	private sealed record ResumeFrame(string? Resume, long LastSeq);
+
+	private sealed record HelloFrame(int? Hello);
 
 	private sealed record ResumeTokenFrame(string ResumeToken);
 

--- a/SharpMUSH.ConnectionServer/Services/TerminalReplayStore.cs
+++ b/SharpMUSH.ConnectionServer/Services/TerminalReplayStore.cs
@@ -3,16 +3,16 @@ using System.Collections.Concurrent;
 namespace SharpMUSH.ConnectionServer.Services;
 
 /// <summary>
-/// In-memory <see cref="ITerminalReplayStore"/>: a per-handle bounded, short-lived output buffer.
+/// In-memory <see cref="ITerminalReplayStore"/>: a per-session bounded, short-lived output buffer.
 /// Bounded by count and age to stay "minimal". Does NOT survive a ConnectionServer restart — use
 /// <see cref="JetStreamTerminalReplayStore"/> for durable, restart-survivable replay.
 /// </summary>
 public sealed class TerminalReplayStore : ITerminalReplayStore
 {
-	private const int MaxFramesPerHandle = 200;
+	private const int MaxFramesPerSession = 200;
 	private static readonly TimeSpan MaxAge = TimeSpan.FromSeconds(30);
 
-	private readonly ConcurrentDictionary<string, HandleBuffer> _buffers = new();
+	private readonly ConcurrentDictionary<string, SessionBuffer> _buffers = new();
 	private readonly Func<DateTimeOffset> _now;
 
 	public TerminalReplayStore() : this(() => DateTimeOffset.UtcNow) { }
@@ -22,8 +22,8 @@ public sealed class TerminalReplayStore : ITerminalReplayStore
 
 	public ValueTask<(long Seq, byte[] Wrapped)> AppendAsync(string session, byte[] rawUtf8, CancellationToken ct = default)
 	{
-		var buffer = _buffers.GetOrAdd(session, _ => new HandleBuffer());
-		return ValueTask.FromResult(buffer.Append(rawUtf8, _now(), MaxFramesPerHandle));
+		var buffer = _buffers.GetOrAdd(session, _ => new SessionBuffer());
+		return ValueTask.FromResult(buffer.Append(rawUtf8, _now(), MaxFramesPerSession));
 	}
 
 	public ValueTask<IReadOnlyList<byte[]>> AfterAsync(string session, long lastSeq, CancellationToken ct = default)
@@ -37,7 +37,7 @@ public sealed class TerminalReplayStore : ITerminalReplayStore
 		return ValueTask.CompletedTask;
 	}
 
-	private sealed class HandleBuffer
+	private sealed class SessionBuffer
 	{
 		private readonly object _gate = new();
 		private readonly LinkedList<Entry> _entries = new();

--- a/SharpMUSH.ConnectionServer/Services/TerminalReplayStore.cs
+++ b/SharpMUSH.ConnectionServer/Services/TerminalReplayStore.cs
@@ -12,7 +12,7 @@ public sealed class TerminalReplayStore : ITerminalReplayStore
 	private const int MaxFramesPerHandle = 200;
 	private static readonly TimeSpan MaxAge = TimeSpan.FromSeconds(30);
 
-	private readonly ConcurrentDictionary<long, HandleBuffer> _buffers = new();
+	private readonly ConcurrentDictionary<string, HandleBuffer> _buffers = new();
 	private readonly Func<DateTimeOffset> _now;
 
 	public TerminalReplayStore() : this(() => DateTimeOffset.UtcNow) { }
@@ -20,20 +20,20 @@ public sealed class TerminalReplayStore : ITerminalReplayStore
 	// Test seam: inject a clock so age-based eviction is deterministic.
 	public TerminalReplayStore(Func<DateTimeOffset> now) => _now = now;
 
-	public ValueTask<(long Seq, byte[] Wrapped)> AppendAsync(long handle, byte[] rawUtf8, CancellationToken ct = default)
+	public ValueTask<(long Seq, byte[] Wrapped)> AppendAsync(string session, byte[] rawUtf8, CancellationToken ct = default)
 	{
-		var buffer = _buffers.GetOrAdd(handle, _ => new HandleBuffer());
+		var buffer = _buffers.GetOrAdd(session, _ => new HandleBuffer());
 		return ValueTask.FromResult(buffer.Append(rawUtf8, _now(), MaxFramesPerHandle));
 	}
 
-	public ValueTask<IReadOnlyList<byte[]>> AfterAsync(long handle, long lastSeq, CancellationToken ct = default)
-		=> ValueTask.FromResult(_buffers.TryGetValue(handle, out var buffer)
+	public ValueTask<IReadOnlyList<byte[]>> AfterAsync(string session, long lastSeq, CancellationToken ct = default)
+		=> ValueTask.FromResult(_buffers.TryGetValue(session, out var buffer)
 			? buffer.After(lastSeq, _now(), MaxAge)
 			: []);
 
-	public ValueTask DropAsync(long handle, CancellationToken ct = default)
+	public ValueTask DropAsync(string session, CancellationToken ct = default)
 	{
-		_buffers.TryRemove(handle, out _);
+		_buffers.TryRemove(session, out _);
 		return ValueTask.CompletedTask;
 	}
 

--- a/SharpMUSH.ConnectionServer/SharpMUSH.ConnectionServer.csproj
+++ b/SharpMUSH.ConnectionServer/SharpMUSH.ConnectionServer.csproj
@@ -25,6 +25,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="SharpMUSH.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\SharpMUSH.Library\SharpMUSH.Library.csproj" />
     <ProjectReference Include="..\SharpMUSH.Messaging\SharpMUSH.Messaging.csproj" />
     <ProjectReference Include="..\SharpMUSH.MarkupString\SharpMUSH.MarkupString.csproj" />

--- a/SharpMUSH.Tests/ConnectionServer/ConnectionPumpTests.cs
+++ b/SharpMUSH.Tests/ConnectionServer/ConnectionPumpTests.cs
@@ -35,6 +35,39 @@ public class ConnectionPumpTests
 		}
 	}
 
+	// A transport that plays its frames, then — once, when the socket drains (before it reports the
+	// drop with null) — runs an injected callback. Used to interleave a "connection-steal" by a newer
+	// pump into the exact window between this pump's receive loop ending and its finally running.
+	private sealed class DrainCallbackTransport(Func<Task> onDrain, params string?[] frames) : IDuplexTransport
+	{
+		private readonly Queue<string?> _frames = new(frames);
+		private bool _fired;
+		public List<byte[]> Sent { get; } = [];
+		public bool Closed { get; private set; }
+		public string Kind => "fake";
+		public string RemoteIp => "1.2.3.4";
+		public string Hostname => "host";
+
+		public Task SendAsync(ReadOnlyMemory<byte> data, CancellationToken ct)
+		{
+			Sent.Add(data.ToArray());
+			return Task.CompletedTask;
+		}
+
+		public async Task<string?> ReceiveTextAsync(CancellationToken ct)
+		{
+			if (_frames.Count > 0) return _frames.Dequeue();
+			if (!_fired) { _fired = true; await onDrain(); }
+			return null;
+		}
+
+		public Task CloseAsync()
+		{
+			Closed = true;
+			return Task.CompletedTask;
+		}
+	}
+
 	// A replay store that honours its cancellation token (like the real JetStream store, whose
 	// PublishAsync throws when the token is canceled), so a canceled token in the output path is observable.
 	private sealed class CtHonoringReplayStore : ITerminalReplayStore
@@ -332,5 +365,39 @@ public class ConnectionPumpTests
 		await Assert.That(newHandle).IsEqualTo(9L);
 		// The rotated token stays bound to the SAME incarnation, so a further drop still replays this session.
 		await Assert.That(newSession).IsEqualTo("live-incarnation-9");
+	}
+
+	[Test]
+	public async Task Old_pump_exit_does_not_detach_a_transport_a_newer_pump_stole()
+	{
+		var bus = Substitute.For<IMessageBus>();
+		var conn = Substitute.For<IConnectionServerService>();
+		var desc = Substitute.For<IDescriptorGeneratorService>();
+		var registry = new SessionSinkRegistry();
+		var tracker = new DetachedSessionTracker(new ManualScheduler());
+
+		// The newer pump's transport — attached to the sink by the "steal" and expected to survive.
+		var newerTransport = new FakeTransport();
+
+		// The old pump owns handle 7 (fresh registration attaches its own transport to the sink). When its
+		// socket drains, simulate a NEWER pump that rebound handle 7 in the meantime — exactly what
+		// TryRebindAsync does: Attach its own transport to the sink and cancel the grace timer.
+		var oldTransport = new DrainCallbackTransport(
+			() =>
+			{
+				registry.Get(7)!.Attach(newerTransport); // newer pump now owns the sink
+				tracker.Reattach(7);                      // and cancelled any pending grace timer
+				return Task.CompletedTask;
+			},
+			"look");
+
+		var pump = MakePump(bus, conn, desc, registry: registry, tracker: tracker);
+		await pump.RunAsync(oldTransport, candidateHandle: 7, CancellationToken.None);
+
+		// The old pump's finally must recognize it no longer owns the sink and leave the steal intact:
+		// the newer transport stays attached, no disconnect is scheduled for the now-live session.
+		await Assert.That(ReferenceEquals(registry.Get(7)!.Current, newerTransport)).IsTrue();
+		await Assert.That(tracker.IsDetached(7)).IsFalse();
+		await conn.DidNotReceive().DisconnectAsync(7);
 	}
 }

--- a/SharpMUSH.Tests/ConnectionServer/ConnectionPumpTests.cs
+++ b/SharpMUSH.Tests/ConnectionServer/ConnectionPumpTests.cs
@@ -57,6 +57,28 @@ public class ConnectionPumpTests
 		public ValueTask DropAsync(string session, CancellationToken ct = default) => ValueTask.CompletedTask;
 	}
 
+	// Records which sessions were dropped, to prove end-of-session cleanup fires.
+	private sealed class DropRecordingReplayStore : ITerminalReplayStore
+	{
+		public List<string> Dropped { get; } = [];
+		private long _seq;
+
+		public ValueTask<(long Seq, byte[] Wrapped)> AppendAsync(string session, byte[] rawUtf8, CancellationToken ct = default)
+		{
+			var seq = ++_seq;
+			return ValueTask.FromResult((seq, SeqEnvelope.Wrap(seq, rawUtf8)));
+		}
+
+		public ValueTask<IReadOnlyList<byte[]>> AfterAsync(string session, long lastSeq, CancellationToken ct = default)
+			=> ValueTask.FromResult<IReadOnlyList<byte[]>>([]);
+
+		public ValueTask DropAsync(string session, CancellationToken ct = default)
+		{
+			Dropped.Add(session);
+			return ValueTask.CompletedTask;
+		}
+	}
+
 	private static ConnectionPump MakePump(
 		IMessageBus bus,
 		IConnectionServerService conn,
@@ -174,6 +196,25 @@ public class ConnectionPumpTests
 			.Select(SeqEnvelope.ReadSeq)
 			.ToArray();
 		await Assert.That(seqs).IsEquivalentTo(new[] { 2L });
+	}
+
+	[Test]
+	public async Task Grace_expiry_releases_the_sessions_replay_state()
+	{
+		var bus = Substitute.For<IMessageBus>();
+		var conn = Substitute.For<IConnectionServerService>();
+		var desc = Substitute.For<IDescriptorGeneratorService>();
+		var replay = new DropRecordingReplayStore();
+		var scheduler = new ManualScheduler();
+		var tracker = new DetachedSessionTracker(scheduler);
+		var pump = MakePump(bus, conn, desc, replay, tracker: tracker);
+		var transport = new FakeTransport("{\"hello\":1}", null);
+
+		await pump.RunAsync(transport, candidateHandle: 7, CancellationToken.None);
+		await scheduler.Captured!(); // grace expires → the session is over for good
+
+		// The fresh session's per-incarnation id is released so its seq bookkeeping cannot accumulate.
+		await Assert.That(replay.Dropped.Count).IsEqualTo(1);
 	}
 
 	[Test]

--- a/SharpMUSH.Tests/ConnectionServer/ConnectionPumpTests.cs
+++ b/SharpMUSH.Tests/ConnectionServer/ConnectionPumpTests.cs
@@ -35,6 +35,28 @@ public class ConnectionPumpTests
 		}
 	}
 
+	// A replay store that honours its cancellation token (like the real JetStream store, whose
+	// PublishAsync throws when the token is canceled), so a canceled token in the output path is observable.
+	private sealed class CtHonoringReplayStore : ITerminalReplayStore
+	{
+		public List<byte[]> Appended { get; } = [];
+		private long _seq;
+
+		public ValueTask<(long Seq, byte[] Wrapped)> AppendAsync(string session, byte[] rawUtf8, CancellationToken ct = default)
+		{
+			ct.ThrowIfCancellationRequested();
+			var seq = ++_seq;
+			var wrapped = SeqEnvelope.Wrap(seq, rawUtf8);
+			Appended.Add(wrapped);
+			return ValueTask.FromResult((seq, wrapped));
+		}
+
+		public ValueTask<IReadOnlyList<byte[]>> AfterAsync(string session, long lastSeq, CancellationToken ct = default)
+			=> ValueTask.FromResult<IReadOnlyList<byte[]>>([]);
+
+		public ValueTask DropAsync(string session, CancellationToken ct = default) => ValueTask.CompletedTask;
+	}
+
 	private static ConnectionPump MakePump(
 		IMessageBus bus,
 		IConnectionServerService conn,
@@ -72,6 +94,86 @@ public class ConnectionPumpTests
 		// Drop now DETACHES rather than disconnecting immediately.
 		await conn.DidNotReceive().DisconnectAsync(42);
 		await Assert.That(tracker.IsDetached(42)).IsTrue();
+	}
+
+	[Test]
+	public async Task First_frame_that_merely_contains_hello_is_published_not_swallowed()
+	{
+		var bus = Substitute.For<IMessageBus>();
+		var conn = Substitute.For<IConnectionServerService>();
+		var desc = Substitute.For<IDescriptorGeneratorService>();
+		var pump = MakePump(bus, conn, desc);
+		// A real first command whose text contains the substring "hello" (with quotes) — NOT the
+		// {"hello":1} handshake. It must reach the game, not be misread as the hello frame and dropped.
+		var transport = new FakeTransport("say \"hello\"", null);
+
+		await pump.RunAsync(transport, candidateHandle: 7, CancellationToken.None);
+
+		await bus.Received(1).Publish(
+			Arg.Is<WebSocketInputMessage>(m => m.Handle == 7 && m.Input == "say \"hello\""),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task Output_still_buffers_after_the_connection_token_is_canceled()
+	{
+		var bus = Substitute.For<IMessageBus>();
+		var conn = Substitute.For<IConnectionServerService>();
+		var desc = Substitute.For<IDescriptorGeneratorService>();
+		var replay = new CtHonoringReplayStore();
+
+		Func<byte[], ValueTask>? output = null;
+		_ = conn.RegisterAsync(
+			Arg.Any<long>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+			Arg.Do<Func<byte[], ValueTask>>(o => output = o),
+			Arg.Any<Func<byte[], ValueTask>>(),
+			Arg.Any<Func<System.Text.Encoding>>(), Arg.Any<Action>(),
+			Arg.Any<Func<string, string, ValueTask>?>(),
+			Arg.Any<SharpMUSH.ConnectionServer.Models.ProtocolCapabilities?>());
+
+		var pump = MakePump(bus, conn, desc, replay);
+		var cts = new CancellationTokenSource();
+		var transport = new FakeTransport("{\"hello\":1}", null);
+
+		await pump.RunAsync(transport, candidateHandle: 7, cts.Token);
+
+		// The socket dropped: RequestAborted (the connection token) is now canceled. Engine output during
+		// the detached grace window must STILL be buffered for replay — the output path must not be
+		// coupled to the dropped socket's cancellation token.
+		cts.Cancel();
+		await output!(System.Text.Encoding.UTF8.GetBytes("engine output"));
+
+		await Assert.That(replay.Appended).IsNotEmpty();
+	}
+
+	[Test]
+	public async Task Resume_to_dead_replays_the_tokens_session_not_the_reused_handle()
+	{
+		var bus = Substitute.For<IMessageBus>();
+		var conn = Substitute.For<IConnectionServerService>();
+		var desc = Substitute.For<IDescriptorGeneratorService>();
+		var replay = new TerminalReplayStore();
+		var resume = new ResumeTokenService();
+
+		// A now-DEAD session under handle 5 (conn.Get(5) is null → the rebind path fails, resume-to-dead
+		// fires). Its buffered output lives under a per-incarnation session id, and its token carries that id.
+		const string deadSession = "dead-incarnation";
+		await replay.AppendAsync(deadSession, System.Text.Encoding.UTF8.GetBytes("one")); // seq 1
+		await replay.AppendAsync(deadSession, System.Text.Encoding.UTF8.GetBytes("two")); // seq 2
+		var deadToken = await resume.MintAsync(5, deadSession);
+
+		var pump = MakePump(bus, conn, desc, replay, resume);
+		// The client reconnects onto the SAME, now-recycled handle 5 with the dead session's token.
+		var transport = new FakeTransport($"{{\"resume\":\"{deadToken}\",\"lastSeq\":1}}", null);
+
+		await pump.RunAsync(transport, candidateHandle: 5, CancellationToken.None);
+
+		// The dead incarnation's post-ack frame is replayed (keyed by the token's session, not the handle).
+		var seqs = transport.Sent
+			.Where(b => SeqEnvelope.TryReadSeq(b, out _))
+			.Select(SeqEnvelope.ReadSeq)
+			.ToArray();
+		await Assert.That(seqs).IsEquivalentTo(new[] { 2L });
 	}
 
 	[Test]
@@ -114,9 +216,10 @@ public class ConnectionPumpTests
 			new SharpMUSH.ConnectionServer.Models.ProtocolCapabilities(), null, "websocket"));
 		var sink9 = registry.GetOrCreate(9);
 		sink9.Detach();
-		await replay.AppendAsync(9, System.Text.Encoding.UTF8.GetBytes("one")); // seq 1
-		await replay.AppendAsync(9, System.Text.Encoding.UTF8.GetBytes("two")); // seq 2
-		var token = await resume.MintAsync(9);
+		const string session9 = "live-incarnation-9";
+		await replay.AppendAsync(session9, System.Text.Encoding.UTF8.GetBytes("one")); // seq 1
+		await replay.AppendAsync(session9, System.Text.Encoding.UTF8.GetBytes("two")); // seq 2
+		var token = await resume.MintAsync(9, session9);
 
 		var pump = MakePump(bus, conn, desc, replay, resume, registry, tracker);
 		var transport = new FakeTransport($"{{\"resume\":\"{token}\",\"lastSeq\":1}}", null);
@@ -163,7 +266,7 @@ public class ConnectionPumpTests
 			() => System.Text.Encoding.UTF8, () => { }, null,
 			new SharpMUSH.ConnectionServer.Models.ProtocolCapabilities(), null, "websocket"));
 		registry.GetOrCreate(9).Detach();
-		var oldToken = await resume.MintAsync(9);
+		var oldToken = await resume.MintAsync(9, "live-incarnation-9");
 
 		var pump = MakePump(bus, conn, desc, replay, resume, registry);
 		var transport = new FakeTransport($"{{\"resume\":\"{oldToken}\",\"lastSeq\":0}}", null);
@@ -171,7 +274,7 @@ public class ConnectionPumpTests
 		await pump.RunAsync(transport, candidateHandle: 99, CancellationToken.None);
 
 		// The used token is now spent ...
-		var (oldStillValid, _) = await resume.TryResolveAsync(oldToken);
+		var (oldStillValid, _, _) = await resume.TryResolveAsync(oldToken);
 		await Assert.That(oldStillValid).IsFalse();
 
 		// ... and a fresh token was issued that resolves to the same handle.
@@ -179,8 +282,10 @@ public class ConnectionPumpTests
 			.Select(b => System.Text.Encoding.UTF8.GetString(b))
 			.First(s => s.Contains("resumeToken"));
 		var newToken = System.Text.Json.JsonDocument.Parse(newTokenFrame).RootElement.GetProperty("resumeToken").GetString()!;
-		var (newValid, newHandle) = await resume.TryResolveAsync(newToken);
+		var (newValid, newHandle, newSession) = await resume.TryResolveAsync(newToken);
 		await Assert.That(newValid).IsTrue();
 		await Assert.That(newHandle).IsEqualTo(9L);
+		// The rotated token stays bound to the SAME incarnation, so a further drop still replays this session.
+		await Assert.That(newSession).IsEqualTo("live-incarnation-9");
 	}
 }

--- a/SharpMUSH.Tests/ConnectionServer/ConnectionPumpTests.cs
+++ b/SharpMUSH.Tests/ConnectionServer/ConnectionPumpTests.cs
@@ -154,7 +154,7 @@ public class ConnectionPumpTests
 			Arg.Any<SharpMUSH.ConnectionServer.Models.ProtocolCapabilities?>());
 
 		var pump = MakePump(bus, conn, desc, replay);
-		var cts = new CancellationTokenSource();
+		using var cts = new CancellationTokenSource();
 		var transport = new FakeTransport("{\"hello\":1}", null);
 
 		await pump.RunAsync(transport, candidateHandle: 7, cts.Token);
@@ -196,6 +196,10 @@ public class ConnectionPumpTests
 			.Select(SeqEnvelope.ReadSeq)
 			.ToArray();
 		await Assert.That(seqs).IsEquivalentTo(new[] { 2L });
+
+		// The consumed token is spent (single-use), so a retry can't re-fetch the buffer.
+		var (stillValid, _, _) = await resume.TryResolveAsync(deadToken);
+		await Assert.That(stillValid).IsFalse();
 	}
 
 	[Test]

--- a/SharpMUSH.Tests/ConnectionServer/DetachedSessionTrackerTests.cs
+++ b/SharpMUSH.Tests/ConnectionServer/DetachedSessionTrackerTests.cs
@@ -53,4 +53,38 @@ public class DetachedSessionTrackerTests
 
 		await Assert.That(fired).IsEqualTo(0);
 	}
+
+	[Test]
+	public async Task Fire_routes_a_synchronous_throw_to_onFault()
+	{
+		Exception? observed = null;
+		var boom = new InvalidOperationException("sync boom");
+
+		TimerGraceScheduler.Fire(() => throw boom, ex => observed = ex);
+
+		await Assert.That(observed).IsEqualTo(boom);
+	}
+
+	[Test]
+	public async Task Fire_observes_an_async_fault_instead_of_leaving_it_unobserved()
+	{
+		Exception? observed = null;
+		var boom = new InvalidOperationException("async boom");
+
+		// A faulted Task returned by the action must be observed (and routed), not dropped via `_ = action()`.
+		TimerGraceScheduler.Fire(() => Task.FromException(boom), ex => observed = ex);
+
+		await Assert.That(observed).IsNotNull();
+		await Assert.That(observed!.Message).IsEqualTo("async boom");
+	}
+
+	[Test]
+	public async Task Fire_does_not_invoke_onFault_on_success()
+	{
+		var faulted = false;
+
+		TimerGraceScheduler.Fire(() => Task.CompletedTask, _ => faulted = true);
+
+		await Assert.That(faulted).IsFalse();
+	}
 }

--- a/SharpMUSH.Tests/ConnectionServer/JetStreamReplayIntegrationTests.cs
+++ b/SharpMUSH.Tests/ConnectionServer/JetStreamReplayIntegrationTests.cs
@@ -60,31 +60,4 @@ public class JetStreamReplayIntegrationTests
 			await strategy.DisposeAsync();
 		}
 	}
-
-	[Test]
-	public async Task DropAsync_purges_a_handles_buffered_output()
-	{
-		var strategy = new NatsTestContainerStrategy();
-		var session = Guid.NewGuid().ToString("N");
-		try
-		{
-			var url = await strategy.GetUrlAsync();
-			var replay = await JetStreamTerminalReplayStore.CreateAsync(url, NullLogger<JetStreamTerminalReplayStore>.Instance);
-
-			await replay.AppendAsync(session, Encoding.UTF8.GetBytes("one"));
-			await replay.AppendAsync(session, Encoding.UTF8.GetBytes("two"));
-			await Assert.That((await replay.AfterAsync(session, lastSeq: 0)).Count).IsEqualTo(2);
-
-			// Dropping a session reclaims its buffered output.
-			await replay.DropAsync(session);
-
-			await Assert.That(await replay.AfterAsync(session, lastSeq: 0)).IsEmpty();
-
-			await replay.DisposeAsync();
-		}
-		finally
-		{
-			await strategy.DisposeAsync();
-		}
-	}
 }

--- a/SharpMUSH.Tests/ConnectionServer/JetStreamReplayIntegrationTests.cs
+++ b/SharpMUSH.Tests/ConnectionServer/JetStreamReplayIntegrationTests.cs
@@ -17,9 +17,10 @@ public class JetStreamReplayIntegrationTests
 	public async Task Replay_and_resume_survive_a_simulated_restart()
 	{
 		var strategy = new NatsTestContainerStrategy();
-		// Unique handle per run so the reused NATS container (24h retention) doesn't accumulate
+		// Unique ids per run so the reused NATS container (24h retention) doesn't accumulate
 		// output from prior runs on the same subject.
 		var h = Math.Abs(BitConverter.ToInt64(Guid.NewGuid().ToByteArray()));
+		var session = Guid.NewGuid().ToString("N");
 		try
 		{
 			var url = await strategy.GetUrlAsync();
@@ -28,10 +29,10 @@ public class JetStreamReplayIntegrationTests
 			var replay1 = await JetStreamTerminalReplayStore.CreateAsync(url, NullLogger<JetStreamTerminalReplayStore>.Instance);
 			var tokens1 = await NatsKvResumeTokenStore.CreateAsync(url, NullLogger<NatsKvResumeTokenStore>.Instance);
 
-			await replay1.AppendAsync(h, Encoding.UTF8.GetBytes("one"));   // seq 1
-			await replay1.AppendAsync(h, Encoding.UTF8.GetBytes("two"));   // seq 2
-			await replay1.AppendAsync(h, Encoding.UTF8.GetBytes("three")); // seq 3
-			var token = await tokens1.MintAsync(h);
+			await replay1.AppendAsync(session, Encoding.UTF8.GetBytes("one"));   // seq 1
+			await replay1.AppendAsync(session, Encoding.UTF8.GetBytes("two"));   // seq 2
+			await replay1.AppendAsync(session, Encoding.UTF8.GetBytes("three")); // seq 3
+			var token = await tokens1.MintAsync(h, session);
 
 			await replay1.DisposeAsync();
 			await tokens1.DisposeAsync();
@@ -40,18 +41,46 @@ public class JetStreamReplayIntegrationTests
 			var replay2 = await JetStreamTerminalReplayStore.CreateAsync(url, NullLogger<JetStreamTerminalReplayStore>.Instance);
 			var tokens2 = await NatsKvResumeTokenStore.CreateAsync(url, NullLogger<NatsKvResumeTokenStore>.Instance);
 
-			// Resume token still resolves to the old handle.
-			var (found, handle) = await tokens2.TryResolveAsync(token);
+			// Resume token still resolves to the old handle and its session id.
+			var (found, handle, resolvedSession) = await tokens2.TryResolveAsync(token);
 			await Assert.That(found).IsTrue();
 			await Assert.That(handle).IsEqualTo(h);
+			await Assert.That(resolvedSession).IsEqualTo(session);
 
 			// Buffered output after the client's acked seq is still replayable.
-			var replayed = await replay2.AfterAsync(h, lastSeq: 1);
+			var replayed = await replay2.AfterAsync(session, lastSeq: 1);
 			var seqs = replayed.Select(SeqEnvelope.ReadSeq).OrderBy(x => x).ToArray();
 			await Assert.That(seqs).IsEquivalentTo(new[] { 2L, 3L });
 
 			await replay2.DisposeAsync();
 			await tokens2.DisposeAsync();
+		}
+		finally
+		{
+			await strategy.DisposeAsync();
+		}
+	}
+
+	[Test]
+	public async Task DropAsync_purges_a_handles_buffered_output()
+	{
+		var strategy = new NatsTestContainerStrategy();
+		var session = Guid.NewGuid().ToString("N");
+		try
+		{
+			var url = await strategy.GetUrlAsync();
+			var replay = await JetStreamTerminalReplayStore.CreateAsync(url, NullLogger<JetStreamTerminalReplayStore>.Instance);
+
+			await replay.AppendAsync(session, Encoding.UTF8.GetBytes("one"));
+			await replay.AppendAsync(session, Encoding.UTF8.GetBytes("two"));
+			await Assert.That((await replay.AfterAsync(session, lastSeq: 0)).Count).IsEqualTo(2);
+
+			// Dropping a session reclaims its buffered output.
+			await replay.DropAsync(session);
+
+			await Assert.That(await replay.AfterAsync(session, lastSeq: 0)).IsEmpty();
+
+			await replay.DisposeAsync();
 		}
 		finally
 		{

--- a/SharpMUSH.Tests/ConnectionServer/ReplayAndResumeTests.cs
+++ b/SharpMUSH.Tests/ConnectionServer/ReplayAndResumeTests.cs
@@ -98,6 +98,17 @@ public class ReplayAndResumeTests
 	}
 
 	[Test]
+	public async Task ReplayStore_Drop_releases_a_sessions_buffer()
+	{
+		var store = new TerminalReplayStore();
+		await store.AppendAsync("sess", Encoding.UTF8.GetBytes("x"));
+
+		await store.DropAsync("sess");
+
+		await Assert.That(await store.AfterAsync("sess", lastSeq: 0)).IsEmpty();
+	}
+
+	[Test]
 	public async Task ResumeToken_carries_both_handle_and_session()
 	{
 		var svc = new ResumeTokenService();

--- a/SharpMUSH.Tests/ConnectionServer/ReplayAndResumeTests.cs
+++ b/SharpMUSH.Tests/ConnectionServer/ReplayAndResumeTests.cs
@@ -30,16 +30,26 @@ public class ReplayAndResumeTests
 	}
 
 	[Test]
+	public async Task SeqEnvelope_IsHello_matches_only_the_structured_handshake()
+	{
+		await Assert.That(SeqEnvelope.IsHello("{\"hello\":1}")).IsTrue();
+		// A real command that merely contains the substring must NOT be read as the handshake.
+		await Assert.That(SeqEnvelope.IsHello("say \"hello\"")).IsFalse();
+		await Assert.That(SeqEnvelope.IsHello("look north")).IsFalse();
+		await Assert.That(SeqEnvelope.IsHello("{\"resume\":\"tok\",\"lastSeq\":0}")).IsFalse();
+	}
+
+	[Test]
 	public async Task ReplayStore_assigns_monotonic_seq_and_replays_after_lastSeq()
 	{
 		var store = new TerminalReplayStore();
-		var s1 = (await store.AppendAsync(9, Encoding.UTF8.GetBytes("one"))).Seq;
-		var s2 = (await store.AppendAsync(9, Encoding.UTF8.GetBytes("two"))).Seq;
-		var s3 = (await store.AppendAsync(9, Encoding.UTF8.GetBytes("three"))).Seq;
+		var s1 = (await store.AppendAsync("sess", Encoding.UTF8.GetBytes("one"))).Seq;
+		var s2 = (await store.AppendAsync("sess", Encoding.UTF8.GetBytes("two"))).Seq;
+		var s3 = (await store.AppendAsync("sess", Encoding.UTF8.GetBytes("three"))).Seq;
 
 		await Assert.That(new[] { s1, s2, s3 }).IsEquivalentTo(new[] { 1L, 2L, 3L });
 
-		var replay = await store.AfterAsync(9, lastSeq: 1);
+		var replay = await store.AfterAsync("sess", lastSeq: 1);
 		await Assert.That(replay.Count).IsEqualTo(2);
 		await Assert.That(SeqEnvelope.ReadSeq(replay[0])).IsEqualTo(2L);
 	}
@@ -50,11 +60,11 @@ public class ReplayAndResumeTests
 		var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
 		var clock = now;
 		var store = new TerminalReplayStore(() => clock);
-		await store.AppendAsync(1, Encoding.UTF8.GetBytes("old"));
+		await store.AppendAsync("sess", Encoding.UTF8.GetBytes("old"));
 		clock = now.AddSeconds(45); // past the 30s window
-		await store.AppendAsync(1, Encoding.UTF8.GetBytes("fresh"));
+		await store.AppendAsync("sess", Encoding.UTF8.GetBytes("fresh"));
 
-		var replay = await store.AfterAsync(1, lastSeq: 0);
+		var replay = await store.AfterAsync("sess", lastSeq: 0);
 
 		await Assert.That(replay.Count).IsEqualTo(1); // only "fresh" survives the age cutoff
 	}
@@ -65,14 +75,37 @@ public class ReplayAndResumeTests
 		var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
 		var clock = now;
 		var svc = new ResumeTokenService(() => clock);
-		var token = await svc.MintAsync(handle: 55);
+		var token = await svc.MintAsync(handle: 55, session: "sess");
 
-		var (found1, h1) = await svc.TryResolveAsync(token);
+		var (found1, h1, _) = await svc.TryResolveAsync(token);
 		await Assert.That(found1).IsTrue();
 		await Assert.That(h1).IsEqualTo(55L);
 
 		clock = now.AddSeconds(31);
-		var (found2, _) = await svc.TryResolveAsync(token);
+		var (found2, _, _) = await svc.TryResolveAsync(token);
 		await Assert.That(found2).IsFalse();
+	}
+
+	[Test]
+	public async Task ReplayStore_isolates_frames_by_session()
+	{
+		var store = new TerminalReplayStore();
+		await store.AppendAsync("session-A", Encoding.UTF8.GetBytes("prior secret"));
+
+		// A different incarnation (e.g. a recycled handle's new occupant) must never see another's frames.
+		await Assert.That(await store.AfterAsync("session-B", lastSeq: 0)).IsEmpty();
+		await Assert.That((await store.AfterAsync("session-A", lastSeq: 0)).Count).IsEqualTo(1);
+	}
+
+	[Test]
+	public async Task ResumeToken_carries_both_handle_and_session()
+	{
+		var svc = new ResumeTokenService();
+		var token = await svc.MintAsync(handle: 7, session: "session-A");
+
+		var (found, handle, session) = await svc.TryResolveAsync(token);
+		await Assert.That(found).IsTrue();
+		await Assert.That(handle).IsEqualTo(7L);
+		await Assert.That(session).IsEqualTo("session-A");
 	}
 }

--- a/SharpMUSH.Tests/ConnectionServer/ReplayPersistLatencyBenchmark.cs
+++ b/SharpMUSH.Tests/ConnectionServer/ReplayPersistLatencyBenchmark.cs
@@ -12,7 +12,11 @@ namespace SharpMUSH.Tests.ConnectionServer;
 /// JetStream, comparing the current INLINE path (await the JetStream publish before delivering to the
 /// user) with a CHANNEL-DECOUPLED path (deliver immediately; a background drain persists). Prints the
 /// numbers and asserts the decoupled path both wins big on delivery latency and still persists everything.
+///
+/// Marked <see cref="ExplicitAttribute"/>: it asserts an environment-dependent performance ratio against a
+/// real NATS container, so it is a manual perf check rather than a CI gate.
 /// </summary>
+[Explicit]
 public class ReplayPersistLatencyBenchmark
 {
 	private const int Frames = 300;
@@ -24,8 +28,8 @@ public class ReplayPersistLatencyBenchmark
 	public async Task Decoupling_persist_removes_the_nats_rtt_from_output_delivery()
 	{
 		var strategy = new NatsTestContainerStrategy();
-		var hInline = Math.Abs(BitConverter.ToInt64(Guid.NewGuid().ToByteArray()));
-		var hDecoupled = Math.Abs(BitConverter.ToInt64(Guid.NewGuid().ToByteArray()));
+		var sInline = Guid.NewGuid().ToString("N");
+		var sDecoupled = Guid.NewGuid().ToString("N");
 		try
 		{
 			var url = await strategy.GetUrlAsync();
@@ -35,7 +39,7 @@ public class ReplayPersistLatencyBenchmark
 			var line = Encoding.UTF8.GetBytes("You see a dusty room. Exits lead north and east. A brass lantern rests here.");
 
 			// Warm up (JIT + JetStream connection + first-publish setup) so we measure steady state.
-			for (var i = 0; i < 20; i++) await store.AppendAsync(hInline, line);
+			for (var i = 0; i < 20; i++) await store.AppendAsync(sInline, line);
 
 			// ---- INLINE (current): delivery is gated by the JetStream publish ack. ----
 			var inline = new List<double>(Frames);
@@ -43,7 +47,7 @@ public class ReplayPersistLatencyBenchmark
 			for (var i = 0; i < Frames; i++)
 			{
 				var sw = Stopwatch.StartNew();
-				var (_, wrapped) = await store.AppendAsync(hInline, line); // await NATS RTT ...
+				var (_, wrapped) = await store.AppendAsync(sInline, line); // await NATS RTT ...
 				DeliverToUser(wrapped);                                    // ... then the user sees it
 				inline.Add(sw.Elapsed.TotalMilliseconds);
 			}
@@ -62,7 +66,7 @@ public class ReplayPersistLatencyBenchmark
 			{
 				await foreach (var raw in channel.Reader.ReadAllAsync())
 				{
-					await store.AppendAsync(hDecoupled, raw); // off the delivery path
+					await store.AppendAsync(sDecoupled, raw); // off the delivery path
 					Interlocked.Increment(ref persisted);
 				}
 			});

--- a/SharpMUSH.Tests/ConnectionServer/ReplayPersistLatencyBenchmark.cs
+++ b/SharpMUSH.Tests/ConnectionServer/ReplayPersistLatencyBenchmark.cs
@@ -24,11 +24,9 @@ public class ReplayPersistLatencyBenchmark
 	private static double Percentile(List<double> sortedMs, double p)
 		=> sortedMs[Math.Clamp((int)(p / 100.0 * sortedMs.Count), 0, sortedMs.Count - 1)];
 
-	// Explicit: this is a latency benchmark whose assertions compare inline-vs-decoupled timing
-	// ratios. Those ratios are only meaningful when the test has the CPU/NATS to itself; run inside
-	// the parallel suite they flake under contention. Matches the NatsPerformanceValidation timing
-	// tests, which are also [Explicit] (run on demand via the test filter, not in the gating suite).
-	[Test, Explicit]
+	// The whole class is [Explicit] (see class doc): this benchmark asserts an environment-dependent
+	// timing ratio, so it runs on demand via the test filter, not as part of the gating suite.
+	[Test]
 	public async Task Decoupling_persist_removes_the_nats_rtt_from_output_delivery()
 	{
 		var strategy = new NatsTestContainerStrategy();


### PR DESCRIPTION
Follow-up on the review feedback from the merged session-resilience PR (#664). Each behavioral fix is TDD'd; **57 ConnectionServer tests pass**, including two live NATS JetStream integration tests.

## Bugs (from Copilot review)

- **Output closure tied to the dropped socket's token** — the engine-output delegate in `ConnectionPump` captured the per-connection `ct` (`RequestAborted`), which cancels on drop. That aborted replay buffering and delivery-to-reattached-transport *during the grace window* — exactly when resilience matters. Now uses `CancellationToken.None`.
- **`IsHello` substring match** — `frame.Contains("\"hello\"")` misclassified a real first command like `say "hello"` as the handshake and silently dropped it. Now matches the structured `{"hello":n}` frame via `SeqEnvelope.IsHello`.
- **Cross-session replay leak** — replay was keyed by the *reusable* connection handle, so a recycled handle's new occupant could replay a prior session's output (worse after a restart reset the in-memory seq counter). Replay is now keyed by a **per-incarnation session id** minted at fresh registration and carried in the resume token. A recycled handle's new session gets a new id, so it can never read another incarnation's buffer — and this preserves the "resume-to-dead" durable replay (the dead session's buffer lives under its own id). Touches `ITerminalReplayStore` / `IResumeTokenStore` and both in-memory + NATS implementations.
- **Unobserved task fault** — `TimerGraceScheduler` fired `_ = action()`, dropping async faults into `TaskScheduler.UnobservedTaskException`. Extracted a fault-observing `Fire` helper (added an `InternalsVisibleTo` test seam).

## Hygiene

- Removed the unused `System.Text.Json` using in `WebSocketClientService` (CS8019 under `TreatWarningsAsErrors`).
- Marked `ReplayPersistLatencyBenchmark` `[Explicit]` so its environment-dependent perf assertion is a manual check, not a flaky CI gate.

The remaining CodeQL-bot comments on #664 were already resolved before merge (empty catches now `return false`, `.Where` already used, the test predicate is non-throwing) or are deliberate documented broad catches; no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHCRc5CJ6595iMzEgYYdQp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced reconnect/resume so replay buffering and terminal replay history are consistently tied to a unique per-connection incarnation session.
  * Improved handshake detection to only match the structured `{"hello": ...}` frame.

* **Bug Fixes**
  * Prevented replayed output and terminal history from leaking when connection identifiers are reused.
  * Fixed resume token rotation and replay lookup so the correct session is preserved across reconnects.
  * Improved grace-period scheduling fault handling to ensure errors are observed and logged when available.

* **Tests**
  * Expanded coverage for session-scoped replay/resume, handshake classification, and scheduled-fault behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->