### PR TITLE
deploy: pull CI-published images and auto-update via watchtower

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -208,11 +208,21 @@ on boot.
 
 ## Updating
 
-With `COMPOSE_FILE` exported as above (or add `-f <your-compose-file>`):
+**The Cloudflare stack updates itself.** Every merge to `main` runs the full test suite and then
+publishes `sharpmush/sharpmush-server:dev` and `sharpmush/sharpmush-connectionserver:dev` to
+Docker Hub (`.github/workflows/docker-dev.yml`); the `watchtower` service polls Docker Hub every
+5 minutes and recreates the two labeled services when the tag moves, pruning superseded images.
+Nothing on the box ever builds, and no inbound access is required. There is no separate client
+image — the Blazor WASM portal is baked into the server image at build time.
+
+To update the *other* services (nats, cloudflared, backup — deliberately outside watchtower's
+label scope) or to force an immediate app update instead of waiting for the poll:
 
 ```bash
 git pull
-docker compose up -d --build
+docker compose pull
+docker compose up -d
 ```
 
-The `app-data` volume persists across rebuilds, so the world is untouched.
+The `app-data` volume persists across updates, so the world is untouched. Database migrations
+are recorded in the database and re-applied only when new, so unattended restarts are safe.

--- a/deploy/docker-compose.cloudflare.yml
+++ b/deploy/docker-compose.cloudflare.yml
@@ -42,11 +42,12 @@ services:
     restart: unless-stopped
 
   connectionserver:
-    build:
-      context: ../
-      dockerfile: SharpMUSH.ConnectionServer/Dockerfile
-    image: sharpmush/sharpmush-connectionserver:latest
+    # CI-published image (docker-dev.yml pushes :dev on every main merge, gated on the full test
+    # suite). The box never builds — watchtower below pulls and recreates when the tag moves.
+    image: sharpmush/sharpmush-connectionserver:dev
     container_name: sharpmush-connectionserver
+    labels:
+      - com.centurylinklabs.watchtower.enable=true
     environment:
       - NATS_URL=nats://nats:4222
     depends_on:
@@ -61,11 +62,11 @@ services:
     restart: unless-stopped
 
   sharpmush-server:
-    build:
-      context: ../
-      dockerfile: Dockerfile
-    image: sharpmush/sharpmush-server:latest
+    # CI-published image; includes the Blazor WASM client (baked into /app/wwwroot at build time).
+    image: sharpmush/sharpmush-server:dev
     container_name: sharpmush-server
+    labels:
+      - com.centurylinklabs.watchtower.enable=true
     environment:
       - SHARPMUSH_DATABASE_PROVIDER=surrealdb
       - SHARPMUSH_SURREALDB_ENDPOINT=rocksdb://data/surreal
@@ -114,6 +115,25 @@ services:
       - sharpmush-net
     mem_limit: 128m
     cpus: 0.5
+    restart: unless-stopped
+
+  # Auto-deploy: polls Docker Hub and recreates the two labeled services when their :dev tag
+  # moves (pushed by docker-dev.yml after the full test suite passes on main). Label-scoped so
+  # nats/cloudflared/backup are never touched; CLEANUP prunes superseded images so unattended
+  # updates cannot fill the disk. No inbound access needed — fits the tunnel-only posture.
+  watchtower:
+    image: containrrr/watchtower:1.7.1   # pinned (not :latest) for reproducible deploys
+    container_name: sharpmush-watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - WATCHTOWER_LABEL_ENABLE=true
+      - WATCHTOWER_CLEANUP=true
+      - WATCHTOWER_POLL_INTERVAL=300
+    networks:
+      - sharpmush-net
+    mem_limit: 128m
+    cpus: 0.25
     restart: unless-stopped
 
   # Nightly encrypted backup of the game-data volume — identical to the prod stack.


### PR DESCRIPTION
Auto-updates mush.sharpmush.com from GitHub Actions without giving anything inbound access to the box.

- `docker-dev.yml` already publishes `sharpmush/sharpmush-server:dev` + `sharpmush/sharpmush-connectionserver:dev` on every main merge, gated on the full test suite — no workflow changes needed.
- `deploy/docker-compose.cloudflare.yml` drops the on-box `build:` blocks (an on-box build once filled the disk and silently left a stale image running) and pins the `:dev` Hub images. The server image already contains the Blazor WASM client, so no separate client image exists.
- New `watchtower` service (pinned 1.7.1, label-scoped): polls Docker Hub every 5 minutes, recreates only the two labeled app services, prunes superseded images (`WATCHTOWER_CLEANUP`). nats/cloudflared/backup stay pinned and untouched.
- README's Updating section documents the flow.

Safe to run unattended because migrations are database-recorded and idempotent (#679).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvpS6VWQdztvwEHYZqZ6RL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloudflare deployments now automatically detect updated development images and redeploy labeled services.
  * Superseded container images are cleaned up automatically.
  * Application data persists across updates, and database migrations are safely reapplied after restarts.

* **Documentation**
  * Updated deployment instructions to use image pulls and restart commands instead of local image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->