### PR TITLE
Enable IL trimming for the Blazor WASM client

### DIFF
--- a/SharpMUSH.Client/SharpMUSH.Client.csproj
+++ b/SharpMUSH.Client/SharpMUSH.Client.csproj
@@ -7,10 +7,14 @@
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<!-- NU1510: transitive dependency pinning; NU1702: BlazorMonaco targets net9 but is WASM/JS, fully compatible -->
 		<NoWarn>NU1510;NU1702</NoWarn>
-		<!-- Disable trimming due to FSharp.Core incompatibility -->
-		<PublishTrimmed>false</PublishTrimmed>
+		<!-- Trimming is enabled; FSharp.Core (transitive via TelnetNegotiationCore) is rooted below so the trimmer doesn't fail on it. -->
+		<PublishTrimmed>true</PublishTrimmed>
 		<BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
 	</PropertyGroup>
+
+	<ItemGroup>
+		<TrimmerRootAssembly Include="FSharp.Core" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="AutoBogus" Version="2.13.1" />


### PR DESCRIPTION
## Problem

`SharpMUSH.Client` (the Blazor WASM portal) set `<PublishTrimmed>false</PublishTrimmed>`, so `dotnet publish` bundled the **entire untrimmed dependency closure (~278 assemblies)** into the browser download. That closure included things that have no business shipping to a browser:

- **Server-side DB clients**: `Microsoft.Data.SqlClient`, `MySqlConnector`, `Npgsql`, `Neo4j.Driver`, `Core.Arango`, `SurrealDb.Net`
- **Messaging / infra**: `NATS.Net`, `Quartz`, `Serilog`
- **Windows/desktop assemblies**: `WindowsBase`, `System.Windows.*`, `System.Security.Principal.Windows`, `System.IO.FileSystem.Watcher`

This bloats the WASM download, and some of those assemblies fail to load at the edge.

Trimming had been disabled with the comment *"Disable trimming due to FSharp.Core incompatibility."* `FSharp.Core` arrives transitively (via `TelnetNegotiationCore`) and the trimmer chokes on it. The standard workaround is to keep trimming **on** and simply **root** `FSharp.Core` so the trimmer leaves it intact instead of failing.

## Fix

In `SharpMUSH.Client/SharpMUSH.Client.csproj`:

- `<PublishTrimmed>false</PublishTrimmed>` → `<PublishTrimmed>true</PublishTrimmed>`
- Updated the comment to note that trimming is enabled and `FSharp.Core` is rooted so the trimmer doesn't fail on it.
- Added:
  ```xml
  <ItemGroup>
    <TrimmerRootAssembly Include="FSharp.Core" />
  </ItemGroup>
  ```

This is intentionally **scoped to the client project only** — no project decoupling, no changes to the server-side reference graph.

## Validation

⚠️ The build/publish could **not** be validated in the CI/agent environment: no .NET SDK is installed there and the sandbox proxy blocks the SDK-install host (403) as well as the WASM `wasm-tools` workload / NuGet restore needed to trim a Blazor WASM app. **This change should be published locally / in CI to confirm.**

Expected result once published with trimming:
- The `_framework` assembly count drops sharply from the untrimmed ~278.
- The server-side DB clients and Windows/desktop assemblies listed above drop out of `wwwroot/_framework/` entirely.

## Relationship to other work

Complements **#676** (which bundles the client into the server image) — trimming the client keeps that bundled payload small instead of shipping the full untrimmed closure.

## ⚠️ Needs runtime testing

IL trimming a Blazor app can remove types that are only reached via **reflection or DI** (component activation, JSON serialization, MudBlazor/DI-resolved services, SignalR hub proxies, etc.), which trimming analysis can't always see. After merging, the trimmed build should be **smoke-tested end-to-end** — load the portal, exercise auth, the SignalR terminal, widgets, and the wiki/scene flows — and any types that get trimmed away should be added as additional `<TrimmerRootAssembly>` / `[DynamicDependency]` roots as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015GVVduhLNd97AoXxuBhZhp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Enabled application trimming for optimized production builds.
  * Preserved required runtime functionality while reducing unnecessary application code.
  * Retained existing globalization data support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->