### PR TITLE
deploy: make backups opt-in, and reconcile the stack from compose on boot

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -17,7 +17,12 @@ CLOUDFLARE_TUNNEL_TOKEN=
 # https://<your-domain>/setup after a fresh install claims the admin account.
 # Deploy, then complete setup immediately.
 
-# --- Backups (restic) ---
+# --- Backups (restic) --- OPT-IN, OFF BY DEFAULT ---
+# The backup service only runs when the "backup" profile is enabled. Uncomment the line below
+# once the restic settings under it hold real values; leave it commented and the backup container
+# is never created (rather than crash-looping against an unconfigured repository).
+# COMPOSE_PROFILES=backup
+
 # Repository location. Examples:
 #   Backblaze B2:      b2:your-bucket-name:sharpmush
 #   Cloudflare R2/S3:  s3:https://<accountid>.r2.cloudflarestorage.com/your-bucket

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -16,6 +16,7 @@ Two entry points, pick one based on how you terminate TLS:
 | `docker-compose.prod.yml` | The stack: nats, connectionserver, sharpmush-server, backup, and **Caddy** for TLS. Use this if the box faces the internet directly. |
 | `docker-compose.cloudflare.yml` | Same stack but fronted by a **Cloudflare Tunnel** instead of Caddy (no open web ports, hidden origin IP). See the Cloudflare section below. |
 | `Caddyfile` | Automatic-HTTPS reverse proxy config used by `docker-compose.prod.yml` |
+| `sharpmush.service` | Optional systemd unit — brings the stack up from the compose file on boot |
 | `.env.example` | Template for secrets/config — copy to `.env` and fill in |
 | `.gitignore` | Keeps your real `.env` out of git |
 | `README.md` | This file |
@@ -25,10 +26,12 @@ Two entry points, pick one based on how you terminate TLS:
 ```bash
 cd deploy
 cp .env.example .env
-# Edit .env: set your domain and restic/B2 credentials.
-#   openssl rand -base64 32   # for RESTIC_PASSWORD  (SAVE THIS — losing it makes backups unrecoverable)
+# Edit .env: set your domain.
 
-# Initialise the restic repository once (creates the encrypted repo in your bucket):
+# OPTIONAL — backups. Skip this whole block and the stack runs fine without them.
+# Set the restic/B2 credentials in .env, uncomment COMPOSE_PROFILES=backup, then
+# initialise the repository once (creates the encrypted repo in your bucket):
+#   openssl rand -base64 32   # for RESTIC_PASSWORD  (SAVE THIS — losing it makes backups unrecoverable)
 docker compose -f docker-compose.prod.yml run --rm backup restic init
 
 # Build and start everything:
@@ -154,8 +157,8 @@ that resolves straight to your server:
 
 ```bash
 cd deploy
-cp .env.example .env      # fill in CLOUDFLARE_TUNNEL_TOKEN plus the usual domain/restic values
-docker compose -f docker-compose.cloudflare.yml run --rm backup restic init   # once
+cp .env.example .env      # fill in CLOUDFLARE_TUNNEL_TOKEN and your domain
+docker compose -f docker-compose.cloudflare.yml run --rm backup restic init   # optional, once — backups only
 docker compose -f docker-compose.cloudflare.yml up -d --build
 ```
 
@@ -171,12 +174,49 @@ Check the tunnel is healthy with `docker compose -f docker-compose.cloudflare.ym
 | 8080 | ASP.NET server (HTTP) | no — internal, reached via the tunnel |
 | 4222 / 8222 | NATS client / monitoring | no — internal only |
 
+## Starting on boot
+
+`restart: unless-stopped` already brings the containers back after a reboot, and for most
+boxes that is enough. But it replays the **last state**, not the **declared** one: it
+restarts whatever happened to be running when the box went down. A `docker compose down`,
+a hand-stopped container, or an edited compose file therefore survives the reboot, and the
+box silently drifts from what `deploy/` says it should be.
+
+`sharpmush.service` closes that gap by running `docker compose up -d` on boot, so the box
+reconciles against the compose file every time it starts:
+
+```bash
+# as root, on the host
+ln -s /opt/SharpMUSH/deploy/sharpmush.service /etc/systemd/system/sharpmush.service
+systemctl daemon-reload
+systemctl enable --now sharpmush.service
+```
+
+It pulls before starting (so a boot also picks up an image the box missed while it was
+down) and tolerates a registry outage rather than keeping the game offline. Edit the
+`WorkingDirectory` and the compose filename in the unit if your checkout is not at
+`/opt/SharpMUSH` or you deploy the Caddy stack.
+
+Note this does not replace watchtower, which handles updates while the box is *up*.
+
 ## Backups (restic)
 
