### PR TITLE
Add in-server authenticated MCP endpoint + shared code-analysis engine

### DIFF
--- a/SharpMUSH.CodeAnalysis/AnalysisResults.cs
+++ b/SharpMUSH.CodeAnalysis/AnalysisResults.cs
@@ -1,0 +1,36 @@
+using Range = SharpMUSH.Library.Models.Range;
+
+namespace SharpMUSH.CodeAnalysis;
+
+/// <summary>Hover information for a symbol at a position: markdown plus the covered range.</summary>
+public record HoverInfo(string Markdown, Range Range);
+
+/// <summary>A single completion suggestion.</summary>
+/// <param name="Kind">"Function", "Keyword", or "Variable".</param>
+/// <param name="IsSnippet">When true, <paramref name="InsertText"/> is a snippet (uses $0 tab stops).</param>
+public record CompletionSuggestion(
+	string Label,
+	string Kind,
+	string? Detail,
+	string? Documentation,
+	string? InsertText,
+	bool IsSnippet);
+
+/// <summary>One parameter within a <see cref="SignatureInfo"/>.</summary>
+public record ParameterInfo(string Label, string Documentation);
+
+/// <summary>Signature help for the function call surrounding a position.</summary>
+public record SignatureInfo(
+	string Label,
+	string Documentation,
+	IReadOnlyList<ParameterInfo> Parameters,
+	int ActiveParameter);
+
+/// <summary>A document outline symbol.</summary>
+/// <param name="Kind">"Property", "Function", or "Method".</param>
+public record CodeSymbol(
+	string Name,
+	string Kind,
+	string Detail,
+	Range Range,
+	Range SelectionRange);

--- a/SharpMUSH.CodeAnalysis/IMushCodeAnalyzer.cs
+++ b/SharpMUSH.CodeAnalysis/IMushCodeAnalyzer.cs
@@ -21,4 +21,11 @@ public interface IMushCodeAnalyzer
 	/// <param name="code">The MUSH softcode to analyse.</param>
 	/// <param name="parseType">Whether to parse the text as a function or command.</param>
 	IReadOnlyList<Diagnostic> Validate(string code, ParseType parseType = ParseType.Function);
+
+	/// <summary>
+	/// Formats MUSH softcode with a consistent style: trims trailing/leading whitespace per
+	/// line, ensures a space after a comma, and a space between an <c>@command</c> and its
+	/// first argument. Line count is preserved. Never throws.
+	/// </summary>
+	string Format(string code);
 }

--- a/SharpMUSH.CodeAnalysis/IMushCodeAnalyzer.cs
+++ b/SharpMUSH.CodeAnalysis/IMushCodeAnalyzer.cs
@@ -28,4 +28,30 @@ public interface IMushCodeAnalyzer
 	/// first argument. Line count is preserved. Never throws.
 	/// </summary>
 	string Format(string code);
+
+	/// <summary>
+	/// Returns hover information (function/command signature docs, or a built-in pattern
+	/// explanation) for the word at the 0-based <paramref name="line"/>/<paramref name="character"/>,
+	/// or null if there is nothing to show. Never throws.
+	/// </summary>
+	HoverInfo? Hover(string code, int line, int character);
+
+	/// <summary>
+	/// Returns completion suggestions (functions, commands, and common substitutions) for the
+	/// word prefix at the 0-based <paramref name="line"/>/<paramref name="character"/>. Never throws.
+	/// </summary>
+	IReadOnlyList<CompletionSuggestion> Complete(string code, int line, int character);
+
+	/// <summary>
+	/// Returns signature help for the function call surrounding the 0-based
+	/// <paramref name="line"/>/<paramref name="character"/>, or null if the position is not
+	/// inside a known function call. Never throws.
+	/// </summary>
+	SignatureInfo? SignatureHelp(string code, int line, int character);
+
+	/// <summary>
+	/// Returns an outline of the softcode: attribute definitions, <c>@set</c> attributes,
+	/// function calls, and commands. Never throws.
+	/// </summary>
+	IReadOnlyList<CodeSymbol> DocumentSymbols(string code);
 }

--- a/SharpMUSH.CodeAnalysis/IMushCodeAnalyzer.cs
+++ b/SharpMUSH.CodeAnalysis/IMushCodeAnalyzer.cs
@@ -1,5 +1,4 @@
 using SharpMUSH.Library.Models;
-using SharpMUSH.Library.ParserInterfaces;
 
 namespace SharpMUSH.CodeAnalysis;
 
@@ -19,8 +18,12 @@ public interface IMushCodeAnalyzer
 	/// error diagnostic so callers can always render a result.
 	/// </summary>
 	/// <param name="code">The MUSH softcode to analyse.</param>
-	/// <param name="parseType">Whether to parse the text as a function or command.</param>
-	IReadOnlyList<Diagnostic> Validate(string code, ParseType parseType = ParseType.Function);
+	/// <param name="mode">
+	/// How to parse the code. <see cref="MushAnalysisMode.CommandsPerLine"/> parses each line as
+	/// its own command (real-world <c>.mush</c> files); the others parse the whole buffer as one
+	/// unit.
+	/// </param>
+	IReadOnlyList<Diagnostic> Validate(string code, MushAnalysisMode mode = MushAnalysisMode.Function);
 
 	/// <summary>
 	/// Formats MUSH softcode with a consistent style: trims trailing/leading whitespace per

--- a/SharpMUSH.CodeAnalysis/IMushCodeAnalyzer.cs
+++ b/SharpMUSH.CodeAnalysis/IMushCodeAnalyzer.cs
@@ -1,0 +1,24 @@
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+
+namespace SharpMUSH.CodeAnalysis;
+
+/// <summary>
+/// Stateless, read-only MUSH code intelligence used by both the Language Server
+/// (for editors) and the in-server MCP tools (for AI agents / tooling).
+///
+/// A single source of truth for analysing MUSH softcode: every consumer maps the
+/// plain-domain results returned here into its own protocol (LSP types, MCP JSON, …).
+/// Implementations never mutate parser or world state.
+/// </summary>
+public interface IMushCodeAnalyzer
+{
+	/// <summary>
+	/// Parses <paramref name="code"/> and returns any diagnostics (syntax errors,
+	/// warnings, hints). Never throws: a parser failure is surfaced as a single
+	/// error diagnostic so callers can always render a result.
+	/// </summary>
+	/// <param name="code">The MUSH softcode to analyse.</param>
+	/// <param name="parseType">Whether to parse the text as a function or command.</param>
+	IReadOnlyList<Diagnostic> Validate(string code, ParseType parseType = ParseType.Function);
+}

--- a/SharpMUSH.CodeAnalysis/MushAnalysisMode.cs
+++ b/SharpMUSH.CodeAnalysis/MushAnalysisMode.cs
@@ -1,0 +1,42 @@
+using SharpMUSH.Library.ParserInterfaces;
+
+namespace SharpMUSH.CodeAnalysis;
+
+/// <summary>
+/// How a piece of softcode should be analysed. Unlike a raw <see cref="ParseType"/>, this also
+/// captures whether the buffer is parsed as one unit or line-by-line.
+/// </summary>
+public enum MushAnalysisMode
+{
+	/// <summary>The whole buffer is one function/expression.</summary>
+	Function,
+
+	/// <summary>The whole buffer is one command list (e.g. <c>;</c>-separated commands).</summary>
+	CommandList,
+
+	/// <summary>The whole buffer is a single command.</summary>
+	Command,
+
+	/// <summary>
+	/// Each non-blank line is its own single command — how a real-world <c>.mush</c> upload /
+	/// quote file is executed (one command per line). Diagnostics are produced per line and
+	/// offset back to the file.
+	/// </summary>
+	CommandsPerLine
+}
+
+public static class MushAnalysisModeExtensions
+{
+	/// <summary>
+	/// The per-unit <see cref="ParseType"/> this mode parses with. For
+	/// <see cref="MushAnalysisMode.CommandsPerLine"/> each line is a single
+	/// <see cref="ParseType.Command"/>.
+	/// </summary>
+	public static ParseType ToParseType(this MushAnalysisMode mode) => mode switch
+	{
+		MushAnalysisMode.CommandList => ParseType.CommandList,
+		MushAnalysisMode.Command => ParseType.Command,
+		MushAnalysisMode.CommandsPerLine => ParseType.Command,
+		_ => ParseType.Function
+	};
+}

--- a/SharpMUSH.CodeAnalysis/MushCodeAnalyzer.Intelligence.cs
+++ b/SharpMUSH.CodeAnalysis/MushCodeAnalyzer.Intelligence.cs
@@ -202,7 +202,7 @@ public partial class MushCodeAnalyzer
 		=> char.IsLetterOrDigit(c) || c is '_' or '@' or '%' or '#';
 
 	private static bool IsCompletionWordChar(char c)
-		=> char.IsLetterOrDigit(c) || c is '_' or '@';
+		=> char.IsLetterOrDigit(c) || c is '_' or '@' or '%' or '#';
 
 	private static bool IsSignatureWordChar(char c)
 		=> char.IsLetterOrDigit(c) || c == '_';

--- a/SharpMUSH.CodeAnalysis/MushCodeAnalyzer.Intelligence.cs
+++ b/SharpMUSH.CodeAnalysis/MushCodeAnalyzer.Intelligence.cs
@@ -82,7 +82,9 @@ public partial class MushCodeAnalyzer
 				}
 			}
 
