### PR TITLE
look: rooms use @describe/@descformat; missing @idescribe falls back

### DIFF
--- a/SharpMUSH.Implementation/Commands/GeneralCommands.cs
+++ b/SharpMUSH.Implementation/Commands/GeneralCommands.cs
@@ -615,22 +615,35 @@ public partial class Commands
 
 		var baseName = viewingObject.Name;
 		var baseDesc = MModule.empty();
-		var useIdesc = viewingFromInside && !lookOutside;
 
-		var descAttrName = useIdesc ? "IDESCRIBE" : "DESCRIBE";
-		var descResult = await AttributeService!.GetAttributeAsync(executor, realViewing, descAttrName,
-			IAttributeService.AttributeMode.Read, false);
+		// @idescribe is only used for players and things; rooms and exits always use @describe
+		// (help @idescribe). And when no @idescribe is set, the viewer sees the @describe run
+		// through @descformat even when looking from inside (help @idescformat) — so which
+		// format attribute applies follows which description attribute was actually used.
+		var tryIdesc = viewingFromInside && !lookOutside
+			&& (realViewing.IsPlayer || realViewing.IsThing);
+		var usedIdesc = false;
 
-		if (descResult.IsAttribute)
+		if (tryIdesc)
 		{
-			var descAttr = descResult.AsAttribute.Last();
-			baseDesc = MModule.getLength(descAttr.Value) > 0
-				? descAttr.Value
-				: (useIdesc ? MModule.empty() : MModule.single("You see nothing special."));
+			var idescResult = await AttributeService!.GetAttributeAsync(executor, realViewing, "IDESCRIBE",
+				IAttributeService.AttributeMode.Read, false);
+			if (idescResult.IsAttribute)
+			{
+				// A blank @idescribe is meaningful (help @idescribe suggests it to trigger
+				// @aidescribe without text), so an empty value stays empty here.
+				usedIdesc = true;
+				baseDesc = idescResult.AsAttribute.Last().Value;
+			}
 		}
-		else if (!useIdesc)
+
+		if (!usedIdesc)
 		{
-			baseDesc = MModule.single("You see nothing special.");
+			var descResult = await AttributeService!.GetAttributeAsync(executor, realViewing, "DESCRIBE",
+				IAttributeService.AttributeMode.Read, false);
+			baseDesc = descResult.IsAttribute && MModule.getLength(descResult.AsAttribute.Last().Value) > 0
+				? descResult.AsAttribute.Last().Value
+				: MModule.single("You see nothing special.");
 		}
 
 		var flags = await viewingObject.Flags.Value.ToArrayAsync();
@@ -647,18 +660,18 @@ public partial class Commands
 			};
 
 			formattedName = await AttributeHelpers.EvaluateFormatAttribute(
-				AttributeService, parser, executor, realViewing, "NAMEFORMAT",
+				AttributeService!, parser, executor, realViewing, "NAMEFORMAT",
 				nameFormatArgs, defaultFormattedName, checkParents: false);
 		}
 
-		var formatAttrName = useIdesc ? "IDESCFORMAT" : "DESCFORMAT";
+		var formatAttrName = usedIdesc ? "IDESCFORMAT" : "DESCFORMAT";
 		var descFormatArgs = new Dictionary<string, CallState>
 		{
 			["0"] = new CallState(baseDesc)
 		};
 
 		var formattedDesc = await AttributeHelpers.EvaluateFormatAttribute(
-			AttributeService, parser, executor, realViewing, formatAttrName,
+			AttributeService!, parser, executor, realViewing, formatAttrName,
 			descFormatArgs, baseDesc, checkParents: false);
 
 		await NotifyService!.Notify(executor, formattedName, executor);
@@ -744,7 +757,7 @@ public partial class Commands
 				};
 
 				var formattedContents = await AttributeHelpers.EvaluateFormatAttribute(
-					AttributeService, parser, executor, realViewing, "CONFORMAT",
+					AttributeService!, parser, executor, realViewing, "CONFORMAT",
 					conFormatArgs, defaultContents, checkParents: false);
 
 				await NotifyService.Notify(executor, formattedContents, executor);