-The `backup` service snapshots the `app-data` volume (the SurrealDB RocksDB store +
-wiki assets — i.e. the entire game) to your bucket every night at 03:30, keeping 7
+**Backups are opt-in and off by default.** The `backup` service lives behind a compose
+profile, so it is not created at all until you turn it on — an unconfigured box gets no
+backup container rather than one crash-looping against a repository that does not exist.
+To enable it, fill in the restic settings in `.env` and uncomment:
+
+```bash
+COMPOSE_PROFILES=backup
+```
+
+Once enabled, the `backup` service snapshots the `app-data` volume (the SurrealDB RocksDB
+store + wiki assets — i.e. the entire game) to your bucket every night at 03:30, keeping 7
 daily and 4 weekly snapshots. The volume is mounted **read-only**, so a backup run can
 never corrupt live data.
+
+The `docker compose run --rm backup …` commands below work whether or not the profile is
+enabled — `run` activates a service's profile automatically.
 
 > The commands below (and under **Updating**) omit `-f` by exporting `COMPOSE_FILE`, so
 > they work for either stack. Set it once per shell to whichever stack you deployed:

--- a/deploy/docker-compose.cloudflare.yml
+++ b/deploy/docker-compose.cloudflare.yml
@@ -144,20 +144,33 @@ services:
     restart: unless-stopped
 
   # Nightly encrypted backup of the game-data volume — identical to the prod stack.
+  #
+  # OPT-IN. Backups are off unless you enable the "backup" profile, which you do by setting
+  # COMPOSE_PROFILES=backup in deploy/.env (see .env.example) — so the stack has no half-configured
+  # backup state: either .env carries real restic credentials and the profile is on, or the service
+  # does not exist at all. Without this, an unconfigured box ran restic against a placeholder repo
+  # and crash-looped on `b2_authorize_account: 401` forever.
+  #
+  # Note the vars below are NOT `:?`-guarded like the rest of this file. Compose interpolates every
+  # service in the file *before* it filters by profile, so a `:?` here would abort the whole stack
+  # even with the profile off — the exact failure the profile exists to prevent. `:-` keeps
+  # interpolation quiet; restic itself reports a missing repository if you enable the profile
+  # without configuring it.
   backup:
     image: mazzolino/restic:1.8      # pinned (not :latest) so backups are reproducible
     container_name: sharpmush-backup
     hostname: sharpmush
+    profiles: [backup]
     environment:
       - RUN_ON_STARTUP=false
       - BACKUP_CRON=0 30 3 * * *
-      - RESTIC_REPOSITORY=${RESTIC_REPOSITORY:?set RESTIC_REPOSITORY in deploy/.env}
-      - RESTIC_PASSWORD=${RESTIC_PASSWORD:?set RESTIC_PASSWORD in deploy/.env}
+      - RESTIC_REPOSITORY=${RESTIC_REPOSITORY:-}
+      - RESTIC_PASSWORD=${RESTIC_PASSWORD:-}
       - RESTIC_BACKUP_SOURCES=/data
       - RESTIC_BACKUP_ARGS=--tag sharpmush --host sharpmush
       - RESTIC_FORGET_ARGS=--keep-daily 7 --keep-weekly 4 --prune
-      - B2_ACCOUNT_ID=${B2_ACCOUNT_ID}
-      - B2_ACCOUNT_KEY=${B2_ACCOUNT_KEY}
+      - B2_ACCOUNT_ID=${B2_ACCOUNT_ID:-}
+      - B2_ACCOUNT_KEY=${B2_ACCOUNT_KEY:-}
     volumes:
       - app-data:/data:ro
     networks:

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -96,24 +96,27 @@ services:
     restart: unless-stopped
 
   # --- Nightly encrypted backup of the single game-data volume to your bucket ---
+  # OPT-IN — see the backup service in docker-compose.cloudflare.yml for why the profile exists and
+  # why these vars are `:-` rather than `:?`. Enable with COMPOSE_PROFILES=backup in deploy/.env.
   backup:
     image: mazzolino/restic:1.8      # pinned (not :latest) so backups are reproducible
     container_name: sharpmush-backup
     hostname: sharpmush
+    profiles: [backup]
     environment:
       - RUN_ON_STARTUP=false
       # 6-field cron (sec min hour dom mon dow): every day at 03:30.
       - BACKUP_CRON=0 30 3 * * *
-      - RESTIC_REPOSITORY=${RESTIC_REPOSITORY:?set RESTIC_REPOSITORY in deploy/.env}
-      - RESTIC_PASSWORD=${RESTIC_PASSWORD:?set RESTIC_PASSWORD in deploy/.env}
+      - RESTIC_REPOSITORY=${RESTIC_REPOSITORY:-}
+      - RESTIC_PASSWORD=${RESTIC_PASSWORD:-}
       - RESTIC_BACKUP_SOURCES=/data
       - RESTIC_BACKUP_ARGS=--tag sharpmush --host sharpmush
       # Retention: keep a week of dailies + a month of weeklies, prune the rest.
       - RESTIC_FORGET_ARGS=--keep-daily 7 --keep-weekly 4 --prune
       # Credentials for the storage backend. These are for Backblaze B2; swap for
       # AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY if you use S3 or Cloudflare R2.