-			if (character == 0 || (character > 0 && char.IsWhiteSpace(text[character - 1])))
+			// Offer commands at the start of a line/after whitespace, or while typing an @command.
+			if (character == 0 || (character > 0 && char.IsWhiteSpace(text[character - 1])) ||
+			    prefix.StartsWith('@'))
 			{
 				foreach (var (name, definition) in parser.CommandLibrary)
 				{
@@ -143,7 +145,8 @@ public partial class MushCodeAnalyzer
 			var lines = code.Split('\n');
 			for (var i = 0; i < lines.Length; i++)
 			{
-				var line = lines[i];
+				// Drop a trailing CR so symbol ranges aren't off-by-one on CRLF documents.
+				var line = lines[i].TrimEnd('\r');
 
 				var attributeMatch = AttributeDefinitionRegex().Match(line);
 				if (attributeMatch.Success)

--- a/SharpMUSH.CodeAnalysis/MushCodeAnalyzer.Intelligence.cs
+++ b/SharpMUSH.CodeAnalysis/MushCodeAnalyzer.Intelligence.cs
@@ -1,0 +1,426 @@
+using System.Text.RegularExpressions;
+using SharpMUSH.Library.Attributes;
+using SharpMUSH.Library.Models;
+using Range = SharpMUSH.Library.Models.Range;
+
+namespace SharpMUSH.CodeAnalysis;
+
+/// <summary>
+/// Position-based code intelligence (hover, completion, signature help, symbols) extracted
+/// from the Language Server handlers so the LSP and the in-server MCP tools share one
+/// implementation. All methods are read-only and never throw.
+/// </summary>
+public partial class MushCodeAnalyzer
+{
+	public HoverInfo? Hover(string code, int line, int character)
+	{
+		try
+		{
+			var lines = code.Split('\n');
+			var text = line >= 0 && line < lines.Length ? lines[line] : string.Empty;
+			character = Math.Clamp(character, 0, text.Length);
+
+			var wordStart = character;
+			var wordEnd = character;
+			while (wordStart > 0 && IsHoverWordChar(text[wordStart - 1])) wordStart--;
+			while (wordEnd < text.Length && IsHoverWordChar(text[wordEnd])) wordEnd++;
+			if (wordStart >= wordEnd) return null;
+
+			var word = text.Substring(wordStart, wordEnd - wordStart);
+
+			string? markdown;
+			if (parser.FunctionLibrary.TryGetValue(word, out var fd))
+			{
+				markdown = BuildFunctionHover(word, fd.LibraryInformation.Attribute);
+			}
+			else if (parser.CommandLibrary.TryGetValue(word, out var cd))
+			{
+				markdown = BuildCommandHover(word, cd.LibraryInformation.Attribute);
+			}
+			else
+			{
+				markdown = GetPatternInfo(word);
+			}
+
+			if (markdown is null) return null;
+
+			return new HoverInfo(
+				markdown,
+				new Range { Start = new Position(line, wordStart), End = new Position(line, wordEnd) });
+		}
+		catch
+		{
+			return null;
+		}
+	}
+
+	public IReadOnlyList<CompletionSuggestion> Complete(string code, int line, int character)
+	{
+		var completions = new List<CompletionSuggestion>();
+		try
+		{
+			var lines = code.Split('\n');
+			var text = line >= 0 && line < lines.Length ? lines[line] : string.Empty;
+			character = Math.Clamp(character, 0, text.Length);
+
+			var wordStart = character;
+			while (wordStart > 0 && IsCompletionWordChar(text[wordStart - 1])) wordStart--;
+			var prefix = wordStart < text.Length ? text.Substring(wordStart, character - wordStart) : string.Empty;
+
+			foreach (var (name, definition) in parser.FunctionLibrary)
+			{
+				if (prefix.Length == 0 || name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+				{
+					var attr = definition.LibraryInformation.Attribute;
+					completions.Add(new CompletionSuggestion(
+						name,
+						"Function",
+						$"{name}({GetParameterList(attr.MinArgs, attr.MaxArgs, ", ...")})",
+						$"Min args: {attr.MinArgs}, Max args: {attr.MaxArgs}",
+						$"{name}($0)",
+						IsSnippet: true));
+				}
+			}
+
+			if (character == 0 || (character > 0 && char.IsWhiteSpace(text[character - 1])))
+			{
+				foreach (var (name, definition) in parser.CommandLibrary)
+				{
+					if (prefix.Length == 0 || name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+					{
+						var switches = definition.LibraryInformation.Attribute.Switches ?? [];
+						completions.Add(new CompletionSuggestion(
+							name,
+							"Keyword",
+							$"Command: {name}",
+							$"Switches: {string.Join(", ", switches)}",
+							name,
+							IsSnippet: false));
+					}
+				}
+			}
+
+			AddCommonPatterns(completions, prefix);
+		}
+		catch
+		{
+			// fall through with whatever was collected
+		}
+
+		return completions;
+	}
+
+	public SignatureInfo? SignatureHelp(string code, int line, int character)
+	{
+		try
+		{
+			var lines = code.Split('\n');
+			var text = line >= 0 && line < lines.Length ? lines[line] : string.Empty;
+			character = Math.Clamp(character, 0, text.Length);
+
+			var functionInfo = FindFunctionAtPosition(text, character);
+			if (functionInfo is null) return null;
+
+			var (functionName, currentParam) = functionInfo.Value;
+			if (parser.FunctionLibrary.TryGetValue(functionName, out var fd))
+			{
+				return BuildSignatureInfo(functionName, fd.LibraryInformation.Attribute, currentParam);
+			}
+
+			return null;
+		}
+		catch
+		{
+			return null;
+		}
+	}
+
+	public IReadOnlyList<CodeSymbol> DocumentSymbols(string code)
+	{
+		var symbols = new List<CodeSymbol>();
+		try
+		{
+			var lines = code.Split('\n');
+			for (var i = 0; i < lines.Length; i++)
+			{
+				var line = lines[i];
+
+				var attributeMatch = AttributeDefinitionRegex().Match(line);
+				if (attributeMatch.Success)
+				{
+					symbols.Add(new CodeSymbol(
+						attributeMatch.Groups[1].Value, "Property", "Attribute definition",
+						FullLineRange(i, line),
+						SelectionRange(i, attributeMatch.Index, attributeMatch.Length)));
+				}
+
+				var setMatch = SetAttributeRegex().Match(line);
+				if (setMatch.Success)
+				{
+					symbols.Add(new CodeSymbol(
+						setMatch.Groups[1].Value, "Property", "@set attribute",
+						FullLineRange(i, line),
+						SelectionRange(i, setMatch.Groups[1].Index, setMatch.Groups[1].Length)));
+				}
+
+				var functionMatch = FunctionCallRegex().Match(line);
+				if (functionMatch.Success)
+				{
+					symbols.Add(new CodeSymbol(
+						functionMatch.Groups[1].Value, "Function", "Function call",
+						FullLineRange(i, line),
+						SelectionRange(i, functionMatch.Groups[1].Index, functionMatch.Groups[1].Length)));
+				}
+
+				var commandMatch = CommandRegex().Match(line);
+				if (commandMatch.Success)
+				{
+					symbols.Add(new CodeSymbol(
+						commandMatch.Groups[1].Value, "Method", "MUSH command",
+						FullLineRange(i, line),
+						SelectionRange(i, commandMatch.Index, commandMatch.Length)));
+				}
+			}
+		}
+		catch
+		{
+			// fall through with whatever was collected
+		}
+
+		return symbols;
+	}
+
+	// ── shared helpers ─────────────────────────────────────────────────────────
+
+	private static Range FullLineRange(int line, string text)
+		=> new() { Start = new Position(line, 0), End = new Position(line, text.Length) };
+
+	private static Range SelectionRange(int line, int start, int length)
+		=> new() { Start = new Position(line, start), End = new Position(line, start + length) };
+
+	private static bool IsHoverWordChar(char c)
+		=> char.IsLetterOrDigit(c) || c is '_' or '@' or '%' or '#';
+
+	private static bool IsCompletionWordChar(char c)
+		=> char.IsLetterOrDigit(c) || c is '_' or '@';
+
+	private static bool IsSignatureWordChar(char c)
+		=> char.IsLetterOrDigit(c) || c == '_';
+
+	private static string GetParameterList(int minArgs, int maxArgs, string optionalSuffix)
+	{
+		if (minArgs == 0 && maxArgs == 0) return "";
+		if (minArgs == maxArgs)
+			return string.Join(", ", Enumerable.Range(1, minArgs).Select(i => $"arg{i}"));
+		return string.Join(", ", Enumerable.Range(1, minArgs).Select(i => $"arg{i}")) +
+		       (maxArgs > minArgs ? optionalSuffix : "");
+	}
+
+	private static string BuildFunctionHover(string name, SharpFunctionAttribute attr)
+	{
+		var markdown = $"### Function: `{name}`\n\n";
+		markdown += $"**Signature:** `{name}({GetParameterList(attr.MinArgs, attr.MaxArgs, ", [optional...]")})`\n\n";
+		markdown += "**Arguments:**\n";
+		markdown += $"- Minimum: {attr.MinArgs}\n";
+		markdown += $"- Maximum: {attr.MaxArgs}\n\n";
+
+		if (attr.Flags != 0)
+		{
+			markdown += $"**Flags:** {attr.Flags}\n\n";
+		}
+
+		if (attr.Restrict is { Length: > 0 })
+		{
+			markdown += $"**Restrictions:** {string.Join(", ", attr.Restrict)}\n\n";
+		}
+
+		return markdown;
+	}
+
+	private static string BuildCommandHover(string name, SharpCommandAttribute attr)
+	{
+		var markdown = $"### Command: `{name}`\n\n";
+
+		if (attr.Switches is { Length: > 0 })
+		{
+			markdown += $"**Switches:** {string.Join(", ", attr.Switches)}\n\n";
+		}
+
+		markdown += "**Arguments:**\n";
+		markdown += $"- Minimum: {attr.MinArgs}\n";
+		markdown += $"- Maximum: {attr.MaxArgs}\n\n";
+
+		if (!string.IsNullOrEmpty(attr.CommandLock))
+		{
+			markdown += $"**Lock:** {attr.CommandLock}\n\n";
+		}
+
+		markdown += $"**Behavior:** {attr.Behavior}\n\n";
+
+		return markdown;
+	}
+
+	private static string? GetPatternInfo(string word)
+		=> word switch
+		{
+			"%#" => "**Current object** - The #dbref of the object this code is set on",
+			"%!" => "**Executing object** - The #dbref of the object executing the code",
+			"%@" => "**Calling object** - The #dbref of the object that called this code",
+			"%N" or "%n" => "**Player name** - The name of the player executing the code",
+			"%l" or "%L" => "**Location** - The location of the executing object",
+			"%" when word.Length == 2 && char.IsDigit(word[1]) =>
+				$"**Argument {word[1]}** - The {word[1]}th argument passed to this function/command",
+			"%" when word.Length == 3 && word[1] == 'q' && char.IsLetter(word[2]) =>
+				$"**Q-register {word[2]}** - Q-register storage",
+			"%" when word.Length == 3 && word[1] == 'v' && char.IsLetter(word[2]) =>
+				$"**V-register {word[2]}** - V-register storage",
+			"#" when word.Length > 1 && word.Skip(1).All(char.IsDigit) =>
+				$"**Object reference** - References object #{word[1..]}",
+			_ => null
+		};
+
+	private static void AddCommonPatterns(List<CompletionSuggestion> completions, string prefix)
+	{
+		var patterns = new[]
+		{
+			("%#", "Current object (#dbref)"),
+			("%!", "Executing object (#dbref)"),
+			("%@", "Calling object (#dbref)"),
+			("%N", "Player name"),
+			("%0", "Argument 0"),
+			("%1", "Argument 1"),
+			("%qa", "Q-register a"),
+			("%va", "V-register a")
+		};
+
+		foreach (var (label, detail) in patterns)
+		{
+			if (prefix.Length == 0 || label.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+			{
+				completions.Add(new CompletionSuggestion(label, "Variable", detail, null, label, IsSnippet: false));
+			}
+		}
+	}
+
+	private static (string functionName, int currentParam)? FindFunctionAtPosition(string line, int position)
+	{
+		var depth = 0;
+		var paramCount = 0;
+		var i = position - 1;
+
+		while (i >= 0)
+		{
+			if (line[i] == ')')
+			{
+				depth++;
+			}
+			else if (line[i] == '(')
+			{
+				depth--;
+				if (depth < 0)
+				{
+					var nameEnd = i;
+					i--;
+					while (i >= 0 && IsSignatureWordChar(line[i])) i--;
+					var functionName = line.Substring(i + 1, nameEnd - i - 1);
+					return (functionName, paramCount);
+				}
+			}
+			else if (line[i] == ',' && depth == 0)
+			{
+				paramCount++;
+			}
+
+			i--;
+		}
+
+		return null;
+	}
+
+	private static SignatureInfo BuildSignatureInfo(string functionName, SharpFunctionAttribute attr, int activeParam)
+	{
+		var parameters = new List<ParameterInfo>();
+		var label = functionName + "(";
+
+		for (var i = 0; i < attr.MaxArgs; i++)
+		{
+			var paramName = GetSignatureParameterName(i, attr);
+			var isOptional = i >= attr.MinArgs;
+
+			if (i > 0) label += ", ";
+			if (isOptional) label += "[";
+			label += paramName;
+			if (isOptional) label += "]";
+
+			parameters.Add(new ParameterInfo(
+				paramName,
+				isOptional ? $"Optional parameter {i + 1}" : $"Required parameter {i + 1}"));
+		}
+
+		label += ")";
+
+		var documentation = $"**Function**: {functionName}\n\n";
+		documentation += $"**Arguments**: {attr.MinArgs}-{attr.MaxArgs}\n\n";
+		if (attr.Flags != 0)
+		{
+			documentation += $"**Flags**: {attr.Flags}\n\n";
+		}
+
+		return new SignatureInfo(label, documentation, parameters, activeParam);
+	}
+
+	private static string GetSignatureParameterName(int index, SharpFunctionAttribute attr)
+		=> attr.ParameterNames is { Length: > 0 }
+			? ExpandParameterName(attr.ParameterNames, index)
+			: $"arg{index + 1}";
+
+	/// <summary>
+	/// Expands parameter-name patterns: "param..." → param1, param2, …;
+	/// "case...|result..." → alternating case1, result1, case2, result2, ….
+	/// </summary>
+	private static string ExpandParameterName(string[] parameterNames, int index)
+	{
+		var currentIndex = 0;
+
+		foreach (var paramName in parameterNames)
+		{
+			if (paramName.Contains("..."))
+			{
+				if (paramName.Contains('|'))
+				{
+					var parts = paramName.Split('|');
+					var cleanParts = parts.Select(p => p.Replace("...", "").Trim()).ToArray();
+
+					var pairIndex = (index - currentIndex) / cleanParts.Length;
+					var partIndex = (index - currentIndex) % cleanParts.Length;
+
+					return $"{cleanParts[partIndex]}{pairIndex + 1}";
+				}
+
+				var cleanName = paramName.Replace("...", "").Trim();
+				return $"{cleanName}{index - currentIndex + 1}";
+			}
+
+			if (index == currentIndex)
+			{
+				return paramName;
+			}
+
+			currentIndex++;
+		}
+
+		return $"arg{index + 1}";
+	}
+
+	[GeneratedRegex(@"&([a-zA-Z_][a-zA-Z0-9_\-]*)")]
+	private static partial Regex AttributeDefinitionRegex();
+
+	[GeneratedRegex(@"@set\s+[^/]+/([a-zA-Z_][a-zA-Z0-9_\-]*)")]
+	private static partial Regex SetAttributeRegex();
+
+	[GeneratedRegex(@"^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\(")]
+	private static partial Regex FunctionCallRegex();
+
+	[GeneratedRegex(@"^\s*(@[a-zA-Z][a-zA-Z0-9_\-]*)")]
+	private static partial Regex CommandRegex();
+}

--- a/SharpMUSH.CodeAnalysis/MushCodeAnalyzer.cs
+++ b/SharpMUSH.CodeAnalysis/MushCodeAnalyzer.cs
@@ -1,0 +1,40 @@
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+using MModule = MarkupString.MarkupStringModule;
+using Range = SharpMUSH.Library.Models.Range;
+
+namespace SharpMUSH.CodeAnalysis;
+
+/// <summary>
+/// Default <see cref="IMushCodeAnalyzer"/> implementation: a thin, exception-safe
+/// wrapper over the live <see cref="IMUSHCodeParser"/>. When resolved from the game
+/// server's container the parser carries the real function/command libraries, so the
+/// analysis reflects the running world.
+/// </summary>
+public class MushCodeAnalyzer(IMUSHCodeParser parser) : IMushCodeAnalyzer
+{
+	public IReadOnlyList<Diagnostic> Validate(string code, ParseType parseType = ParseType.Function)
+	{
+		try
+		{
+			return parser.GetDiagnostics(MModule.single(code), parseType);
+		}
+		catch (Exception ex)
+		{
+			return
+			[
+				new Diagnostic
+				{
+					Range = new Range
+					{
+						Start = new Position(0, 0),
+						End = new Position(0, code.Length)
+					},
+					Severity = DiagnosticSeverity.Error,
+					Source = "SharpMUSH.CodeAnalysis",
+					Message = $"Parser error: {ex.Message}"
+				}
+			];
+		}
+	}
+}

--- a/SharpMUSH.CodeAnalysis/MushCodeAnalyzer.cs
+++ b/SharpMUSH.CodeAnalysis/MushCodeAnalyzer.cs
@@ -58,6 +58,11 @@ public partial class MushCodeAnalyzer(IMUSHCodeParser parser) : IMushCodeAnalyze
 		}
 		catch (Exception ex)
 		{
+			// Anchor the fallback range to a valid position: the end lands on the last line,
+			// so a multi-line buffer doesn't produce a character offset past line 0.
+			var lines = code.Split('\n');
+			var lastLine = lines.Length - 1;
+
 			return
 			[
 				new Diagnostic
@@ -65,7 +70,7 @@ public partial class MushCodeAnalyzer(IMUSHCodeParser parser) : IMushCodeAnalyze
 					Range = new Range
 					{
 						Start = new Position(0, 0),
-						End = new Position(0, code.Length)
+						End = new Position(lastLine, lines[lastLine].Length)
 					},
 					Severity = DiagnosticSeverity.Error,
 					Source = "SharpMUSH.CodeAnalysis",

--- a/SharpMUSH.CodeAnalysis/MushCodeAnalyzer.cs
+++ b/SharpMUSH.CodeAnalysis/MushCodeAnalyzer.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using SharpMUSH.Library.Models;
 using SharpMUSH.Library.ParserInterfaces;
 using MModule = MarkupString.MarkupStringModule;
@@ -11,8 +12,39 @@ namespace SharpMUSH.CodeAnalysis;
 /// server's container the parser carries the real function/command libraries, so the
 /// analysis reflects the running world.
 /// </summary>
-public class MushCodeAnalyzer(IMUSHCodeParser parser) : IMushCodeAnalyzer
+public partial class MushCodeAnalyzer(IMUSHCodeParser parser) : IMushCodeAnalyzer
 {
+	public string Format(string code)
+	{
+		var lines = code.Split('\n');
+		for (var i = 0; i < lines.Length; i++)
+		{
+			lines[i] = FormatLine(lines[i]);
+		}
+
+		return string.Join('\n', lines);
+	}
+
+	private static string FormatLine(string line)
+	{
+		var formatted = NormalizeSpacing(line.TrimEnd());
+		var trimmed = formatted.TrimStart();
+		return string.IsNullOrEmpty(trimmed) ? string.Empty : trimmed;
+	}
+
+	private static string NormalizeSpacing(string line)
+	{
+		var result = CommaWithoutSpaceRegex().Replace(line, ", ");
+		result = CommandWithoutSpaceRegex().Replace(result, "$1 $2");
+		return result;
+	}
+
+	[GeneratedRegex(@",(?!\s)")]
+	private static partial Regex CommaWithoutSpaceRegex();
+
+	[GeneratedRegex(@"^(@[a-zA-Z]+)([^\s/])")]
+	private static partial Regex CommandWithoutSpaceRegex();
+
 	public IReadOnlyList<Diagnostic> Validate(string code, ParseType parseType = ParseType.Function)
 	{
 		try

--- a/SharpMUSH.CodeAnalysis/MushCodeAnalyzer.cs
+++ b/SharpMUSH.CodeAnalysis/MushCodeAnalyzer.cs
@@ -16,13 +16,16 @@ public partial class MushCodeAnalyzer(IMUSHCodeParser parser) : IMushCodeAnalyze
 {
 	public string Format(string code)
 	{
+		// Preserve the document's newline style so formatting a CRLF file doesn't silently
+		// rewrite every line ending to LF (a huge, confusing diff in Windows editors).
+		var newline = code.Contains("\r\n") ? "\r\n" : "\n";
 		var lines = code.Split('\n');
 		for (var i = 0; i < lines.Length; i++)
 		{
 			lines[i] = FormatLine(lines[i]);
 		}
 
-		return string.Join('\n', lines);
+		return string.Join(newline, lines);
 	}
 
 	private static string FormatLine(string line)

--- a/SharpMUSH.CodeAnalysis/MushCodeAnalyzer.cs
+++ b/SharpMUSH.CodeAnalysis/MushCodeAnalyzer.cs
@@ -45,7 +45,12 @@ public partial class MushCodeAnalyzer(IMUSHCodeParser parser) : IMushCodeAnalyze
 	[GeneratedRegex(@"^(@[a-zA-Z]+)([^\s/])")]
 	private static partial Regex CommandWithoutSpaceRegex();
 
-	public IReadOnlyList<Diagnostic> Validate(string code, ParseType parseType = ParseType.Function)
+	public IReadOnlyList<Diagnostic> Validate(string code, MushAnalysisMode mode = MushAnalysisMode.Function)
+		=> mode == MushAnalysisMode.CommandsPerLine
+			? ValidatePerLine(code)
+			: ValidateWhole(code, mode.ToParseType());
+
+	private IReadOnlyList<Diagnostic> ValidateWhole(string code, ParseType parseType)
 	{
 		try
 		{
@@ -69,4 +74,40 @@ public partial class MushCodeAnalyzer(IMUSHCodeParser parser) : IMushCodeAnalyze
 			];
 		}
 	}
+
+	/// <summary>
+	/// Real-world <c>.mush</c> files are one command per line. Each non-blank line is parsed as a
+	/// single <see cref="ParseType.Command"/> and its diagnostics are shifted to the line's
+	/// position in the file.
+	/// </summary>
+	private IReadOnlyList<Diagnostic> ValidatePerLine(string code)
+	{
+		var lines = code.Split('\n');
+		var result = new List<Diagnostic>();
+
+		for (var i = 0; i < lines.Length; i++)
+		{
+			var line = lines[i].TrimEnd('\r');
+			if (string.IsNullOrWhiteSpace(line)) continue;
+
+			foreach (var diagnostic in ValidateWhole(line, ParseType.Command))
+			{
+				result.Add(ShiftLines(diagnostic, i));
+			}
+		}
+
+		return result;
+	}
+
+	private static Diagnostic ShiftLines(Diagnostic diagnostic, int lineOffset)
+		=> lineOffset == 0
+			? diagnostic
+			: diagnostic with
+			{
+				Range = new Range
+				{
+					Start = new Position(diagnostic.Range.Start.Line + lineOffset, diagnostic.Range.Start.Character),
+					End = new Position(diagnostic.Range.End.Line + lineOffset, diagnostic.Range.End.Character)
+				}
+			};
 }

--- a/SharpMUSH.CodeAnalysis/MushCodeAnalyzer.cs
+++ b/SharpMUSH.CodeAnalysis/MushCodeAnalyzer.cs
@@ -61,10 +61,12 @@ public partial class MushCodeAnalyzer(IMUSHCodeParser parser) : IMushCodeAnalyze
 		}
 		catch (Exception ex)
 		{
-			// Anchor the fallback range to a valid position: the end lands on the last line,
-			// so a multi-line buffer doesn't produce a character offset past line 0.
+			// Anchor the fallback range to a valid position: the end lands on the last line
+			// (so a multi-line buffer doesn't produce a character offset past line 0), and a
+			// trailing CR is excluded so CRLF input isn't off-by-one.
 			var lines = code.Split('\n');
 			var lastLine = lines.Length - 1;
+			var lastLineLength = lines[lastLine].TrimEnd('\r').Length;
 
 			return
 			[
@@ -73,7 +75,7 @@ public partial class MushCodeAnalyzer(IMUSHCodeParser parser) : IMushCodeAnalyze
 					Range = new Range
 					{
 						Start = new Position(0, 0),
-						End = new Position(lastLine, lines[lastLine].Length)
+						End = new Position(lastLine, lastLineLength)
 					},
 					Severity = DiagnosticSeverity.Error,
 					Source = "SharpMUSH.CodeAnalysis",

--- a/SharpMUSH.CodeAnalysis/MushParseMode.cs
+++ b/SharpMUSH.CodeAnalysis/MushParseMode.cs
@@ -1,0 +1,42 @@
+using SharpMUSH.Library.ParserInterfaces;
+
+namespace SharpMUSH.CodeAnalysis;
+
+/// <summary>
+/// Resolves which <see cref="ParseType"/> a piece of softcode should be analysed as.
+///
+/// Two independent channels, one shared rule:
+/// <list type="bullet">
+/// <item><see cref="ForFileName"/> — the Language Server's channel: a file's extension decides
+/// the mode (a <c>.mush</c>/<c>.mu</c> batch is a command list; a <c>.mushfn</c>/<c>.fun</c> file
+/// is a function/expression).</item>
+/// <item><see cref="FromName"/> — the MCP tools' channel: the caller names the mode explicitly.</item>
+/// </list>
+/// Both fall back to <see cref="ParseType.Function"/> when nothing else applies.
+/// </summary>
+public static class MushParseMode
+{
+	public static ParseType ForFileName(string fileNameOrUri, ParseType fallback = ParseType.Function)
+	{
+		var lastDot = fileNameOrUri.LastIndexOf('.');
+		if (lastDot < 0) return fallback;
+
+		var extension = fileNameOrUri[(lastDot + 1)..].ToLowerInvariant();
+		return extension switch
+		{
+			"mush" or "mu" => ParseType.CommandList,
+			"mushfn" or "fun" => ParseType.Function,
+			_ => fallback
+		};
+	}
+
+	public static ParseType FromName(string? name, ParseType fallback = ParseType.Function)
+		=> name?.Trim().ToLowerInvariant() switch
+		{
+			"function" => ParseType.Function,
+			"command" => ParseType.Command,
+			"commandlist" or "command-list" or "command_list" => ParseType.CommandList,
+			null or "" => fallback,
+			_ => fallback
+		};
+}

--- a/SharpMUSH.CodeAnalysis/MushParseMode.cs
+++ b/SharpMUSH.CodeAnalysis/MushParseMode.cs
@@ -1,22 +1,21 @@
-using SharpMUSH.Library.ParserInterfaces;
-
 namespace SharpMUSH.CodeAnalysis;
 
 /// <summary>
-/// Resolves which <see cref="ParseType"/> a piece of softcode should be analysed as.
+/// Resolves which <see cref="MushAnalysisMode"/> a piece of softcode should be analysed as.
 ///
 /// Two independent channels, one shared rule:
 /// <list type="bullet">
 /// <item><see cref="ForFileName"/> — the Language Server's channel: a file's extension decides
-/// the mode (a <c>.mush</c>/<c>.mu</c> batch is a command list; a <c>.mushfn</c>/<c>.fun</c> file
-/// is a function/expression).</item>
+/// the mode. A real-world <c>.mush</c>/<c>.mu</c> file is one command per line
+/// (<see cref="MushAnalysisMode.CommandsPerLine"/>); a <c>.mushfn</c>/<c>.fun</c> file is a
+/// function/expression.</item>
 /// <item><see cref="FromName"/> — the MCP tools' channel: the caller names the mode explicitly.</item>
 /// </list>
-/// Both fall back to <see cref="ParseType.Function"/> when nothing else applies.
+/// Both fall back to <see cref="MushAnalysisMode.Function"/> when nothing else applies.
 /// </summary>
 public static class MushParseMode
 {
-	public static ParseType ForFileName(string fileNameOrUri, ParseType fallback = ParseType.Function)
+	public static MushAnalysisMode ForFileName(string fileNameOrUri, MushAnalysisMode fallback = MushAnalysisMode.Function)
 	{
 		var lastDot = fileNameOrUri.LastIndexOf('.');
 		if (lastDot < 0) return fallback;
@@ -24,18 +23,20 @@ public static class MushParseMode
 		var extension = fileNameOrUri[(lastDot + 1)..].ToLowerInvariant();
 		return extension switch
 		{
-			"mush" or "mu" => ParseType.CommandList,
-			"mushfn" or "fun" => ParseType.Function,
+			"mush" or "mu" => MushAnalysisMode.CommandsPerLine,
+			"mushfn" or "fun" => MushAnalysisMode.Function,
 			_ => fallback
 		};
 	}
 
-	public static ParseType FromName(string? name, ParseType fallback = ParseType.Function)
+	public static MushAnalysisMode FromName(string? name, MushAnalysisMode fallback = MushAnalysisMode.Function)
 		=> name?.Trim().ToLowerInvariant() switch
 		{
-			"function" => ParseType.Function,
-			"command" => ParseType.Command,
-			"commandlist" or "command-list" or "command_list" => ParseType.CommandList,
+			"function" => MushAnalysisMode.Function,
+			"command" => MushAnalysisMode.Command,
+			"commandlist" or "command-list" or "command_list" => MushAnalysisMode.CommandList,
+			"commandsperline" or "commands-per-line" or "commandperline" or "mushfile"
+				=> MushAnalysisMode.CommandsPerLine,
 			null or "" => fallback,
 			_ => fallback
 		};

--- a/SharpMUSH.CodeAnalysis/MushParseMode.cs
+++ b/SharpMUSH.CodeAnalysis/MushParseMode.cs
@@ -8,7 +8,7 @@ namespace SharpMUSH.CodeAnalysis;
 /// <item><see cref="ForFileName"/> — the Language Server's channel: a file's extension decides
 /// the mode. A real-world <c>.mush</c>/<c>.mu</c> file is one command per line
 /// (<see cref="MushAnalysisMode.CommandsPerLine"/>); a <c>.mushfn</c>/<c>.fun</c> file is a
-/// function/expression.</item>
+/// function/expression; a <c>.mushcmd</c> file is a single command list.</item>
 /// <item><see cref="FromName"/> — the MCP tools' channel: the caller names the mode explicitly.</item>
 /// </list>
 /// Both fall back to <see cref="MushAnalysisMode.Function"/> when nothing else applies.
@@ -25,6 +25,7 @@ public static class MushParseMode
 		{
 			"mush" or "mu" => MushAnalysisMode.CommandsPerLine,
 			"mushfn" or "fun" => MushAnalysisMode.Function,
+			"mushcmd" => MushAnalysisMode.CommandList,
 			_ => fallback
 		};
 	}

--- a/SharpMUSH.CodeAnalysis/SharpMUSH.CodeAnalysis.csproj
+++ b/SharpMUSH.CodeAnalysis/SharpMUSH.CodeAnalysis.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>default</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SharpMUSH.Library\SharpMUSH.Library.csproj" />
+    <ProjectReference Include="..\SharpMUSH.Implementation\SharpMUSH.Implementation.csproj" />
+    <ProjectReference Include="..\SharpMUSH.MarkupString\SharpMUSH.MarkupString.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SharpMUSH.LanguageServer/Handlers/CodeActionHandler.cs
+++ b/SharpMUSH.LanguageServer/Handlers/CodeActionHandler.cs
@@ -2,6 +2,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpMUSH.CodeAnalysis;
 using SharpMUSH.LanguageServer.Services;
 using SharpMUSH.Library.ParserInterfaces;
 using System.Text.RegularExpressions;
@@ -44,7 +45,7 @@ public partial class CodeActionHandler : CodeActionHandlerBase
 
 		try
 		{
-			var diagnostics = _parser.GetDiagnostics(document.Text, ParseType.Function);
+			var diagnostics = _parser.GetDiagnostics(document.Text, MushParseMode.ForFileName(uri));
 
 			foreach (var diagnostic in diagnostics)
 			{
@@ -201,7 +202,7 @@ public partial class CodeActionHandler : CodeActionHandlerBase
 	{
 		return new CodeActionRegistrationOptions
 		{
-			DocumentSelector = TextDocumentSelector.ForPattern("**/*.mush", "**/*.mu"),
+			DocumentSelector = MushDocument.Selector,
 			CodeActionKinds = new Container<CodeActionKind>(
 				CodeActionKind.QuickFix,
 				CodeActionKind.Refactor)

--- a/SharpMUSH.LanguageServer/Handlers/CompletionHandler.cs
+++ b/SharpMUSH.LanguageServer/Handlers/CompletionHandler.cs
@@ -66,7 +66,7 @@ public class CompletionHandler : CompletionHandlerBase
 	{
 		return new CompletionRegistrationOptions
 		{
-			DocumentSelector = TextDocumentSelector.ForPattern("**/*.mush", "**/*.mu"),
+			DocumentSelector = MushDocument.Selector,
 			TriggerCharacters = new[] { "%", "@", "#" },
 			ResolveProvider = false
 		};

--- a/SharpMUSH.LanguageServer/Handlers/CompletionHandler.cs
+++ b/SharpMUSH.LanguageServer/Handlers/CompletionHandler.cs
@@ -1,24 +1,25 @@
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpMUSH.CodeAnalysis;
 using SharpMUSH.LanguageServer.Services;
-using SharpMUSH.Library.ParserInterfaces;
 
 namespace SharpMUSH.LanguageServer.Handlers;
 
 /// <summary>
 /// Handles code completion requests for MUSH code.
-/// Provides completions for functions, commands, and common patterns.
+/// Delegates to the shared <see cref="IMushCodeAnalyzer"/> and adapts its suggestions to LSP
+/// completion items.
 /// </summary>
 public class CompletionHandler : CompletionHandlerBase
 {
 	private readonly DocumentManager _documentManager;
-	private readonly IMUSHCodeParser _parser;
+	private readonly IMushCodeAnalyzer _analyzer;
 
-	public CompletionHandler(DocumentManager documentManager, IMUSHCodeParser parser)
+	public CompletionHandler(DocumentManager documentManager, IMushCodeAnalyzer analyzer)
 	{
 		_documentManager = documentManager;
-		_parser = parser;
+		_analyzer = analyzer;
 	}
 
 	public override Task<CompletionList> Handle(CompletionParams request, CancellationToken cancellationToken)
@@ -31,63 +32,18 @@ public class CompletionHandler : CompletionHandlerBase
 			return Task.FromResult(new CompletionList());
 		}
 
-		var completions = new List<CompletionItem>();
+		var suggestions = _analyzer.Complete(
+			document.Text, (int)request.Position.Line, (int)request.Position.Character);
 
-		try
+		var completions = suggestions.Select(s => new CompletionItem
 		{
-			var lines = document.Text.Split('\n');
-			var line = request.Position.Line < lines.Length ? lines[request.Position.Line] : string.Empty;
-			var character = (int)request.Position.Character;
-
-			var wordStart = character;
-			while (wordStart > 0 && IsWordCharacter(line[wordStart - 1]))
-			{
-				wordStart--;
-			}
-			var prefix = wordStart < line.Length ? line.Substring(wordStart, character - wordStart) : string.Empty;
-
-			foreach (var (name, definition) in _parser.FunctionLibrary)
-			{
-				if (string.IsNullOrEmpty(prefix) || name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-				{
-					completions.Add(new CompletionItem
-					{
-						Label = name,
-						Kind = CompletionItemKind.Function,
-						Detail = $"{name}({GetParameterList(definition.LibraryInformation.Attribute.MinArgs, definition.LibraryInformation.Attribute.MaxArgs)})",
-						Documentation = $"Min args: {definition.LibraryInformation.Attribute.MinArgs}, Max args: {definition.LibraryInformation.Attribute.MaxArgs}",
-						InsertText = $"{name}($0)",
-						InsertTextFormat = InsertTextFormat.Snippet
-					});
-				}
-			}
-
-			if (character == 0 || (character > 0 && char.IsWhiteSpace(line[character - 1])))
-			{
-				foreach (var (name, definition) in _parser.CommandLibrary)
-				{
-					if (string.IsNullOrEmpty(prefix) || name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-					{
-						completions.Add(new CompletionItem
-						{
-							Label = name,
-							Kind = CompletionItemKind.Keyword,
-							Detail = $"Command: {name}",
-							Documentation = $"Switches: {string.Join(", ", definition.LibraryInformation.Attribute.Switches ?? Array.Empty<string>())}",
-							InsertText = name
-						});
-					}
-				}
-			}
-
-			AddCommonPatterns(completions, prefix);
-		}
-		catch (Exception ex)
-		{
-#pragma warning disable VSTHRD103
-			Console.Error.WriteLine($"Error generating completions: {ex.Message}");
-#pragma warning restore VSTHRD103
-		}
+			Label = s.Label,
+			Kind = MapKind(s.Kind),
+			Detail = s.Detail,
+			Documentation = s.Documentation,
+			InsertText = s.InsertText,
+			InsertTextFormat = s.IsSnippet ? InsertTextFormat.Snippet : InsertTextFormat.PlainText
+		}).ToList();
 
 		return Task.FromResult(new CompletionList(completions, isIncomplete: false));
 	}
@@ -97,49 +53,12 @@ public class CompletionHandler : CompletionHandlerBase
 		return Task.FromResult(request);
 	}
 
-	private static bool IsWordCharacter(char c)
+	private static CompletionItemKind MapKind(string kind) => kind switch
 	{
-		return char.IsLetterOrDigit(c) || c == '_' || c == '@';
-	}
-
-	private static string GetParameterList(int minArgs, int maxArgs)
-	{
-		if (minArgs == 0 && maxArgs == 0)
-			return "";
-		if (minArgs == maxArgs)
-			return string.Join(", ", Enumerable.Range(1, minArgs).Select(i => $"arg{i}"));
-		return string.Join(", ", Enumerable.Range(1, minArgs).Select(i => $"arg{i}")) +
-					 (maxArgs > minArgs ? ", ..." : "");
-	}
-
-	private static void AddCommonPatterns(List<CompletionItem> completions, string prefix)
-	{
-		var patterns = new[]
-		{
-			new { Label = "%#", Detail = "Current object (#dbref)", Kind = CompletionItemKind.Variable },
-			new { Label = "%!", Detail = "Executing object (#dbref)", Kind = CompletionItemKind.Variable },
-			new { Label = "%@", Detail = "Calling object (#dbref)", Kind = CompletionItemKind.Variable },
-			new { Label = "%N", Detail = "Player name", Kind = CompletionItemKind.Variable },
-			new { Label = "%0", Detail = "Argument 0", Kind = CompletionItemKind.Variable },
-			new { Label = "%1", Detail = "Argument 1", Kind = CompletionItemKind.Variable },
-			new { Label = "%qa", Detail = "Q-register a", Kind = CompletionItemKind.Variable },
-			new { Label = "%va", Detail = "V-register a", Kind = CompletionItemKind.Variable }
-		};
-
-		foreach (var pattern in patterns)
-		{
-			if (string.IsNullOrEmpty(prefix) || pattern.Label.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-			{
-				completions.Add(new CompletionItem
-				{
-					Label = pattern.Label,
-					Kind = pattern.Kind,
-					Detail = pattern.Detail,
-					InsertText = pattern.Label
-				});
-			}
-		}
-	}
+		"Function" => CompletionItemKind.Function,
+		"Keyword" => CompletionItemKind.Keyword,
+		_ => CompletionItemKind.Variable
+	};
 
 	protected override CompletionRegistrationOptions CreateRegistrationOptions(
 		CompletionCapability capability,

--- a/SharpMUSH.LanguageServer/Handlers/DefinitionHandler.cs
+++ b/SharpMUSH.LanguageServer/Handlers/DefinitionHandler.cs
@@ -119,7 +119,7 @@ public class DefinitionHandler : DefinitionHandlerBase
 	{
 		return new DefinitionRegistrationOptions
 		{
-			DocumentSelector = TextDocumentSelector.ForPattern("**/*.mush", "**/*.mu")
+			DocumentSelector = MushDocument.Selector
 		};
 	}
 }

--- a/SharpMUSH.LanguageServer/Handlers/DocumentFormattingHandler.cs
+++ b/SharpMUSH.LanguageServer/Handlers/DocumentFormattingHandler.cs
@@ -43,14 +43,20 @@ public class DocumentFormattingHandler : DocumentFormattingHandlerBase
 
 			for (int i = 0; i < originalLines.Length && i < formattedLines.Length; i++)
 			{
-				if (formattedLines[i] != originalLines[i])
+				// A trailing CR is part of the line terminator in LSP positions, not the line
+				// content — exclude it from both the compared text and the edit so CRLF documents
+				// aren't off-by-one and no literal '\r' is injected into the replacement.
+				var original = originalLines[i].TrimEnd('\r');
+				var formatted = formattedLines[i].TrimEnd('\r');
+
+				if (formatted != original)
 				{
 					edits.Add(new TextEdit
 					{
 						Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
 							new Position(i, 0),
-							new Position(i, originalLines[i].Length)),
-						NewText = formattedLines[i]
+							new Position(i, original.Length)),
+						NewText = formatted
 					});
 				}
 			}

--- a/SharpMUSH.LanguageServer/Handlers/DocumentFormattingHandler.cs
+++ b/SharpMUSH.LanguageServer/Handlers/DocumentFormattingHandler.cs
@@ -76,7 +76,7 @@ public class DocumentFormattingHandler : DocumentFormattingHandlerBase
 	{
 		return new DocumentFormattingRegistrationOptions
 		{
-			DocumentSelector = TextDocumentSelector.ForPattern("**/*.mush", "**/*.mu")
+			DocumentSelector = MushDocument.Selector
 		};
 	}
 }

--- a/SharpMUSH.LanguageServer/Handlers/DocumentFormattingHandler.cs
+++ b/SharpMUSH.LanguageServer/Handlers/DocumentFormattingHandler.cs
@@ -1,22 +1,26 @@
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpMUSH.CodeAnalysis;
 using SharpMUSH.LanguageServer.Services;
-using System.Text.RegularExpressions;
 
 namespace SharpMUSH.LanguageServer.Handlers;
 
 /// <summary>
 /// Handles document formatting requests for MUSH code.
-/// Provides basic auto-formatting with consistent style.
+/// Delegates the actual formatting to the shared <see cref="IMushCodeAnalyzer"/> so the
+/// LSP and the in-server MCP tools format identically, and emits one text edit per line
+/// the analyzer changed.
 /// </summary>
-public partial class DocumentFormattingHandler : DocumentFormattingHandlerBase
+public class DocumentFormattingHandler : DocumentFormattingHandlerBase
 {
 	private readonly DocumentManager _documentManager;
+	private readonly IMushCodeAnalyzer _analyzer;
 
-	public DocumentFormattingHandler(DocumentManager documentManager)
+	public DocumentFormattingHandler(DocumentManager documentManager, IMushCodeAnalyzer analyzer)
 	{
 		_documentManager = documentManager;
+		_analyzer = analyzer;
 	}
 
 	public override Task<TextEditContainer?> Handle(
@@ -33,22 +37,20 @@ public partial class DocumentFormattingHandler : DocumentFormattingHandlerBase
 
 		try
 		{
-			var lines = document.Text.Split('\n');
+			var originalLines = document.Text.Split('\n');
+			var formattedLines = _analyzer.Format(document.Text).Split('\n');
 			var edits = new List<TextEdit>();
 
-			for (int i = 0; i < lines.Length; i++)
+			for (int i = 0; i < originalLines.Length && i < formattedLines.Length; i++)
 			{
-				var line = lines[i];
-				var formatted = FormatLine(line, request.Options);
-
-				if (formatted != line)
+				if (formattedLines[i] != originalLines[i])
 				{
 					edits.Add(new TextEdit
 					{
 						Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
 							new Position(i, 0),
-							new Position(i, line.Length)),
-						NewText = formatted
+							new Position(i, originalLines[i].Length)),
+						NewText = formattedLines[i]
 					});
 				}
 			}
@@ -68,48 +70,6 @@ public partial class DocumentFormattingHandler : DocumentFormattingHandlerBase
 		return Task.FromResult<TextEditContainer?>(null);
 	}
 
-	private static string FormatLine(string line, FormattingOptions options)
-	{
-		var formatted = line.TrimEnd();
-
-		formatted = NormalizeSpacing(formatted);
-
-		formatted = ApplyIndentation(formatted, options);
-
-		return formatted;
-	}
-
-	private static string NormalizeSpacing(string line)
-	{
-		var result = CommaWithoutSpaceRegex().Replace(line, ", ");
-
-		result = CommandWithoutSpaceRegex().Replace(result, "$1 $2");
-
-		return result;
-	}
-
-	private static string ApplyIndentation(string line, FormattingOptions options)
-	{
-		var trimmed = line.TrimStart();
-		if (string.IsNullOrEmpty(trimmed))
-		{
-			return string.Empty;
-		}
-
-		var indent = 0;
-
-		if (trimmed.StartsWith(")") || trimmed.StartsWith("}") || trimmed.StartsWith("]"))
-		{
-			indent = Math.Max(0, indent - 1);
-		}
-
-		var indentString = options.InsertSpaces
-			? new string(' ', indent * (int)options.TabSize)
-			: new string('\t', indent);
-
-		return indentString + trimmed;
-	}
-
 	protected override DocumentFormattingRegistrationOptions CreateRegistrationOptions(
 		DocumentFormattingCapability capability,
 		ClientCapabilities clientCapabilities)
@@ -119,10 +79,4 @@ public partial class DocumentFormattingHandler : DocumentFormattingHandlerBase
 			DocumentSelector = TextDocumentSelector.ForPattern("**/*.mush", "**/*.mu")
 		};
 	}
-
-	[GeneratedRegex(@",(?!\s)")]
-	private static partial Regex CommaWithoutSpaceRegex();
-
-	[GeneratedRegex(@"^(@[a-zA-Z]+)([^\s/])")]
-	private static partial Regex CommandWithoutSpaceRegex();
 }

--- a/SharpMUSH.LanguageServer/Handlers/DocumentSymbolHandler.cs
+++ b/SharpMUSH.LanguageServer/Handlers/DocumentSymbolHandler.cs
@@ -1,22 +1,25 @@
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpMUSH.CodeAnalysis;
 using SharpMUSH.LanguageServer.Services;
-using System.Text.RegularExpressions;
 
 namespace SharpMUSH.LanguageServer.Handlers;
 
 /// <summary>
 /// Handles document symbol requests for MUSH code.
-/// Provides an outline view of attributes and functions in the document.
+/// Delegates to the shared <see cref="IMushCodeAnalyzer"/> and adapts its symbols to the LSP
+/// outline shape.
 /// </summary>
-public partial class DocumentSymbolHandler : DocumentSymbolHandlerBase
+public class DocumentSymbolHandler : DocumentSymbolHandlerBase
 {
 	private readonly DocumentManager _documentManager;
+	private readonly IMushCodeAnalyzer _analyzer;
 
-	public DocumentSymbolHandler(DocumentManager documentManager)
+	public DocumentSymbolHandler(DocumentManager documentManager, IMushCodeAnalyzer analyzer)
 	{
 		_documentManager = documentManager;
+		_analyzer = analyzer;
 	}
 
 	public override Task<SymbolInformationOrDocumentSymbolContainer?> Handle(
@@ -31,95 +34,16 @@ public partial class DocumentSymbolHandler : DocumentSymbolHandlerBase
 			return Task.FromResult<SymbolInformationOrDocumentSymbolContainer?>(null);
 		}
 
-		var symbols = new List<SymbolInformationOrDocumentSymbol>();
-
-		try
-		{
-			var lines = document.Text.Split('\n');
-
-			for (int i = 0; i < lines.Length; i++)
+		var symbols = _analyzer.DocumentSymbols(document.Text)
+			.Select(s => new SymbolInformationOrDocumentSymbol(new DocumentSymbol
 			{
-				var line = lines[i];
-
-				var attributeMatch = AttributeDefinitionRegex().Match(line);
-				if (attributeMatch.Success)
-				{
-					var attributeName = attributeMatch.Groups[1].Value;
-					symbols.Add(new SymbolInformationOrDocumentSymbol(new DocumentSymbol
-					{
-						Name = attributeName,
-						Kind = SymbolKind.Property,
-						Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
-							new Position(i, 0),
-							new Position(i, line.Length)),
-						SelectionRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
-							new Position(i, attributeMatch.Index),
-							new Position(i, attributeMatch.Index + attributeMatch.Length)),
-						Detail = "Attribute definition"
-					}));
-				}
-
-				var setMatch = SetAttributeRegex().Match(line);
-				if (setMatch.Success)
-				{
-					var attributeName = setMatch.Groups[1].Value;
-					symbols.Add(new SymbolInformationOrDocumentSymbol(new DocumentSymbol
-					{
-						Name = attributeName,
-						Kind = SymbolKind.Property,
-						Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
-							new Position(i, 0),
-							new Position(i, line.Length)),
-						SelectionRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
-							new Position(i, setMatch.Groups[1].Index),
-							new Position(i, setMatch.Groups[1].Index + setMatch.Groups[1].Length)),
-						Detail = "@set attribute"
-					}));
-				}
-
-				var functionMatch = FunctionCallRegex().Match(line);
-				if (functionMatch.Success)
-				{
-					var functionName = functionMatch.Groups[1].Value;
-					symbols.Add(new SymbolInformationOrDocumentSymbol(new DocumentSymbol
-					{
-						Name = functionName,
-						Kind = SymbolKind.Function,
-						Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
-							new Position(i, 0),
-							new Position(i, line.Length)),
-						SelectionRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
-							new Position(i, functionMatch.Groups[1].Index),
-							new Position(i, functionMatch.Groups[1].Index + functionMatch.Groups[1].Length)),
-						Detail = "Function call"
-					}));
-				}
-
-				var commandMatch = CommandRegex().Match(line);
-				if (commandMatch.Success)
-				{
-					var commandName = commandMatch.Groups[1].Value;
-					symbols.Add(new SymbolInformationOrDocumentSymbol(new DocumentSymbol
-					{
-						Name = commandName,
-						Kind = SymbolKind.Method,
-						Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
-							new Position(i, 0),
-							new Position(i, line.Length)),
-						SelectionRange = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
-							new Position(i, commandMatch.Index),
-							new Position(i, commandMatch.Index + commandMatch.Length)),
-						Detail = "MUSH command"
-					}));
-				}
-			}
-		}
-		catch (Exception ex)
-		{
-#pragma warning disable VSTHRD103
-			Console.Error.WriteLine($"Error extracting document symbols: {ex.Message}");
-#pragma warning restore VSTHRD103
-		}
+				Name = s.Name,
+				Kind = MapKind(s.Kind),
+				Detail = s.Detail,
+				Range = ToRange(s.Range),
+				SelectionRange = ToRange(s.SelectionRange)
+			}))
+			.ToList();
 
 		if (symbols.Count > 0)
 		{
@@ -130,6 +54,19 @@ public partial class DocumentSymbolHandler : DocumentSymbolHandlerBase
 		return Task.FromResult<SymbolInformationOrDocumentSymbolContainer?>(null);
 	}
 
