### PR TITLE
Shrink the client bundle 20%: drop dead AutoBogus, shard ICU

### DIFF
--- a/SharpMUSH.Client/SharpMUSH.Client.csproj
+++ b/SharpMUSH.Client/SharpMUSH.Client.csproj
@@ -11,7 +11,8 @@
 		     SharpMUSH.Library: the browser bundle no longer pulls FSharp.Core / TelnetNegotiationCore
 		     (they reached it only transitively through Library). -->
 		<PublishTrimmed>true</PublishTrimmed>
-		<BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
+		<!-- Sharded ICU (default): the portal offers en and fr (LanguagePicker), both covered by the
+		     EFIGS shard the runtime loads on demand — full ICU shipped ~120 KB of dead locale data. -->
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -31,7 +32,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AutoBogus" Version="2.13.1" />
 		<PackageReference Include="BlazorMonaco" Version="3.5.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" PrivateAssets="all" />

--- a/SharpMUSH.Client/wwwroot/index.html
+++ b/SharpMUSH.Client/wwwroot/index.html
@@ -58,7 +58,21 @@
     <!-- Mermaid (wiki diagram rendering) + the wiki post-render pass (mermaid run + anchor scroll) -->
     <script src="js/mermaid.min.js"></script>
     <script src="js/wiki-render.js"></script>
-    <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
+    <!-- Manual start so the runtime knows the culture BEFORE boot: with sharded ICU (we ship no
+         full globalization data), Blazor hard-errors if the culture changes during startup.
+         Program.cs applies the same locale afterwards, which is then a no-op rather than a
+         "change". Offered locales (en, fr — see LanguagePicker) both live in the EFIGS shard. -->
+    <script src="_framework/blazor.webassembly#[.{fingerprint}].js" autostart="false"></script>
+    <script>
+        const locale = (() => {
+            try {
+                const stored = localStorage.getItem('locale');
+                if (stored === 'en' || stored === 'fr') return stored;
+            } catch { /* storage unavailable — fall through */ }
+            return 'en';
+        })();
+        Blazor.start({ applicationCulture: locale });
+    </script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
 
 </body>


### PR DESCRIPTION
Two measured cuts to the WASM bundle; compressed transfer for an en/fr visitor goes **6.6 MB → 5.26 MB (−20%)**.

| Change | Saving (brotli) |
|---|---|
| Remove `AutoBogus` (zero usages; cascades Bogus + System.Data.Common + DataSetExtensions + System.Private.Xml, which only Bogus's DataSet fakers referenced) | −1.17 MB |
| Shard ICU instead of `BlazorWebAssemblyLoadAllGlobalizationData` (portal offers en + fr, both in the EFIGS shard) | −182 KB effective |

The ICU change needs the runtime to know the culture before boot: `Program.cs` sets culture from localStorage during startup, which hard-errors under sharded ICU ("Blazor detected a change in the application's culture…"). `index.html` now starts Blazor manually with `applicationCulture` read from the same `locale` key, so `Program.cs`'s assignment becomes a no-op rather than a change.

Verified: bUnit 112 passed; the published bundle was served and booted in Chrome in both `en` and `fr` with no culture errors (it failed to boot outright with sharded ICU before the manual-start change — caught by the browser smoke test, invisible to unit tests).

Remaining size menu, not in this PR: un-rooting MudBlazor (−~1.05 MB, trades against the compiled-plugin-components surface), wasm-tools relinking (−100–200 KB, Dockerfile workload install), replacing Slugify.Core (−88 KB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvpS6VWQdztvwEHYZqZ6RL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting English or French language settings at startup.
  * The selected language is remembered between sessions and applied when the application loads.

* **Bug Fixes**
  * Improved startup behavior when language preferences are unavailable or unsupported by defaulting to English.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->