@@ -801,7 +814,7 @@ public partial class Commands
 				}
 
 				var formattedExits = await AttributeHelpers.EvaluateFormatAttribute(
-					AttributeService, parser, executor, realViewing, "EXITFORMAT",
+					AttributeService!, parser, executor, realViewing, "EXITFORMAT",
 					exitFormatArgs, defaultExits, checkParents: false);
 
 				if (formattedExits == defaultExits && isTransparent)

--- a/SharpMUSH.Tests/Commands/BuildingCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/BuildingCommandTests.cs
@@ -596,6 +596,115 @@ public class BuildingCommandTests
 	}
 
 	/// <summary>
+	/// Looking at the room you are in shows its @describe run through @descformat.
+	/// Rooms always use @describe/@descformat, never the @idescribe path (help @idescribe:
+	/// "It's only used for players and things; rooms and exits always use @describe").
+	/// </summary>
+	[Test]
+	public async ValueTask Look_Room_ShowsDescriptionThroughDescFormat()
+	{
+		var token = TestIsolationHelpers.GenerateUniqueName("ldf");
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, $"LookRoomDF{token}");
+		var parser = WebAppFactoryArg.CommandParserFor(player.DbRef, player.Handle);
+
+		var digResult = await parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig RoomDF_{token}"));
+		var roomDbRef = DBRef.Parse(digResult.Message!.ToPlainText()!.Trim());
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@tel me={roomDbRef}"));
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@desc here=roomdesc_{token}"));
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single("&DESCFORMAT here=[ucstr(%0)]"));
+
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single("look"));
+
+		await NotifyService
+			.Received()
+			.Notify(TestHelpers.MatchingObject(player.DbRef), Arg.Is<OneOf<MString, string>>(msg =>
+				TestHelpers.MessagePlainTextEquals(msg, $"ROOMDESC_{token.ToUpper()}")), TestHelpers.MatchingObject(player.DbRef), INotifyService.NotificationType.Announce);
+	}
+
+	/// <summary>
+	/// Looking at a room with no @describe shows the default description, still run
+	/// through @descformat.
+	/// </summary>
+	[Test]
+	public async ValueTask Look_Room_NoDescription_ShowsDefaultThroughDescFormat()
+	{
+		var token = TestIsolationHelpers.GenerateUniqueName("lnd");
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, $"LookRoomND{token}");
+		var parser = WebAppFactoryArg.CommandParserFor(player.DbRef, player.Handle);
+
+		var digResult = await parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig RoomND_{token}"));
+		var roomDbRef = DBRef.Parse(digResult.Message!.ToPlainText()!.Trim());
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@tel me={roomDbRef}"));
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single("&DESCFORMAT here=[ucstr(%0)]"));
+
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single("look"));
+
+		await NotifyService
+			.Received()
+			.Notify(TestHelpers.MatchingObject(player.DbRef), Arg.Is<OneOf<MString, string>>(msg =>
+				TestHelpers.MessagePlainTextEquals(msg, "YOU SEE NOTHING SPECIAL.")), TestHelpers.MatchingObject(player.DbRef), INotifyService.NotificationType.Announce);
+	}
+
+	/// <summary>
+	/// Looking while inside a thing with no @idescribe falls back to @describe and
+	/// @descformat (help @idescformat: "When no @idescribe is set, the @descformat (and
+	/// @describe) attributes are used, even when someone looks inside").
+	/// </summary>
+	[Test]
+	public async ValueTask Look_InsideThing_NoIdesc_FallsBackToDescribeAndDescFormat()
+	{
+		var token = TestIsolationHelpers.GenerateUniqueName("lit");
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, $"LookThing{token}");
+		var parser = WebAppFactoryArg.CommandParserFor(player.DbRef, player.Handle);
+
+		var objResult = await parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@create ThingIT_{token}"));
+		var objDbRef = DBRef.Parse(objResult.Message!.ToPlainText()!.Trim());
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@desc {objDbRef}=thingdesc_{token}"));
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single($"&DESCFORMAT {objDbRef}=[ucstr(%0)]"));
+		// @create puts the thing in inventory; drop it so entering it isn't a containment loop.
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single($"drop {objDbRef}"));
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@tel me={objDbRef}"));
+
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single("look"));
+
+		await NotifyService
+			.Received()
+			.Notify(TestHelpers.MatchingObject(player.DbRef), Arg.Is<OneOf<MString, string>>(msg =>
+				TestHelpers.MessagePlainTextEquals(msg, $"THINGDESC_{token.ToUpper()}")), TestHelpers.MatchingObject(player.DbRef), INotifyService.NotificationType.Announce);
+	}
+
+	/// <summary>
+	/// Looking while inside a thing WITH an @idescribe uses it, run through @idescformat.
+	/// </summary>
+	[Test]
+	public async ValueTask Look_InsideThing_WithIdesc_UsesIdescThroughIdescFormat()
+	{
+		var token = TestIsolationHelpers.GenerateUniqueName("lii");
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, $"LookIdesc{token}");
+		var parser = WebAppFactoryArg.CommandParserFor(player.DbRef, player.Handle);
+
+		var objResult = await parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@create ThingII_{token}"));
+		var objDbRef = DBRef.Parse(objResult.Message!.ToPlainText()!.Trim());
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@desc {objDbRef}=outsidedesc_{token}"));
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single($"&IDESCRIBE {objDbRef}=insidedesc_{token}"));
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single($"&IDESCFORMAT {objDbRef}=[ucstr(%0)]"));
+		// @create puts the thing in inventory; drop it so entering it isn't a containment loop.
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single($"drop {objDbRef}"));
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@tel me={objDbRef}"));
+
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single("look"));
+
+		await NotifyService
+			.Received()
+			.Notify(TestHelpers.MatchingObject(player.DbRef), Arg.Is<OneOf<MString, string>>(msg =>
+				TestHelpers.MessagePlainTextEquals(msg, $"INSIDEDESC_{token.ToUpper()}")), TestHelpers.MatchingObject(player.DbRef), INotifyService.NotificationType.Announce);
+	}
+
+	/// <summary>
 	/// Tests error case: @desc with invalid target shows error notification.
 	/// </summary>
 	[Test]