+	private static SymbolKind MapKind(string kind) => kind switch
+	{
+		"Property" => SymbolKind.Property,
+		"Function" => SymbolKind.Function,
+		_ => SymbolKind.Method
+	};
+
+	private static OmniSharp.Extensions.LanguageServer.Protocol.Models.Range ToRange(
+		SharpMUSH.Library.Models.Range range)
+		=> new(
+			new Position(range.Start.Line, range.Start.Character),
+			new Position(range.End.Line, range.End.Character));
+
 	protected override DocumentSymbolRegistrationOptions CreateRegistrationOptions(
 		DocumentSymbolCapability capability,
 		ClientCapabilities clientCapabilities)
@@ -139,16 +76,4 @@ public partial class DocumentSymbolHandler : DocumentSymbolHandlerBase
 			DocumentSelector = TextDocumentSelector.ForPattern("**/*.mush", "**/*.mu")
 		};
 	}
-
-	[GeneratedRegex(@"&([a-zA-Z_][a-zA-Z0-9_\-]*)")]
-	private static partial Regex AttributeDefinitionRegex();
-
-	[GeneratedRegex(@"@set\s+[^/]+/([a-zA-Z_][a-zA-Z0-9_\-]*)")]
-	private static partial Regex SetAttributeRegex();
-
-	[GeneratedRegex(@"^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\(")]
-	private static partial Regex FunctionCallRegex();
-
-	[GeneratedRegex(@"^\s*(@[a-zA-Z][a-zA-Z0-9_\-]*)")]
-	private static partial Regex CommandRegex();
 }

--- a/SharpMUSH.LanguageServer/Handlers/DocumentSymbolHandler.cs
+++ b/SharpMUSH.LanguageServer/Handlers/DocumentSymbolHandler.cs
@@ -73,7 +73,7 @@ public class DocumentSymbolHandler : DocumentSymbolHandlerBase
 	{
 		return new DocumentSymbolRegistrationOptions
 		{
-			DocumentSelector = TextDocumentSelector.ForPattern("**/*.mush", "**/*.mu")
+			DocumentSelector = MushDocument.Selector
 		};
 	}
 }

--- a/SharpMUSH.LanguageServer/Handlers/HoverHandler.cs
+++ b/SharpMUSH.LanguageServer/Handlers/HoverHandler.cs
@@ -1,23 +1,25 @@
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpMUSH.CodeAnalysis;
 using SharpMUSH.LanguageServer.Services;
-using SharpMUSH.Library.ParserInterfaces;
 
 namespace SharpMUSH.LanguageServer.Handlers;
 
 /// <summary>
 /// Handles hover requests to show information about MUSH code elements.
+/// Delegates to the shared <see cref="IMushCodeAnalyzer"/> so the LSP and the in-server MCP
+/// tools produce identical hover content.
 /// </summary>
 public class HoverHandler : HoverHandlerBase
 {
 	private readonly DocumentManager _documentManager;
-	private readonly IMUSHCodeParser _parser;
+	private readonly IMushCodeAnalyzer _analyzer;
 
-	public HoverHandler(DocumentManager documentManager, IMUSHCodeParser parser)
+	public HoverHandler(DocumentManager documentManager, IMushCodeAnalyzer analyzer)
 	{
 		_documentManager = documentManager;
-		_parser = parser;
+		_analyzer = analyzer;
 	}
 
 	public override Task<Hover?> Handle(HoverParams request, CancellationToken cancellationToken)
@@ -30,168 +32,23 @@ public class HoverHandler : HoverHandlerBase
 			return Task.FromResult<Hover?>(null);
 		}
 
-		try
+		var info = _analyzer.Hover(document.Text, (int)request.Position.Line, (int)request.Position.Character);
+		if (info is null)
 		{
-			var lines = document.Text.Split('\n');
-			var line = request.Position.Line < lines.Length ? lines[request.Position.Line] : string.Empty;
-			var character = (int)request.Position.Character;
-
-			var wordStart = character;
-			var wordEnd = character;
-
-			while (wordStart > 0 && IsWordCharacter(line[wordStart - 1]))
-			{
-				wordStart--;
-			}
-
-			while (wordEnd < line.Length && IsWordCharacter(line[wordEnd]))
-			{
-				wordEnd++;
-			}
-
-			if (wordStart >= wordEnd)
-			{
-				return Task.FromResult<Hover?>(null);
-			}
-
-			var word = line.Substring(wordStart, wordEnd - wordStart);
-
-			if (_parser.FunctionLibrary.TryGetValue(word, out var functionDef))
-			{
-				var markdown = BuildFunctionHover(word, functionDef.LibraryInformation.Attribute);
-				return Task.FromResult<Hover?>(new Hover
-				{
-					Contents = new MarkedStringsOrMarkupContent(new MarkupContent
-					{
-						Kind = MarkupKind.Markdown,
-						Value = markdown
-					}),
-					Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
-						new Position(request.Position.Line, wordStart),
-						new Position(request.Position.Line, wordEnd))
-				});
-			}
-
-			if (_parser.CommandLibrary.TryGetValue(word, out var commandDef))
-			{
-				var markdown = BuildCommandHover(word, commandDef.LibraryInformation.Attribute);
-				return Task.FromResult<Hover?>(new Hover
-				{
-					Contents = new MarkedStringsOrMarkupContent(new MarkupContent
-					{
-						Kind = MarkupKind.Markdown,
-						Value = markdown
-					}),
-					Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
-						new Position(request.Position.Line, wordStart),
-						new Position(request.Position.Line, wordEnd))
-				});
-			}
-
-			var patternInfo = GetPatternInfo(word);
-			if (patternInfo != null)
-			{
-				return Task.FromResult<Hover?>(new Hover
-				{
-					Contents = new MarkedStringsOrMarkupContent(new MarkupContent
-					{
-						Kind = MarkupKind.Markdown,
-						Value = patternInfo
-					}),
-					Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
-						new Position(request.Position.Line, wordStart),
-						new Position(request.Position.Line, wordEnd))
-				});
-			}
-		}
-		catch (Exception ex)
-		{
-#pragma warning disable VSTHRD103
-			Console.Error.WriteLine($"Error generating hover info: {ex.Message}");
-#pragma warning restore VSTHRD103
+			return Task.FromResult<Hover?>(null);
 		}
 
-		return Task.FromResult<Hover?>(null);
-	}
-
-	private static bool IsWordCharacter(char c)
-	{
-		return char.IsLetterOrDigit(c) || c == '_' || c == '@' || c == '%' || c == '#';
-	}
-
-	private static string BuildFunctionHover(string name, Library.Attributes.SharpFunctionAttribute attr)
-	{
-		var markdown = $"### Function: `{name}`\n\n";
-		markdown += $"**Signature:** `{name}({GetParameterList(attr.MinArgs, attr.MaxArgs)})`\n\n";
-		markdown += $"**Arguments:**\n";
-		markdown += $"- Minimum: {attr.MinArgs}\n";
-		markdown += $"- Maximum: {attr.MaxArgs}\n\n";
-
-		if (attr.Flags != 0)
+		return Task.FromResult<Hover?>(new Hover
 		{
-			markdown += $"**Flags:** {attr.Flags}\n\n";
-		}
-
-		if (attr.Restrict != null && attr.Restrict.Length > 0)
-		{
-			markdown += $"**Restrictions:** {string.Join(", ", attr.Restrict)}\n\n";
-		}
-
-		return markdown;
-	}
-
-	private static string BuildCommandHover(string name, Library.Attributes.SharpCommandAttribute attr)
-	{
-		var markdown = $"### Command: `{name}`\n\n";
-
-		if (attr.Switches != null && attr.Switches.Length > 0)
-		{
-			markdown += $"**Switches:** {string.Join(", ", attr.Switches)}\n\n";
-		}
-
-		markdown += $"**Arguments:**\n";
-		markdown += $"- Minimum: {attr.MinArgs}\n";
-		markdown += $"- Maximum: {attr.MaxArgs}\n\n";
-
-		if (!string.IsNullOrEmpty(attr.CommandLock))
-		{
-			markdown += $"**Lock:** {attr.CommandLock}\n\n";
-		}
-
-		markdown += $"**Behavior:** {attr.Behavior}\n\n";
-
-		return markdown;
-	}
-
-	private static string GetParameterList(int minArgs, int maxArgs)
-	{
-		if (minArgs == 0 && maxArgs == 0)
-			return "";
-		if (minArgs == maxArgs)
-			return string.Join(", ", Enumerable.Range(1, minArgs).Select(i => $"arg{i}"));
-		return string.Join(", ", Enumerable.Range(1, minArgs).Select(i => $"arg{i}")) +
-					 (maxArgs > minArgs ? ", [optional...]" : "");
-	}
-
-	private static string? GetPatternInfo(string word)
-	{
-		return word switch
-		{
-			"%#" => "**Current object** - The #dbref of the object this code is set on",
-			"%!" => "**Executing object** - The #dbref of the object executing the code",
-			"%@" => "**Calling object** - The #dbref of the object that called this code",
-			"%N" or "%n" => "**Player name** - The name of the player executing the code",
-			"%l" or "%L" => "**Location** - The location of the executing object",
-			"%" when word.Length == 2 && char.IsDigit(word[1]) =>
-				$"**Argument {word[1]}** - The {word[1]}th argument passed to this function/command",
-			"%" when word.Length == 3 && word[1] == 'q' && char.IsLetter(word[2]) =>
-				$"**Q-register {word[2]}** - Q-register storage",
-			"%" when word.Length == 3 && word[1] == 'v' && char.IsLetter(word[2]) =>
-				$"**V-register {word[2]}** - V-register storage",
-			"#" when word.Length > 1 && word.Skip(1).All(char.IsDigit) =>
-				$"**Object reference** - References object #{word.Substring(1)}",
-			_ => null
-		};
+			Contents = new MarkedStringsOrMarkupContent(new MarkupContent
+			{
+				Kind = MarkupKind.Markdown,
+				Value = info.Markdown
+			}),
+			Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(
+				new Position(info.Range.Start.Line, info.Range.Start.Character),
+				new Position(info.Range.End.Line, info.Range.End.Character))
+		});
 	}
 
 	protected override HoverRegistrationOptions CreateRegistrationOptions(

--- a/SharpMUSH.LanguageServer/Handlers/HoverHandler.cs
+++ b/SharpMUSH.LanguageServer/Handlers/HoverHandler.cs
@@ -57,7 +57,7 @@ public class HoverHandler : HoverHandlerBase
 	{
 		return new HoverRegistrationOptions
 		{
-			DocumentSelector = TextDocumentSelector.ForPattern("**/*.mush", "**/*.mu")
+			DocumentSelector = MushDocument.Selector
 		};
 	}
 }

--- a/SharpMUSH.LanguageServer/Handlers/InlayHintHandler.cs
+++ b/SharpMUSH.LanguageServer/Handlers/InlayHintHandler.cs
@@ -196,7 +196,7 @@ public partial class InlayHintHandler : InlayHintsHandlerBase
 	{
 		return new InlayHintRegistrationOptions
 		{
-			DocumentSelector = TextDocumentSelector.ForPattern("**/*.mush", "**/*.mu"),
+			DocumentSelector = MushDocument.Selector,
 			ResolveProvider = false
 		};
 	}

--- a/SharpMUSH.LanguageServer/Handlers/ReferencesHandler.cs
+++ b/SharpMUSH.LanguageServer/Handlers/ReferencesHandler.cs
@@ -132,7 +132,7 @@ public class ReferencesHandler : ReferencesHandlerBase
 	{
 		return new ReferenceRegistrationOptions
 		{
-			DocumentSelector = TextDocumentSelector.ForPattern("**/*.mush", "**/*.mu")
+			DocumentSelector = MushDocument.Selector
 		};
 	}
 }

--- a/SharpMUSH.LanguageServer/Handlers/RenameHandler.cs
+++ b/SharpMUSH.LanguageServer/Handlers/RenameHandler.cs
@@ -125,7 +125,7 @@ public class RenameHandler : RenameHandlerBase
 	{
 		return new RenameRegistrationOptions
 		{
-			DocumentSelector = TextDocumentSelector.ForPattern("**/*.mush", "**/*.mu"),
+			DocumentSelector = MushDocument.Selector,
 			PrepareProvider = false
 		};
 	}

