### PR TITLE
Bundle Blazor portal into server image; fix prod cert crash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,13 @@
 FROM mcr.microsoft.com/dotnet/nightly/sdk:10.0 AS build
 WORKDIR /src
 COPY . .
-RUN dotnet restore && dotnet publish SharpMUSH.Server/SharpMUSH.Server.csproj -c Release -o /app
+# Restore once for the whole solution, then publish with --no-restore so neither publish re-restores.
+RUN dotnet restore
+RUN dotnet publish SharpMUSH.Server/SharpMUSH.Server.csproj -c Release -o /app --no-restore
 # Publish the Blazor WASM portal and bundle its static assets into the server's web root, so a
 # single image serves the API + SignalR + the portal at one origin (see UseBlazorFrameworkFiles in
 # Program.cs). Without this the server has no wwwroot/index.html and "/" returns 404.
-RUN dotnet publish SharpMUSH.Client/SharpMUSH.Client.csproj -c Release -o /client
+RUN dotnet publish SharpMUSH.Client/SharpMUSH.Client.csproj -c Release -o /client --no-restore
 RUN mkdir -p /app/wwwroot && cp -a /client/wwwroot/. /app/wwwroot/
 # Copy the dev certificate if it exists (optional for build, can be mounted at runtime)
 RUN if [ -f SharpMUSH.Server/sharpmush-dev.pfx ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ FROM mcr.microsoft.com/dotnet/nightly/sdk:10.0 AS build
 WORKDIR /src
 COPY . .
 RUN dotnet restore && dotnet publish SharpMUSH.Server/SharpMUSH.Server.csproj -c Release -o /app
+# Publish the Blazor WASM portal and bundle its static assets into the server's web root, so a
+# single image serves the API + SignalR + the portal at one origin (see UseBlazorFrameworkFiles in
+# Program.cs). Without this the server has no wwwroot/index.html and "/" returns 404.
+RUN dotnet publish SharpMUSH.Client/SharpMUSH.Client.csproj -c Release -o /client
+RUN mkdir -p /app/wwwroot && cp -a /client/wwwroot/. /app/wwwroot/
 # Copy the dev certificate if it exists (optional for build, can be mounted at runtime)
 RUN if [ -f SharpMUSH.Server/sharpmush-dev.pfx ]; then \
       cp SharpMUSH.Server/sharpmush-dev.pfx /app/sharpmush-dev.pfx; \

--- a/SharpMUSH.Server/Program.cs
+++ b/SharpMUSH.Server/Program.cs
@@ -119,6 +119,10 @@ public class Program
 		// ── URL canonicalisation: must run before static files so redirects fire first
 		app.UseMiddleware<CanonicalUrlMiddleware>();
 
+		// Serve the bundled Blazor WASM portal's framework files (_framework/*, blazor.boot.json,
+		// compressed variants) with the correct content types, then its static assets. Paired with
+		// MapFallbackToFile("index.html") below so the SPA is served from this server.
+		app.UseBlazorFrameworkFiles();
 		app.UseStaticFiles();
 
 		app.UseMiddleware<BotDetectionMiddleware>();

--- a/deploy/docker-compose.cloudflare.yml
+++ b/deploy/docker-compose.cloudflare.yml
@@ -73,6 +73,11 @@ services:
       - NATS_URL=nats://nats:4222
       # HTTP only — Cloudflare terminates TLS at the edge and the tunnel reaches this over the private network.
       - ASPNETCORE_URLS=http://+:8080
+      # Neutralize the dev-cert path baked into the image's ENV. Kestrel eagerly loads the "Default"
+      # certificate whenever that config exists, and the dev .pfx isn't in a prod image, so it would
+      # crash on boot even though we only serve HTTP. Empty path = no cert loaded.
+      - ASPNETCORE_Kestrel__Certificates__Default__Path=
+      - ASPNETCORE_Kestrel__Certificates__Default__Password=
       # Trust the tunnel's forwarded client IP/proto so rate-limiting, bot detection and canonical-URL
       # middleware see the real visitor, not the cloudflared container. (ASP.NET ForwardedHeaders.)
       - ASPNETCORE_FORWARDEDHEADERS_ENABLED=true

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -63,7 +63,10 @@ services:
       - Wiki__AssetRoot=/app/data/wiki-assets
       # --- Messaging ---
       - NATS_URL=nats://nats:4222
-      # --- Web: serve HTTP only; Caddy terminates TLS in front (or expose 8080 directly if you don't use Caddy) ---
+      # --- Web: serve HTTP only. A TLS-terminating proxy (Caddy, below) is REQUIRED: the app always
+      #     calls UseHttpsRedirection(), so exposing 8080 directly WITHOUT a proxy that sets
+      #     X-Forwarded-Proto=https would bounce clients to an unbound HTTPS URL. Caddy sets that header
+      #     and ASPNETCORE_FORWARDEDHEADERS_ENABLED (below) makes the app trust it. ---
       - ASPNETCORE_URLS=http://+:8080
       # Neutralize the dev-cert path baked into the image's ENV. We serve HTTP only (TLS is at the
       # proxy), but Kestrel eagerly loads the "Default" certificate whenever that config exists, and

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -65,6 +65,11 @@ services:
       - NATS_URL=nats://nats:4222
       # --- Web: serve HTTP only; Caddy terminates TLS in front (or expose 8080 directly if you don't use Caddy) ---
       - ASPNETCORE_URLS=http://+:8080
+      # Neutralize the dev-cert path baked into the image's ENV. We serve HTTP only (TLS is at the
+      # proxy), but Kestrel eagerly loads the "Default" certificate whenever that config exists, and
+      # the dev .pfx isn't in a prod image — so it would crash on boot. Empty path = no cert loaded.
+      - ASPNETCORE_Kestrel__Certificates__Default__Path=
+      - ASPNETCORE_Kestrel__Certificates__Default__Password=
       # Trust Caddy's X-Forwarded-Proto/-For. Without this the app (which always calls
       # UseHttpsRedirection) sees the plain-HTTP backend hop and redirect-loops, and
       # rate-limiting / canonical-URL logic sees the proxy IP instead of the real client.


### PR DESCRIPTION
## Summary

Follow-up to #675. When deploying the stack, the server image served the API/SignalR/telnet backend fine (`/health` = 200) but returned **404 for `/`** — it wasn't serving the Blazor portal at all — and before that it crash-looped on a missing dev certificate. This fixes both so a fresh clone comes up with a reachable portal.

## Problems fixed

### 1. Portal frontend was never in the image
The `SharpMUSH.Server` build doesn't reference `SharpMUSH.Client` (only the test projects do), and `Program.cs` never called `UseBlazorFrameworkFiles()`. So `dotnet publish SharpMUSH.Server` produced an image with no `wwwroot/index.html`, and `MapFallbackToFile("index.html")` 404'd.

- **Dockerfile:** also `dotnet publish SharpMUSH.Client` and copy its published `wwwroot` into `/app/wwwroot`.
- **Program.cs:** add `app.UseBlazorFrameworkFiles()` before `UseStaticFiles()` so `_framework/*` + `blazor.boot.json` are served with correct content types, paired with the existing `MapFallbackToFile("index.html")`.

Result: a single image serves the API, SignalR, and the portal at one origin.

### 2. Server crash-looped on a missing dev cert
The runtime image bakes `ASPNETCORE_Kestrel__Certificates__Default__Path=/app/sharpmush-dev.pfx`. Kestrel eagerly loads that "Default" certificate whenever the config exists — but the dev `.pfx` isn't present in a production image, so the host threw `FileNotFoundException` on boot and restart-looped (which surfaced as a Cloudflare/Caddy 502). We serve HTTP only (TLS is terminated at Caddy/Cloudflare), so no cert is needed.

- **Both compose files:** blank `ASPNETCORE_Kestrel__Certificates__Default__Path` / `__Password`, so Kestrel treats the default cert as absent and binds the HTTP endpoint cleanly.

## Testing

- `docker compose -f deploy/docker-compose.prod.yml config` and `deploy/docker-compose.cloudflare.yml config` validate.
- The client publishes without AOT/native tooling (`PublishTrimmed=false`, no `RunAOTCompilation`), so it builds in the SDK stage.

## Known follow-ups (NOT changed here — design decisions)

Bundling makes the portal **load**, but two items in the client's production config affect whether it's fully functional, and they're maintainer calls:

- `SharpMUSH.Client/Program.cs` hardcodes the `api` HttpClient to `https://<host>:8081`, which is unreachable behind a same-origin reverse proxy / Cloudflare. It likely wants to be same-origin in production.
- Production auth uses OIDC (`Local` section, placeholder Azure AD ClientId), so the JWT/account bootstrap-admin flow the deploy stack configures won't log in through the portal as-is.

Happy to address either in a separate PR once you decide the intended approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015GVVduhLNd97AoXxuBhZhp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The portal frontend is now packaged and served directly from the server container.
  * Blazor WebAssembly framework and static assets load correctly alongside the API.

* **Bug Fixes**
  * Improved container startup in production and Cloudflare deployments by preventing unnecessary certificate loading.
  * Services now run reliably over HTTP when TLS is terminated by an external proxy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->