### PR TITLE
Add hobby-scale production deployment stack

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,30 @@
+# Copy this file to `.env` (in the deploy/ folder) and fill in real values.
+# `.env` holds secrets — do NOT commit it. (deploy/.gitignore already excludes it.)
+
+# --- Web portal ---
+# Domain the portal is served on (used by Caddy for automatic HTTPS). e.g. mush.example.com
+SHARPMUSH_DOMAIN=mush.example.com
+
+# --- Auth ---
+# JWT signing key — REQUIRED in production. Generate a strong random one, e.g.:
+#   openssl rand -base64 48
+JWT_SIGNING_KEY=
+
+# Initial God/admin character, created on first boot.
+BOOTSTRAP_USERNAME=admin
+BOOTSTRAP_PASSWORD=change-me-to-something-strong
+
+# --- Backups (restic) ---
+# Repository location. Examples:
+#   Backblaze B2:      b2:your-bucket-name:sharpmush
+#   Cloudflare R2/S3:  s3:https://<accountid>.r2.cloudflarestorage.com/your-bucket
+RESTIC_REPOSITORY=b2:your-bucket-name:sharpmush
+
+# Encryption passphrase for the backup repo. GENERATE ONCE, then STORE IT SOMEWHERE SAFE
+# (a password manager) — if you lose this, your backups are unrecoverable. e.g. openssl rand -base64 32
+RESTIC_PASSWORD=
+
+# Backblaze B2 application key (from the B2 dashboard). If you use S3/R2 instead, delete these
+# and set AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY in the compose file's backup service.
+B2_ACCOUNT_ID=
+B2_ACCOUNT_KEY=

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -5,6 +5,10 @@
 # Domain the portal is served on (used by Caddy for automatic HTTPS). e.g. mush.example.com
 SHARPMUSH_DOMAIN=mush.example.com
 