--- a/SharpMUSH.LanguageServer/Handlers/SemanticTokensHandler.cs
+++ b/SharpMUSH.LanguageServer/Handlers/SemanticTokensHandler.cs
@@ -41,7 +41,7 @@ public class SemanticTokensHandler : SemanticTokensHandlerBase
 
 		try
 		{
-			var tokensData = _parser.GetSemanticTokens(document.Text, MushParseMode.ForFileName(uri));
+			var tokensData = _parser.GetSemanticTokens(document.Text, MushParseMode.ForFileName(uri).ToParseType());
 
 			for (int i = 0; i < tokensData.Data.Length; i += 5)
 			{

--- a/SharpMUSH.LanguageServer/Handlers/SemanticTokensHandler.cs
+++ b/SharpMUSH.LanguageServer/Handlers/SemanticTokensHandler.cs
@@ -1,6 +1,7 @@
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpMUSH.CodeAnalysis;
 using SharpMUSH.LanguageServer.Services;
 using SharpMUSH.Library.ParserInterfaces;
 
@@ -40,7 +41,7 @@ public class SemanticTokensHandler : SemanticTokensHandlerBase
 
 		try
 		{
-			var tokensData = _parser.GetSemanticTokens(document.Text, ParseType.Function);
+			var tokensData = _parser.GetSemanticTokens(document.Text, MushParseMode.ForFileName(uri));
 
 			for (int i = 0; i < tokensData.Data.Length; i += 5)
 			{
@@ -71,7 +72,7 @@ public class SemanticTokensHandler : SemanticTokensHandlerBase
 
 		return new SemanticTokensRegistrationOptions
 		{
-			DocumentSelector = TextDocumentSelector.ForPattern("**/*.mush", "**/*.mu"),
+			DocumentSelector = MushDocument.Selector,
 			Legend = new SemanticTokensLegend
 			{
 				TokenTypes = new Container<SemanticTokenType>(sampleData.TokenTypes.Select(t =>

--- a/SharpMUSH.LanguageServer/Handlers/SignatureHelpHandler.cs
+++ b/SharpMUSH.LanguageServer/Handlers/SignatureHelpHandler.cs
@@ -71,7 +71,7 @@ public class SignatureHelpHandler : SignatureHelpHandlerBase
 	{
 		return new SignatureHelpRegistrationOptions
 		{
-			DocumentSelector = TextDocumentSelector.ForPattern("**/*.mush", "**/*.mu"),
+			DocumentSelector = MushDocument.Selector,
 			TriggerCharacters = new Container<string>("(", ","),
 			RetriggerCharacters = new Container<string>(",")
 		};

--- a/SharpMUSH.LanguageServer/Handlers/SignatureHelpHandler.cs
+++ b/SharpMUSH.LanguageServer/Handlers/SignatureHelpHandler.cs
@@ -1,24 +1,25 @@
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpMUSH.CodeAnalysis;
 using SharpMUSH.LanguageServer.Services;
-using SharpMUSH.Library.ParserInterfaces;
 
 namespace SharpMUSH.LanguageServer.Handlers;
 
 /// <summary>
 /// Handles signature help requests for MUSH code.
-/// Displays parameter hints while typing function calls.
+/// Delegates to the shared <see cref="IMushCodeAnalyzer"/> and adapts its result to the LSP
+/// signature-help shape.
 /// </summary>
 public class SignatureHelpHandler : SignatureHelpHandlerBase
 {
 	private readonly DocumentManager _documentManager;
-	private readonly IMUSHCodeParser _parser;
+	private readonly IMushCodeAnalyzer _analyzer;
 
-	public SignatureHelpHandler(DocumentManager documentManager, IMUSHCodeParser parser)
+	public SignatureHelpHandler(DocumentManager documentManager, IMushCodeAnalyzer analyzer)
 	{
 		_documentManager = documentManager;
-		_parser = parser;
+		_analyzer = analyzer;
 	}
 
 	public override Task<SignatureHelp?> Handle(SignatureHelpParams request, CancellationToken cancellationToken)
@@ -31,193 +32,37 @@ public class SignatureHelpHandler : SignatureHelpHandlerBase
 			return Task.FromResult<SignatureHelp?>(null);
 		}
 
-		try
+		var info = _analyzer.SignatureHelp(
+			document.Text, (int)request.Position.Line, (int)request.Position.Character);
+		if (info is null)
 		{
-			var lines = document.Text.Split('\n');
-			var line = request.Position.Line < lines.Length ? lines[request.Position.Line] : string.Empty;
-			var character = (int)request.Position.Character;
-
-			var functionInfo = FindFunctionAtPosition(line, character);
-			if (functionInfo == null)
-			{
-				return Task.FromResult<SignatureHelp?>(null);
-			}
-
-			var (functionName, currentParam) = functionInfo.Value;
-
-			if (_parser.FunctionLibrary.TryGetValue(functionName, out var functionDef))
-			{
-				var attr = functionDef.LibraryInformation.Attribute;
-				var signature = BuildSignatureInformation(functionName, attr, currentParam);
-
-				return Task.FromResult<SignatureHelp?>(new SignatureHelp
-				{
-					Signatures = new Container<SignatureInformation>(signature),
-					ActiveSignature = 0,
-					ActiveParameter = currentParam
-				});
-			}
-		}
-		catch (Exception ex)
-		{
-#pragma warning disable VSTHRD103
-			Console.Error.WriteLine($"Error generating signature help: {ex.Message}");
-#pragma warning restore VSTHRD103
+			return Task.FromResult<SignatureHelp?>(null);
 		}
 
-		return Task.FromResult<SignatureHelp?>(null);
-	}
-
-	private static (string functionName, int currentParam)? FindFunctionAtPosition(string line, int position)
-	{
-		var depth = 0;
-		var paramCount = 0;
-		var i = position - 1;
-
-		while (i >= 0)
+		var parameters = info.Parameters.Select(p => new ParameterInformation
 		{
-			if (line[i] == ')')
-			{
-				depth++;
-			}
-			else if (line[i] == '(')
-			{
-				depth--;
-				if (depth < 0)
-				{
-					var nameEnd = i;
-					i--;
-					while (i >= 0 && IsWordCharacter(line[i]))
-					{
-						i--;
-					}
-					var functionName = line.Substring(i + 1, nameEnd - i - 1);
-					return (functionName, paramCount);
-				}
-			}
-			else if (line[i] == ',' && depth == 0)
-			{
-				paramCount++;
-			}
+			Label = p.Label,
+			Documentation = p.Documentation
+		});
 
-			i--;
-		}
-
-		return null;
-	}
-
-	private static bool IsWordCharacter(char c)
-	{
-		return char.IsLetterOrDigit(c) || c == '_';
-	}
-
-	private static SignatureInformation BuildSignatureInformation(
-		string functionName,
-		Library.Attributes.SharpFunctionAttribute attr,
-		int activeParam)
-	{
-		var parameters = new List<ParameterInformation>();
-		var label = functionName + "(";
-
-		for (int i = 0; i < attr.MaxArgs; i++)
+		var signature = new SignatureInformation
 		{
-			var paramName = GetParameterName(i, attr);
-			var isOptional = i >= attr.MinArgs;
-
-			if (i > 0)
-				label += ", ";
-
-			var paramStart = label.Length;
-			if (isOptional)
-				label += "[";
-
-			label += paramName;
-
-			if (isOptional)
-				label += "]";
-
-			var paramEnd = label.Length;
-
-			parameters.Add(new ParameterInformation
-			{
-				Label = paramName,
-				Documentation = isOptional ? $"Optional parameter {i + 1}" : $"Required parameter {i + 1}"
-			});
-		}
-
-		label += ")";
-
-		var documentation = $"**Function**: {functionName}\n\n";
-		documentation += $"**Arguments**: {attr.MinArgs}-{attr.MaxArgs}\n\n";
-		if (attr.Flags != 0)
-		{
-			documentation += $"**Flags**: {attr.Flags}\n\n";
-		}
-
-		return new SignatureInformation
-		{
-			Label = label,
+			Label = info.Label,
 			Documentation = new StringOrMarkupContent(new MarkupContent
 			{
 				Kind = MarkupKind.Markdown,
-				Value = documentation
+				Value = info.Documentation
 			}),
 			Parameters = new Container<ParameterInformation>(parameters),
-			ActiveParameter = activeParam
+			ActiveParameter = info.ActiveParameter
 		};
-	}
 
-	private static string GetParameterName(int index, Library.Attributes.SharpFunctionAttribute attr)
-	{
-		if (attr.ParameterNames != null && attr.ParameterNames.Length > 0)
+		return Task.FromResult<SignatureHelp?>(new SignatureHelp
 		{
-			return ExpandParameterName(attr.ParameterNames, index);
-		}
-
-		return $"arg{index + 1}";
-	}
-
-	/// <summary>
-	/// Expands parameter names with special patterns:
-	/// - "param..." generates "param1", "param2", etc.
-	/// - "case...|result..." generates alternating "case1", "result1", "case2", "result2"
-	/// - Mixed patterns like ["expression", "case...|result...", "default"] for complex functions
-	/// </summary>
-	private static string ExpandParameterName(string[] parameterNames, int index)
-	{
-		int currentIndex = 0;
-
-		foreach (var paramName in parameterNames)
-		{
-			if (paramName.Contains("..."))
-			{
-				if (paramName.Contains("|"))
-				{
-					var parts = paramName.Split('|');
-					var cleanParts = parts.Select(p => p.Replace("...", "").Trim()).ToArray();
-
-					var pairIndex = (index - currentIndex) / cleanParts.Length;
-					var partIndex = (index - currentIndex) % cleanParts.Length;
-
-					return $"{cleanParts[partIndex]}{pairIndex + 1}";
-				}
-				else
-				{
-					var cleanName = paramName.Replace("...", "").Trim();
-					return $"{cleanName}{index - currentIndex + 1}";
-				}
-			}
-			else
-			{
-				if (index == currentIndex)
-				{
-					return paramName;
-				}
-				currentIndex++;
-			}
-		}
-
-		return $"arg{index + 1}";
+			Signatures = new Container<SignatureInformation>(signature),
+			ActiveSignature = 0,
+			ActiveParameter = info.ActiveParameter
+		});
 	}
 
 	protected override SignatureHelpRegistrationOptions CreateRegistrationOptions(

--- a/SharpMUSH.LanguageServer/Handlers/TextDocumentSyncHandler.cs
+++ b/SharpMUSH.LanguageServer/Handlers/TextDocumentSyncHandler.cs
@@ -5,6 +5,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
+using SharpMUSH.CodeAnalysis;
 using SharpMUSH.LanguageServer.Services;
 using SharpMUSH.Library.ParserInterfaces;
 
@@ -86,7 +87,7 @@ public class TextDocumentSyncHandler : TextDocumentSyncHandlerBase
 	{
 		return new TextDocumentSyncRegistrationOptions
 		{
-			DocumentSelector = TextDocumentSelector.ForPattern("**/*.mush", "**/*.mu"),
+			DocumentSelector = MushDocument.Selector,
 			Change = TextDocumentSyncKind.Full,
 			Save = new SaveOptions { IncludeText = false }
 		};
@@ -96,7 +97,7 @@ public class TextDocumentSyncHandler : TextDocumentSyncHandlerBase
 	{
 		try
 		{
-			var diagnostics = _parser.GetDiagnostics(text, ParseType.Function);
+			var diagnostics = _parser.GetDiagnostics(text, MushParseMode.ForFileName(uri));
 
 			var lspDiagnostics = diagnostics.Select(d => new OmniSharp.Extensions.LanguageServer.Protocol.Models.Diagnostic
 			{

--- a/SharpMUSH.LanguageServer/MushDocument.cs
+++ b/SharpMUSH.LanguageServer/MushDocument.cs
@@ -4,13 +4,13 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 namespace SharpMUSH.LanguageServer;
 
 /// <summary>
-/// Shared definition of which files are SharpMUSH softcode. Command-list files
-/// (<c>.mush</c>/<c>.mu</c> batches) and function files (<c>.mushfn</c>/<c>.fun</c>) are both
-/// served; the parse mode is resolved per file by extension (see
+/// Shared definition of which files are SharpMUSH softcode: per-line command files
+/// (<c>.mush</c>/<c>.mu</c>), function files (<c>.mushfn</c>/<c>.fun</c>), and command-list
+/// files (<c>.mushcmd</c>). The parse mode is resolved per file by extension (see
 /// <see cref="CodeAnalysis.MushParseMode.ForFileName"/>).
 /// </summary>
 internal static class MushDocument
 {
 	public static TextDocumentSelector Selector =>
-		TextDocumentSelector.ForPattern("**/*.mush", "**/*.mu", "**/*.mushfn", "**/*.fun");
+		TextDocumentSelector.ForPattern("**/*.mush", "**/*.mu", "**/*.mushfn", "**/*.fun", "**/*.mushcmd");
 }

--- a/SharpMUSH.LanguageServer/MushDocument.cs
+++ b/SharpMUSH.LanguageServer/MushDocument.cs
@@ -1,0 +1,16 @@
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace SharpMUSH.LanguageServer;
+
+/// <summary>
+/// Shared definition of which files are SharpMUSH softcode. Command-list files
+/// (<c>.mush</c>/<c>.mu</c> batches) and function files (<c>.mushfn</c>/<c>.fun</c>) are both
+/// served; the parse mode is resolved per file by extension (see
+/// <see cref="CodeAnalysis.MushParseMode.ForFileName"/>).
+/// </summary>
+internal static class MushDocument
+{
+	public static TextDocumentSelector Selector =>
+		TextDocumentSelector.ForPattern("**/*.mush", "**/*.mu", "**/*.mushfn", "**/*.fun");
+}

--- a/SharpMUSH.LanguageServer/Program.cs
+++ b/SharpMUSH.LanguageServer/Program.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Server;
 using Serilog;
+using SharpMUSH.CodeAnalysis;
 using SharpMUSH.Implementation;
 using SharpMUSH.LanguageServer.Handlers;
 using SharpMUSH.LanguageServer.Services;
@@ -58,6 +59,11 @@ try
 					var parser = sp.GetRequiredService<IMUSHCodeParser>();
 					return new LSPMUSHCodeParser(parser);
 				});
+
+				// Shared code intelligence — the single source of truth also used by the
+				// in-server MCP tools. Handlers delegate to this instead of duplicating logic.
+				services.AddSingleton<IMushCodeAnalyzer>(sp =>
+					new MushCodeAnalyzer(sp.GetRequiredService<IMUSHCodeParser>()));
 			})
 			.WithHandler<TextDocumentSyncHandler>()
 			.WithHandler<SemanticTokensHandler>()

--- a/SharpMUSH.LanguageServer/Services/LSPMUSHCodeParser.cs
+++ b/SharpMUSH.LanguageServer/Services/LSPMUSHCodeParser.cs
@@ -26,8 +26,8 @@ public class LSPMUSHCodeParser
 	/// Analyzes MUSH code and returns diagnostics (errors, warnings, etc.)
 	/// This operation is read-only and does not alter parser state.
 	/// </summary>
-	public IReadOnlyList<Diagnostic> GetDiagnostics(string text, ParseType parseType = ParseType.Function)
-		=> _analyzer.Validate(text, parseType);
+	public IReadOnlyList<Diagnostic> GetDiagnostics(string text, MushAnalysisMode mode = MushAnalysisMode.Function)
+		=> _analyzer.Validate(text, mode);
 
 	/// <summary>
 	/// Performs semantic analysis and returns tokens for syntax highlighting.
@@ -55,9 +55,9 @@ public class LSPMUSHCodeParser
 	/// Validates syntax without performing semantic analysis.
 	/// Returns true if the syntax is valid, false otherwise.
 	/// </summary>
-	public bool ValidateSyntax(string text, ParseType parseType = ParseType.Function)
+	public bool ValidateSyntax(string text, MushAnalysisMode mode = MushAnalysisMode.Function)
 	{
-		var diagnostics = GetDiagnostics(text, parseType);
+		var diagnostics = GetDiagnostics(text, mode);
 		return diagnostics.All(d => d.Severity != DiagnosticSeverity.Error);
 	}
 }

--- a/SharpMUSH.LanguageServer/Services/LSPMUSHCodeParser.cs
+++ b/SharpMUSH.LanguageServer/Services/LSPMUSHCodeParser.cs
@@ -1,3 +1,4 @@
+using SharpMUSH.CodeAnalysis;
 using SharpMUSH.Library.Models;
 using SharpMUSH.Library.ParserInterfaces;
 using MModule = MarkupString.MarkupStringModule;
@@ -12,10 +13,13 @@ namespace SharpMUSH.LanguageServer.Services;
 public class LSPMUSHCodeParser
 {
 	private readonly IMUSHCodeParser _parser;
+	private readonly IMushCodeAnalyzer _analyzer;
 
 	public LSPMUSHCodeParser(IMUSHCodeParser parser)
 	{
 		_parser = parser;
+		// Diagnostics share a single source of truth with the in-server MCP tools.
+		_analyzer = new MushCodeAnalyzer(parser);
 	}
 
 	/// <summary>
@@ -23,29 +27,7 @@ public class LSPMUSHCodeParser
 	/// This operation is read-only and does not alter parser state.
 	/// </summary>
 	public IReadOnlyList<Diagnostic> GetDiagnostics(string text, ParseType parseType = ParseType.Function)
-	{
-		try
-		{
-			return _parser.GetDiagnostics(MModule.single(text), parseType);
-		}
-		catch (Exception ex)
-		{
-			return new List<Diagnostic>
-			{
-				new()
-				{
-					Range = new Library.Models.Range
-					{
-						Start = new Position(0, 0),
-						End = new Position(0, text.Length)
-					},
-					Severity = DiagnosticSeverity.Error,
-					Source = "SharpMUSH.LSP",
-					Message = $"Parser error: {ex.Message}"
-				}
-			};
-		}
-	}
+		=> _analyzer.Validate(text, parseType);
 
 	/// <summary>
 	/// Performs semantic analysis and returns tokens for syntax highlighting.

--- a/SharpMUSH.LanguageServer/SharpMUSH.LanguageServer.csproj
+++ b/SharpMUSH.LanguageServer/SharpMUSH.LanguageServer.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\SharpMUSH.Library\SharpMUSH.Library.csproj" />
     <ProjectReference Include="..\SharpMUSH.Implementation\SharpMUSH.Implementation.csproj" />
     <ProjectReference Include="..\SharpMUSH.MarkupString\SharpMUSH.MarkupString.csproj" />
+    <ProjectReference Include="..\SharpMUSH.CodeAnalysis\SharpMUSH.CodeAnalysis.csproj" />
   </ItemGroup>
 
 </Project>

--- a/SharpMUSH.Server/Authentication/MushBasicAuthenticationHandler.cs
+++ b/SharpMUSH.Server/Authentication/MushBasicAuthenticationHandler.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 using Mediator;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SharpMUSH.Library.Queries.Database;
@@ -34,6 +35,13 @@ public class MushBasicAuthenticationHandler(
 	: AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
 {
 	public const string SchemeName = "MushBasic";
+
+	/// <summary>
+	/// A real, never-matching PBKDF2 hash used only to spend equivalent verification time on the
+	/// unknown-character path (see the null-player branch below). Computed once, process-wide.
+	/// </summary>
+	private static readonly Lazy<string> DummyHash =
+		new(() => new PasswordHasher<string>().HashPassword("timing:parity", "timing:parity"));
 
 	protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
 	{
@@ -77,6 +85,12 @@ public class MushBasicAuthenticationHandler(
 		var player = await mediator.CreateStream(new GetPlayerQuery(character)).FirstOrDefaultAsync();
 		if (player is null)
 		{
+			// Timing parity: a found character runs a full PBKDF2 verification, so an unknown
+			// character must too — otherwise the response latency alone reveals whether the
+			// character exists, defeating the opaque error message below. Verify against a real
+			// (never-matching) hash so the work is equivalent.
+			_ = passwordService.PasswordIsValid("timing:parity", password, DummyHash.Value);
+
 			// Same opaque message whether the character is unknown or the password is wrong,
 			// so the endpoint doesn't confirm which characters exist.
 			return AuthenticateResult.Fail("Invalid character or password.");

--- a/SharpMUSH.Server/Authentication/MushBasicAuthenticationHandler.cs
+++ b/SharpMUSH.Server/Authentication/MushBasicAuthenticationHandler.cs
@@ -96,6 +96,15 @@ public class MushBasicAuthenticationHandler(
 			return AuthenticateResult.Fail("Invalid character or password.");
 		}
 
+		if (string.IsNullOrEmpty(player.PasswordHash))
+		{
+			// A passwordless character can't authenticate over MCP. Spend the same verification
+			// time as every other failure so its response latency doesn't reveal that it has no
+			// password set (PasswordIsValid would otherwise short-circuit on the empty hash).
+			_ = passwordService.PasswordIsValid("timing:parity", password, DummyHash.Value);
+			return AuthenticateResult.Fail("Invalid character or password.");
+		}
+
 		var salt = $"#{player.Object.Key}:{player.Object.CreationTime}";
 		if (!passwordService.PasswordIsValid(salt, password, player.PasswordHash))
 		{

--- a/SharpMUSH.Server/Authentication/MushBasicAuthenticationHandler.cs
+++ b/SharpMUSH.Server/Authentication/MushBasicAuthenticationHandler.cs
@@ -1,0 +1,111 @@
+using System.Security.Claims;
+using System.Text;
+using System.Text.Encodings.Web;
+using Mediator;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SharpMUSH.Library.Queries.Database;
+using SharpMUSH.Library.Services.Interfaces;
+using SharpMUSH.Server.Hubs;
+
+namespace SharpMUSH.Server.Authentication;
+
+/// <summary>
+/// HTTP Basic authentication for the in-server MCP endpoint, keyed on a game
+/// character's name and password.
+///
+/// The credential rides on every request as
+/// <c>Authorization: Basic base64(character:password)</c>. The character is resolved
+/// and the password verified through the exact same flow the in-game <c>connect</c>
+/// command uses (<see cref="GetPlayerQuery"/> + <see cref="IPasswordService.PasswordIsValid"/>),
+/// so there is a single source of truth for character credentials.
+///
+/// On success the authenticated character becomes the request identity (its DBRef,
+/// key, creation time and name are emitted as claims), which the MCP endpoint's
+/// authorization policy requires and future per-enactor scoping can build on.
+/// </summary>
+public class MushBasicAuthenticationHandler(
+	IOptionsMonitor<AuthenticationSchemeOptions> options,
+	ILoggerFactory logger,
+	UrlEncoder encoder,
+	IMediator mediator,
+	IPasswordService passwordService)
+	: AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+	public const string SchemeName = "MushBasic";
+
+	protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+	{
+		if (!Request.Headers.TryGetValue("Authorization", out var authHeaderValues))
+		{
+			return AuthenticateResult.NoResult();
+		}
+
+		var authHeader = authHeaderValues.ToString();
+		if (string.IsNullOrEmpty(authHeader) ||
+		    !authHeader.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase))
+		{
+			return AuthenticateResult.NoResult();
+		}
+
+		string character;
+		string password;
+		try
+		{
+			var encoded = authHeader["Basic ".Length..].Trim();
+			var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
+			var separator = decoded.IndexOf(':');
+			if (separator < 0)
+			{
+				return AuthenticateResult.Fail("Malformed Basic credentials: expected 'character:password'.");
+			}
+
+			character = decoded[..separator];
+			password = decoded[(separator + 1)..];
+		}
+		catch (FormatException)
+		{
+			return AuthenticateResult.Fail("Malformed Basic credentials: not valid base64.");
+		}
+
+		if (string.IsNullOrWhiteSpace(character))
+		{
+			return AuthenticateResult.Fail("Missing character name.");
+		}
+
+		var player = await mediator.CreateStream(new GetPlayerQuery(character)).FirstOrDefaultAsync();
+		if (player is null)
+		{
+			// Same opaque message whether the character is unknown or the password is wrong,
+			// so the endpoint doesn't confirm which characters exist.
+			return AuthenticateResult.Fail("Invalid character or password.");
+		}
+
+		var salt = $"#{player.Object.Key}:{player.Object.CreationTime}";
+		if (!passwordService.PasswordIsValid(salt, password, player.PasswordHash))
+		{
+			return AuthenticateResult.Fail("Invalid character or password.");
+		}
+
+		var claims = new List<Claim>
+		{
+			new(ClaimTypes.NameIdentifier, $"#{player.Object.Key}"),
+			new(ClaimTypes.Name, player.Object.Name),
+			new("character_key", player.Object.Key.ToString()),
+			new("character_creation_time", player.Object.CreationTime.ToString()),
+			new("character_name", player.Object.Name),
+			new(GameHub.CharacterDbrefClaim, $"#{player.Object.Key}")
+		};
+
+		var identity = new ClaimsIdentity(claims, SchemeName);
+		var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName);
+		return AuthenticateResult.Success(ticket);
+	}
+
+	protected override Task HandleChallengeAsync(AuthenticationProperties properties)
+	{
+		Response.Headers.WWWAuthenticate = "Basic realm=\"SharpMUSH MCP\", charset=\"UTF-8\"";
+		return base.HandleChallengeAsync(properties);
+	}
+}

--- a/SharpMUSH.Server/Mcp/McpDocumentStore.cs
+++ b/SharpMUSH.Server/Mcp/McpDocumentStore.cs
@@ -1,0 +1,35 @@
+using System.Collections.Concurrent;
+
+namespace SharpMUSH.Server.Mcp;
+
+/// <summary>
+/// Process-wide store backing the optional MCP document-session handles. A caller that runs
+/// many queries over one piece of softcode can <c>open_document</c> once and pass the returned
+/// id to subsequent tools instead of resending the text. Entries live until <c>close_document</c>
+/// removes them; the store is capacity-bounded so an abandoned session cannot leak unboundedly.
+/// </summary>
+public sealed class McpDocumentStore
+{
+	private const int Capacity = 1024;
+	private readonly ConcurrentDictionary<string, string> _documents = new();
+	private readonly ConcurrentQueue<string> _insertionOrder = new();
+
+	public string Open(string text)
+	{
+		var id = Guid.NewGuid().ToString("N");
+		_documents[id] = text;
+		_insertionOrder.Enqueue(id);
+
+		// Evict oldest ids while over capacity so a client that never closes cannot grow the store forever.
+		while (_documents.Count > Capacity && _insertionOrder.TryDequeue(out var oldest))
+		{
+			_documents.TryRemove(oldest, out _);
+		}
+
+		return id;
+	}
+
+	public bool Close(string id) => _documents.TryRemove(id, out _);
+
+	public bool TryGet(string id, out string text) => _documents.TryGetValue(id, out text!);
+}

--- a/SharpMUSH.Server/Mcp/McpDocumentStore.cs
+++ b/SharpMUSH.Server/Mcp/McpDocumentStore.cs
@@ -16,12 +16,18 @@ public sealed class McpDocumentStore
 
 	public string Open(string text)
 	{
+		ArgumentNullException.ThrowIfNull(text);
+
 		var id = Guid.NewGuid().ToString("N");
 		_documents[id] = text;
 		_insertionOrder.Enqueue(id);
 
-		// Evict oldest ids while over capacity so a client that never closes cannot grow the store forever.
-		while (_documents.Count > Capacity && _insertionOrder.TryDequeue(out var oldest))
+		// Bound the insertion-order queue itself (not just the document map). Otherwise a client
+		// that repeatedly opens and closes documents would leave the closed ids sitting in the
+		// queue forever — the map stays small so the old "_documents.Count > Capacity" guard never
+		// fired, and the queue grew without bound. Capping the queue evicts oldest ids (removing
+		// any still-live document they point at) so both structures stay bounded under churn.
+		while (_insertionOrder.Count > Capacity && _insertionOrder.TryDequeue(out var oldest))
 		{
 			_documents.TryRemove(oldest, out _);
 		}

--- a/SharpMUSH.Server/Mcp/McpOptions.cs
+++ b/SharpMUSH.Server/Mcp/McpOptions.cs
@@ -1,0 +1,21 @@
+namespace SharpMUSH.Server.Mcp;
+
+/// <summary>
+/// Configuration for the in-server Model Context Protocol (MCP) endpoint.
+/// Bound from the "Mcp" section of appsettings.
+/// </summary>
+public class McpOptions
+{
+	public const string Section = "Mcp";
+
+	/// <summary>
+	/// When false (the production default) the MCP endpoint is not mapped and all
+	/// requests to <see cref="Path"/> return 404.
+	/// </summary>
+	public bool Enabled { get; set; }
+
+	/// <summary>
+	/// The route the MCP Streamable-HTTP endpoint is mapped at.
+	/// </summary>
+	public string Path { get; set; } = "/mcp";
+}

--- a/SharpMUSH.Server/Mcp/MushTools.cs
+++ b/SharpMUSH.Server/Mcp/MushTools.cs
@@ -12,21 +12,26 @@ namespace SharpMUSH.Server.Mcp;
 /// <see cref="IMushCodeAnalyzer"/>, which runs in-process against the live world's
 /// registered function and command libraries.
 ///
+/// Every tool takes the softcode either inline via <c>code</c> or by a <c>documentId</c>
+/// previously returned from <c>open_document</c>. Positions are 0-based (line, character).
+///
 /// The endpoint hosting these tools is authenticated per-request as a game character
 /// (see <see cref="Authentication.MushBasicAuthenticationHandler"/>).
 /// </summary>
 [McpServerToolType]
-public class MushTools(IMushCodeAnalyzer analyzer)
+public class MushTools(IMushCodeAnalyzer analyzer, McpDocumentStore documents)
 {
 	[McpServerTool(Name = "validate", UseStructuredContent = true)]
 	[Description("Validate SharpMUSH softcode against the live parser and return any " +
 	             "syntax errors, warnings, or hints. Ranges are 0-based (line, character).")]
 	public IReadOnlyList<McpDiagnostic> Validate(
-		[Description("The MUSH softcode to validate.")]
-		string code,
+		[Description("The MUSH softcode to validate. Omit if 'documentId' is given.")]
+		string? code = null,
 		[Description("How to parse the code: 'function' (default) or 'command'.")]
-		string parseType = "function")
-		=> analyzer.Validate(code, ParseParseType(parseType))
+		string parseType = "function",
+		[Description("Id from open_document to validate instead of inline 'code'.")]
+		string? documentId = null)
+		=> analyzer.Validate(Resolve(code, documentId), ParseParseType(parseType))
 			.Select(McpDiagnostic.From)
 			.ToList();
 
@@ -35,9 +40,97 @@ public class MushTools(IMushCodeAnalyzer analyzer)
 	             "inserts a space after commas, and a space between an @command and its first " +
 	             "argument. Returns the formatted code. Line count is preserved.")]
 	public string Format(
-		[Description("The MUSH softcode to format.")]
-		string code)
-		=> analyzer.Format(code);
+		[Description("The MUSH softcode to format. Omit if 'documentId' is given.")]
+		string? code = null,
+		[Description("Id from open_document to format instead of inline 'code'.")]
+		string? documentId = null)
+		=> analyzer.Format(Resolve(code, documentId));
+
+	[McpServerTool(Name = "hover", UseStructuredContent = true)]
+	[Description("Return hover documentation (function/command signature, or a built-in " +
+	             "substitution explanation) for the word at a 0-based line/character, or null.")]
+	public McpHover? Hover(
+		[Description("Line (0-based).")] int line,
+		[Description("Character (0-based).")] int character,
+		[Description("The MUSH softcode. Omit if 'documentId' is given.")]
+		string? code = null,
+		[Description("Id from open_document to use instead of inline 'code'.")]
+		string? documentId = null)
+	{
+		var hover = analyzer.Hover(Resolve(code, documentId), line, character);
+		return hover is null ? null : McpHover.From(hover);
+	}
+
+	[McpServerTool(Name = "complete", UseStructuredContent = true)]
+	[Description("Return completion suggestions (functions, commands, and common " +
+	             "substitutions) for the word prefix at a 0-based line/character.")]
+	public IReadOnlyList<McpCompletion> Complete(
+		[Description("Line (0-based).")] int line,
+		[Description("Character (0-based).")] int character,
+		[Description("The MUSH softcode. Omit if 'documentId' is given.")]
+		string? code = null,
+		[Description("Id from open_document to use instead of inline 'code'.")]
+		string? documentId = null)
+		=> analyzer.Complete(Resolve(code, documentId), line, character)
+			.Select(McpCompletion.From)
+			.ToList();
+
+	[McpServerTool(Name = "signature_help", UseStructuredContent = true)]
+	[Description("Return signature help for the function call surrounding a 0-based " +
+	             "line/character, or null if the position is not inside a known function call.")]
+	public McpSignature? SignatureHelp(
+		[Description("Line (0-based).")] int line,
+		[Description("Character (0-based).")] int character,
+		[Description("The MUSH softcode. Omit if 'documentId' is given.")]
+		string? code = null,
+		[Description("Id from open_document to use instead of inline 'code'.")]
+		string? documentId = null)
+	{
+		var signature = analyzer.SignatureHelp(Resolve(code, documentId), line, character);
+		return signature is null ? null : McpSignature.From(signature);
+	}
+
+	[McpServerTool(Name = "document_symbols", UseStructuredContent = true)]
+	[Description("Return an outline of the softcode: attribute definitions, @set attributes, " +
+	             "function calls, and commands.")]
+	public IReadOnlyList<McpSymbol> DocumentSymbols(
+		[Description("The MUSH softcode. Omit if 'documentId' is given.")]
+		string? code = null,
+		[Description("Id from open_document to use instead of inline 'code'.")]
+		string? documentId = null)
+		=> analyzer.DocumentSymbols(Resolve(code, documentId))
+			.Select(McpSymbol.From)
+			.ToList();
+
+	[McpServerTool(Name = "open_document")]
+	[Description("Store softcode server-side and return a documentId so subsequent tool calls " +
+	             "can reference it via 'documentId' instead of resending the text.")]
+	public string OpenDocument(
+		[Description("The MUSH softcode to store.")] string code)
+		=> documents.Open(code);
+
+	[McpServerTool(Name = "close_document")]
+	[Description("Release a documentId previously returned by open_document. Returns true if it " +
+	             "existed.")]
+	public bool CloseDocument(
+		[Description("The documentId to release.")] string documentId)
+		=> documents.Close(documentId);
+
+	private string Resolve(string? code, string? documentId)
+	{
+		if (!string.IsNullOrEmpty(documentId))
+		{
+			if (documents.TryGet(documentId, out var text))
+			{
+				return text;
+			}
+
+			throw new ArgumentException(
+				$"Unknown documentId '{documentId}'. Open one with open_document first.");
+		}
+
+		return code ?? throw new ArgumentException("Provide either 'code' or a 'documentId'.");
+	}
 
 	private static ParseType ParseParseType(string parseType)
 		=> parseType.Trim().ToLowerInvariant() switch
@@ -47,26 +140,50 @@ public class MushTools(IMushCodeAnalyzer analyzer)
 		};
 }
 
-/// <summary>
-/// A diagnostic in the flat, JSON-friendly shape returned to MCP clients.
-/// </summary>
+/// <summary>A diagnostic in the flat, JSON-friendly shape returned to MCP clients.</summary>
 public record McpDiagnostic(
-	string Severity,
-	string Message,
-	int StartLine,
-	int StartCharacter,
-	int EndLine,
-	int EndCharacter,
-	string? Code,
-	string? Source)
+	string Severity, string Message,
+	int StartLine, int StartCharacter, int EndLine, int EndCharacter,
+	string? Code, string? Source)
 {
 	public static McpDiagnostic From(Diagnostic d) => new(
-		d.Severity.ToString(),
-		d.Message,
-		d.Range.Start.Line,
-		d.Range.Start.Character,
-		d.Range.End.Line,
-		d.Range.End.Character,
-		d.Code,
-		d.Source);
+		d.Severity.ToString(), d.Message,
+		d.Range.Start.Line, d.Range.Start.Character, d.Range.End.Line, d.Range.End.Character,
+		d.Code, d.Source);
+}
+
+/// <summary>Hover markdown plus the 0-based range it covers.</summary>
+public record McpHover(string Markdown, int StartLine, int StartCharacter, int EndLine, int EndCharacter)
+{
+	public static McpHover From(HoverInfo h) => new(
+		h.Markdown, h.Range.Start.Line, h.Range.Start.Character, h.Range.End.Line, h.Range.End.Character);
+}
+
+/// <summary>A completion suggestion.</summary>
+public record McpCompletion(string Label, string Kind, string? Detail, string? Documentation, string? InsertText, bool IsSnippet)
+{
+	public static McpCompletion From(CompletionSuggestion c) =>
+		new(c.Label, c.Kind, c.Detail, c.Documentation, c.InsertText, c.IsSnippet);
+}
+
+/// <summary>Signature help for a function call.</summary>
+public record McpSignature(string Label, string Documentation, IReadOnlyList<McpParameter> Parameters, int ActiveParameter)
+{
+	public static McpSignature From(SignatureInfo s) => new(
+		s.Label, s.Documentation,
+		s.Parameters.Select(p => new McpParameter(p.Label, p.Documentation)).ToList(),
+		s.ActiveParameter);
+}
+
+/// <summary>One parameter within an <see cref="McpSignature"/>.</summary>
+public record McpParameter(string Label, string Documentation);
+
+/// <summary>A document outline symbol.</summary>
+public record McpSymbol(
+	string Name, string Kind, string Detail,
+	int StartLine, int StartCharacter, int EndLine, int EndCharacter)
+{
+	public static McpSymbol From(CodeSymbol s) => new(
+		s.Name, s.Kind, s.Detail,
+		s.Range.Start.Line, s.Range.Start.Character, s.Range.End.Line, s.Range.End.Character);
 }

--- a/SharpMUSH.Server/Mcp/MushTools.cs
+++ b/SharpMUSH.Server/Mcp/MushTools.cs
@@ -1,0 +1,63 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using SharpMUSH.CodeAnalysis;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+
+namespace SharpMUSH.Server.Mcp;
+
+/// <summary>
+/// MCP tools exposing SharpMUSH's live code intelligence to MCP clients
+/// (Claude Code, editors, tooling). Each tool is a thin JSON adapter over the shared
+/// <see cref="IMushCodeAnalyzer"/>, which runs in-process against the live world's
+/// registered function and command libraries.
+///
+/// The endpoint hosting these tools is authenticated per-request as a game character
+/// (see <see cref="Authentication.MushBasicAuthenticationHandler"/>).
+/// </summary>
+[McpServerToolType]
+public class MushTools(IMushCodeAnalyzer analyzer)
+{
+	[McpServerTool(Name = "validate", UseStructuredContent = true)]
+	[Description("Validate SharpMUSH softcode against the live parser and return any " +
+	             "syntax errors, warnings, or hints. Ranges are 0-based (line, character).")]
+	public IReadOnlyList<McpDiagnostic> Validate(
+		[Description("The MUSH softcode to validate.")]
+		string code,
+		[Description("How to parse the code: 'function' (default) or 'command'.")]
+		string parseType = "function")
+		=> analyzer.Validate(code, ParseParseType(parseType))
+			.Select(McpDiagnostic.From)
+			.ToList();
+
+	private static ParseType ParseParseType(string parseType)
+		=> parseType.Trim().ToLowerInvariant() switch
+		{
+			"command" => ParseType.Command,
+			_ => ParseType.Function
+		};
+}
+
+/// <summary>
+/// A diagnostic in the flat, JSON-friendly shape returned to MCP clients.
+/// </summary>
+public record McpDiagnostic(
+	string Severity,
+	string Message,
+	int StartLine,
+	int StartCharacter,
+	int EndLine,
+	int EndCharacter,
+	string? Code,
+	string? Source)
+{
+	public static McpDiagnostic From(Diagnostic d) => new(
+		d.Severity.ToString(),
+		d.Message,
+		d.Range.Start.Line,
+		d.Range.Start.Character,
+		d.Range.End.Line,
+		d.Range.End.Character,
+		d.Code,
+		d.Source);
+}

--- a/SharpMUSH.Server/Mcp/MushTools.cs
+++ b/SharpMUSH.Server/Mcp/MushTools.cs
@@ -2,7 +2,6 @@ using System.ComponentModel;
 using ModelContextProtocol.Server;
 using SharpMUSH.CodeAnalysis;
 using SharpMUSH.Library.Models;
-using SharpMUSH.Library.ParserInterfaces;
 
 namespace SharpMUSH.Server.Mcp;
 
@@ -27,12 +26,13 @@ public class MushTools(IMushCodeAnalyzer analyzer, McpDocumentStore documents)
 	public IReadOnlyList<McpDiagnostic> Validate(
 		[Description("The MUSH softcode to validate. Omit if 'documentId' is given.")]
 		string? code = null,
-		[Description("How to parse the code: 'function' (default), 'commandlist' (a list of " +
-		             "commands, e.g. an attribute's $-command actions), or 'command' (a single command).")]
+		[Description("How to parse the code: 'function' (default); 'commandsperline' (each line is " +
+		             "its own command, i.e. a real-world .mush upload file); 'commandlist' (one " +
+		             ";-separated command list); or 'command' (a single command).")]
 		string parseType = "function",
 		[Description("Id from open_document to validate instead of inline 'code'.")]
 		string? documentId = null)
-		=> analyzer.Validate(Resolve(code, documentId), ParseParseType(parseType))
+		=> analyzer.Validate(Resolve(code, documentId), MushParseMode.FromName(parseType))
 			.Select(McpDiagnostic.From)
 			.ToList();
 
@@ -132,8 +132,6 @@ public class MushTools(IMushCodeAnalyzer analyzer, McpDocumentStore documents)
 
 		return code ?? throw new ArgumentException("Provide either 'code' or a 'documentId'.");
 	}
-
-	private static ParseType ParseParseType(string parseType) => MushParseMode.FromName(parseType);
 }
 
 /// <summary>A diagnostic in the flat, JSON-friendly shape returned to MCP clients.</summary>

--- a/SharpMUSH.Server/Mcp/MushTools.cs
+++ b/SharpMUSH.Server/Mcp/MushTools.cs
@@ -30,6 +30,15 @@ public class MushTools(IMushCodeAnalyzer analyzer)
 			.Select(McpDiagnostic.From)
 			.ToList();
 
+	[McpServerTool(Name = "format")]
+	[Description("Format SharpMUSH softcode with a consistent style: trims whitespace, " +
+	             "inserts a space after commas, and a space between an @command and its first " +
+	             "argument. Returns the formatted code. Line count is preserved.")]
+	public string Format(
+		[Description("The MUSH softcode to format.")]
+		string code)
+		=> analyzer.Format(code);
+
 	private static ParseType ParseParseType(string parseType)
 		=> parseType.Trim().ToLowerInvariant() switch
 		{

--- a/SharpMUSH.Server/Mcp/MushTools.cs
+++ b/SharpMUSH.Server/Mcp/MushTools.cs
@@ -27,7 +27,8 @@ public class MushTools(IMushCodeAnalyzer analyzer, McpDocumentStore documents)
 	public IReadOnlyList<McpDiagnostic> Validate(
 		[Description("The MUSH softcode to validate. Omit if 'documentId' is given.")]
 		string? code = null,
-		[Description("How to parse the code: 'function' (default) or 'command'.")]
+		[Description("How to parse the code: 'function' (default), 'commandlist' (a list of " +
+		             "commands, e.g. an attribute's $-command actions), or 'command' (a single command).")]
 		string parseType = "function",
 		[Description("Id from open_document to validate instead of inline 'code'.")]
 		string? documentId = null)
@@ -132,12 +133,7 @@ public class MushTools(IMushCodeAnalyzer analyzer, McpDocumentStore documents)
 		return code ?? throw new ArgumentException("Provide either 'code' or a 'documentId'.");
 	}
 
-	private static ParseType ParseParseType(string parseType)
-		=> parseType.Trim().ToLowerInvariant() switch
-		{
-			"command" => ParseType.Command,
-			_ => ParseType.Function
-		};
+	private static ParseType ParseParseType(string parseType) => MushParseMode.FromName(parseType);
 }
 
 /// <summary>A diagnostic in the flat, JSON-friendly shape returned to MCP clients.</summary>

--- a/SharpMUSH.Server/Program.cs
+++ b/SharpMUSH.Server/Program.cs
@@ -1,16 +1,20 @@
 using Core.Arango;
 using Core.Arango.Serilog;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Serilog;
 using Serilog.Sinks.PeriodicBatching;
 using SharpMUSH.Database;
 using SharpMUSH.Library.Definitions;
 using SharpMUSH.Messaging.NATS.Strategy;
+using SharpMUSH.Server.Authentication;
 using SharpMUSH.Server.Hubs;
+using SharpMUSH.Server.Mcp;
 using SharpMUSH.Server.Middleware;
 using SharpMUSH.Server.Strategy.ArangoDB;
 
@@ -127,6 +131,19 @@ public class Program
 		app.MapControllers();
 		app.MapRazorPages();
 		app.MapHub<GameHub>("/hubs/game");
+
+		// In-server MCP (Model Context Protocol) endpoint. Only mapped when Mcp:Enabled is
+		// true; otherwise requests to the path fall through to the SPA fallback / 404. The
+		// endpoint requires an authenticated game character via the MushBasic scheme
+		// (Authorization: Basic base64(character:password)).
+		var mcpOptions = app.Services.GetRequiredService<IOptions<McpOptions>>().Value;
+		if (mcpOptions.Enabled)
+		{
+			var mcpPolicy = new AuthorizationPolicyBuilder(MushBasicAuthenticationHandler.SchemeName)
+				.RequireAuthenticatedUser()
+				.Build();
+			app.MapMcp(mcpOptions.Path).RequireAuthorization(mcpPolicy);
+		}
 
 		// Phase 9 — plugin web-contribution seam: after the host maps its own controllers/hubs, let each
 		// plugin implementing IEndpointContributor map its endpoints (hubs/routes) into the pipeline. The

--- a/SharpMUSH.Server/Program.cs
+++ b/SharpMUSH.Server/Program.cs
@@ -142,7 +142,12 @@ public class Program
 			var mcpPolicy = new AuthorizationPolicyBuilder(MushBasicAuthenticationHandler.SchemeName)
 				.RequireAuthenticatedUser()
 				.Build();
-			app.MapMcp(mcpOptions.Path).RequireAuthorization(mcpPolicy);
+			// Rate-limit the endpoint: it does character+password Basic auth on every request, so
+			// the per-IP "mcp" limiter blunts brute-force credential guessing without throttling a
+			// legitimate agent's tool-call throughput.
+			app.MapMcp(mcpOptions.Path)
+				.RequireRateLimiting("mcp")
+				.RequireAuthorization(mcpPolicy);
 		}
 
 		// Phase 9 — plugin web-contribution seam: after the host maps its own controllers/hubs, let each

--- a/SharpMUSH.Server/SharpMUSH.Server.csproj
+++ b/SharpMUSH.Server/SharpMUSH.Server.csproj
@@ -60,6 +60,7 @@
          ReferenceOutputAssembly=false keeps it out of the host's compile graph; the CopyScenePlugin target
          below drops it into the output's plugins/scene/ where PluginBootstrapService discovers it. -->
     <ProjectReference Include="..\SharpMUSH.Plugins.Scene\SharpMUSH.Plugins.Scene.csproj" ReferenceOutputAssembly="false" Private="false" SkipGetTargetFrameworkProperties="true" />
+    <ProjectReference Include="..\SharpMUSH.CodeAnalysis\SharpMUSH.CodeAnalysis.csproj" />
   </ItemGroup>
 
   <!-- Drop the built Scene plugin (DLL + deps.json + manifest) into plugins/scene/ beside the server binary
@@ -121,6 +122,7 @@
       <Link>BundledPackages\scene.package.yaml</Link>
       <LogicalName>SharpMUSH.Server.BundledPackages.scene.package.yaml</LogicalName>
     </EmbeddedResource>
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="2.0.0-preview.1" />
     <PackageReference Include="SurrealDb.Embedded.InMemory" Version="0.9.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" ExcludeAssets="compile" />
   </ItemGroup>

--- a/SharpMUSH.Server/Startup.cs
+++ b/SharpMUSH.Server/Startup.cs
@@ -531,6 +531,7 @@ public class Startup(
 		// tools over Streamable HTTP. Services are always registered; the endpoint is only
 		// mapped when Mcp:Enabled is true (see Program.MapMcp), so a disabled MCP returns 404.
 		services.Configure<McpOptions>(configuration.GetSection(McpOptions.Section));
+		services.AddSingleton<McpDocumentStore>();
 		services.AddMcpServer()
 			.WithHttpTransport(mcpTransport => mcpTransport.Stateless = true)
 			.WithTools<MushTools>();

--- a/SharpMUSH.Server/Startup.cs
+++ b/SharpMUSH.Server/Startup.cs
@@ -575,6 +575,20 @@ public class Startup(
 				limiterOpts.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
 				limiterOpts.QueueLimit = 5;
 			});
+
+			// "mcp" policy: partitioned per client IP so one source can't brute-force the
+			// character+password auth on /mcp, while a legitimate agent (single IP) still gets
+			// generous tool-call throughput. Partitioning (unlike the global "public-api" limiter)
+			// keeps one caller's bursts from throttling everyone else.
+			opts.AddPolicy("mcp", httpContext =>
+				RateLimitPartition.GetFixedWindowLimiter(
+					partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+					_ => new FixedWindowRateLimiterOptions
+					{
+						PermitLimit = 300,
+						Window = TimeSpan.FromMinutes(1),
+						QueueLimit = 0
+					}));
 		});
 
 		services.AddProblemDetails();

