### PR TITLE
fix(client): stop the mobile pane switcher from rendering on desktop

### DIFF
--- a/SharpMUSH.Client/Pages/SoftcodeEditor.razor
+++ b/SharpMUSH.Client/Pages/SoftcodeEditor.razor
@@ -18,7 +18,7 @@
 
     @* Mobile-only pane switcher: the three IDE panes can't coexist on a phone, so show one at
        a time. Selecting an object/attribute drills forward automatically (see handlers). *@
-    <div class="sc-mobilebar mobile-only">
+    <div class="sc-mobilebar">
         <button type="button" class="sc-mobiletab @(_mobilePane == MobilePane.Objects ? "sc-mobiletab--on" : "")"
                 @onclick="@(() => _mobilePane = MobilePane.Objects)">Objects</button>
         <button type="button" class="sc-mobiletab @(_mobilePane == MobilePane.Attrs ? "sc-mobiletab--on" : "")"

--- a/SharpMUSH.Client/Pages/SoftcodeEditor.razor.css
+++ b/SharpMUSH.Client/Pages/SoftcodeEditor.razor.css
@@ -200,10 +200,13 @@
     text-overflow: ellipsis;
 }
 
-/* The mobile pane switcher itself is hidden on desktop (.mobile-only handles that).
-   On desktop all three panes show side by side as authored. */
+/* Hidden on desktop, where all three panes show side by side as authored. Both this rule
+   and the reveal in the phone block below are scoped, so they carry equal specificity and
+   the media query wins on source order. A global `.mobile-only` helper cannot do this job:
+   scoped CSS appends a [b-<hash>] attribute to every selector here, outbidding any plain
+   utility class. */
 .sc-mobilebar {
-    display: flex;
+    display: none;
     gap: 0.375rem;
     padding: 0.5rem 0.625rem;
     background: var(--surface-3);
@@ -234,6 +237,9 @@
 /* Mobile: one full-height pane at a time, chosen by the switcher. The editor pane keeps
    a real height so Monaco lays out; panes scroll internally rather than the page. */
 @media (max-width: 760px) {
+    .sc-mobilebar {
+        display: flex;
+    }
     .sc-shell {
         flex-direction: column !important;
         height: 100% !important;

--- a/SharpMUSH.Client/wwwroot/css/custom.css
+++ b/SharpMUSH.Client/wwwroot/css/custom.css
@@ -1420,17 +1420,10 @@ body {
 	color: var(--accent);
 }
 
-/* ── Reusable helpers (consumed by the page batches) ── */
-.mobile-only { display: none; }
-
 /* ══ PHONE-WIDTH content: single-column helpers + a condensed topbar. Tablets and
    landscape phones are WIDER than this, so they keep the desktop multi-column content
    (the readability win) — only their chrome goes touch-friendly (next block). ══ */
 @media (max-width: 760px) {
-	.mobile-only { display: revert; }
-	.desktop-only { display: none !important; }
-	.mobile-stack { flex-direction: column !important; }
-	.mobile-full { width: 100% !important; }
 
 	/* Condense the topbar: drop the search box, kbd hint, language picker, and divider.
 	   Tablets (>760px) keep them — they have the room. */


### PR DESCRIPTION
## The bug

The Softcode Editor showed three tall vertical strips — `Objects`, `ttribute` (clipped), `Editor` — wedged between the nav and the Objects panel on desktop.

They aren't a desktop control. They're the **mobile pane switcher** (`.sc-mobilebar`, `SoftcodeEditor.razor:21`) leaking. It's tagged `.mobile-only`, but that hide never applied:

| Rule | Specificity |
|---|---|
| `.mobile-only { display: none }` (`custom.css`) | 0,1,0 |
| `.sc-mobilebar[b-m9oq62suu6] { display: flex }` (scoped) | **0,2,0 — wins** |

Blazor scoped CSS appends a `[b-<hash>]` attribute to every selector, which outbids a plain utility class. So the bar stayed `display: flex` at every width. Because `.sc-shell` is a horizontal flex row on desktop, the bar stretched full height and its `flex: 1` tabs became 763×57px strips.

Desktop already has the correct control — the `<` chevrons that collapse each panel to a 46px rail. This was just junk on top of it.

## The fix

Hide the bar from inside its own scoped stylesheet. Both rules are then scoped and carry equal specificity, so the phone media query wins on source order — no `!important`.

Also removes the `.mobile-only` / `.desktop-only` / `.mobile-stack` / `.mobile-full` helpers. Three had **zero** consumers; the fourth was this bug.

**The helper could not have worked here.** Inside the media query it sets `display: revert`, which resolves to `block` for a `<div>` — not the `flex` the bar needs. The tempting one-line fix (`!important` on `.mobile-only`) would have fixed desktop and silently broken the mobile switcher into a stack of block elements with `flex: 1` ignored. Scoped CSS and global display-utilities are structurally at odds; each component should own its own responsive behavior.

## Verification

Real Chromium against a running server (`SHARPMUSH_DATABASE_PROVIDER=surrealdb`), reading **computed** styles on `.sc-mobilebar` — before/after captured from the same harness, toggling only this commit:

| build | width | `display` | bar height | tab size |
|---|---|---|---|---|
| before | 1440px | `flex` | 780px | 763×57 ← **the bug** |
| before | 700px | `flex` | 55px | 38×223 |
| after | 1440px | `none` | 0px | 0×0 ← **fixed** |
| after | 700px | `flex` | 55px | 38×223 ← **unchanged** |

The "before" run reproduces the reported screenshot pixel-for-pixel, clipped `ttribute` included. Mobile behaviour is byte-identical before and after.

`SharpMUSH.Tests.BUnit`: **172/172 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the Softcode Editor’s pane switcher to appear only on small-screen layouts.
  * Preserved the full three-pane editor layout for desktop users.
  * Refined responsive styling for improved mobile presentation and a more condensed top bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->