+# Only for docker-compose.cloudflare.yml: the token for your Cloudflare Tunnel,
+# copied from the Zero Trust dashboard when you create the tunnel. Leave blank otherwise.
+CLOUDFLARE_TUNNEL_TOKEN=
+
 # --- Auth ---
 # JWT signing key — REQUIRED in production. Generate a strong random one, e.g.:
 #   openssl rand -base64 48

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,0 +1,2 @@
+# Real secrets live here — never commit them.
+.env

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -5,13 +5,18 @@
 {$SHARPMUSH_DOMAIN} {
 	encode zstd gzip
 
-	# SignalR (/hubs/game) and the raw WebSocket terminal (/ws) need WebSocket upgrades;
-	# reverse_proxy passes these through transparently.
-	reverse_proxy sharpmush-server:8080
+	# The in-browser terminal's WebSocket endpoint (/ws) is served by the CONNECTION SERVER
+	# on :4202, NOT the main server. Route it explicitly, or the catch-all below would send
+	# it to :8080 (which has no /ws handler) and the web terminal would fail to connect.
+	# Set the portal's Server URI to wss://{$SHARPMUSH_DOMAIN}/ws so it stays same-origin.
+	@ws path /ws /ws/*
+	handle @ws {
+		reverse_proxy connectionserver:4202
+	}
 
-	# The Blazor WASM portal talks to the connection server's websocket gateway.
-	# Uncomment if you route browser websocket traffic through the domain instead of a direct port:
-	# handle_path /cs/* {
-	# 	reverse_proxy connectionserver:4202
-	# }
+	# Everything else — Blazor portal, REST API, and the SignalR hub (/hubs/game) — goes to
+	# the main server. reverse_proxy passes WebSocket upgrades (SignalR) through transparently.
+	handle {
+		reverse_proxy sharpmush-server:8080
+	}
 }

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,17 @@
+# Automatic HTTPS for the SharpMUSH web portal.
+# Caddy fetches and renews a Let's Encrypt certificate for {$SHARPMUSH_DOMAIN} on its own.
+# Point your domain's DNS A/AAAA record at this host first, then `docker compose up -d`.
+
+{$SHARPMUSH_DOMAIN} {
+	encode zstd gzip
+
+	# SignalR (/hubs/game) and the raw WebSocket terminal (/ws) need WebSocket upgrades;
+	# reverse_proxy passes these through transparently.
+	reverse_proxy sharpmush-server:8080
+
+	# The Blazor WASM portal talks to the connection server's websocket gateway.
+	# Uncomment if you route browser websocket traffic through the domain instead of a direct port:
+	# handle_path /cs/* {
+	# 	reverse_proxy connectionserver:4202
+	# }
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,84 @@
+# Deploying SharpMUSH (hobby scale, single host)
+
+This stack runs the whole game on one small VM (~€4–6/mo on a budget VPS such as
+Hetzner CX22/CAX11, or $0 on Oracle Cloud Always Free ARM). It uses **SurrealDB
+embedded** (a RocksDB directory on disk — no separate database server), **NATS**
+for messaging, and a **restic** sidecar for nightly encrypted backups.
+
+Everything runs under Docker Compose. **Kubernetes is not needed** at this scale.
+
+## What's here
+
+| File | Purpose |
+|------|---------|
+| `docker-compose.prod.yml` | The stack: nats, connectionserver, sharpmush-server, backup, (optional) caddy |
+| `Caddyfile` | Automatic-HTTPS reverse proxy for the web portal (optional) |
+| `.env.example` | Template for secrets/config — copy to `.env` and fill in |
+
+## First-time setup
+
+```bash
+cd deploy
+cp .env.example .env
+# Edit .env: set a JWT key, admin password, your domain, and restic/B2 credentials.
+#   openssl rand -base64 48   # for JWT_SIGNING_KEY
+#   openssl rand -base64 32   # for RESTIC_PASSWORD  (SAVE THIS — losing it makes backups unrecoverable)
+
+# Initialise the restic repository once (creates the encrypted repo in your bucket):
+docker compose -f docker-compose.prod.yml run --rm backup restic init
+
+# Build and start everything:
+docker compose -f docker-compose.prod.yml up -d --build
+```
+
+The web portal comes up on `https://<your-domain>` (via Caddy) and telnet on port `4201`.
+The God/admin character named in `.env` is created on first boot.
+
+## Ports
+
+| Port | Service | Exposed to internet? |
+|------|---------|----------------------|
+| 80 / 443 | Caddy (web portal, SignalR, WebSocket) | yes |
+| 4201 | Telnet | yes |
+| 8080 | ASP.NET server (HTTP) | no — internal, behind Caddy |
+| 4222 / 8222 | NATS client / monitoring | no — internal only |
+
+If you don't use Caddy (e.g. you front the app with Cloudflare), delete the `caddy`
+service and publish `8080` on `sharpmush-server` instead.
+
+## Backups (restic)
+
+The `backup` service snapshots the `app-data` volume (the SurrealDB RocksDB store +
+wiki assets — i.e. the entire game) to your bucket every night at 03:30, keeping 7
+daily and 4 weekly snapshots. The volume is mounted **read-only**, so a backup run can
+never corrupt live data.
+
+```bash
+# List snapshots:
+docker compose -f docker-compose.prod.yml run --rm backup restic snapshots
+
+# Run a backup right now:
+docker compose -f docker-compose.prod.yml run --rm backup backup   # (entrypoint verb)
+
+# Restore the latest snapshot into a scratch dir to inspect it:
+docker compose -f docker-compose.prod.yml run --rm -v restore:/restore backup \
+  restic restore latest --target /restore
+```
+
+**To restore for real:** stop the stack, restore the snapshot's `/data` contents back
+into the `app-data` volume, then start again. The game reads whatever is in the volume
+on boot.
+
+> Note: restic copies the live RocksDB files while the server runs. RocksDB is
+> crash-consistent and recovers from its own write-ahead log, so this is fine for hobby
+> use. For a guaranteed-quiet snapshot, `docker compose stop sharpmush-server` before the
+> backup and start it after.
+
+## Updating
+
+```bash
+git pull
+docker compose -f docker-compose.prod.yml up -d --build
+```
+
+The `app-data` volume persists across rebuilds, so the world is untouched.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -179,15 +179,21 @@ wiki assets — i.e. the entire game) to your bucket every night at 03:30, keepi
 daily and 4 weekly snapshots. The volume is mounted **read-only**, so a backup run can
 never corrupt live data.
 
+> The commands below (and under **Updating**) omit `-f` by exporting `COMPOSE_FILE`, so
+> they work for either stack. Set it once per shell to whichever stack you deployed:
+> ```bash
+> export COMPOSE_FILE=docker-compose.prod.yml        # or docker-compose.cloudflare.yml
+> ```
+
 ```bash
 # List snapshots:
-docker compose -f docker-compose.prod.yml run --rm backup restic snapshots
+docker compose run --rm backup restic snapshots
 
 # Run a backup right now:
-docker compose -f docker-compose.prod.yml run --rm backup backup   # (entrypoint verb)
+docker compose run --rm backup backup   # (entrypoint verb)
 
 # Restore the latest snapshot into a scratch dir to inspect it:
-docker compose -f docker-compose.prod.yml run --rm -v restore:/restore backup \
+docker compose run --rm -v restore:/restore backup \
   restic restore latest --target /restore
 ```
 
@@ -202,9 +208,11 @@ on boot.
 
 ## Updating
 
+With `COMPOSE_FILE` exported as above (or add `-f <your-compose-file>`):
+
 ```bash
 git pull
-docker compose -f docker-compose.prod.yml up -d --build
+docker compose up -d --build
 ```
 
 The `app-data` volume persists across rebuilds, so the world is untouched.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -9,11 +9,16 @@ Everything runs under Docker Compose. **Kubernetes is not needed** at this scale
 
 ## What's here
 
+Two entry points, pick one based on how you terminate TLS:
+
 | File | Purpose |
 |------|---------|
-| `docker-compose.prod.yml` | The stack: nats, connectionserver, sharpmush-server, backup, (optional) caddy |
-| `Caddyfile` | Automatic-HTTPS reverse proxy for the web portal (optional) |
+| `docker-compose.prod.yml` | The stack: nats, connectionserver, sharpmush-server, backup, and **Caddy** for TLS. Use this if the box faces the internet directly. |
+| `docker-compose.cloudflare.yml` | Same stack but fronted by a **Cloudflare Tunnel** instead of Caddy (no open web ports, hidden origin IP). See the Cloudflare section below. |
+| `Caddyfile` | Automatic-HTTPS reverse proxy config used by `docker-compose.prod.yml` |
 | `.env.example` | Template for secrets/config — copy to `.env` and fill in |
+| `.gitignore` | Keeps your real `.env` out of git |
+| `README.md` | This file |
 
 ## First-time setup
 
@@ -34,14 +39,33 @@ docker compose -f docker-compose.prod.yml up -d --build
 The web portal comes up on `https://<your-domain>` (via Caddy) and telnet on port `4201`.
 The God/admin character named in `.env` is created on first boot.
 
+### Pointing the in-browser terminal at the right place
+
+The portal's web terminal connects to a **WebSocket** endpoint, `/ws`, which is served by the
+**connection server** (`:4202`), *not* the main server. The `Caddyfile` already routes
+`https://<your-domain>/ws` to the connection server for you, so in the portal set the terminal's
+**Server URI** to:
+
+```
+wss://<your-domain>/ws
+```
+
+(Same origin, so no mixed-content or CORS issues.) The default `ws://localhost:4202/ws` is for
+local development only — over HTTPS a browser will refuse a plaintext `ws://` connection.
+
 ## Ports
 
 | Port | Service | Exposed to internet? |
 |------|---------|----------------------|
-| 80 / 443 | Caddy (web portal, SignalR, WebSocket) | yes |
+| 80 / 443 | Caddy (web portal, SignalR, and `/ws` → connection server) | yes |
 | 4201 | Telnet | yes |
 | 8080 | ASP.NET server (HTTP) | no — internal, behind Caddy |
+| 4202 | Connection server HTTP / `/ws` WebSocket | no — internal, reached via Caddy's `/ws` route |
 | 4222 / 8222 | NATS client / monitoring | no — internal only |
+
+If you **don't** use Caddy (e.g. you terminate TLS at a load balancer), remember the browser
+terminal's `/ws` endpoint lives on the connection server (`:4202`), not the main server — you must
+publish `4202` or add an equivalent `/ws` proxy route, in addition to publishing `8080`.
 
 If you want to front the app with **Cloudflare** instead of Caddy, don't edit this file —
 use `docker-compose.cloudflare.yml` and follow the section below.
@@ -94,10 +118,21 @@ This is the part the Zero Trust dashboard is for. It does **not** touch telnet.
    Cloudflare automatically creates the proxied (orange-cloud) DNS record for that
    hostname for you — you don't add it by hand. `HTTP` here is correct: the hop from the
    tunnel to the container is on the private docker network; the public side is still HTTPS.
+4. **Add the WebSocket route — required for the in-browser terminal.** The terminal's `/ws`
+   endpoint is served by the **connection server** (`:4202`), not the main server, so it needs
+   its own Public Hostname entry. Add a route and make sure it sits **above** the catch-all from
+   step 3 (Cloudflare matches top-to-bottom):
+   - **Subdomain/domain:** `mush.example.com`
+   - **Path:** `ws`  *(matches `/ws`)*
+   - **Service type:** `HTTP`
+   - **URL:** `connectionserver:4202`
 
-   > Optional: if you route browser WebSocket-terminal traffic through the domain rather
-   > than a direct port, add a second Public Hostname, e.g. `ws.mush.example.com` →
-   > `HTTP` → `connectionserver:4202`. WebSockets work through the tunnel without extra config.
+   Then set the portal's terminal **Server URI** to `wss://mush.example.com/ws` (same origin —
+   no mixed-content). WebSockets traverse the tunnel with no extra config.
+
+   > Alternative: instead of a path route, use a dedicated hostname — add
+   > `ws.mush.example.com` → `HTTP` → `connectionserver:4202` and point the Server URI at
+   > `wss://ws.mush.example.com/ws`. Either works; the path route keeps everything same-origin.
 
 ### Part B — the telnet side (plain DNS, no Zero Trust involved)
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -43,8 +43,99 @@ The God/admin character named in `.env` is created on first boot.
 | 8080 | ASP.NET server (HTTP) | no — internal, behind Caddy |
 | 4222 / 8222 | NATS client / monitoring | no — internal only |
 
-If you don't use Caddy (e.g. you front the app with Cloudflare), delete the `caddy`
-service and publish `8080` on `sharpmush-server` instead.
+If you want to front the app with **Cloudflare** instead of Caddy, don't edit this file —
+use `docker-compose.cloudflare.yml` and follow the section below.
+
+## Fronting with Cloudflare (`docker-compose.cloudflare.yml`)
+
+This variant replaces Caddy with a **Cloudflare Tunnel**. A small `cloudflared` container
+dials *outbound* to Cloudflare and Cloudflare routes public traffic back down that
+connection, which means:
+
+- you open **no inbound web ports** (no 80/443 on the host firewall),
+- you manage **no TLS certificate** (Cloudflare terminates HTTPS at its edge),
+- your server's **origin IP stays hidden** behind Cloudflare.
+
+### The one thing to understand first: there are TWO independent front doors
+
+SharpMUSH is reached two different ways, and Cloudflare only handles one of them:
+
+| Traffic | Protocol | Path | Goes through Cloudflare? |
+|---------|----------|------|--------------------------|
+| Web portal, REST, SignalR, WebSocket terminal | HTTP/HTTPS + WS | Cloudflare Tunnel → `sharpmush-server:8080` | **Yes** |
+| Telnet (MU\* clients) | raw TCP | Client → host IP `:4201` directly | **No** |
+
+Cloudflare's normal proxy (the orange cloud) only carries HTTP/HTTPS and WebSockets.
+**Raw telnet is plain TCP and cannot go through it** on free/standard plans — that would
+require the paid Spectrum product. So the Zero Trust / Tunnel steps below apply **only to
+the web side**. Telnet is configured entirely separately, with a plain DNS record, and is
+served straight off the host. Keep the two in separate mental buckets.
+
+### Part A — the web side (Cloudflare Zero Trust Tunnel)
+
+This is the part the Zero Trust dashboard is for. It does **not** touch telnet.
+
+1. **Create the tunnel.** In the Cloudflare dashboard go to
+   **Zero Trust → Networks → Tunnels → Create a tunnel**, choose the **Cloudflared**
+   connector type, and give it a name (e.g. `sharpmush`).
+2. **Copy the token.** After creating it, Cloudflare shows an install command containing a
+   long token (the value after `--token`). Copy just that token into your `.env`:
+   ```
+   CLOUDFLARE_TUNNEL_TOKEN=eyJh...   # the token string, nothing else
+   ```
+   You do **not** need to run the install command Cloudflare shows — the `cloudflared`
+   service in the compose file runs the tunnel for you using this token.
+3. **Map your public hostname(s).** Still on the tunnel's config page, open the
+   **Public Hostname** tab and add a route:
+   - **Subdomain/domain:** `mush.example.com` (your portal address)
+   - **Service type:** `HTTP`
+   - **URL:** `sharpmush-server:8080`
+
+   Cloudflare automatically creates the proxied (orange-cloud) DNS record for that
+   hostname for you — you don't add it by hand. `HTTP` here is correct: the hop from the
+   tunnel to the container is on the private docker network; the public side is still HTTPS.
+
+   > Optional: if you route browser WebSocket-terminal traffic through the domain rather
+   > than a direct port, add a second Public Hostname, e.g. `ws.mush.example.com` →
+   > `HTTP` → `connectionserver:4202`. WebSockets work through the tunnel without extra config.
+
+### Part B — the telnet side (plain DNS, no Zero Trust involved)
+
+Telnet does not use the tunnel at all. You expose it directly and give players a hostname
+that resolves straight to your server:
+
+1. In the normal Cloudflare **DNS** app (not Zero Trust), add an `A` (and/or `AAAA`)
+   record, e.g. `telnet.mush.example.com` → your host's public IP.
+2. Set that record to **DNS only (grey cloud)**, *not* proxied. A proxied record would try
+   to send telnet through Cloudflare's HTTP proxy, which does not work.
+3. Make sure the host firewall allows inbound **TCP 4201** (the compose file already
+   publishes it). Players then connect their MU\* client to `telnet.mush.example.com 4201`.
+
+> Trade-off to be aware of: because this record is DNS-only, that hostname reveals your
+> server's real IP. The web portal stays hidden behind Cloudflare; only the telnet
+> hostname is exposed. If hiding the telnet IP matters to you, that requires Cloudflare
+> Spectrum (paid) or a different TCP proxy.
+
+### Part C — bring it up
+
+```bash
+cd deploy
+cp .env.example .env      # fill in CLOUDFLARE_TUNNEL_TOKEN plus the usual JWT/admin/restic values
+docker compose -f docker-compose.cloudflare.yml run --rm backup restic init   # once
+docker compose -f docker-compose.cloudflare.yml up -d --build
+```
+
+Check the tunnel is healthy with `docker compose -f docker-compose.cloudflare.yml logs -f cloudflared`
+(you want to see it register a connection to Cloudflare), then load `https://mush.example.com`.
+
+### Ports with Cloudflare
+
+| Port | Service | Open on host firewall? |
+|------|---------|------------------------|
+| 4201 | Telnet | **yes** (Part B) |
+| 80 / 443 | — | **no** — the tunnel is outbound-only |
+| 8080 | ASP.NET server (HTTP) | no — internal, reached via the tunnel |
+| 4222 / 8222 | NATS client / monitoring | no — internal only |
 
 ## Backups (restic)
 

--- a/deploy/docker-compose.cloudflare.yml
+++ b/deploy/docker-compose.cloudflare.yml
@@ -97,7 +97,7 @@ services:
   # Cloudflare Tunnel: dials out to Cloudflare, routes the public hostname(s) you
   # configured in the Zero Trust dashboard to the services on this network.
   cloudflared:
-    image: cloudflare/cloudflared:latest
+    image: cloudflare/cloudflared:2026.7.1   # pinned (not :latest) for reproducible deploys
     container_name: sharpmush-cloudflared
     command: ["tunnel", "--no-autoupdate", "run"]
     environment:

--- a/deploy/docker-compose.cloudflare.yml
+++ b/deploy/docker-compose.cloudflare.yml
@@ -25,7 +25,7 @@
 
 services:
   nats:
-    image: nats:2-alpine
+    image: nats:2.10-alpine
     container_name: sharpmush-nats
     command: ["-js", "-sd", "/data", "-m", "8222"]
     volumes:
@@ -37,6 +37,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    mem_limit: 256m
+    cpus: 0.5
     restart: unless-stopped
 
   connectionserver:
@@ -54,6 +56,8 @@ services:
       - "4201:4201"   # telnet — DIRECT to host (Cloudflare can't proxy raw TCP); use a DNS-only record
     networks:
       - sharpmush-net
+    mem_limit: 512m
+    cpus: 1.0
     restart: unless-stopped
 
   sharpmush-server:
@@ -72,9 +76,10 @@ services:
       # Trust the tunnel's forwarded client IP/proto so rate-limiting, bot detection and canonical-URL
       # middleware see the real visitor, not the cloudflared container. (ASP.NET ForwardedHeaders.)
       - ASPNETCORE_FORWARDEDHEADERS_ENABLED=true
-      - Jwt__SigningKey=${JWT_SIGNING_KEY}
-      - SHARPMUSH_BOOTSTRAP_USERNAME=${BOOTSTRAP_USERNAME}
-      - SHARPMUSH_BOOTSTRAP_PASSWORD=${BOOTSTRAP_PASSWORD}
+      # :? makes compose abort if the value is missing from .env rather than booting misconfigured.
+      - Jwt__SigningKey=${JWT_SIGNING_KEY:?set JWT_SIGNING_KEY in deploy/.env}
+      - SHARPMUSH_BOOTSTRAP_USERNAME=${BOOTSTRAP_USERNAME:?set BOOTSTRAP_USERNAME in deploy/.env}
+      - SHARPMUSH_BOOTSTRAP_PASSWORD=${BOOTSTRAP_PASSWORD:?set BOOTSTRAP_PASSWORD in deploy/.env}
     volumes:
       - app-data:/app/data
     # NOTE: no `ports:` — the server is only reachable via the tunnel and the internal network.
@@ -85,6 +90,8 @@ services:
         condition: service_started
     networks:
       - sharpmush-net
+    mem_limit: 768m
+    cpus: 1.5
     restart: unless-stopped
 
   # Cloudflare Tunnel: dials out to Cloudflare, routes the public hostname(s) you
@@ -94,23 +101,26 @@ services:
     container_name: sharpmush-cloudflared
     command: ["tunnel", "--no-autoupdate", "run"]
     environment:
-      - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
+      - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN:?set CLOUDFLARE_TUNNEL_TOKEN in deploy/.env}
     depends_on:
       - sharpmush-server
+      - connectionserver
     networks:
       - sharpmush-net
+    mem_limit: 128m
+    cpus: 0.5
     restart: unless-stopped
 
   # Nightly encrypted backup of the game-data volume — identical to the prod stack.
   backup:
-    image: mazzolino/restic:latest
+    image: mazzolino/restic:1.8      # pinned (not :latest) so backups are reproducible
     container_name: sharpmush-backup
     hostname: sharpmush
     environment:
       - RUN_ON_STARTUP=false
       - BACKUP_CRON=0 30 3 * * *
-      - RESTIC_REPOSITORY=${RESTIC_REPOSITORY}
-      - RESTIC_PASSWORD=${RESTIC_PASSWORD}
+      - RESTIC_REPOSITORY=${RESTIC_REPOSITORY:?set RESTIC_REPOSITORY in deploy/.env}
+      - RESTIC_PASSWORD=${RESTIC_PASSWORD:?set RESTIC_PASSWORD in deploy/.env}
       - RESTIC_BACKUP_SOURCES=/data
       - RESTIC_BACKUP_ARGS=--tag sharpmush --host sharpmush
       - RESTIC_FORGET_ARGS=--keep-daily 7 --keep-weekly 4 --prune
@@ -120,6 +130,8 @@ services:
       - app-data:/data:ro
     networks:
       - sharpmush-net
+    mem_limit: 256m
+    cpus: 0.5
     restart: unless-stopped
 
 volumes:

--- a/deploy/docker-compose.cloudflare.yml
+++ b/deploy/docker-compose.cloudflare.yml
@@ -1,0 +1,131 @@
+# SharpMUSH — hobby-scale stack fronted by CLOUDFLARE (single host).
+#
+# Difference vs docker-compose.prod.yml: TLS + web ingress are handled by Cloudflare,
+# not Caddy. A `cloudflared` tunnel dials OUT to Cloudflare, so:
+#   - no inbound 80/443 to open, no Let's Encrypt cert to manage
+#   - the origin server's IP stays hidden behind Cloudflare
+#   - the ASP.NET server is never published to the host — cloudflared reaches it
+#     over the private docker network.
+#
+# IMPORTANT — telnet is NOT proxied by Cloudflare:
+#   Cloudflare's proxy only carries HTTP/HTTPS + WebSockets. Raw telnet (:4201) is
+#   plain TCP and cannot go through the orange cloud on free/standard plans (that
+#   needs paid Spectrum). So telnet is published DIRECTLY on this host, and you
+#   point a DNS-ONLY (grey-cloud) record — e.g. telnet.mush.example.com — at the
+#   origin IP. The web portal/SignalR/WebSocket go through the tunnel; telnet does not.
+#
+# Setup:
+#   1. In the Cloudflare Zero Trust dashboard, create a Tunnel, copy its token into
+#      CLOUDFLARE_TUNNEL_TOKEN in .env.
+#   2. Add a Public Hostname on that tunnel:  mush.example.com  ->  http://sharpmush-server:8080
+#      (add a second one for the websocket gateway if you route it via the domain:
+#       ws.mush.example.com -> http://connectionserver:4202)
+#   3. Add a DNS-only A/AAAA record for telnet -> this host's IP.
+#   4. docker compose -f deploy/docker-compose.cloudflare.yml up -d --build
+
+services:
+  nats:
+    image: nats:2-alpine
+    container_name: sharpmush-nats
+    command: ["-js", "-sd", "/data", "-m", "8222"]
+    volumes:
+      - nats-data:/data
+    networks:
+      - sharpmush-net
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q http://localhost:8222/healthz -O /dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  connectionserver:
+    build:
+      context: ../
+      dockerfile: SharpMUSH.ConnectionServer/Dockerfile
+    image: sharpmush/sharpmush-connectionserver:latest
+    container_name: sharpmush-connectionserver
+    environment:
+      - NATS_URL=nats://nats:4222
+    depends_on:
+      nats:
+        condition: service_healthy
+    ports:
+      - "4201:4201"   # telnet — DIRECT to host (Cloudflare can't proxy raw TCP); use a DNS-only record
+    networks:
+      - sharpmush-net
+    restart: unless-stopped
+
+  sharpmush-server:
+    build:
+      context: ../
+      dockerfile: Dockerfile
+    image: sharpmush/sharpmush-server:latest
+    container_name: sharpmush-server
+    environment:
+      - SHARPMUSH_DATABASE_PROVIDER=surrealdb
+      - SHARPMUSH_SURREALDB_ENDPOINT=rocksdb://data/surreal
+      - Wiki__AssetRoot=/app/data/wiki-assets
+      - NATS_URL=nats://nats:4222
+      # HTTP only — Cloudflare terminates TLS at the edge and the tunnel reaches this over the private network.
+      - ASPNETCORE_URLS=http://+:8080
+      # Trust the tunnel's forwarded client IP/proto so rate-limiting, bot detection and canonical-URL
+      # middleware see the real visitor, not the cloudflared container. (ASP.NET ForwardedHeaders.)
+      - ASPNETCORE_FORWARDEDHEADERS_ENABLED=true
+      - Jwt__SigningKey=${JWT_SIGNING_KEY}
+      - SHARPMUSH_BOOTSTRAP_USERNAME=${BOOTSTRAP_USERNAME}
+      - SHARPMUSH_BOOTSTRAP_PASSWORD=${BOOTSTRAP_PASSWORD}
+    volumes:
+      - app-data:/app/data
+    # NOTE: no `ports:` — the server is only reachable via the tunnel and the internal network.
+    depends_on:
+      nats:
+        condition: service_healthy
+      connectionserver:
+        condition: service_started
+    networks:
+      - sharpmush-net
+    restart: unless-stopped
+
+  # Cloudflare Tunnel: dials out to Cloudflare, routes the public hostname(s) you
+  # configured in the Zero Trust dashboard to the services on this network.
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: sharpmush-cloudflared
+    command: ["tunnel", "--no-autoupdate", "run"]
+    environment:
+      - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
+    depends_on:
+      - sharpmush-server
+    networks:
+      - sharpmush-net
+    restart: unless-stopped
+
+  # Nightly encrypted backup of the game-data volume — identical to the prod stack.
+  backup:
+    image: mazzolino/restic:latest
+    container_name: sharpmush-backup
+    hostname: sharpmush
+    environment:
+      - RUN_ON_STARTUP=false
+      - BACKUP_CRON=0 30 3 * * *
+      - RESTIC_REPOSITORY=${RESTIC_REPOSITORY}
+      - RESTIC_PASSWORD=${RESTIC_PASSWORD}
+      - RESTIC_BACKUP_SOURCES=/data
+      - RESTIC_BACKUP_ARGS=--tag sharpmush --host sharpmush
+      - RESTIC_FORGET_ARGS=--keep-daily 7 --keep-weekly 4 --prune
+      - B2_ACCOUNT_ID=${B2_ACCOUNT_ID}
+      - B2_ACCOUNT_KEY=${B2_ACCOUNT_KEY}
+    volumes:
+      - app-data:/data:ro
+    networks:
+      - sharpmush-net
+    restart: unless-stopped
+
+volumes:
+  app-data:
+  nats-data:
+
+networks:
+  sharpmush-net:
+    driver: bridge

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -1,0 +1,133 @@
+# SharpMUSH — hobby-scale production stack (single host).
+#
+# Layout (see deploy/README.md):
+#   nats              — message bus (JetStream), the ONLY required backing service
+#   connectionserver  — telnet :4201 + websocket gateway
+#   sharpmush-server  — ASP.NET Core: REST + SignalR + Blazor portal, SurrealDB embedded (RocksDB on disk)
+#   backup            — restic sidecar: nightly encrypted snapshot of the game data to your bucket
+#   caddy             — OPTIONAL reverse proxy giving the web portal automatic HTTPS (Let's Encrypt)
+#
+# All game state lives in ONE named volume (app-data) so a single restic target covers everything.
+# Copy .env.example -> .env and fill it in before `docker compose -f deploy/docker-compose.prod.yml up -d`.
+
+services:
+  nats:
+    image: nats:2-alpine
+    container_name: sharpmush-nats
+    # -js: enable JetStream   -sd /data: persist JetStream state   -m 8222: monitoring/health port
+    command: ["-js", "-sd", "/data", "-m", "8222"]
+    volumes:
+      - nats-data:/data
+    networks:
+      - sharpmush-net
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q http://localhost:8222/healthz -O /dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  connectionserver:
+    build:
+      context: ../
+      dockerfile: SharpMUSH.ConnectionServer/Dockerfile
+    image: sharpmush/sharpmush-connectionserver:latest
+    container_name: sharpmush-connectionserver
+    environment:
+      - NATS_URL=nats://nats:4222
+    depends_on:
+      nats:
+        condition: service_healthy
+    ports:
+      - "4201:4201"   # raw telnet — exposed directly (plaintext protocol)
+    networks:
+      - sharpmush-net
+    restart: unless-stopped
+
+  sharpmush-server:
+    build:
+      context: ../
+      dockerfile: Dockerfile
+    image: sharpmush/sharpmush-server:latest
+    container_name: sharpmush-server
+    environment:
+      # --- Object database: SurrealDB embedded, file-backed RocksDB (no separate DB server) ---
+      - SHARPMUSH_DATABASE_PROVIDER=surrealdb
+      # Relative path resolves under the /app WORKDIR -> /app/data/surreal, which is the mounted volume.
+      - SHARPMUSH_SURREALDB_ENDPOINT=rocksdb://data/surreal
+      # Wiki asset uploads (filesystem) land in the same persisted volume.
+      - Wiki__AssetRoot=/app/data/wiki-assets
+      # --- Messaging ---
+      - NATS_URL=nats://nats:4222
+      # --- Web: serve HTTP only; Caddy terminates TLS in front (or expose 8080 directly if you don't use Caddy) ---
+      - ASPNETCORE_URLS=http://+:8080
+      # --- Auth: a JWT signing key is REQUIRED for portal auth in production ---
+      - Jwt__SigningKey=${JWT_SIGNING_KEY}
+      # --- Initial God/admin account, created on first boot ---
+      - SHARPMUSH_BOOTSTRAP_USERNAME=${BOOTSTRAP_USERNAME}
+      - SHARPMUSH_BOOTSTRAP_PASSWORD=${BOOTSTRAP_PASSWORD}
+    volumes:
+      - app-data:/app/data
+    depends_on:
+      nats:
+        condition: service_healthy
+      connectionserver:
+        condition: service_started
+    networks:
+      - sharpmush-net
+    restart: unless-stopped
+
+  # --- Nightly encrypted backup of the single game-data volume to your bucket ---
+  backup:
+    image: mazzolino/restic:latest
+    container_name: sharpmush-backup
+    hostname: sharpmush
+    environment:
+      - RUN_ON_STARTUP=false
+      # 6-field cron (sec min hour dom mon dow): every day at 03:30.
+      - BACKUP_CRON=0 30 3 * * *
+      - RESTIC_REPOSITORY=${RESTIC_REPOSITORY}
+      - RESTIC_PASSWORD=${RESTIC_PASSWORD}
+      - RESTIC_BACKUP_SOURCES=/data
+      - RESTIC_BACKUP_ARGS=--tag sharpmush --host sharpmush
+      # Retention: keep a week of dailies + a month of weeklies, prune the rest.
+      - RESTIC_FORGET_ARGS=--keep-daily 7 --keep-weekly 4 --prune
+      # Credentials for the storage backend. These are for Backblaze B2; swap for
+      # AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY if you use S3 or Cloudflare R2.
+      - B2_ACCOUNT_ID=${B2_ACCOUNT_ID}
+      - B2_ACCOUNT_KEY=${B2_ACCOUNT_KEY}
+    volumes:
+      - app-data:/data:ro          # read-only: the backup can never corrupt live data
+    networks:
+      - sharpmush-net
+    restart: unless-stopped
+
+  # --- OPTIONAL: automatic HTTPS for the web portal. Delete this service if you ---
+  # --- terminate TLS elsewhere (Cloudflare, a load balancer) or only use telnet. ---
+  caddy:
+    image: caddy:2-alpine
+    container_name: sharpmush-caddy
+    environment:
+      - SHARPMUSH_DOMAIN=${SHARPMUSH_DOMAIN}
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      - sharpmush-server
+    networks:
+      - sharpmush-net
+    restart: unless-stopped
+
+volumes:
+  app-data:      # SurrealDB RocksDB + wiki assets — the game. This is what gets backed up.
+  nats-data:     # JetStream state (transient I/O, not the source of truth) — not backed up.
+  caddy-data:    # Let's Encrypt certificates
+  caddy-config:
+
+networks:
+  sharpmush-net:
+    driver: bridge

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -12,7 +12,7 @@
 
 services:
   nats:
-    image: nats:2-alpine
+    image: nats:2.10-alpine
     container_name: sharpmush-nats
     # -js: enable JetStream   -sd /data: persist JetStream state   -m 8222: monitoring/health port
     command: ["-js", "-sd", "/data", "-m", "8222"]
@@ -25,6 +25,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    mem_limit: 256m
+    cpus: 0.5
     restart: unless-stopped
 
   connectionserver:
@@ -42,6 +44,8 @@ services:
       - "4201:4201"   # raw telnet — exposed directly (plaintext protocol)
     networks:
       - sharpmush-net
+    mem_limit: 512m
+    cpus: 1.0
     restart: unless-stopped
 
   sharpmush-server:
@@ -62,10 +66,12 @@ services:
       # --- Web: serve HTTP only; Caddy terminates TLS in front (or expose 8080 directly if you don't use Caddy) ---
       - ASPNETCORE_URLS=http://+:8080
       # --- Auth: a JWT signing key is REQUIRED for portal auth in production ---
-      - Jwt__SigningKey=${JWT_SIGNING_KEY}
+      # The :? syntax makes compose ABORT with an error if the value is missing from .env,
+      # instead of silently substituting an empty string and booting without auth configured.
+      - Jwt__SigningKey=${JWT_SIGNING_KEY:?set JWT_SIGNING_KEY in deploy/.env}
       # --- Initial God/admin account, created on first boot ---
-      - SHARPMUSH_BOOTSTRAP_USERNAME=${BOOTSTRAP_USERNAME}
-      - SHARPMUSH_BOOTSTRAP_PASSWORD=${BOOTSTRAP_PASSWORD}
+      - SHARPMUSH_BOOTSTRAP_USERNAME=${BOOTSTRAP_USERNAME:?set BOOTSTRAP_USERNAME in deploy/.env}
+      - SHARPMUSH_BOOTSTRAP_PASSWORD=${BOOTSTRAP_PASSWORD:?set BOOTSTRAP_PASSWORD in deploy/.env}
     volumes:
       - app-data:/app/data
     depends_on:
@@ -75,19 +81,21 @@ services:
         condition: service_started
     networks:
       - sharpmush-net
+    mem_limit: 768m
+    cpus: 1.5
     restart: unless-stopped
 
   # --- Nightly encrypted backup of the single game-data volume to your bucket ---
   backup:
-    image: mazzolino/restic:latest
+    image: mazzolino/restic:1.8      # pinned (not :latest) so backups are reproducible
     container_name: sharpmush-backup
     hostname: sharpmush
     environment:
       - RUN_ON_STARTUP=false
       # 6-field cron (sec min hour dom mon dow): every day at 03:30.
       - BACKUP_CRON=0 30 3 * * *
-      - RESTIC_REPOSITORY=${RESTIC_REPOSITORY}
-      - RESTIC_PASSWORD=${RESTIC_PASSWORD}
+      - RESTIC_REPOSITORY=${RESTIC_REPOSITORY:?set RESTIC_REPOSITORY in deploy/.env}
+      - RESTIC_PASSWORD=${RESTIC_PASSWORD:?set RESTIC_PASSWORD in deploy/.env}
       - RESTIC_BACKUP_SOURCES=/data
       - RESTIC_BACKUP_ARGS=--tag sharpmush --host sharpmush
       # Retention: keep a week of dailies + a month of weeklies, prune the rest.
@@ -100,6 +108,8 @@ services:
       - app-data:/data:ro          # read-only: the backup can never corrupt live data
     networks:
       - sharpmush-net
+    mem_limit: 256m
+    cpus: 0.5
     restart: unless-stopped
 
   # --- OPTIONAL: automatic HTTPS for the web portal. Delete this service if you ---
@@ -118,8 +128,11 @@ services:
       - caddy-config:/config
     depends_on:
       - sharpmush-server
+      - connectionserver
     networks:
       - sharpmush-net
+    mem_limit: 128m
+    cpus: 0.5
     restart: unless-stopped
 
 volumes:

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -65,6 +65,10 @@ services:
       - NATS_URL=nats://nats:4222
       # --- Web: serve HTTP only; Caddy terminates TLS in front (or expose 8080 directly if you don't use Caddy) ---
       - ASPNETCORE_URLS=http://+:8080
+      # Trust Caddy's X-Forwarded-Proto/-For. Without this the app (which always calls
+      # UseHttpsRedirection) sees the plain-HTTP backend hop and redirect-loops, and
+      # rate-limiting / canonical-URL logic sees the proxy IP instead of the real client.
+      - ASPNETCORE_FORWARDEDHEADERS_ENABLED=true
       # --- Auth: a JWT signing key is REQUIRED for portal auth in production ---
       # The :? syntax makes compose ABORT with an error if the value is missing from .env,
       # instead of silently substituting an empty string and booting without auth configured.
@@ -118,7 +122,8 @@ services:
     image: caddy:2-alpine
     container_name: sharpmush-caddy
     environment:
-      - SHARPMUSH_DOMAIN=${SHARPMUSH_DOMAIN}
+      # Required: Caddy can't render a valid site block without it. Fail fast if unset.
+      - SHARPMUSH_DOMAIN=${SHARPMUSH_DOMAIN:?set SHARPMUSH_DOMAIN in deploy/.env}
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
## Summary

Adds a `deploy/` folder with a single-host Docker Compose stack that implements the recommended low-cost, low-license-risk deployment pattern for SharpMUSH at hobby scale (a handful to a few dozen concurrent players).

The stack drops the separate database server entirely in favour of **SurrealDB embedded** (a file-backed RocksDB directory), keeps **NATS** self-hosted, and adds automated encrypted backups.

## What's included

| File | Purpose |
|------|---------|
| `deploy/docker-compose.prod.yml` | The stack: `nats` (JetStream), `connectionserver` (telnet :4201), `sharpmush-server` (SurrealDB embedded → RocksDB), `backup` (restic sidecar), optional `caddy` (auto-HTTPS) |
| `deploy/Caddyfile` | Automatic Let's Encrypt TLS for the portal + SignalR/WebSocket |
| `deploy/.env.example` | Secrets/config template (JWT key, admin login, domain, restic/bucket creds) |
| `deploy/.gitignore` | Keeps the real `.env` out of git |
| `deploy/README.md` | Setup, ports, update, and backup/restore instructions |

## Design rationale

- **One database, embedded.** Uses the `surrealdb` provider with `rocksdb://data/surreal`, so there's no separate DB container to run or license — the whole object store is a directory on disk.
- **All state in one volume.** The SurrealDB RocksDB store and filesystem wiki assets both live in the `app-data` volume, giving the backup a single target. JetStream state is a separate volume and intentionally not backed up (transient I/O, not the source of truth).
- **NATS internal + self-hosted.** Not published to the host; avoids external managed-NATS free-tier caps.
- **restic backup sidecar.** Nightly encrypted, deduplicated snapshots to an object-storage bucket (Backblaze B2 by default; S3/R2 by swapping creds), with 7-daily/4-weekly retention. The data volume is mounted read-only so a backup can never corrupt live data.
- **TLS via optional Caddy.** Delete the `caddy` service if TLS is terminated elsewhere (e.g. Cloudflare) or only telnet is used.

This does not modify the existing root `docker-compose.yml` (the Arango-based dev stack); it lives alongside it under `deploy/`.

## Testing

- `docker compose -f deploy/docker-compose.prod.yml config` validates cleanly.

## Notes / follow-ups

- The SurrealDB endpoint uses a workdir-relative `rocksdb://data/surreal` path that maps onto the mounted `app-data` volume. This matches the code's default path handling but has not been exercised with a full container boot in CI — worth confirming the `surreal` directory materializes in the volume on first start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015GVVduhLNd97AoXxuBhZhp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added production single-host Docker Compose stacks for the web portal, messaging, game server, and encrypted backups, with optional HTTPS and Cloudflare Tunnel-based ingress.
  * Added reverse proxy configuration with automated HTTPS, response compression, and dedicated WebSocket routing for `/ws`.
  * Added a complete deployment environment template with required domain, JWT authentication, bootstrap credentials, and backup settings.

* **Documentation**
  * Added a full deployment guide covering first-time setup, updates, terminal WebSocket endpoint configuration, backup/restore workflows, and exposed port guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->