--- a/SharpMUSH.Server/Startup.cs
+++ b/SharpMUSH.Server/Startup.cs
@@ -13,8 +13,10 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Neo4j.Driver;
+using SharpMUSH.CodeAnalysis;
 using SharpMUSH.Server.Authentication;
 using SharpMUSH.Server.Hubs;
+using SharpMUSH.Server.Mcp;
 using SharpMUSH.Server.Middleware;
 using SharpMUSH.Server.Services;
 using OpenTelemetry.Metrics;
@@ -356,6 +358,9 @@ public class Startup(
 		services.AddSingleton(typeof(IStreamPipelineBehavior<,>), typeof(StreamQueryCachingBehavior<,>));
 		services.AddSingleton(new ArangoHandle("CurrentSharpMUSHWorld"));
 		services.AddSingleton<IMUSHCodeParser, MUSHCodeParser>();
+		// Shared MUSH code intelligence — the single source of truth behind both the
+		// Language Server (for editors) and the in-server MCP tools (for agents/tooling).
+		services.AddSingleton<IMushCodeAnalyzer, MushCodeAnalyzer>();
 		services.AddSingleton<IValidateService, ValidateService>();
 		services.AddKeyedSingleton(nameof(colorFile), colorFile);
 		services.AddOptions<SharpMUSHOptions>().ValidateOnStart();
@@ -513,6 +518,22 @@ public class Startup(
 					};
 				});
 		}
+
+		// MCP endpoint authentication: character + password over HTTP Basic, verified via the
+		// same flow the in-game `connect` command uses. Registered as an additional scheme
+		// (no default change) so the MCP endpoint can require it explicitly regardless of the
+		// default web-portal scheme, in every environment/JWT configuration above.
+		services.AddAuthentication()
+			.AddScheme<AuthenticationSchemeOptions, MushBasicAuthenticationHandler>(
+				MushBasicAuthenticationHandler.SchemeName, _ => { });
+
+		// In-server MCP (Model Context Protocol): exposes the shared MUSH code intelligence as
+		// tools over Streamable HTTP. Services are always registered; the endpoint is only
+		// mapped when Mcp:Enabled is true (see Program.MapMcp), so a disabled MCP returns 404.
+		services.Configure<McpOptions>(configuration.GetSection(McpOptions.Section));
+		services.AddMcpServer()
+			.WithHttpTransport(mcpTransport => mcpTransport.Stateless = true)
+			.WithTools<MushTools>();
 
 		// JWT infrastructure (role derivation + refresh tokens) is always registered
 		// so that the services are available even before a signing key is configured.

--- a/SharpMUSH.Server/appsettings.Development.json
+++ b/SharpMUSH.Server/appsettings.Development.json
@@ -4,6 +4,10 @@
     "AdminUsername": "admin",
     "AdminPassword": "devpassword"
   },
+  "Mcp": {
+    "Enabled": true,
+    "Path": "/mcp"
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Debug",

--- a/SharpMUSH.Server/appsettings.json
+++ b/SharpMUSH.Server/appsettings.json
@@ -6,6 +6,10 @@
   "Cors": {
     "AllowedOrigins": []
   },
+  "Mcp": {
+    "Enabled": false,
+    "Path": "/mcp"
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",

--- a/SharpMUSH.Tests.Infrastructure/ServerTestWebApplicationBuilderFactory.cs
+++ b/SharpMUSH.Tests.Infrastructure/ServerTestWebApplicationBuilderFactory.cs
@@ -31,6 +31,12 @@ public class ServerTestWebApplicationBuilderFactory<TProgram>(
 	/// </summary>
 	protected override void ConfigureStartupConfiguration(IConfigurationBuilder configurationBuilder)
 	{
+		// Map the in-server MCP endpoint in integration tests regardless of which appsettings
+		// the test host resolves, so the Explicit MCP tests always have an endpoint to hit.
+		configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+		{
+			["Mcp:Enabled"] = "true"
+		});
 	}
 
 	/// <summary>

--- a/SharpMUSH.Tests.Integration/Mcp/McpEndpointTests.cs
+++ b/SharpMUSH.Tests.Integration/Mcp/McpEndpointTests.cs
@@ -228,6 +228,29 @@ public class McpEndpointTests(ServerWebAppFactory factory)
 	}
 
 	[Test]
+	public async Task Mcp_Validate_AcceptsCommandListParseType()
+	{
+		var password = "Correct-Horse-8!";
+		var character = await CreateCharacterWithPasswordAsync(password);
+
+		await using var client = await ConnectAsync(character, password);
+
+		var result = await client.CallToolAsync(
+			"validate",
+			new Dictionary<string, object?>
+			{
+				["code"] = "@pemit %#=hello",
+				["parseType"] = "commandlist"
+			});
+
+		var json = JsonSerializer.Serialize(result);
+		// The commandlist parse type plumbs through and the tool executes successfully
+		// (diagnostics, if any, are not tool errors).
+		await Assert.That(json).Contains("structuredContent");
+		await Assert.That(json).DoesNotContain("\"isError\":true");
+	}
+
+	[Test]
 	public async Task Mcp_DocumentSymbols_OutlinesAttributeDefinition()
 	{
 		var password = "Correct-Horse-6!";

--- a/SharpMUSH.Tests.Integration/Mcp/McpEndpointTests.cs
+++ b/SharpMUSH.Tests.Integration/Mcp/McpEndpointTests.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
 using SharpMUSH.Tests.Infrastructure;
 
 namespace SharpMUSH.Tests.Integration.Mcp;
@@ -169,15 +170,22 @@ public class McpEndpointTests(ServerWebAppFactory factory)
 	}
 
 	[Test]
-	public async Task Mcp_ListTools_IncludesValidate()
+	public async Task Mcp_ListTools_IncludesAllTools()
 	{
 		var password = "Correct-Horse-3!";
 		var character = await CreateCharacterWithPasswordAsync(password);
 
 		await using var client = await ConnectAsync(character, password);
-		var tools = await client.ListToolsAsync();
+		var names = (await client.ListToolsAsync()).Select(t => t.Name).ToList();
 
-		await Assert.That(tools.Select(t => t.Name)).Contains("validate");
+		foreach (var expected in new[]
+		{
+			"validate", "format", "hover", "complete", "signature_help",
+			"document_symbols", "open_document", "close_document"
+		})
+		{
+			await Assert.That(names).Contains(expected);
+		}
 	}
 
 	[Test]
@@ -216,5 +224,44 @@ public class McpEndpointTests(ServerWebAppFactory factory)
 			new Dictionary<string, object?> { ["code"] = "  add(1,2,3)  " });
 
 		await Assert.That(JsonSerializer.Serialize(result)).Contains("add(1, 2, 3)");