-      - B2_ACCOUNT_ID=${B2_ACCOUNT_ID}
-      - B2_ACCOUNT_KEY=${B2_ACCOUNT_KEY}
+      - B2_ACCOUNT_ID=${B2_ACCOUNT_ID:-}
+      - B2_ACCOUNT_KEY=${B2_ACCOUNT_KEY:-}
     volumes:
       - app-data:/data:ro          # read-only: the backup can never corrupt live data
     networks:

--- a/deploy/sharpmush.service
+++ b/deploy/sharpmush.service
@@ -1,0 +1,46 @@
+# Brings the whole stack up on boot, from the compose file — not just whatever containers happened
+# to be running when the box went down.
+#
+# `restart: unless-stopped` on the services already survives a reboot, so this is not about
+# restarting crashed containers. It is about reconciliation: the restart policy replays the LAST
+# STATE, while this unit replays the DECLARED state. Without it, a `docker compose down`, a
+# hand-stopped container, or an edited compose file quietly persists across the next boot, and the
+# box drifts from what deploy/ says it should be.
+#
+# Install (as root, on the host):
+#   ln -s /opt/SharpMUSH/deploy/sharpmush.service /etc/systemd/system/sharpmush.service
+#   systemctl daemon-reload
+#   systemctl enable --now sharpmush.service
+#
+# Adjust WorkingDirectory below if the checkout does not live at /opt/SharpMUSH.
+# Swap the compose file in the Exec* lines for docker-compose.prod.yml on a Caddy-fronted host.
+
+[Unit]
+Description=SharpMUSH stack (docker compose)
+Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/SharpMUSH/deploy
+
+# Pull first so a boot also picks up any image the box missed while it was down; `|| true` because
+# a transient registry outage must never keep the game offline — compose will just start the images
+# already on disk. (watchtower still handles steady-state updates while the box is up.)
+ExecStartPre=-/usr/bin/docker compose -f docker-compose.cloudflare.yml pull --quiet
+
+# --remove-orphans so a service deleted from the compose file also disappears from the box, rather
+# than lingering as an unmanaged container that nothing owns.
+ExecStart=/usr/bin/docker compose -f docker-compose.cloudflare.yml up -d --remove-orphans
+
+# Leave containers running on `systemctl stop` of this unit? No — stop means stop. On shutdown this
+# lets compose tear the stack down gracefully instead of letting the docker daemon SIGKILL it.
+ExecStop=/usr/bin/docker compose -f docker-compose.cloudflare.yml down
+
+# Boot pulls images over a possibly-slow link; the default 90s is not enough.
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Two symptoms found while investigating the `mush.sharpmush.com` outage (client fix is #692 — this PR is independent). Both come from the same root: the box's state was not the state `deploy/` declares.

## 1. The backup sidecar crash-loops when unconfigured

`backup` ran unconditionally, and its `RESTIC_*` vars were `:?`-guarded — so compose aborted the **entire stack** unless they were set. That leaves no way to run without backups except inventing placeholder values, which is exactly what the live box did:

```
RESTIC_REPOSITORY=b2:disabled:sharpmush
```

...producing a container crash-looping on `b2_authorize_account: 401` forever, with no backups either way.

Now the service sits behind a `backup` profile, so it isn't created at all unless `deploy/.env` opts in with `COMPOSE_PROFILES=backup`.

**The profile alone is not sufficient** — which is why the `:?` guards become `:-`. Compose interpolates every service in the file *before* filtering by profile, so a `:?` on a profile-excluded service still aborts the whole stack. Verified against compose v2.32.4:

```
# profiles: [backup], var unset, profile NOT enabled:
error while interpolating services.gated.environment.[]: required variable MUST_BE_SET is missing a value
exit=15
```

With `:-` and the profile off, the stack renders cleanly and `backup` is absent. Verified for both compose files, including with the `RESTIC_*`/`B2_*` vars deleted from `.env` entirely (exit 0, no warnings).

`docker compose run --rm backup …` still works unchanged — `run` activates a service's profile automatically, so the documented backup/restore commands are unaffected.

Applied to `docker-compose.prod.yml` too, since `.env.example` is shared between both stacks.

## 2. Boot brings back the last state, not the declared one

`restart: unless-stopped` does survive a reboot (the box rebooted mid-investigation and everything came back), so this is not about restarting crashed containers. It is that the restart policy replays the **last state** while the compose file declares the **intended** one: a `compose down`, a hand-stopped container, or an edited compose file silently persists across the next boot.

Adds an optional `sharpmush.service` systemd unit that runs `compose up -d --remove-orphans` on boot, so the box reconciles against `deploy/` every time it starts. It pulls first (picking up anything missed while the box was down) but tolerates a registry outage rather than keeping the game offline. It does not replace watchtower, which handles updates while the box is up.

## Docs

`restic init` is no longer presented as a required setup step in either flow, and the README documents both the profile opt-in and the boot unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)