### PR TITLE
Fix: client API base address resolves same-origin, not hardcoded :8081

### DIFF
--- a/SharpMUSH.Client/Program.cs
+++ b/SharpMUSH.Client/Program.cs
@@ -113,7 +113,7 @@ builder.Services.AddSingleton<IConnectionStateService>(sp => sp.GetRequiredServi
 // Same singleton, exposed for scene group join/leave (client-only control surface).
 builder.Services.AddSingleton<ISceneHubControl>(sp => sp.GetRequiredService<ConnectionStateService>());
 
-builder.Services.AddHttpClient("api", sp => sp.BaseAddress = apiBaseAddress);
+builder.Services.AddHttpClient("api", c => c.BaseAddress = apiBaseAddress);
 
 if (builder.HostEnvironment.IsDevelopment())
 {

--- a/SharpMUSH.Client/Program.cs
+++ b/SharpMUSH.Client/Program.cs
@@ -105,14 +105,13 @@ builder.Services.AddSingleton<IConnectionStateService>(sp => sp.GetRequiredServi
 // Same singleton, exposed for scene group join/leave (client-only control surface).
 builder.Services.AddSingleton<ISceneHubControl>(sp => sp.GetRequiredService<ConnectionStateService>());
 
+// Same origin as the app itself unless configuration says otherwise; the dev launch profile splits
+// the client (http:8080) from the API (https:8081) and opts in via appsettings.Development.json.
 builder.Services.AddHttpClient("api", sp =>
 {
-	var uri = new UriBuilder(builder.HostEnvironment.BaseAddress)
-	{
-		Scheme = "https",
-		Port = 8081
-	};
-	sp.BaseAddress = uri.Uri;
+	sp.BaseAddress = ApiBaseAddressResolver.Resolve(
+		builder.HostEnvironment.BaseAddress,
+		builder.Configuration[ApiBaseAddressResolver.ConfigurationKey]);
 });
 
 if (builder.HostEnvironment.IsDevelopment())

--- a/SharpMUSH.Client/Program.cs
+++ b/SharpMUSH.Client/Program.cs
@@ -81,10 +81,18 @@ registry.Register(new OnlineCharactersWidgetDescriptor());
 registry.Register(new QuickstartWidgetDescriptor());
 registry.Register(new SchemaWidgetDescriptor());
 
+// Where the server's API lives: same origin as the app itself unless configuration says otherwise
+// (the dev launch profile splits the client on http:8080 from the API on https:8081 and opts in via
+// appsettings.Development.json). Resolved once here and shared by every API caller below, so the
+// answer cannot drift between them.
+var apiBaseAddress = ApiBaseAddressResolver.Resolve(
+	builder.HostEnvironment.BaseAddress,
+	builder.Configuration[ApiBaseAddressResolver.ConfigurationKey]);
+
 // Bridge Widget-kind Dynamic Applications (Area 21) into the layout palette: load the registry once
 // at startup (anonymous) and register a synthetic widget per app, rendered by SchemaWidget. The
 // catalog is also injected so SchemaWidget can resolve a placement's schema/data routes by slug.
-var applicationCatalog = await ApplicationCatalog.LoadAsync(builder.HostEnvironment.BaseAddress);
+var applicationCatalog = await ApplicationCatalog.LoadAsync(apiBaseAddress);
 foreach (var widgetApp in applicationCatalog.WidgetApps)
 {
 	registry.Register(new ApplicationPortalWidget(widgetApp));
@@ -105,14 +113,7 @@ builder.Services.AddSingleton<IConnectionStateService>(sp => sp.GetRequiredServi
 // Same singleton, exposed for scene group join/leave (client-only control surface).
 builder.Services.AddSingleton<ISceneHubControl>(sp => sp.GetRequiredService<ConnectionStateService>());
 
-// Same origin as the app itself unless configuration says otherwise; the dev launch profile splits
-// the client (http:8080) from the API (https:8081) and opts in via appsettings.Development.json.
-builder.Services.AddHttpClient("api", sp =>
-{
-	sp.BaseAddress = ApiBaseAddressResolver.Resolve(
-		builder.HostEnvironment.BaseAddress,
-		builder.Configuration[ApiBaseAddressResolver.ConfigurationKey]);
-});
+builder.Services.AddHttpClient("api", sp => sp.BaseAddress = apiBaseAddress);
 
 if (builder.HostEnvironment.IsDevelopment())
 {

--- a/SharpMUSH.Client/Services/ApiBaseAddressResolver.cs
+++ b/SharpMUSH.Client/Services/ApiBaseAddressResolver.cs
@@ -1,0 +1,34 @@
+namespace SharpMUSH.Client.Services;
+
+/// <summary>
+/// Derives the "api" HttpClient's BaseAddress from the WASM host's base address.
+///
+/// Same-origin by default: the server that serves the client also serves /api, so whatever scheme,
+/// host and port the app was loaded from is already the right target — and it is the only answer
+/// that survives a reverse proxy (behind Cloudflare the site is served on 443; a rewritten port is
+/// not routable). Dev setups that split the two — the launch profile serves the client over
+/// http:8080 while the API listens on https:8081 — opt in explicitly via the "ApiBaseAddress" key
+/// in appsettings.Development.json instead of the code assuming it.
+/// </summary>
+public static class ApiBaseAddressResolver
+{
+	public const string ConfigurationKey = "ApiBaseAddress";
+
+	/// <param name="hostBaseAddress">The WASM host's base address (where the client was loaded from).</param>
+	/// <param name="configuredOverride">Optional absolute URI from configuration; blank means "same origin".</param>
+	public static Uri Resolve(string hostBaseAddress, string? configuredOverride)
+	{
+		var target = string.IsNullOrWhiteSpace(configuredOverride)
+			? hostBaseAddress
+			: configuredOverride;
+
+		// HttpClient resolves a relative request against a BaseAddress by replacing its last path
+		// segment, so a base without a trailing slash would drop "/base" from "/base/api/health".
+		if (!target.EndsWith('/'))
+		{
+			target += "/";
+		}
+
+		return new Uri(target, UriKind.Absolute);
+	}
+}

--- a/SharpMUSH.Client/Services/ApplicationCatalog.cs
+++ b/SharpMUSH.Client/Services/ApplicationCatalog.cs
@@ -29,15 +29,19 @@ public sealed class ApplicationCatalog
 	/// Loads the application registry once at startup. Uses a bare client with a short timeout so a
 	/// slow/unreachable API degrades to an empty catalog instead of hanging boot. The GET is anonymous.
 	/// </summary>
-	public static async Task<ApplicationCatalog> LoadAsync(string hostBaseAddress)
+	/// <param name="apiBaseAddress">
+	/// The server's API root, already resolved by <see cref="ApiBaseAddressResolver"/> — this takes the
+	/// answer rather than deriving its own, so it cannot disagree with the "api" HttpClient about where
+	/// the API lives.
+	/// </param>
+	public static async Task<ApplicationCatalog> LoadAsync(Uri apiBaseAddress)
 	{
 		try
 		{
-			var uri = new UriBuilder(hostBaseAddress) { Scheme = "https", Port = 8081 }.Uri;
-			using var http = new HttpClient { BaseAddress = uri, Timeout = TimeSpan.FromSeconds(5) };
+			using var http = new HttpClient { BaseAddress = apiBaseAddress, Timeout = TimeSpan.FromSeconds(5) };
 			var apps = await http.GetFromJsonAsync<List<PortalApplication>>("api/applications");
 			var catalog = new ApplicationCatalog(apps ?? []);
-			Console.WriteLine($"[ApplicationCatalog] Loaded {catalog._bySlug.Count} application(s), {catalog.WidgetApps.Count} widget(s) from {uri}api/applications.");
+			Console.WriteLine($"[ApplicationCatalog] Loaded {catalog._bySlug.Count} application(s), {catalog.WidgetApps.Count} widget(s) from {apiBaseAddress}api/applications.");
 			return catalog;
 		}
 		catch (Exception ex)

--- a/SharpMUSH.Client/wwwroot/appsettings.Development.json
+++ b/SharpMUSH.Client/wwwroot/appsettings.Development.json
@@ -2,5 +2,6 @@
   "Local": {
     "Authority": "https://login.microsoftonline.com/",
     "ClientId": "33333333-3333-3333-33333333333333333"
-  }
+  },
+  "ApiBaseAddress": "https://localhost:8081/"
 }

--- a/SharpMUSH.Tests.BUnit/Services/ApiBaseAddressResolverTests.cs
+++ b/SharpMUSH.Tests.BUnit/Services/ApiBaseAddressResolverTests.cs
@@ -1,0 +1,69 @@
+using SharpMUSH.Client.Services;
+
+namespace SharpMUSH.Tests.BUnit.Services;
+
+/// <summary>
+/// Coverage for how the "api" HttpClient's BaseAddress is derived from the WASM host's base
+/// address (see <see cref="ApiBaseAddressResolver"/>).
+///
+/// Regression coverage for the "Game is starting up" hang: the client used to rewrite the host
+/// address to a hardcoded https://…:8081. That is only correct for the dev launch profile
+/// (SharpMUSH.Server/Properties/launchSettings.json binds https://localhost:8081), and it breaks
+/// every reverse-proxied deployment — behind Cloudflare the site is served on 443 and :8081 is
+/// not routable at all, so ServerStartupGate's /api/health probe could never succeed and the app
+/// sat behind the startup screen forever.
+///
+/// The rule: same-origin by default (correct behind any proxy), with an explicit opt-in override
+/// for dev, supplied via appsettings.Development.json rather than baked into the code.
+/// </summary>
+public class ApiBaseAddressResolverTests
+{
+	[TUnit.Core.Test]
+	public async Task NoOverride_UsesHostBaseAddressUnchanged()
+	{
+		// The deployed case: served from https://mush.sharpmush.com/, the API is the same origin.
+		var resolved = ApiBaseAddressResolver.Resolve("https://mush.sharpmush.com/", configuredOverride: null);
+
+		await Assert.That(resolved.ToString()).IsEqualTo("https://mush.sharpmush.com/");
+	}
+
+	[TUnit.Core.Test]
+	public async Task NoOverride_DoesNotRewriteSchemeOrPort()
+	{
+		// A non-default port that the host is genuinely served on must survive untouched — the
+		// resolver's job is not to invent an endpoint.
+		var resolved = ApiBaseAddressResolver.Resolve("http://localhost:5000/", configuredOverride: null);
+
+		await Assert.That(resolved.ToString()).IsEqualTo("http://localhost:5000/");
+	}
+
+	[TUnit.Core.Test]
+	public async Task Override_TakesPrecedenceOverHostBaseAddress()
+	{
+		// The dev case, expressed as config instead of a hardcode: client served over http:8080,
+		// API reached over https:8081.
+		var resolved = ApiBaseAddressResolver.Resolve("http://localhost:8080/", configuredOverride: "https://localhost:8081/");
+
+		await Assert.That(resolved.ToString()).IsEqualTo("https://localhost:8081/");
+	}
+
+	[TUnit.Core.Test]
+	public async Task BlankOverride_IsIgnored()
+	{
+		// An empty/whitespace key in appsettings must not produce a broken relative Uri.
+		var resolved = ApiBaseAddressResolver.Resolve("https://mush.sharpmush.com/", configuredOverride: "   ");
+
+		await Assert.That(resolved.ToString()).IsEqualTo("https://mush.sharpmush.com/");
+	}
+
+	[TUnit.Core.Test]
+	public async Task Override_WithoutTrailingSlash_StillResolvesRelativePathsUnderIt()
+	{
+		// HttpClient drops the last path segment of a BaseAddress that lacks a trailing slash, so
+		// "api/health" against ".../base" would silently become ".../api/health" at the root.
+		var resolved = ApiBaseAddressResolver.Resolve("https://example.test/", configuredOverride: "https://api.example.test/base");
+
+		var probe = new Uri(resolved, "api/health");
+		await Assert.That(probe.ToString()).IsEqualTo("https://api.example.test/base/api/health");
+	}
+}


### PR DESCRIPTION
## The bug

`mush.sharpmush.com` is stuck on **"Game is starting up…"**. The game itself is healthy — the server logs `MainProcessReadyMessage` and the ConnectionServer confirms `[LIFECYCLE] MainProcess is ready`. Nothing is crashed.

The client's health probe is what's broken. `SharpMUSH.Client/Program.cs` built the `"api"` HttpClient by rewriting the WASM host's base address to a hardcoded port:

```csharp
var uri = new UriBuilder(builder.HostEnvironment.BaseAddress) { Scheme = "https", Port = 8081 };
```

So the browser probes `https://mush.sharpmush.com:8081/api/health`. The tunnel serves 443 only, and Cloudflare cannot proxy 8081 over HTTPS at all. Confirmed against the live deployment:

| Request | Result |
|---|---|
| `https://mush.sharpmush.com:8081/api/health` (what the client asked for) | `000` — timeout |
| `https://mush.sharpmush.com/api/health` (same origin) | `200` |

`ServerStartupGate` polls that endpoint every 2.5s and renders the startup screen until it gets a 2xx, so the gate never lifted.

## Why it surfaced now

The `:8081` hardcode is old — it dates to "feat: Enable HTTPS for secure API communication" and is correct for the dev launch profile, where `launchSettings.json` really does bind `https://localhost:8081`. It stayed latent because only login/admin calls used that client.

#691 added `ServerStartupGate`, which gates the **entire app** behind a probe on that client — turning a latent misconfiguration into a total outage. The same misconfiguration also breaks every `AccountAuthService` call, so login was dead too.

## The fix

Default to the host's own base address — same-origin is what the deployment actually serves, and it is the only answer that survives a reverse proxy. The dev split (client on http:8080, API on https:8081) moves to an explicit `ApiBaseAddress` key in `appsettings.Development.json`, which the WASM host already loads. Dev behaviour is unchanged; the assumption is just no longer baked into the code.

The resolution logic is extracted to `ApiBaseAddressResolver` so it is testable at all — `Program.cs` isn't.

## Tests

Written test-first, and watched fail before implementing (`ApiBaseAddressResolver` did not exist). 5 new tests in `SharpMUSH.Tests.BUnit/Services/ApiBaseAddressResolverTests.cs` cover same-origin defaulting, no scheme/port rewriting, the config override, blank-override handling, and trailing-slash semantics (an override without a trailing slash would otherwise silently drop its path segment).

Full BUnit suite: **172/172 pass**. Client builds clean.

Worth noting the existing `ServerStartupGateTests` could not have caught this — they register the `"api"` client themselves with a fake handler, so the real base address never participates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * API connections now automatically use the current application host when no separate address is configured.
  * Development environments can specify a custom API address through configuration, supporting split client and API origins.
  * API URL handling now preserves the configured scheme and port and reliably resolves relative paths.
* **Tests**
  * Added coverage for default, custom, blank, and path-based API address configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->