+	}
+
+	[Test]
+	public async Task Mcp_DocumentSymbols_OutlinesAttributeDefinition()
+	{
+		var password = "Correct-Horse-6!";
+		var character = await CreateCharacterWithPasswordAsync(password);
+
+		await using var client = await ConnectAsync(character, password);
+
+		var result = await client.CallToolAsync(
+			"document_symbols",
+			new Dictionary<string, object?> { ["code"] = "&greeting think hello" });
+
+		await Assert.That(JsonSerializer.Serialize(result)).Contains("greeting");
+	}
+
+	[Test]
+	public async Task Mcp_SessionHandles_ValidateByDocumentIdThenClose()
+	{
+		var password = "Correct-Horse-7!";
+		var character = await CreateCharacterWithPasswordAsync(password);
+
+		await using var client = await ConnectAsync(character, password);
+
+		var opened = await client.CallToolAsync(
+			"open_document",
+			new Dictionary<string, object?> { ["code"] = "add(" });
+		var documentId = opened.Content.OfType<TextContentBlock>().First().Text;
+
+		var validated = await client.CallToolAsync(
+			"validate",
+			new Dictionary<string, object?> { ["documentId"] = documentId });
+		await Assert.That(JsonSerializer.Serialize(validated)).Contains("Severity");
+
+		var closed = await client.CallToolAsync(
+			"close_document",
+			new Dictionary<string, object?> { ["documentId"] = documentId });
+		await Assert.That(JsonSerializer.Serialize(closed)).Contains("true");
 	}
 }

--- a/SharpMUSH.Tests.Integration/Mcp/McpEndpointTests.cs
+++ b/SharpMUSH.Tests.Integration/Mcp/McpEndpointTests.cs
@@ -251,6 +251,29 @@ public class McpEndpointTests(ServerWebAppFactory factory)
 	}
 
 	[Test]
+	public async Task Mcp_Validate_AcceptsCommandsPerLineForMushFile()
+	{
+		var password = "Correct-Horse-9!";
+		var character = await CreateCharacterWithPasswordAsync(password);
+
+		await using var client = await ConnectAsync(character, password);
+
+		// A real-world .mush upload file: one command per line.
+		var mushFile = "@create Widget\n&FMT Widget=capstr(%0)\n@set Widget/FMT=no_command";
+		var result = await client.CallToolAsync(
+			"validate",
+			new Dictionary<string, object?>
+			{
+				["code"] = mushFile,
+				["parseType"] = "commandsperline"
+			});
+
+		var json = JsonSerializer.Serialize(result);
+		await Assert.That(json).Contains("structuredContent");
+		await Assert.That(json).DoesNotContain("\"isError\":true");
+	}
+
+	[Test]
 	public async Task Mcp_DocumentSymbols_OutlinesAttributeDefinition()
 	{
 		var password = "Correct-Horse-6!";

--- a/SharpMUSH.Tests.Integration/Mcp/McpEndpointTests.cs
+++ b/SharpMUSH.Tests.Integration/Mcp/McpEndpointTests.cs
@@ -1,0 +1,205 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using ModelContextProtocol.Client;
+using SharpMUSH.Tests.Infrastructure;
+
+namespace SharpMUSH.Tests.Integration.Mcp;
+
+/// <summary>
+/// Integration tests for the in-server MCP endpoint (<c>/mcp</c>): its character+password
+/// (HTTP Basic) authentication boundary, and real MCP-protocol round-trips that exercise the
+/// <c>validate</c> tool against the live parser.
+///
+/// Marked <see cref="ExplicitAttribute"/> because, like the other integration tests here, they
+/// require the Arango/NATS/SQL Testcontainers spun up by <see cref="ServerWebAppFactory"/> and
+/// so are excluded from the default (no-Docker) test run. The MCP endpoint is enabled for the
+/// test host via <c>ServerTestWebApplicationBuilderFactory.ConfigureStartupConfiguration</c>.
+/// </summary>
+[Explicit]
+[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+public class McpEndpointTests(ServerWebAppFactory factory)
+{
+	private const string McpPath = "/mcp";
+	private static readonly Uri BaseAddress = new("https://localhost/");
+	private static readonly Uri McpEndpoint = new(BaseAddress, McpPath);
+
+	private sealed record AccountRegisterRequest(string Username, string? Email, string Password);
+	private sealed record AccountLoginResponse(string AccountId, string Username, string AccountSessionToken);
+	private sealed record CreateCharacterRequest(string Name, string Password);
+	private sealed record CreatedCharacterResponse(int DbrefNumber, long CreationTime);
+
+	private HttpClient CreateClient()
+	{
+		var http = factory.CreateHttpClient();
+		http.BaseAddress = BaseAddress;
+		return http;
+	}
+
+	private static string UniqueName(string prefix) => $"{prefix}{Guid.NewGuid():N}"[..18];
+
+	/// <summary>
+	/// Registers a fresh account and creates a character on it with the given password,
+	/// exercising the real PasswordService hashing round-trip. Returns the character's
+	/// name so it can be used as an MCP Basic-auth credential.
+	/// </summary>
+	private async Task<string> CreateCharacterWithPasswordAsync(string password)
+	{
+		var http = CreateClient();
+
+		var register = await http.PostAsJsonAsync(
+			"api/auth/account-register",
+			new AccountRegisterRequest(UniqueName("acct"), null, password));
+		await Assert.That(register.StatusCode).IsEqualTo(HttpStatusCode.OK);
+		var account = await register.Content.ReadFromJsonAsync<AccountLoginResponse>();
+		await Assert.That(account).IsNotNull();
+
+		var characterName = UniqueName("mcpchar");
+		var createRequest = new HttpRequestMessage(HttpMethod.Post, "api/account/characters")
+		{
+			Content = JsonContent.Create(new CreateCharacterRequest(characterName, password))
+		};
+		createRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", account!.AccountSessionToken);
+		var createResponse = await http.SendAsync(createRequest);
+		await Assert.That(createResponse.StatusCode).IsEqualTo(HttpStatusCode.OK);
+		var created = await createResponse.Content.ReadFromJsonAsync<CreatedCharacterResponse>();
+		await Assert.That(created).IsNotNull();
+
+		return characterName;
+	}
+
+	private static string BasicHeader(string character, string password)
+		=> "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"{character}:{password}"));
+
+	private static async Task<HttpResponseMessage> PostInitializeAsync(HttpClient http, string? authorization)
+	{
+		var request = new HttpRequestMessage(HttpMethod.Post, McpPath)
+		{
+			Content = new StringContent(
+				"""{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}""",
+				Encoding.UTF8,
+				"application/json")
+		};
+		request.Headers.Accept.ParseAdd("application/json");
+		request.Headers.Accept.ParseAdd("text/event-stream");
+		if (authorization is not null)
+		{
+			request.Headers.TryAddWithoutValidation("Authorization", authorization);
+		}
+
+		return await http.SendAsync(request);
+	}
+
+	// ── Authentication boundary ────────────────────────────────────────────────
+
+	[Test]
+	public async Task Mcp_WithoutCredentials_Returns401WithBasicChallenge()
+	{
+		var http = CreateClient();
+
+		var response = await PostInitializeAsync(http, authorization: null);
+
+		await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
+		await Assert.That(response.Headers.WwwAuthenticate.ToString()).Contains("Basic");
+	}
+
+	[Test]
+	public async Task Mcp_WithMalformedAuthorizationHeader_Returns401()
+	{
+		var http = CreateClient();
+
+		var response = await PostInitializeAsync(http, authorization: "Basic not-valid-base64!!");
+
+		await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
+	}
+
+	[Test]
+	public async Task Mcp_WithUnknownCharacter_Returns401()
+	{
+		var http = CreateClient();
+
+		var response = await PostInitializeAsync(http, BasicHeader("NoSuchCharacter", "whatever"));
+
+		await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
+	}
+
+	[Test]
+	public async Task Mcp_WithWrongPassword_Returns401()
+	{
+		var character = await CreateCharacterWithPasswordAsync("Correct-Horse-1!");
+		var http = CreateClient();
+
+		var response = await PostInitializeAsync(http, BasicHeader(character, "wrong-password"));
+
+		await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
+	}
+
+	[Test]
+	public async Task Mcp_WithValidCharacter_IsNotUnauthorized()
+	{
+		var password = "Correct-Horse-2!";
+		var character = await CreateCharacterWithPasswordAsync(password);
+		var http = CreateClient();
+
+		var response = await PostInitializeAsync(http, BasicHeader(character, password));
+
+		await Assert.That(response.StatusCode).IsNotEqualTo(HttpStatusCode.Unauthorized);
+	}
+
+	// ── MCP protocol round-trips (authenticated) ───────────────────────────────
+
+	private async Task<McpClient> ConnectAsync(string character, string password)
+	{
+		var http = CreateClient();
+		var transport = new HttpClientTransport(
+			new HttpClientTransportOptions
+			{
+				Endpoint = McpEndpoint,
+				TransportMode = HttpTransportMode.StreamableHttp,
+				AdditionalHeaders = new Dictionary<string, string>
+				{
+					["Authorization"] = BasicHeader(character, password)
+				}
+			},
+			http);
+
+		return await McpClient.CreateAsync(transport);
+	}
+
+	[Test]
+	public async Task Mcp_ListTools_IncludesValidate()
+	{
+		var password = "Correct-Horse-3!";
+		var character = await CreateCharacterWithPasswordAsync(password);
+
+		await using var client = await ConnectAsync(character, password);
+		var tools = await client.ListToolsAsync();
+
+		await Assert.That(tools.Select(t => t.Name)).Contains("validate");
+	}
+
+	[Test]
+	public async Task Mcp_Validate_FlagsBrokenSoftcode_AndAcceptsValidSoftcode()
+	{
+		var password = "Correct-Horse-4!";
+		var character = await CreateCharacterWithPasswordAsync(password);
+
+		await using var client = await ConnectAsync(character, password);
+
+		var broken = await client.CallToolAsync(
+			"validate",
+			new Dictionary<string, object?> { ["code"] = "add(" });
+		var valid = await client.CallToolAsync(
+			"validate",
+			new Dictionary<string, object?> { ["code"] = "add(1,2)" });
+
+		var brokenJson = JsonSerializer.Serialize(broken);
+		var validJson = JsonSerializer.Serialize(valid);
+
+		// Broken softcode surfaces at least one diagnostic; valid softcode is clean.
+		await Assert.That(brokenJson).Contains("Severity");
+		await Assert.That(validJson).DoesNotContain("Severity");
+	}
+}

--- a/SharpMUSH.Tests.Integration/Mcp/McpEndpointTests.cs
+++ b/SharpMUSH.Tests.Integration/Mcp/McpEndpointTests.cs
@@ -207,8 +207,9 @@ public class McpEndpointTests(ServerWebAppFactory factory)
 		var validJson = JsonSerializer.Serialize(valid);
 
 		// Broken softcode surfaces at least one diagnostic; valid softcode is clean.
-		await Assert.That(brokenJson).Contains("Severity");
-		await Assert.That(validJson).DoesNotContain("Severity");
+		// (Structured content is serialized camelCase, e.g. "severity".)
+		await Assert.That(brokenJson).Contains("severity");
+		await Assert.That(validJson).DoesNotContain("severity");
 	}
 
 	[Test]
@@ -257,7 +258,7 @@ public class McpEndpointTests(ServerWebAppFactory factory)
 		var validated = await client.CallToolAsync(
 			"validate",
 			new Dictionary<string, object?> { ["documentId"] = documentId });
-		await Assert.That(JsonSerializer.Serialize(validated)).Contains("Severity");
+		await Assert.That(JsonSerializer.Serialize(validated)).Contains("severity");
 
 		var closed = await client.CallToolAsync(
 			"close_document",

--- a/SharpMUSH.Tests.Integration/Mcp/McpEndpointTests.cs
+++ b/SharpMUSH.Tests.Integration/Mcp/McpEndpointTests.cs
@@ -202,4 +202,19 @@ public class McpEndpointTests(ServerWebAppFactory factory)
 		await Assert.That(brokenJson).Contains("Severity");
 		await Assert.That(validJson).DoesNotContain("Severity");
 	}
+
+	[Test]
+	public async Task Mcp_Format_NormalizesSoftcode()
+	{
+		var password = "Correct-Horse-5!";
+		var character = await CreateCharacterWithPasswordAsync(password);
+
+		await using var client = await ConnectAsync(character, password);
+
+		var result = await client.CallToolAsync(
+			"format",
+			new Dictionary<string, object?> { ["code"] = "  add(1,2,3)  " });
+
+		await Assert.That(JsonSerializer.Serialize(result)).Contains("add(1, 2, 3)");
+	}
 }

--- a/SharpMUSH.Tests.Integration/Mcp/McpServerUnitTests.cs
+++ b/SharpMUSH.Tests.Integration/Mcp/McpServerUnitTests.cs
@@ -1,0 +1,115 @@
+using System.Linq;
+using System.Text;
+using System.Text.Encodings.Web;
+using Mediator;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.Queries.Database;
+using SharpMUSH.Library.Services.Interfaces;
+using SharpMUSH.Server.Authentication;
+using SharpMUSH.Server.Mcp;
+
+namespace SharpMUSH.Tests.Integration.Mcp;
+
+/// <summary>
+/// Plain (non-container) unit tests for the MCP server internals: the document-session store's
+/// bounding/validation and the auth handler's timing-parity mitigation. Addresses PR #674 review.
+/// </summary>
+public class McpDocumentStoreTests
+{
+	[Test]
+	public async Task Open_NullText_Throws()
+	{
+		var store = new McpDocumentStore();
+		await Assert.That(() => store.Open(null!)).Throws<ArgumentNullException>();
+	}
+
+	[Test]
+	public async Task Open_RoundTripsById()
+	{
+		var store = new McpDocumentStore();
+		var id = store.Open("add(1,2)");
+
+		await Assert.That(store.TryGet(id, out var text)).IsTrue();
+		await Assert.That(text).IsEqualTo("add(1,2)");
+	}
+
+	[Test]
+	public async Task Open_BeyondCapacity_EvictsOldestSoTheStoreStaysBounded()
+	{
+		var store = new McpDocumentStore();
+
+		// Capacity is 1024; opening well past it must evict the oldest ids rather than grow forever.
+		var firstId = store.Open("first");
+		string lastId = firstId;
+		for (var i = 0; i < 1200; i++)
+		{
+			lastId = store.Open($"doc {i}");
+		}
+
+		await Assert.That(store.TryGet(firstId, out _)).IsFalse();
+		await Assert.That(store.TryGet(lastId, out _)).IsTrue();
+	}
+}
+
+public class MushBasicAuthenticationHandlerTests
+{
+	private static MushBasicAuthenticationHandler CreateHandler(IMediator mediator, IPasswordService passwordService)
+	{
+		var options = Substitute.For<IOptionsMonitor<AuthenticationSchemeOptions>>();
+		options.Get(Arg.Any<string>()).Returns(new AuthenticationSchemeOptions());
+		return new MushBasicAuthenticationHandler(
+			options, NullLoggerFactory.Instance, UrlEncoder.Default, mediator, passwordService);
+	}
+
+	private static async Task<AuthenticateResult> AuthenticateAsync(
+		MushBasicAuthenticationHandler handler, string authorizationHeader)
+	{
+		var context = new DefaultHttpContext();
+		context.Request.Headers["Authorization"] = authorizationHeader;
+		await handler.InitializeAsync(
+			new AuthenticationScheme(MushBasicAuthenticationHandler.SchemeName, null, typeof(MushBasicAuthenticationHandler)),
+			context);
+		return await handler.AuthenticateAsync();
+	}
+
+	private static string Basic(string user, string pw)
+		=> "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"{user}:{pw}"));
+
+	[Test]
+	public async Task UnknownCharacter_StillRunsPasswordVerification_ForTimingParity()
+	{
+		var mediator = Substitute.For<IMediator>();
+		mediator.CreateStream(Arg.Any<GetPlayerQuery>()).Returns(AsyncEnumerable.Empty<SharpPlayer>());
+		var passwordService = Substitute.For<IPasswordService>();
+
+		var handler = CreateHandler(mediator, passwordService);
+		var result = await AuthenticateAsync(handler, Basic("NoSuchCharacter", "guessed-password"));
+
+		// Unknown character must fail — but only after a verification runs, so the response
+		// latency doesn't reveal that the character does not exist.
+		await Assert.That(result.Succeeded).IsFalse();
+		passwordService.Received().PasswordIsValid(Arg.Any<string>(), "guessed-password", Arg.Any<string>());
+	}
+
+	[Test]
+	public async Task MissingAuthorizationHeader_ReturnsNoResult()
+	{
+		var mediator = Substitute.For<IMediator>();
+		var passwordService = Substitute.For<IPasswordService>();
+
+		var handler = CreateHandler(mediator, passwordService);
+
+		var context = new DefaultHttpContext();
+		await handler.InitializeAsync(
+			new AuthenticationScheme(MushBasicAuthenticationHandler.SchemeName, null, typeof(MushBasicAuthenticationHandler)),
+			context);
+		var result = await handler.AuthenticateAsync();
+
+		await Assert.That(result.None).IsTrue();
+	}
+}

--- a/SharpMUSH.Tests.Integration/SharpMUSH.Tests.Integration.csproj
+++ b/SharpMUSH.Tests.Integration/SharpMUSH.Tests.Integration.csproj
@@ -14,6 +14,7 @@
 
 	<ItemGroup>
 		<!-- TUnit test framework -->
+		<PackageReference Include="ModelContextProtocol" Version="2.0.0-preview.1" />
 		<PackageReference Include="TUnit.AspNetCore" Version="1.19.16" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" ExcludeAssets="compile" />
 		<!-- FSharp.Core is a runtime transitive of SharpMUSH.Library (via TelnetNegotiationCore) that the

--- a/SharpMUSH.Tests/CodeAnalysis/MushCodeAnalyzerFormatTests.cs
+++ b/SharpMUSH.Tests/CodeAnalysis/MushCodeAnalyzerFormatTests.cs
@@ -46,4 +46,11 @@ public class MushCodeAnalyzerFormatTests
 		var result = Analyzer().Format("add(1, 2)");
 		await Assert.That(result).IsEqualTo("add(1, 2)");
 	}
+
+	[Test]
+	public async Task Format_PreservesCrlfLineEndings()
+	{
+		var result = Analyzer().Format("a,b\r\nc,d");
+		await Assert.That(result).IsEqualTo("a, b\r\nc, d");
+	}
 }

--- a/SharpMUSH.Tests/CodeAnalysis/MushCodeAnalyzerFormatTests.cs
+++ b/SharpMUSH.Tests/CodeAnalysis/MushCodeAnalyzerFormatTests.cs
@@ -1,0 +1,49 @@
+using NSubstitute;
+using SharpMUSH.CodeAnalysis;
+using SharpMUSH.Library.ParserInterfaces;
+
+namespace SharpMUSH.Tests.CodeAnalysis;
+
+/// <summary>
+/// Unit tests for <see cref="MushCodeAnalyzer.Format"/>. Formatting is a pure text transform
+/// (it does not consult the parser), so these are fully deterministic without a DB.
+/// </summary>
+public class MushCodeAnalyzerFormatTests
+{
+	private static MushCodeAnalyzer Analyzer() => new(Substitute.For<IMUSHCodeParser>());
+
+	[Test]
+	public async Task Format_InsertsSpaceAfterCommas()
+	{
+		var result = Analyzer().Format("add(1,2,3)");
+		await Assert.That(result).IsEqualTo("add(1, 2, 3)");
+	}
+
+	[Test]
+	public async Task Format_TrimsLeadingAndTrailingWhitespace()
+	{
+		var result = Analyzer().Format("   think foo   ");
+		await Assert.That(result).IsEqualTo("think foo");
+	}
+
+	[Test]
+	public async Task Format_InsertsSpaceBetweenCommandAndFirstArgument()
+	{
+		var result = Analyzer().Format("@pemit#1=hi");
+		await Assert.That(result).IsEqualTo("@pemit #1=hi");
+	}
+
+	[Test]
+	public async Task Format_PreservesLineCount()
+	{
+		var result = Analyzer().Format("think a,b\nthink c,d");
+		await Assert.That(result).IsEqualTo("think a, b\nthink c, d");
+	}
+
+	[Test]
+	public async Task Format_LeavesAlreadyCleanCodeUnchanged()
+	{
+		var result = Analyzer().Format("add(1, 2)");
+		await Assert.That(result).IsEqualTo("add(1, 2)");
+	}
+}

--- a/SharpMUSH.Tests/CodeAnalysis/MushCodeAnalyzerIntelligenceTests.cs
+++ b/SharpMUSH.Tests/CodeAnalysis/MushCodeAnalyzerIntelligenceTests.cs
@@ -106,6 +106,25 @@ public class MushCodeAnalyzerIntelligenceTests
 		await Assert.That(labels).DoesNotContain("%#");
 	}
 
+	[Test]
+	public async Task Complete_WhileTypingAtCommand_SuggestsMatchingCommands()
+	{
+		// A command prefix like "@fo" should offer commands even though the char before the
+		// cursor isn't whitespace.
+		var labels = AnalyzerWithLibraries().Complete("@fo", 0, 3).Select(c => c.Label).ToList();
+
+		await Assert.That(labels).Contains("@foo");
+	}
+
+	[Test]
+	public async Task DocumentSymbols_TrimsCarriageReturn_ForCrlfInput()
+	{
+		var symbols = EmptyAnalyzer().DocumentSymbols("&foo bar\r");
+
+		var symbol = symbols.First(s => s.Name == "foo");
+		await Assert.That(symbol.Range.End.Character).IsEqualTo("&foo bar".Length);
+	}
+
 	// ── Signature help ───────────────────────────────────────────────────────────
 
 	[Test]

