### PR TITLE
chore(deps): collate Dependabot NuGet bumps (#686–#690)

### DIFF
--- a/SharpMUSH.Benchmarks/SharpMUSH.Benchmarks.csproj
+++ b/SharpMUSH.Benchmarks/SharpMUSH.Benchmarks.csproj
@@ -11,7 +11,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />

--- a/SharpMUSH.Client/SharpMUSH.Client.csproj
+++ b/SharpMUSH.Client/SharpMUSH.Client.csproj
@@ -33,9 +33,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="BlazorMonaco" Version="3.5.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.8" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.7" />
 		<PackageReference Include="MudBlazor" Version="9.4.0" />

--- a/SharpMUSH.Database/SharpMUSH.Database.csproj
+++ b/SharpMUSH.Database/SharpMUSH.Database.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNext" Version="6.3.0" />
+    <PackageReference Include="DotNext" Version="6.4.1" />
     <ProjectReference Include="..\SharpMUSH.Library\SharpMUSH.Library.csproj" />
     <!-- MarkupString used directly across the providers. Referenced explicitly because SharpMUSH.Library
          marks its SharpMUSH.* ProjectReferences PrivateAssets="all" (to keep them out of its NuGet

--- a/SharpMUSH.Database/SharpMUSH.Database.csproj
+++ b/SharpMUSH.Database/SharpMUSH.Database.csproj
@@ -19,7 +19,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNext" Version="6.4.1" />
     <ProjectReference Include="..\SharpMUSH.Library\SharpMUSH.Library.csproj" />
     <!-- MarkupString used directly across the providers. Referenced explicitly because SharpMUSH.Library
          marks its SharpMUSH.* ProjectReferences PrivateAssets="all" (to keep them out of its NuGet

--- a/SharpMUSH.Library/SharpMUSH.Library.csproj
+++ b/SharpMUSH.Library/SharpMUSH.Library.csproj
@@ -63,9 +63,9 @@
 	</Target>
 
   <ItemGroup>
-    <PackageReference Include="DotNext" Version="6.3.0" />
+    <PackageReference Include="DotNext" Version="6.4.1" />
     <PackageReference Include="Markdig" Version="1.3.2" />
-    <PackageReference Include="DotNext.Threading" Version="6.4.0" />
+    <PackageReference Include="DotNext.Threading" Version="6.4.1" />
     <PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />

--- a/SharpMUSH.Server/SharpMUSH.Server.csproj
+++ b/SharpMUSH.Server/SharpMUSH.Server.csproj
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.9" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.11.0-beta.1" />
@@ -91,7 +91,7 @@
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Mvc" Version="10.0.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
     <None Include="..\SharpMUSH.Documentation\Helpfiles\SharpMUSH\*.md">
       <Link>TextFiles\help\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/SharpMUSH.Tests.Infrastructure/SharpMUSH.Tests.Infrastructure.csproj
+++ b/SharpMUSH.Tests.Infrastructure/SharpMUSH.Tests.Infrastructure.csproj
@@ -24,7 +24,7 @@
 		<PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
 		<PackageReference Include="MySqlConnector" Version="2.5.0" />
 		<!-- Logging -->
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
 		<PackageReference Include="Serilog" Version="4.3.1" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" ExcludeAssets="compile" />

--- a/SharpMUSH.Tests.Infrastructure/SharpMUSH.Tests.Infrastructure.csproj
+++ b/SharpMUSH.Tests.Infrastructure/SharpMUSH.Tests.Infrastructure.csproj
@@ -23,8 +23,8 @@
 		<PackageReference Include="Testcontainers.Nats" Version="4.11.0" />
 		<PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
 		<PackageReference Include="MySqlConnector" Version="2.5.0" />
-		<!-- Logging -->
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+		<!-- Logging (Microsoft.Extensions.Logging.Abstractions flows in transitively via
+		     Microsoft.AspNetCore.Mvc.Testing and TUnit.AspNetCore, so no direct pin needed). -->
 		<PackageReference Include="Serilog" Version="4.3.1" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" ExcludeAssets="compile" />


### PR DESCRIPTION
Collates the five open Dependabot NuGet PRs into one change so the version family moves together and CI runs once instead of five times.

## Bumps from the Dependabot PRs
| Package | From | To | PR |
|---|---|---|---|
| DotNext | 6.3.0 | 6.4.1 | #686 |
| DotNext.Threading | 6.4.0 | 6.4.1 | #686 |
| Microsoft.AspNetCore.Authentication.JwtBearer | 10.0.8 | 10.0.9 | #687 |
| Microsoft.AspNetCore.Components.WebAssembly | 10.0.8 | 10.0.9 | #688 |
| Microsoft.AspNetCore.Components.WebAssembly.Authentication | 10.0.8 | 10.0.9 | #689 |
| Microsoft.AspNetCore.Components.WebAssembly.DevServer | 10.0.8 | 10.0.9 | #690 |

## Graph consistency — removed instead of pinned
Dependabot edits one `.csproj` per PR and can't see cross-project effects. Collating exposed two direct references that were only causing `NU1605` downgrades. Rather than pin them, they're **removed** — a sibling already supplies each at the required version, so there's nothing left for Dependabot to track or pin:

- **`DotNext` dropped from `SharpMUSH.Database`** — the project has zero DotNext usages and inherits 6.4.1 transitively via `SharpMUSH.Library`.
- **`Microsoft.Extensions.Logging.Abstractions` dropped from `SharpMUSH.Tests.Infrastructure`** — supplied transitively at 10.0.9 by `Microsoft.AspNetCore.Mvc.Testing` and `TUnit.AspNetCore`.

This follows the maintainer's earlier "drop redundant direct package references" pattern.

## One necessary lockstep bump
- **`Microsoft.AspNetCore.Components.WebAssembly.Server` 10.0.8 → 10.0.9 in `SharpMUSH.Server`** — same ASP.NET Core 10.0.9 patch family; a genuine direct dependency (`UseBlazorFrameworkFiles()`), so it's bumped rather than removed.

## Dropped from #688
Dependabot's #688 also tried to *add* a plain `Microsoft.AspNetCore.Components.WebAssembly` reference to `SharpMUSH.Server`. That's spurious — the Server project uses the `.Server` host package, not the client WASM package — so it's omitted. (The maintainer's earlier audit removed this exact reference for the same reason.)

## Verification
`dotnet restore` and `dotnet build` both clean — 0 errors, no `NU1605` (the 21 warnings are pre-existing in projects without `TreatWarningsAsErrors`).

Closes #686, closes #687, closes #688, closes #689, closes #690.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated application framework components to version 10.0.9.
  * Updated concurrency and utility libraries to their latest supported versions.
  * Removed redundant dependency references to streamline project configuration.
  * No user-facing features or interface changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->