### PR DESCRIPTION
Looking at a room never ran its description (or the `You see nothing special.` default) through `@descformat`, while looking at an object worked. Root cause: the look command switched to the `@idescribe`/`@idescformat` pair for **any** container viewed from inside — and you are always inside the room you look at — reading only `IDESCRIBE` with no fallback and choosing the format attribute by viewer position.

The project's own help files define the correct semantics, violated in three ways:
1. `@idescribe` "is only used for players and things; **rooms and exits always use @describe**"
2. "If there is no IDESCRIBE set … will see its @describe" (with the usual default)
3. `@idescformat` "is only used when an @idescribe is set. When no @idescribe is set, the @descformat (and @describe) attributes are used, even when someone looks inside"

The description resolution now tries `IDESCRIBE` only for players/things viewed from inside (blank stays meaningful for `@aidescribe`), falls back to `DESCRIBE` + default, and formats through whichever pair actually supplied the text.

Four new tests pin each rule (room desc via `@descformat`, room default via `@descformat`, inside-a-thing fallback, preserved `@idescribe` path). Full suite: 4519 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvpS6VWQdztvwEHYZqZ6RL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `LOOK` description handling for rooms and objects.
  * Looking inside an object now uses its inside description and formatting when available.
  * Falls back to the standard description and formatting when no inside description is set.
  * Rooms consistently use their standard description formatting, including when no description is configured.
  * Displays a default message when nothing special is described.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->