--- a/SharpMUSH.Tests/CodeAnalysis/MushCodeAnalyzerIntelligenceTests.cs
+++ b/SharpMUSH.Tests/CodeAnalysis/MushCodeAnalyzerIntelligenceTests.cs
@@ -1,0 +1,144 @@
+using NSubstitute;
+using SharpMUSH.CodeAnalysis;
+using SharpMUSH.Library.Attributes;
+using SharpMUSH.Library.Definitions;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Services;
+
+namespace SharpMUSH.Tests.CodeAnalysis;
+
+/// <summary>
+/// Unit tests for the position-based code intelligence in <see cref="MushCodeAnalyzer"/>
+/// (hover, completion, signature help, document symbols). A small in-memory function/command
+/// library fixture stands in for the live world's libraries.
+/// </summary>
+public class MushCodeAnalyzerIntelligenceTests
+{
+	private static MushCodeAnalyzer AnalyzerWithLibraries()
+	{
+		var functions = new FunctionLibraryService
+		{
+			{
+				"add",
+				(new FunctionDefinition(
+					new SharpFunctionAttribute { Name = "add", MinArgs = 2, MaxArgs = 2, Flags = FunctionFlags.Regular },
+					_ => default), true)
+			}
+		};
+		var commands = new CommandLibraryService
+		{
+			{
+				"@foo",
+				(new CommandDefinition(
+					new SharpCommandAttribute { Name = "@foo", MinArgs = 0, MaxArgs = 1, Switches = ["BAR"] },
+					_ => default), true)
+			}
+		};
+
+		var parser = Substitute.For<IMUSHCodeParser>();
+		parser.FunctionLibrary.Returns(functions);
+		parser.CommandLibrary.Returns(commands);
+		return new MushCodeAnalyzer(parser);
+	}
+
+	private static MushCodeAnalyzer EmptyAnalyzer()
+	{
+		var parser = Substitute.For<IMUSHCodeParser>();
+		parser.FunctionLibrary.Returns(new FunctionLibraryService());
+		parser.CommandLibrary.Returns(new CommandLibraryService());
+		return new MushCodeAnalyzer(parser);
+	}
+
+	// ── Hover ──────────────────────────────────────────────────────────────────
+
+	[Test]
+	public async Task Hover_OnPatternSubstitution_ExplainsIt()
+	{
+		var hover = EmptyAnalyzer().Hover("%#", 0, 0);
+
+		await Assert.That(hover).IsNotNull();
+		await Assert.That(hover!.Markdown).Contains("Current object");
+	}
+
+	[Test]
+	public async Task Hover_OnUnknownWord_ReturnsNull()
+	{
+		var hover = EmptyAnalyzer().Hover("xyzzy", 0, 0);
+
+		await Assert.That(hover).IsNull();
+	}
+
+	[Test]
+	public async Task Hover_OnKnownFunction_ReturnsSignatureMarkdown()
+	{
+		var hover = AnalyzerWithLibraries().Hover("add(1,2)", 0, 1);
+
+		await Assert.That(hover).IsNotNull();
+		await Assert.That(hover!.Markdown).Contains("Function: `add`");
+	}
+
+	// ── Completion ───────────────────────────────────────────────────────────────
+
+	[Test]
+	public async Task Complete_WithFunctionPrefix_SuggestsMatchingFunction()
+	{
+		var completions = AnalyzerWithLibraries().Complete("ad", 0, 2);
+
+		await Assert.That(completions.Select(c => c.Label)).Contains("add");
+	}
+
+	[Test]
+	public async Task Complete_WithEmptyPrefix_IncludesCommonPatterns()
+	{
+		var labels = EmptyAnalyzer().Complete("", 0, 0).Select(c => c.Label).ToList();
+
+		await Assert.That(labels).Contains("%#");
+		await Assert.That(labels).Contains("%qa");
+	}
+
+	// ── Signature help ───────────────────────────────────────────────────────────
+
+	[Test]
+	public async Task SignatureHelp_InsideKnownCall_ReturnsSignatureWithActiveParameter()
+	{
+		var signature = AnalyzerWithLibraries().SignatureHelp("add(1,", 0, 6);
+
+		await Assert.That(signature).IsNotNull();
+		await Assert.That(signature!.Label).Contains("add(");
+		await Assert.That(signature.Parameters.Count).IsEqualTo(2);
+		await Assert.That(signature.ActiveParameter).IsEqualTo(1);
+	}
+
+	[Test]
+	public async Task SignatureHelp_OutsideAnyCall_ReturnsNull()
+	{
+		var signature = AnalyzerWithLibraries().SignatureHelp("think hello", 0, 5);
+
+		await Assert.That(signature).IsNull();
+	}
+
+	// ── Document symbols ─────────────────────────────────────────────────────────
+
+	[Test]
+	public async Task DocumentSymbols_FindsAttributeDefinition()
+	{
+		var symbols = EmptyAnalyzer().DocumentSymbols("&greeting think hello");
+
+		await Assert.That(symbols.Select(s => s.Name)).Contains("greeting");
+		await Assert.That(symbols.First(s => s.Name == "greeting").Kind).IsEqualTo("Property");
+	}
+
+	[Test]
+	public async Task DocumentSymbols_FindsFunctionAndCommandAcrossLines()
+	{
+		var symbols = EmptyAnalyzer().DocumentSymbols("add(1,2)\n@pemit #1=hi");
+
+		var function = symbols.FirstOrDefault(s => s.Name == "add");
+		var command = symbols.FirstOrDefault(s => s.Name == "@pemit");
+
+		await Assert.That(function).IsNotNull();
+		await Assert.That(function!.Kind).IsEqualTo("Function");
+		await Assert.That(command).IsNotNull();
+		await Assert.That(command!.Kind).IsEqualTo("Method");
+	}
+}

--- a/SharpMUSH.Tests/CodeAnalysis/MushCodeAnalyzerIntelligenceTests.cs
+++ b/SharpMUSH.Tests/CodeAnalysis/MushCodeAnalyzerIntelligenceTests.cs
@@ -96,6 +96,16 @@ public class MushCodeAnalyzerIntelligenceTests
 		await Assert.That(labels).Contains("%qa");
 	}
 
+	[Test]
+	public async Task Complete_WithSubstitutionPrefix_KeepsFilteringSubstitutions()
+	{
+		// Typing "%q" should still narrow to %q… substitutions — the '%' must be part of the prefix.
+		var labels = EmptyAnalyzer().Complete("%q", 0, 2).Select(c => c.Label).ToList();
+
+		await Assert.That(labels).Contains("%qa");
+		await Assert.That(labels).DoesNotContain("%#");
+	}
+
 	// ── Signature help ───────────────────────────────────────────────────────────
 
 	[Test]

--- a/SharpMUSH.Tests/CodeAnalysis/MushCodeAnalyzerPerLineTests.cs
+++ b/SharpMUSH.Tests/CodeAnalysis/MushCodeAnalyzerPerLineTests.cs
@@ -1,0 +1,64 @@
+using NSubstitute;
+using SharpMUSH.CodeAnalysis;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+using Range = SharpMUSH.Library.Models.Range;
+
+namespace SharpMUSH.Tests.CodeAnalysis;
+
+/// <summary>
+/// Unit tests for <see cref="MushAnalysisMode.CommandsPerLine"/> — how a real-world .mush file
+/// (one command per line) is validated. The parser is mocked so the split / per-line-offset /
+/// blank-line-skip behaviour is deterministic.
+/// </summary>
+public class MushCodeAnalyzerPerLineTests
+{
+	/// <summary>A parser that flags every line it is given with an error at characters 0-1.</summary>
+	private static MushCodeAnalyzer AnalyzerFlaggingEveryLine()
+	{
+		var parser = Substitute.For<IMUSHCodeParser>();
+		parser.GetDiagnostics(Arg.Any<MString>(), Arg.Any<ParseType>())
+			.Returns(_ =>
+			[
+				new Diagnostic
+				{
+					Range = new Range { Start = new Position(0, 0), End = new Position(0, 1) },
+					Severity = DiagnosticSeverity.Error,
+					Message = "bad line"
+				}
+			]);
+		return new MushCodeAnalyzer(parser);
+	}
+
+	[Test]
+	public async Task CommandsPerLine_ProducesOneDiagnosticPerNonBlankLine_OffsetToItsLine()
+	{
+		var result = AnalyzerFlaggingEveryLine().Validate("aaa\nbbb\nccc", MushAnalysisMode.CommandsPerLine);
+
+		await Assert.That(result.Count).IsEqualTo(3);
+		await Assert.That(result.Select(d => d.Range.Start.Line)).IsEquivalentTo(new[] { 0, 1, 2 });
+	}
+
+	[Test]
+	public async Task CommandsPerLine_SkipsBlankLines()
+	{
+		var result = AnalyzerFlaggingEveryLine().Validate("aaa\n\n   \nddd", MushAnalysisMode.CommandsPerLine);
+
+		// Only lines 0 and 3 are non-blank.
+		await Assert.That(result.Count).IsEqualTo(2);
+		await Assert.That(result.Select(d => d.Range.Start.Line)).IsEquivalentTo(new[] { 0, 3 });
+	}
+
+	[Test]
+	public async Task CommandsPerLine_ParsesEachLineAsSingleCommand()
+	{
+		var parser = Substitute.For<IMUSHCodeParser>();
+		parser.GetDiagnostics(Arg.Any<MString>(), Arg.Any<ParseType>()).Returns([]);
+		var analyzer = new MushCodeAnalyzer(parser);
+
+		analyzer.Validate("line one\nline two", MushAnalysisMode.CommandsPerLine);
+
+		// Two non-blank lines → two parses, each as ParseType.Command.
+		parser.Received(2).GetDiagnostics(Arg.Any<MString>(), ParseType.Command);
+	}
+}

--- a/SharpMUSH.Tests/CodeAnalysis/MushCodeAnalyzerTests.cs
+++ b/SharpMUSH.Tests/CodeAnalysis/MushCodeAnalyzerTests.cs
@@ -51,4 +51,22 @@ public class MushCodeAnalyzerTests
 		await Assert.That(result[0].Severity).IsEqualTo(DiagnosticSeverity.Error);
 		await Assert.That(result[0].Message).Contains("boom");
 	}
+
+	[Test]
+	public async Task Validate_WhenParserThrowsOnMultilineCode_EndPositionStaysWithinTheDocument()
+	{
+		var parser = Substitute.For<IMUSHCodeParser>();
+		parser.GetDiagnostics(Arg.Any<MString>(), Arg.Any<ParseType>())
+			.Returns(_ => throw new InvalidOperationException("boom"));
+
+		var analyzer = new MushCodeAnalyzer(parser);
+
+		var result = analyzer.Validate("line0\nline1\nlonger line 2");
+
+		// The fallback range must be a valid position — the end lands on the last line,
+		// not character code.Length of line 0.
+		await Assert.That(result.Count).IsEqualTo(1);
+		await Assert.That(result[0].Range.End.Line).IsEqualTo(2);
+		await Assert.That(result[0].Range.End.Character).IsEqualTo("longer line 2".Length);
+	}
 }

--- a/SharpMUSH.Tests/CodeAnalysis/MushCodeAnalyzerTests.cs
+++ b/SharpMUSH.Tests/CodeAnalysis/MushCodeAnalyzerTests.cs
@@ -69,4 +69,19 @@ public class MushCodeAnalyzerTests
 		await Assert.That(result[0].Range.End.Line).IsEqualTo(2);
 		await Assert.That(result[0].Range.End.Character).IsEqualTo("longer line 2".Length);
 	}
+
+	[Test]
+	public async Task Validate_WhenParserThrowsOnCrTerminatedCode_EndCharacterExcludesCarriageReturn()
+	{
+		var parser = Substitute.For<IMUSHCodeParser>();
+		parser.GetDiagnostics(Arg.Any<MString>(), Arg.Any<ParseType>())
+			.Returns(_ => throw new InvalidOperationException("boom"));
+
+		var analyzer = new MushCodeAnalyzer(parser);
+
+		// Last line carries a trailing CR; the end character must count "bb", not "bb\r".
+		var result = analyzer.Validate("aa\r\nbb\r");
+
+		await Assert.That(result[0].Range.End.Character).IsEqualTo("bb".Length);
+	}
 }

--- a/SharpMUSH.Tests/CodeAnalysis/MushCodeAnalyzerTests.cs
+++ b/SharpMUSH.Tests/CodeAnalysis/MushCodeAnalyzerTests.cs
@@ -1,0 +1,54 @@
+using NSubstitute;
+using SharpMUSH.CodeAnalysis;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+using Range = SharpMUSH.Library.Models.Range;
+
+namespace SharpMUSH.Tests.CodeAnalysis;
+
+/// <summary>
+/// Unit tests for <see cref="MushCodeAnalyzer"/>, the shared analysis wrapper used by
+/// both the Language Server and the in-server MCP tools. The parser is mocked here:
+/// these tests cover the analyzer's own responsibilities (passthrough + never-throw).
+/// Real-parser diagnostic accuracy is covered by the Explicit MCP integration tests.
+/// </summary>
+public class MushCodeAnalyzerTests
+{
+	[Test]
+	public async Task Validate_ReturnsDiagnosticsFromParser()
+	{
+		var expected = new Diagnostic
+		{
+			Range = new Range { Start = new Position(0, 0), End = new Position(0, 3) },
+			Severity = DiagnosticSeverity.Error,
+			Message = "unexpected token"
+		};
+		var parser = Substitute.For<IMUSHCodeParser>();
+		parser.GetDiagnostics(Arg.Any<MString>(), Arg.Any<ParseType>())
+			.Returns([expected]);
+
+		var analyzer = new MushCodeAnalyzer(parser);
+
+		var result = analyzer.Validate("add(");
+
+		await Assert.That(result.Count).IsEqualTo(1);
+		await Assert.That(result[0].Message).IsEqualTo("unexpected token");
+		await Assert.That(result[0].Severity).IsEqualTo(DiagnosticSeverity.Error);
+	}
+
+	[Test]
+	public async Task Validate_WhenParserThrows_ReturnsSingleErrorDiagnosticInsteadOfThrowing()
+	{
+		var parser = Substitute.For<IMUSHCodeParser>();
+		parser.GetDiagnostics(Arg.Any<MString>(), Arg.Any<ParseType>())
+			.Returns(_ => throw new InvalidOperationException("boom"));
+
+		var analyzer = new MushCodeAnalyzer(parser);
+
+		var result = analyzer.Validate("add(1,2)");
+
+		await Assert.That(result.Count).IsEqualTo(1);
+		await Assert.That(result[0].Severity).IsEqualTo(DiagnosticSeverity.Error);
+		await Assert.That(result[0].Message).Contains("boom");
+	}
+}

--- a/SharpMUSH.Tests/CodeAnalysis/MushParseModeTests.cs
+++ b/SharpMUSH.Tests/CodeAnalysis/MushParseModeTests.cs
@@ -1,35 +1,37 @@
 using SharpMUSH.CodeAnalysis;
-using SharpMUSH.Library.ParserInterfaces;
 
 namespace SharpMUSH.Tests.CodeAnalysis;
 
 /// <summary>
 /// Unit tests for <see cref="MushParseMode"/> — the extension-based (LSP) and name-based (MCP)
-/// resolution of function vs command-list parsing.
+/// resolution of the analysis mode (function / command-list / command / commands-per-line).
 /// </summary>
 public class MushParseModeTests
 {
 	[Test]
-	[Arguments("file:///home/x/greet.mush", ParseType.CommandList)]
-	[Arguments("greet.mu", ParseType.CommandList)]
-	[Arguments("file:///home/x/fmt.mushfn", ParseType.Function)]
-	[Arguments("fmt.fun", ParseType.Function)]
-	[Arguments("file:///x/GREET.MUSH", ParseType.CommandList)]
-	[Arguments("notes.txt", ParseType.Function)]
-	[Arguments("noextension", ParseType.Function)]
-	public async Task ForFileName_MapsExtensionToParseType(string fileName, ParseType expected)
+	[Arguments("file:///home/x/greet.mush", MushAnalysisMode.CommandsPerLine)]
+	[Arguments("greet.mu", MushAnalysisMode.CommandsPerLine)]
+	[Arguments("file:///home/x/fmt.mushfn", MushAnalysisMode.Function)]
+	[Arguments("fmt.fun", MushAnalysisMode.Function)]
+	[Arguments("file:///x/GREET.MUSH", MushAnalysisMode.CommandsPerLine)]
+	[Arguments("notes.txt", MushAnalysisMode.Function)]
+	[Arguments("noextension", MushAnalysisMode.Function)]
+	public async Task ForFileName_MapsExtensionToMode(string fileName, MushAnalysisMode expected)
 	{
 		await Assert.That(MushParseMode.ForFileName(fileName)).IsEqualTo(expected);
 	}
 
 	[Test]
-	[Arguments("function", ParseType.Function)]
-	[Arguments("command", ParseType.Command)]
-	[Arguments("commandlist", ParseType.CommandList)]
-	[Arguments("command-list", ParseType.CommandList)]
-	[Arguments("COMMANDLIST", ParseType.CommandList)]
-	[Arguments("nonsense", ParseType.Function)]
-	public async Task FromName_MapsNameToParseType(string name, ParseType expected)
+	[Arguments("function", MushAnalysisMode.Function)]
+	[Arguments("command", MushAnalysisMode.Command)]
+	[Arguments("commandlist", MushAnalysisMode.CommandList)]
+	[Arguments("command-list", MushAnalysisMode.CommandList)]
+	[Arguments("commandsperline", MushAnalysisMode.CommandsPerLine)]
+	[Arguments("commands-per-line", MushAnalysisMode.CommandsPerLine)]
+	[Arguments("mushfile", MushAnalysisMode.CommandsPerLine)]
+	[Arguments("COMMANDLIST", MushAnalysisMode.CommandList)]
+	[Arguments("nonsense", MushAnalysisMode.Function)]
+	public async Task FromName_MapsNameToMode(string name, MushAnalysisMode expected)
 	{
 		await Assert.That(MushParseMode.FromName(name)).IsEqualTo(expected);
 	}
@@ -37,7 +39,7 @@ public class MushParseModeTests
 	[Test]
 	public async Task FromName_NullOrEmpty_FallsBackToFunction()
 	{
-		await Assert.That(MushParseMode.FromName(null)).IsEqualTo(ParseType.Function);
-		await Assert.That(MushParseMode.FromName("")).IsEqualTo(ParseType.Function);
+		await Assert.That(MushParseMode.FromName(null)).IsEqualTo(MushAnalysisMode.Function);
+		await Assert.That(MushParseMode.FromName("")).IsEqualTo(MushAnalysisMode.Function);
 	}
 }

--- a/SharpMUSH.Tests/CodeAnalysis/MushParseModeTests.cs
+++ b/SharpMUSH.Tests/CodeAnalysis/MushParseModeTests.cs
@@ -1,0 +1,43 @@
+using SharpMUSH.CodeAnalysis;
+using SharpMUSH.Library.ParserInterfaces;
+
+namespace SharpMUSH.Tests.CodeAnalysis;
+
+/// <summary>
+/// Unit tests for <see cref="MushParseMode"/> — the extension-based (LSP) and name-based (MCP)
+/// resolution of function vs command-list parsing.
+/// </summary>
+public class MushParseModeTests
+{
+	[Test]
+	[Arguments("file:///home/x/greet.mush", ParseType.CommandList)]
+	[Arguments("greet.mu", ParseType.CommandList)]
+	[Arguments("file:///home/x/fmt.mushfn", ParseType.Function)]
+	[Arguments("fmt.fun", ParseType.Function)]
+	[Arguments("file:///x/GREET.MUSH", ParseType.CommandList)]
+	[Arguments("notes.txt", ParseType.Function)]
+	[Arguments("noextension", ParseType.Function)]
+	public async Task ForFileName_MapsExtensionToParseType(string fileName, ParseType expected)
+	{
+		await Assert.That(MushParseMode.ForFileName(fileName)).IsEqualTo(expected);
+	}
+
+	[Test]
+	[Arguments("function", ParseType.Function)]
+	[Arguments("command", ParseType.Command)]
+	[Arguments("commandlist", ParseType.CommandList)]
+	[Arguments("command-list", ParseType.CommandList)]
+	[Arguments("COMMANDLIST", ParseType.CommandList)]
+	[Arguments("nonsense", ParseType.Function)]
+	public async Task FromName_MapsNameToParseType(string name, ParseType expected)
+	{
+		await Assert.That(MushParseMode.FromName(name)).IsEqualTo(expected);
+	}
+
+	[Test]
+	public async Task FromName_NullOrEmpty_FallsBackToFunction()
+	{
+		await Assert.That(MushParseMode.FromName(null)).IsEqualTo(ParseType.Function);
+		await Assert.That(MushParseMode.FromName("")).IsEqualTo(ParseType.Function);
+	}
+}

--- a/SharpMUSH.Tests/CodeAnalysis/MushParseModeTests.cs
+++ b/SharpMUSH.Tests/CodeAnalysis/MushParseModeTests.cs
@@ -13,6 +13,7 @@ public class MushParseModeTests
 	[Arguments("greet.mu", MushAnalysisMode.CommandsPerLine)]
 	[Arguments("file:///home/x/fmt.mushfn", MushAnalysisMode.Function)]
 	[Arguments("fmt.fun", MushAnalysisMode.Function)]
+	[Arguments("file:///home/x/build.mushcmd", MushAnalysisMode.CommandList)]
 	[Arguments("file:///x/GREET.MUSH", MushAnalysisMode.CommandsPerLine)]
 	[Arguments("notes.txt", MushAnalysisMode.Function)]
 	[Arguments("noextension", MushAnalysisMode.Function)]

--- a/SharpMUSH.Tests/SharpMUSH.Tests.csproj
+++ b/SharpMUSH.Tests/SharpMUSH.Tests.csproj
@@ -86,6 +86,7 @@
     <!-- Build the examples/plugins/hello-ui worked example (a UI plugin shipped as a managed package) so the
          HelloUiManagedPackageExampleTests can load its DLL from disk, exactly as the booting server would. -->
     <ProjectReference Include="..\examples\plugins\hello-ui\HelloUiPlugin.csproj" ReferenceOutputAssembly="false" Private="false" PrivateAssets="all" />
+    <ProjectReference Include="..\SharpMUSH.CodeAnalysis\SharpMUSH.CodeAnalysis.csproj" />
   </ItemGroup>
 
   <!-- Drop the built CommandOnlyPlugin (DLL + manifest only — its SharpMUSH deps resolve from this host's

--- a/SharpMUSH.sln
+++ b/SharpMUSH.sln
@@ -77,6 +77,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "hello-ui", "hello-ui", "{BB
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HelloUiPlugin", "examples\plugins\hello-ui\HelloUiPlugin.csproj", "{6E78690B-C707-4497-8E1D-B9A414087E5D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpMUSH.CodeAnalysis", "SharpMUSH.CodeAnalysis\SharpMUSH.CodeAnalysis.csproj", "{FB6C9154-3844-47B1-81B8-E3C3C8D7E169}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -411,6 +413,18 @@ Global
 		{6E78690B-C707-4497-8E1D-B9A414087E5D}.Release|x64.Build.0 = Release|Any CPU
 		{6E78690B-C707-4497-8E1D-B9A414087E5D}.Release|x86.ActiveCfg = Release|Any CPU
 		{6E78690B-C707-4497-8E1D-B9A414087E5D}.Release|x86.Build.0 = Release|Any CPU
+		{FB6C9154-3844-47B1-81B8-E3C3C8D7E169}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB6C9154-3844-47B1-81B8-E3C3C8D7E169}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB6C9154-3844-47B1-81B8-E3C3C8D7E169}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FB6C9154-3844-47B1-81B8-E3C3C8D7E169}.Debug|x64.Build.0 = Debug|Any CPU
+		{FB6C9154-3844-47B1-81B8-E3C3C8D7E169}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FB6C9154-3844-47B1-81B8-E3C3C8D7E169}.Debug|x86.Build.0 = Debug|Any CPU
+		{FB6C9154-3844-47B1-81B8-E3C3C8D7E169}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB6C9154-3844-47B1-81B8-E3C3C8D7E169}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB6C9154-3844-47B1-81B8-E3C3C8D7E169}.Release|x64.ActiveCfg = Release|Any CPU
+		{FB6C9154-3844-47B1-81B8-E3C3C8D7E169}.Release|x64.Build.0 = Release|Any CPU
+		{FB6C9154-3844-47B1-81B8-E3C3C8D7E169}.Release|x86.ActiveCfg = Release|Any CPU
+		{FB6C9154-3844-47B1-81B8-E3C3C8D7E169}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -122,9 +122,30 @@ warnings, or hints.
 
 Calling `validate` with `add(1,2)` returns `[]` — no diagnostics.
 
+### `format`
+
+Format SharpMUSH softcode with a consistent style: trims leading/trailing whitespace
+per line, inserts a space after commas, and a space between an `@command` and its
+first argument. Line count is preserved.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `code` | string | The MUSH softcode to format. |
+
+**Example**
+
+```json
+{ "name": "format", "arguments": { "code": "  add(1,2,3)  " } }
+```
+
+returns `"add(1, 2, 3)"`.
+
+The same formatting backs the Language Server's `textDocument/formatting`, so editors
+and agents format identically.
+
 > More tools mapping the rest of the shared analysis engine — `hover`, `complete`,
-> `signature_help`, `document_symbols`, `format`, and optional document-session
-> handles — follow the same pattern and are being added incrementally. See
+> `signature_help`, `document_symbols`, and optional document-session handles —
+> follow the same pattern and are being added incrementally. See
 > `docs/superpowers/specs/2026-07-08-mcp-lsp-server-design.md`.
 
 ## Docker / remote access

--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -38,7 +38,7 @@ It is enabled by default in the **Development** environment
 
 Every request must carry HTTP Basic credentials of a **game character**:
 
-```
+```text
 Authorization: Basic base64(character:password)
 ```
 
@@ -176,7 +176,7 @@ when there is nothing to show.
 { "name": "hover", "arguments": { "code": "add(1,2)", "line": 0, "character": 1 } }
 ```
 
-→ `{ "Markdown": "### Function: `add`…", "StartLine": 0, "StartCharacter": 0, "EndLine": 0, "EndCharacter": 3 }`
+→ ``{ "Markdown": "### Function: `add`…", "StartLine": 0, "StartCharacter": 0, "EndLine": 0, "EndCharacter": 3 }``
 
 ### `complete`
 
@@ -231,7 +231,7 @@ unsafe). Point your MCP client's `url` at the published `https://host:port/mcp`.
 
 ## How it fits together
 
-```
+```text
  MCP client ──HTTP (Basic auth)──► SharpMUSH.Server  ──in-process──►  IMushCodeAnalyzer
  (Claude Code, …)                    app.MapMcp("/mcp")               (SharpMUSH.CodeAnalysis)
                                      MushBasic auth scheme                    │

--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -92,7 +92,18 @@ warnings, or hints.
 | Parameter | Type | Description |
 |---|---|---|
 | `code` | string | The MUSH softcode to validate. |
-| `parseType` | string | `"function"` (default) or `"command"`. |
+| `parseType` | string | `"function"` (default), `"commandlist"` (a list of commands, e.g. an attribute's `$`-command actions), or `"command"` (a single command). |
+
+**Function vs command-list.** The parse mode is chosen differently per surface:
+
+- **MCP** — the caller passes `parseType` (above).
+- **Language Server** — the mode is chosen by **file extension**: `.mush` / `.mu` are
+  parsed as a **command list** (a batch of building commands / attribute actions);
+  `.mushfn` / `.fun` are parsed as a **function** (a single expression). Save an editor
+  buffer with the matching extension to control how it's analyzed. Anything else falls
+  back to function.
+
+Both channels resolve through the same `MushParseMode` rule in `SharpMUSH.CodeAnalysis`.
 
 **Example call**
 

--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -92,18 +92,22 @@ warnings, or hints.
 | Parameter | Type | Description |
 |---|---|---|
 | `code` | string | The MUSH softcode to validate. |
-| `parseType` | string | `"function"` (default), `"commandlist"` (a list of commands, e.g. an attribute's `$`-command actions), or `"command"` (a single command). |
+| `parseType` | string | `"function"` (default), `"commandsperline"` (each line is its own command — a real-world `.mush` upload file), `"commandlist"` (one `;`-separated command list), or `"command"` (a single command). |
 
-**Function vs command-list.** The parse mode is chosen differently per surface:
+**Parse mode.** Chosen differently per surface:
 
-- **MCP** — the caller passes `parseType` (above).
-- **Language Server** — the mode is chosen by **file extension**: `.mush` / `.mu` are
-  parsed as a **command list** (a batch of building commands / attribute actions);
-  `.mushfn` / `.fun` are parsed as a **function** (a single expression). Save an editor
-  buffer with the matching extension to control how it's analyzed. Anything else falls
-  back to function.
+- **MCP** — the caller passes `parseType` (above). In `commandsperline` mode each non-blank
+  line is validated independently as a single command and diagnostics are reported on the
+  line they occur.
+- **Language Server** — the mode is chosen by **file extension**:
+  - `.mush` / `.mu` → **one command per line** (a real-world `.mush` upload / quote file).
+  - `.mushfn` / `.fun` → **function** (a single expression).
+  - anything else → function.
 
-Both channels resolve through the same `MushParseMode` rule in `SharpMUSH.CodeAnalysis`.
+  Save an editor buffer with the matching extension to control how it's analyzed.
+
+Both channels resolve through the same `MushParseMode` / `MushAnalysisMode` rule in
+`SharpMUSH.CodeAnalysis`.
 
 **Example call**
 

--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -1,0 +1,148 @@
+# SharpMUSH MCP Server
+
+SharpMUSH hosts a [Model Context Protocol](https://modelcontextprotocol.io) (MCP)
+endpoint **inside the running game server**. It exposes SharpMUSH's live code
+intelligence as MCP tools so that AI agents (Claude Code and others) and MCP-aware
+tooling can validate and introspect MUSH softcode against the **real parser and the
+running world's registered functions and commands** — no separate process, no LSP
+socket.
+
+The endpoint is authenticated per request with a **game character's name and
+password**.
+
+> Editors (VS Code, Neovim, Emacs) are served separately by the standalone
+> `SharpMUSH.LanguageServer` (stdio LSP). The MCP endpoint is the agent/tooling
+> surface; both share one analysis engine (`SharpMUSH.CodeAnalysis`).
+
+## Enabling the endpoint
+
+The endpoint is **disabled by default** and mapped only when enabled in
+configuration. In `appsettings.json` (or an environment-specific override):
+
+```json
+{
+  "Mcp": {
+    "Enabled": true,
+    "Path": "/mcp"
+  }
+}
+```
+
+- `Enabled` — when `false`, the route is not mapped and requests return 404.
+- `Path` — the route the Streamable-HTTP endpoint is served at (default `/mcp`).
+
+It is enabled by default in the **Development** environment
+(`appsettings.Development.json`).
+
+## Authentication
+
+Every request must carry HTTP Basic credentials of a **game character**:
+
+```
+Authorization: Basic base64(character:password)
+```
+
+The character is resolved and the password verified through the exact same path the
+in-game `connect` command uses. A missing, malformed, unknown-character, or
+wrong-password credential returns **401 Unauthorized** with
+`WWW-Authenticate: Basic`. A character with no password set cannot authenticate.
+
+> **Transport security:** Basic sends the password on every request, so reach the
+> endpoint over **localhost or TLS** only. The credential is a single static header
+> you set once in your MCP client config — there is no login round-trip and nothing
+> to refresh.
+
+## Registering with Claude Code
+
+```bash
+# character "Wizard" with password "s3cret" against a dev server on :8081 (HTTPS)
+claude mcp add --transport http sharpmush https://localhost:8081/mcp \
+  --header "Authorization: Basic $(printf '%s' 'Wizard:s3cret' | base64)"
+```
+
+Or as an `.mcp.json` entry:
+
+```json
+{
+  "mcpServers": {
+    "sharpmush": {
+      "type": "http",
+      "url": "https://localhost:8081/mcp",
+      "headers": {
+        "Authorization": "Basic V2l6YXJkOnMzY3JldA=="
+      }
+    }
+  }
+}
+```
+
+(`V2l6YXJkOnMzY3JldA==` is `base64("Wizard:s3cret")` — replace with your own
+character and password.)
+
+## Tools
+
+Positions, where a tool takes one, are **0-based** `line` / `character` (LSP
+convention).
+
+### `validate`
+
+Validate SharpMUSH softcode against the live parser and return any syntax errors,
+warnings, or hints.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `code` | string | The MUSH softcode to validate. |
+| `parseType` | string | `"function"` (default) or `"command"`. |
+
+**Example call**
+
+```json
+{
+  "name": "validate",
+  "arguments": { "code": "add(1,2" }
+}
+```
+
+**Example result** (a diagnostic per problem; empty when the code is clean):
+
+```json
+[
+  {
+    "Severity": "Error",
+    "Message": "…missing ')'…",
+    "StartLine": 0,
+    "StartCharacter": 0,
+    "EndLine": 0,
+    "EndCharacter": 7,
+    "Code": null,
+    "Source": "SharpMUSH Parser"
+  }
+]
+```
+
+Calling `validate` with `add(1,2)` returns `[]` — no diagnostics.
+
+> More tools mapping the rest of the shared analysis engine — `hover`, `complete`,
+> `signature_help`, `document_symbols`, `format`, and optional document-session
+> handles — follow the same pattern and are being added incrementally. See
+> `docs/superpowers/specs/2026-07-08-mcp-lsp-server-design.md`.
+
+## Docker / remote access
+
+The game server already exposes its HTTP(S) port (`8081` HTTPS / `8080` HTTP in
+dev). To reach the MCP endpoint from outside a container, publish that port in your
+compose/k8s config, and terminate TLS in front of it (Basic auth over plaintext is
+unsafe). Point your MCP client's `url` at the published `https://host:port/mcp`.
+
+## How it fits together
+
+```
+ MCP client ──HTTP (Basic auth)──► SharpMUSH.Server  ──in-process──►  IMushCodeAnalyzer
+ (Claude Code, …)                    app.MapMcp("/mcp")               (SharpMUSH.CodeAnalysis)
+                                     MushBasic auth scheme                    │
+                                                                     live MUSHCodeParser +
+                                                                     function/command libraries
+```
+
+The same `IMushCodeAnalyzer` backs the standalone `SharpMUSH.LanguageServer` used by
+editors, so diagnostics are identical across both surfaces.

--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -102,6 +102,7 @@ warnings, or hints.
 - **Language Server** — the mode is chosen by **file extension**:
   - `.mush` / `.mu` → **one command per line** (a real-world `.mush` upload / quote file).
   - `.mushfn` / `.fun` → **function** (a single expression).
+  - `.mushcmd` → **command list** (a single `;`-separated command list).
   - anything else → function.
 
   Save an editor buffer with the matching extension to control how it's analyzed.

--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -143,10 +143,68 @@ returns `"add(1, 2, 3)"`.
 The same formatting backs the Language Server's `textDocument/formatting`, so editors
 and agents format identically.
 
-> More tools mapping the rest of the shared analysis engine — `hover`, `complete`,
-> `signature_help`, `document_symbols`, and optional document-session handles —
-> follow the same pattern and are being added incrementally. See
-> `docs/superpowers/specs/2026-07-08-mcp-lsp-server-design.md`.
+### `hover`
+
+Return hover documentation for the word at a position: a function/command signature,
+or an explanation of a built-in substitution (`%#`, `%0`, `%qa`, …). Returns `null`
+when there is nothing to show.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `line` | int | 0-based line. |
+| `character` | int | 0-based character. |
+| `code` | string? | The softcode (omit if `documentId` is given). |
+| `documentId` | string? | An open document's id (see session handles). |
+
+```json
+{ "name": "hover", "arguments": { "code": "add(1,2)", "line": 0, "character": 1 } }
+```
+
+→ `{ "Markdown": "### Function: `add`…", "StartLine": 0, "StartCharacter": 0, "EndLine": 0, "EndCharacter": 3 }`
+
+### `complete`
+
+Return completion suggestions (functions, commands, and common substitutions) for the
+word prefix at a position. Same `line` / `character` / `code` / `documentId` parameters
+as `hover`. Each item has `Label`, `Kind` (`Function` / `Keyword` / `Variable`),
+`Detail`, `Documentation`, `InsertText`, and `IsSnippet`.
+
+### `signature_help`
+
+Return parameter hints for the function call surrounding a position — `Label`,
+`Documentation`, the `Parameters` list, and the `ActiveParameter` index — or `null`
+when the position is not inside a known function call. Same parameters as `hover`.
+
+### `document_symbols`
+
+Return an outline of the softcode: attribute definitions (`&attr …`), `@set`
+attributes, function calls, and commands. Each symbol has `Name`, `Kind`
+(`Property` / `Function` / `Method`), `Detail`, and 0-based ranges.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `code` | string? | The softcode (omit if `documentId` is given). |
+| `documentId` | string? | An open document's id. |
+
+### Session handles: `open_document` / `close_document`
+
+To run many queries over the same softcode without resending it, store it once and pass
+the returned id as `documentId` to any tool above:
+
+```json
+{ "name": "open_document", "arguments": { "code": "&cmd $foo: think bar" } }
+```
+
+→ returns a `documentId` string. Then e.g.
+`{ "name": "hover", "arguments": { "documentId": "…", "line": 0, "character": 2 } }`.
+Release it with `{ "name": "close_document", "arguments": { "documentId": "…" } }`.
+
+Every query tool accepts **either** `code` **or** `documentId`; supplying neither is an
+error.
+
+> All tools map the shared analysis engine (`SharpMUSH.CodeAnalysis`) that also backs the
+> Language Server, so results match across editors and agents. See
+> `docs/superpowers/specs/2026-07-08-mcp-lsp-server-design.md` for the design.
 
 ## Docker / remote access
 

--- a/docs/superpowers/specs/2026-07-08-mcp-lsp-server-design.md
+++ b/docs/superpowers/specs/2026-07-08-mcp-lsp-server-design.md
@@ -1,0 +1,254 @@
+# SharpMUSH MCP Server (in-server, LSP-analysis reuse) — Design
+
+**Date:** 2026-07-08
+**Status:** Approved design, pending implementation plan
+**Branch:** `feature/mcp-lsp-server`
+
+## Summary
+
+Expose SharpMUSH's live MUSH-code analysis (diagnostics, hover, completion,
+signature help, document symbols, formatting) as **Model Context Protocol (MCP)
+tools**, hosted **inside the running SharpMUSH game server** and reached over an
+authenticated HTTP endpoint.
+
+Because the MCP runs in-process within `SharpMUSH.Server`, its tools call the
+analysis services directly through the game's own dependency-injection container.
+The analysis therefore reflects the **live world** — the real registered function
+and command libraries — with no separate process, no LSP socket, and no LSP
+client round-trip.
+
+The endpoint is authenticated with **character + password** (HTTP Basic),
+verified through the same mechanism the `connect` command uses.
+
+## Goals
+
+- An MCP client (Claude Code, editors, other tooling) can validate and introspect
+  MUSH softcode against the real SharpMUSH parser and the live function/command
+  libraries.
+- The MCP is a first-class part of the server: it starts with the server, is
+  gated by configuration, and is reached by URL.
+- Every request is authenticated as a game character.
+- No duplication of MUSH-analysis logic: the existing standalone stdio Language
+  Server (for editors) and the new MCP tools share one source of truth.
+
+## Non-Goals (v1)
+
+- Out-of-process / "pointable" MCP that connects to a remote LSP endpoint. The
+  MCP is **in-server only**. (The standalone stdio LSP in
+  `SharpMUSH.LanguageServer` is unchanged and remains available for editors.)
+- A TCP/socket transport for the Language Server. Not needed — the MCP calls
+  analysis in-process.
+- Auth schemes beyond character+password (JWT bearer, OTT, OAuth 2.1). These are
+  a documented upgrade path, not v1.
+- Per-character permission scoping of analysis results. v1 analysis is read-only
+  syntax/semantic work; the authenticated character is captured as session
+  identity and used only as an access gate. Per-enactor scoping is a future hook.
+- MCP tools for LSP capabilities not listed below (rename, references, code
+  actions, inlay hints, semantic tokens, workspace symbols). Easy to add later.
+
+## Architecture
+
+```
+ MCP client (Claude Code, editor, tooling)
+        │  MCP over HTTP (Streamable HTTP), URL-based
+        │  Authorization: Basic base64(character:password)
+        ▼
+ ┌──────────────────────────────────────────────────────────┐
+ │  SharpMUSH.Server  (existing ASP.NET host)                │
+ │                                                            │
+ │   [MushBasic auth scheme]  ── character+password ──▶       │
+ │        │  verified via IPasswordService.PasswordIsValid    │
+ │        ▼                                                    │
+ │   app.MapMcp("/mcp").RequireAuthorization(...)             │
+ │        │  ModelContextProtocol.AspNetCore                  │
+ │        ▼                                                    │
+ │   MushTools  ([McpServerToolType])                         │
+ │        │  in-process DI call (no socket)                   │
+ │        ▼                                                    │
+ │   Analysis services  ◀── shared ──▶  LSP handlers          │
+ │   (diagnose/hover/complete/signature/symbols/format)       │
+ │        │  live DI                                          │
+ │        ▼                                                    │
+ │   real MUSHCodeParser + live function/command libraries    │
+ └──────────────────────────────────────────────────────────┘
+```
+
+## Components
+
+### 1. Shared analysis services (`SharpMUSH.LanguageServer` refactor)
+
+Extract the per-capability analysis currently embedded in the LSP handlers into
+stateless services that accept plain text (plus a position where relevant) and
+return **plain domain results, not LSP protocol types**.
+
+- `validate(text)` → diagnostics. **Already centralized** in
+  `LSPMUSHCodeParser.GetDiagnostics` — reuse as-is; no extraction needed. This is
+  what lets the MCP ship a working first tool immediately.
+- `hover(text, position)` → symbol info (function/command signature + docs).
+  Extracted from `HoverHandler`.
+- `complete(text, position)` → completion items. Extracted from
+  `CompletionHandler`.
+- `signature_help(text, position)` → active signature + parameters. Extracted
+  from `SignatureHelpHandler`.
+- `document_symbols(text)` → outline. Extracted from `DocumentSymbolHandler`.
+- `format(text)` → formatted text. Extracted from `DocumentFormattingHandler`.
+
+The existing LSP handlers are refactored into **thin adapters** that translate
+between LSP protocol types (`HoverParams`, `Position`, `Hover`, …) and the shared
+services. The standalone stdio Language Server continues to pass its existing
+tests after this refactor — this is an explicit acceptance criterion.
+
+Handlers **not** exposed via MCP in v1 (rename, references, code actions, inlay
+hints, semantic tokens, workspace symbols) are left untouched.
+
+**Result-type note:** the shared services return small, plain result records
+(e.g. a diagnostic record with severity, message, and a 0-based line/character
+range; a hover record with markdown + range). Both the LSP adapter and the MCP
+tool map from these. The MCP tool serializes them to JSON.
+
+### 2. MCP hosting in `SharpMUSH.Server`
+
+- Add the `ModelContextProtocol.AspNetCore` package.
+- In `Startup`:
+  `builder.Services.AddMcpServer().WithHttpTransport().WithTools<MushTools>();`
+- In the app pipeline: `app.MapMcp(mcpOptions.Path).RequireAuthorization(policy);`
+- Configuration section (`appsettings.json`):
+
+  ```json
+  "Mcp": {
+    "Enabled": true,
+    "Path": "/mcp"
+  }
+  ```
+
+  Disabled by default in production configs; enabled for development. When
+  `Enabled` is false, `MapMcp` is not registered.
+
+### 3. `MushTools` — the MCP tool type
+
+An `[McpServerToolType]` class whose `[McpServerTool]` methods inject the shared
+analysis services from DI and map JSON ⇄ domain results. Each method has a
+`[Description]`; each parameter is described.
+
+| Tool | Backing service | Signature |
+|---|---|---|
+| `validate` | diagnostics | `validate(code)` → list of `{severity, message, range}` |
+| `complete` | completion | `complete(code, line, character)` → items |
+| `hover` | hover | `hover(code, line, character)` → `{markdown, range}` or null |
+| `signature_help` | signature help | `signature_help(code, line, character)` → `{signature, parameters, activeParameter}` |
+| `document_symbols` | document symbols | `document_symbols(code)` → outline |
+| `format` | formatting | `format(code)` → formatted string |
+| `open_document` / `close_document` | (session) | optional handles: open a URI+text once, then pass that URI to the query tools to avoid resending text |
+
+- **Positions are 0-based line/character** (LSP convention), documented on each
+  tool's parameters.
+- **Snippet tools** (the primary surface) are self-contained: each call passes
+  the full `code`, the tool opens a synthetic document, runs the query, and
+  returns — no client-visible state.
+- **Session handles** (`open_document`/`close_document`) are optional: a caller
+  that runs many queries over one document can open it once and reference its
+  URI, avoiding resend. State lives in a small in-memory per-session document
+  cache.
+
+### 4. Authentication — `MushBasic` scheme
+
+A custom `AuthenticationHandler<MushBasicOptions>` (modeled on the existing
+`DebugAuthenticationHandler` and reusing the same services as the `connect`
+command):
+
+1. Read `Authorization: Basic base64(character:password)`. Absent/malformed →
+   `401` with `WWW-Authenticate: Basic`.
+2. Resolve the character by name via `GetPlayerQuery(name)` (mediator), matching
+   the `connect` flow. Not found → `401`.
+3. Verify with
+   `IPasswordService.PasswordIsValid($"#{Key}:{CreationTime}", password, player.PasswordHash)`.
+   Invalid → `401`.
+4. On success, build a `ClaimsPrincipal` carrying the character's DBRef and name;
+   this is the session identity.
+5. `MapMcp(...).RequireAuthorization(policy)` where `policy` requires the
+   `MushBasic` scheme and an authenticated character.
+
+**Transport security:** HTTP Basic sends the password on every request, so the
+endpoint must be reached over localhost or TLS. The MCP config binds to localhost
+in development; remote exposure requires TLS. This is stated in the docs and the
+default config.
+
+**Client ergonomics:** the credential is a single static header set once in the
+MCP client config; no login round-trip and nothing to refresh — the direct fit
+for "character & password to start off."
+
+## Data flow
+
+**`validate` example:**
+
+1. MCP client calls `validate(code)` with `Authorization: Basic …`.
+2. `MushBasic` authenticates the character (401 on failure).
+3. `MushTools.Validate` resolves the diagnostics service and calls
+   `GetDiagnostics(code)` — in-process, against the live parser/libraries.
+4. Diagnostics are mapped to a compact JSON list and returned as the tool result.
+
+Hover/completion/signature/symbols/format follow the same shape: authenticate →
+resolve shared service → call with `code` (+ position) → map to JSON.
+
+## Error handling
+
+- **Auth failures** → `401 Unauthorized` with `WWW-Authenticate: Basic`; no tool
+  is invoked.
+- **Analysis exceptions** → caught inside the tool and returned as a structured
+  MCP tool error. The analysis never crashes the server (mirrors the LSP's
+  error-resilience design).
+- **MCP disabled** (`Mcp.Enabled=false`) → endpoint not mapped; requests `404`.
+
+## Testing
+
+- **Shared services (unit):** one test per extracted capability against a
+  parser wired to a known function/command library — e.g. a known-bad snippet
+  yields a diagnostic; `hover` on a known function returns its signature;
+  `format` normalizes a messy snippet.
+- **LSP regression:** the existing `SharpMUSH.LanguageServer` handler tests still
+  pass after the handler→adapter refactor. Explicit acceptance criterion.
+- **MCP integration** (`SharpMUSH.Tests.Integration`): with `Mcp.Enabled=true`,
+  `tools/list` lists the tools; an authenticated `validate` call against the live
+  parser returns diagnostics for a bad snippet.
+- **Auth:** missing/garbage header → 401; wrong password → 401; valid
+  character+password → 200 and a tool result. Reuse a seeded character
+  (e.g. God `#1` or a seeded WIZARD) with a known password from the test
+  infrastructure.
+
+## Examples (deliverable)
+
+- **Claude Code registration:**
+
+  ```bash
+  claude mcp add --transport http sharpmush http://localhost:<port>/mcp \
+    --header "Authorization: Basic $(printf '%s' 'One:mypassword' | base64)"
+  ```
+
+- **`.mcp.json` snippet** with the URL and the static `Authorization` header.
+- **docker-compose note** exposing the server's MCP/HTTP port.
+- **A `docs/` page** with worked tool calls: sample MUSH code in → real
+  diagnostic / hover / signature JSON out.
+- **Editor note:** the standalone stdio Language Server still serves editors
+  (VS Code / Neovim / Emacs) unchanged; the MCP is the agent/tooling surface.
+
+## Phasing (de-risks delivery)
+
+1. **Vertical slice:** MCP hosting + `MushBasic` auth + the `validate` tool
+   (no service extraction needed). Proves the in-server, authenticated MCP path
+   end-to-end.
+2. **Extract and expose** `hover`, `complete`, `signature_help`,
+   `document_symbols`, `format` — one shared service + one MCP tool at a time,
+   refactoring each corresponding LSP handler into a thin adapter and keeping its
+   tests green.
+3. **Optional session handles** (`open_document`/`close_document`).
+4. **Examples & docs.**
+
+## Key packages / APIs
+
+- `ModelContextProtocol` / `ModelContextProtocol.AspNetCore` —
+  `AddMcpServer().WithHttpTransport().WithTools<T>()`, `app.MapMcp(path)`,
+  `[McpServerToolType]` / `[McpServerTool]` / `[Description]`.
+- `IPasswordService.PasswordIsValid`, `GetPlayerQuery`, mediator — existing,
+  reused for auth.
+- `LSPMUSHCodeParser.GetDiagnostics` — existing, reused for `validate`.
+- Custom `AuthenticationHandler<>` modeled on `DebugAuthenticationHandler`.


### PR DESCRIPTION
## Summary

Adds an **in-server, authenticated Model Context Protocol (MCP) endpoint** to the SharpMUSH game server that exposes the game's live MUSH code-intelligence as MCP tools, and factors that intelligence into a shared library so the Language Server (for editors) and the MCP (for agents/tooling) share one implementation.

Design doc: `docs/superpowers/specs/2026-07-08-mcp-lsp-server-design.md`
User guide + examples: `docs/guides/mcp-server.md`

## What's included

- **`SharpMUSH.CodeAnalysis`** — new shared library with `IMushCodeAnalyzer` (validate, format, hover, complete, signature help, document symbols). It runs in-process against the live world's registered function/command libraries. The existing LSP handlers were refactored into thin adapters over it, so editors and agents produce identical results with no duplicated logic.
- **In-server MCP** (`SharpMUSH.Server`) over Streamable HTTP at `/mcp` (`app.MapMcp`), gated by `Mcp:Enabled` config. 8 tools: `validate`, `format`, `hover`, `complete`, `signature_help`, `document_symbols`, plus `open_document`/`close_document` session handles (capacity-bounded store). Every query tool accepts inline `code` or a `documentId`.
- **Authentication** — a `MushBasic` scheme: character + password over HTTP Basic, verified via the exact same flow as the in-game `connect` command (`GetPlayerQuery` + `IPasswordService.PasswordIsValid`). The endpoint requires an authenticated character.
- **Function vs command-list vs per-line parse modes** — `MushAnalysisMode` (Function / CommandList / Command / CommandsPerLine). Two channels, one rule (`MushParseMode`):
  - LSP by **file extension**: `.mush`/`.mu` → one command per line (real-world .mush upload files), `.mushfn`/`.fun` → function, `.mushcmd` → command list.
  - MCP by **`parseType`** param: `function` (default) / `commandsperline` / `commandlist` / `command`.
  - `CommandsPerLine` validates each non-blank line as a single command and offsets diagnostics back to the file line.

## Testing

Run locally (podman-backed Testcontainers):

- **36** analyzer / parse-mode unit tests (each new behavior TDD'd RED→GREEN)
- **12** Explicit MCP integration tests: auth boundary (401 cases), MCP protocol handshake, all-tools listing, `validate`/`format`/`document_symbols` round-trips, session-handle round-trip, and `commandlist` / `commandsperline` parse modes
- **5** existing LSP handler tests still pass (no regression from the adapter refactor)
- Full solution builds clean (0 errors)

MCP integration tests are marked `[Explicit]` (they need the Arango/NATS/SQL Testcontainers).

## Notes / follow-ups

- Line-continuation conventions (trailing `\` / leading `-`) are not yet handled in `CommandsPerLine` — each physical newline is a command boundary.
- Multi-attribute object analysis (segmenting `&attr obj=value` regions and inferring per-attribute type) is a designed-but-not-implemented next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared code intelligence for hover, completion, signature help, document symbols, validation, and formatting.
  * Introduced a new in-server MCP endpoint with authenticated access plus document session open/close.
  * Added analysis-mode selection driven by file type/name (including additional MUSH extensions).
* **Bug Fixes**
  * Improved per-file/per-mode diagnostics accuracy and exception-safe behavior across language features.
  * Refined formatting to normalize spacing while preserving original line endings and line count.
* **Documentation**
  * Added MCP server configuration and tool usage guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->