### PR TITLE
examine owner-crash fix + attribute/object owner invariant & transactional parity (SurrealDB/Memgraph)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -423,3 +423,6 @@ pennmush
 # Agent worktrees (created by the Agent tool; never commit)
 .claude/worktrees/
 .superpowers/
+
+# Local SurrealDB rocksdb data dir from running the server locally
+surrealdb-data/

--- a/SharpMUSH.Database.Memgraph/MemgraphDatabase.Attributes.cs
+++ b/SharpMUSH.Database.Memgraph/MemgraphDatabase.Attributes.cs
@@ -263,11 +263,12 @@ RETURN child ORDER BY child.longName
 			if (isLast)
 			{
 				sb.AppendLine($"ON CREATE SET {childAlias}.key = ${keyParam}, {childAlias}.longName = ${longParam}, {childAlias}.value = $value");
-				sb.AppendLine($"ON MATCH SET {childAlias}.value = $value");
+				sb.AppendLine($"ON MATCH SET {childAlias}.longName = ${longParam}, {childAlias}.value = $value");
 			}
 			else
 			{
 				sb.AppendLine($"ON CREATE SET {childAlias}.key = ${keyParam}, {childAlias}.longName = ${longParam}, {childAlias}.value = $emptyValue");
+				sb.AppendLine($"ON MATCH SET {childAlias}.longName = ${longParam}");
 			}
 		}
 

--- a/SharpMUSH.Database.Memgraph/MemgraphDatabase.Attributes.cs
+++ b/SharpMUSH.Database.Memgraph/MemgraphDatabase.Attributes.cs
@@ -272,14 +272,22 @@ RETURN child ORDER BY child.longName
 			}
 		}
 
+		// Own EVERY level — the leaf and every branch parent auto-created along the path — not just
+		// the leaf. A branch parent (e.g. FOO when setting FOO`BAR) that is never owned comes back with
+		// a null owner, and a reader (examine) crashes on it. This whole query is one implicit
+		// transaction, so the reassignment is atomic to concurrent readers.
+		var allAliases = string.Join(", ", Enumerable.Range(0, attribute.Length).Select(i => $"a{i}"));
 		var leafAlias = $"a{attribute.Length - 1}";
 
-		sb.AppendLine($"WITH {leafAlias}");
-		sb.AppendLine($"OPTIONAL MATCH ({leafAlias})-[oldOwner:HAS_ATTRIBUTE_OWNER]->()");
-		sb.AppendLine("DELETE oldOwner");
-		sb.AppendLine($"WITH {leafAlias}");
-		sb.AppendLine($"MATCH (p:Player {{key: $ownerKey}})");
-		sb.AppendLine($"CREATE ({leafAlias})-[:HAS_ATTRIBUTE_OWNER]->(p)");
+		sb.AppendLine($"WITH {allAliases}");
+		sb.AppendLine("MATCH (p:Player {key: $ownerKey})");
+		sb.AppendLine($"WITH {allAliases}, p");
+		for (var i = 0; i < attribute.Length; i++)
+			sb.AppendLine($"OPTIONAL MATCH (a{i})-[oo{i}:HAS_ATTRIBUTE_OWNER]->()");
+		sb.AppendLine($"DELETE {string.Join(", ", Enumerable.Range(0, attribute.Length).Select(i => $"oo{i}"))}");
+		sb.AppendLine($"WITH {allAliases}, p");
+		for (var i = 0; i < attribute.Length; i++)
+			sb.AppendLine($"CREATE (a{i})-[:HAS_ATTRIBUTE_OWNER]->(p)");
 		sb.AppendLine($"RETURN {leafAlias}.key AS leafKey");
 
 		var result = await ExecuteWithRetryAsync(sb.ToString(), parameters, cancellationToken);

--- a/SharpMUSH.Database.Memgraph/MemgraphDatabase.cs
+++ b/SharpMUSH.Database.Memgraph/MemgraphDatabase.cs
@@ -574,7 +574,7 @@ RETURN o, p
 		node["name"].As<string>(),
 		flags,
 		null,
-		node.Properties.ContainsKey("longName") ? node["longName"].As<string?>() : null,
+		node["longName"].As<string>(),
 		new AsyncLazy<IAsyncEnumerable<SharpAttribute>>(innerCt => Task.FromResult<IAsyncEnumerable<SharpAttribute>>(new FreshEnumerable<SharpAttribute>(() => GetTopLevelAttributesAsync(id, innerCt)))),
 		new AsyncLazy<SharpPlayer?>(async innerCt => await GetAttributeOwnerAsync(id, innerCt)),
 		new AsyncLazy<SharpAttributeEntry?>(async innerCt => await GetRelatedAttributeEntryAsync(id, innerCt)))
@@ -595,7 +595,7 @@ RETURN o, p
 		node["name"].As<string>(),
 		flags,
 		null,
-		node.Properties.ContainsKey("longName") ? node["longName"].As<string?>() : null,
+		node["longName"].As<string>(),
 		new AsyncLazy<IAsyncEnumerable<LazySharpAttribute>>(innerCt => Task.FromResult<IAsyncEnumerable<LazySharpAttribute>>(new FreshEnumerable<LazySharpAttribute>(() => GetTopLevelLazyAttributesAsync(id, innerCt)))),
 		new AsyncLazy<SharpPlayer?>(async innerCt => await GetAttributeOwnerAsync(id, innerCt)),
 		new AsyncLazy<SharpAttributeEntry?>(async innerCt => await GetRelatedAttributeEntryAsync(id, innerCt)),

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Accounts.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Accounts.cs
@@ -115,8 +115,8 @@ CREATE account CONTENT {
 		// One transaction so the account row and its ownership edges are torn down atomically.
 		await ExecuteAsync(
 			"BEGIN TRANSACTION;" +
-			"DELETE $id;" +
 			"DELETE account_owns_character WHERE in = $id;" +
+			"DELETE $id;" +
 			"COMMIT TRANSACTION",
 			parameters, cancellationToken);
 	}

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Accounts.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Accounts.cs
@@ -112,8 +112,13 @@ CREATE account CONTENT {
 	{
 		var key = NormalizeSurrealId(accountId, "account");
 		var parameters = new Dictionary<string, object?> { ["id"] = new StringRecordId(key) };
-		await ExecuteAsync("DELETE $id", parameters, cancellationToken);
-		await ExecuteAsync("DELETE account_owns_character WHERE in = $id", parameters, cancellationToken);
+		// One transaction so the account row and its ownership edges are torn down atomically.
+		await ExecuteAsync(
+			"BEGIN TRANSACTION;" +
+			"DELETE $id;" +
+			"DELETE account_owns_character WHERE in = $id;" +
+			"COMMIT TRANSACTION",
+			parameters, cancellationToken);
 	}
 
 	public async ValueTask LinkCharacterToAccountAsync(string accountId, DBRef characterRef, CancellationToken cancellationToken = default)

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Attributes.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Attributes.cs
@@ -340,12 +340,14 @@ public partial class SurrealDatabase
 				["ownerKey"] = ownerKey
 			};
 
+			// Re-create the owner edge inside a transaction so the attribute is never observed
+			// owner-less between the DELETE and the RELATE (examine -> GetAttributeOwnerAsync returns
+			// null, then crashes) — the same guard as ReassignAttributeOwnerAsync.
 			await ExecuteAsync(
-				"DELETE has_attribute_owner WHERE in = attribute:⟨$attrKey⟩",
-				ownerParams, cancellationToken);
-
-			await ExecuteAsync(
-				"RELATE attribute:⟨$attrKey⟩->has_attribute_owner->player:$ownerKey",
+				"BEGIN TRANSACTION;" +
+				"DELETE has_attribute_owner WHERE in = attribute:⟨$attrKey⟩;" +
+				"RELATE attribute:⟨$attrKey⟩->has_attribute_owner->player:$ownerKey;" +
+				"COMMIT TRANSACTION",
 				ownerParams, cancellationToken);
 		}
 
@@ -481,11 +483,17 @@ public partial class SurrealDatabase
 		else
 		{
 			var deleteParams = new Dictionary<string, object?> { ["key"] = attrKey };
-			await ExecuteAsync("DELETE has_attribute WHERE out = attribute:⟨$key⟩", deleteParams, cancellationToken);
-			await ExecuteAsync("DELETE has_attribute_flag WHERE in = attribute:⟨$key⟩", deleteParams, cancellationToken);
-			await ExecuteAsync("DELETE has_attribute_owner WHERE in = attribute:⟨$key⟩", deleteParams, cancellationToken);
-			await ExecuteAsync("DELETE has_attribute_entry WHERE in = attribute:⟨$key⟩", deleteParams, cancellationToken);
-			await ExecuteAsync("DELETE attribute:⟨$key⟩", deleteParams, cancellationToken);
+			// One transaction: the owner edge is deleted before the node, so without isolation a
+			// concurrent examine sees the still-present node with no owner and crashes.
+			await ExecuteAsync(
+				"BEGIN TRANSACTION;" +
+				"DELETE has_attribute WHERE out = attribute:⟨$key⟩;" +
+				"DELETE has_attribute_flag WHERE in = attribute:⟨$key⟩;" +
+				"DELETE has_attribute_owner WHERE in = attribute:⟨$key⟩;" +
+				"DELETE has_attribute_entry WHERE in = attribute:⟨$key⟩;" +
+				"DELETE attribute:⟨$key⟩;" +
+				"COMMIT TRANSACTION",
+				deleteParams, cancellationToken);
 
 			if (attribute.Length > 1)
 			{
@@ -510,12 +518,18 @@ public partial class SurrealDatabase
 		await WipeAttributeDescendantsAsync(attrKey, cancellationToken);
 
 		var deleteParams = new Dictionary<string, object?> { ["key"] = attrKey };
-		await ExecuteAsync("DELETE has_attribute WHERE out = attribute:⟨$key⟩", deleteParams, cancellationToken);
-		await ExecuteAsync("DELETE has_attribute WHERE in = attribute:⟨$key⟩", deleteParams, cancellationToken);
-		await ExecuteAsync("DELETE has_attribute_flag WHERE in = attribute:⟨$key⟩", deleteParams, cancellationToken);
-		await ExecuteAsync("DELETE has_attribute_owner WHERE in = attribute:⟨$key⟩", deleteParams, cancellationToken);
-		await ExecuteAsync("DELETE has_attribute_entry WHERE in = attribute:⟨$key⟩", deleteParams, cancellationToken);
-		await ExecuteAsync("DELETE attribute:⟨$key⟩", deleteParams, cancellationToken);
+		// One transaction: owner edge deleted before the node — isolate so a concurrent examine never
+		// sees the node without its owner.
+		await ExecuteAsync(
+			"BEGIN TRANSACTION;" +
+			"DELETE has_attribute WHERE out = attribute:⟨$key⟩;" +
+			"DELETE has_attribute WHERE in = attribute:⟨$key⟩;" +
+			"DELETE has_attribute_flag WHERE in = attribute:⟨$key⟩;" +
+			"DELETE has_attribute_owner WHERE in = attribute:⟨$key⟩;" +
+			"DELETE has_attribute_entry WHERE in = attribute:⟨$key⟩;" +
+			"DELETE attribute:⟨$key⟩;" +
+			"COMMIT TRANSACTION",
+			deleteParams, cancellationToken);
 
 		if (attribute.Length > 1)
 		{

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Attributes.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Attributes.cs
@@ -788,9 +788,16 @@ public partial class SurrealDatabase
 					["attrKey"] = attrKey,
 					["newKey"] = newKey
 				};
+				// Re-create the owner edge inside a transaction so the attribute is never observed
+				// owner-less between the DELETE and the RELATE — a concurrent examine ->
+				// GetAttributeOwnerAsync would otherwise see a null owner and crash. SurrealDB graph-edge
+				// in/out cannot be UPDATEd, so the edge must be re-created; the transaction is what makes
+				// that atomic to outside readers.
 				await ExecuteAsync(
+					"BEGIN TRANSACTION;" +
 					"DELETE has_attribute_owner WHERE in = attribute:⟨$attrKey⟩;" +
-					"RELATE attribute:⟨$attrKey⟩->has_attribute_owner->player:$newKey",
+					"RELATE attribute:⟨$attrKey⟩->has_attribute_owner->player:$newKey;" +
+					"COMMIT TRANSACTION",
 					attrParams, cancellationToken);
 			}
 		}

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Attributes.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Attributes.cs
@@ -13,6 +13,7 @@ using SurrealDb.Net;
 using SurrealDb.Net.Models.Response;
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 
@@ -255,9 +256,35 @@ public partial class SurrealDatabase
 
 		var typedRecordId = GetSurrealRecordId(objRecords[0].type.ToLower(), objKey);
 
-		string currentParentRecordId = typedRecordId;
-		string? lastAttrKey = null;
+		// Read each level's default-flag config up front so the write below can run as a single
+		// transaction with no interleaved reads.
+		var defaultFlagsPerLevel = new List<string[]>();
+		for (var i = 0; i < attribute.Length; i++)
+		{
+			var levelLongName = string.Join('`', attribute.Take(i + 1));
+			var attrEntry = await GetSharpAttributeEntry(levelLongName, cancellationToken);
+			defaultFlagsPerLevel.Add(attrEntry?.DefaultFlags ?? []);
+		}
 
+		// The entire attribute write is ONE transaction: every attribute node, its edge to its parent,
+		// its owner edge, and its flags are committed together. No partial state is ever visible to a
+		// concurrent reader — a newly-created node (leaf or auto-created branch parent) is never observed
+		// owner-less (which would crash examine via GetAttributeOwnerAsync), and a re-set re-owns atomically.
+		// ExecuteAsync inlines $params textually, so each value gets a distinctive, unique param name to
+		// avoid cross-statement token collisions.
+		var txnParams = new Dictionary<string, object?>();
+		var paramCounter = 0;
+		string P(object? v)
+		{
+			var name = $"txnp{paramCounter++}";
+			txnParams[name] = v;
+			return $"${name}";
+		}
+
+		var sb = new StringBuilder();
+		sb.Append("BEGIN TRANSACTION;");
+
+		// 1. Attribute nodes + the edge linking each to its parent.
 		for (var i = 0; i < attribute.Length; i++)
 		{
 			var attrName = attribute[i];
@@ -265,126 +292,54 @@ public partial class SurrealDatabase
 			var attrKey = $"{objKey}_{longName}";
 			var isLast = i == attribute.Length - 1;
 
-			if (isLast)
-			{
-				var upsertParams = new Dictionary<string, object?>
-				{
-					["key"] = attrKey,
-					["name"] = attrName,
-					["longName"] = longName,
-					["value"] = serializedValue
-				};
-
-				await ExecuteAsync(
-					"UPSERT attribute:⟨$key⟩ SET key = $key, name = $name, longName = $longName, value = $value",
-					upsertParams, cancellationToken);
-			}
-			else
-			{
-				var upsertParams = new Dictionary<string, object?>
-				{
-					["key"] = attrKey,
-					["name"] = attrName,
-					["longName"] = longName
-				};
-
-				await ExecuteAsync(
-					"UPSERT attribute:⟨$key⟩ SET key = $key, name = $name, longName = $longName, value = value ?? ''",
-					upsertParams, cancellationToken);
-			}
+			var valueAssignment = isLast ? $"value = {P(serializedValue)}" : "value = value ?? ''";
+			sb.Append($"UPSERT attribute:⟨{P(attrKey)}⟩ SET key = {P(attrKey)}, name = {P(attrName)}, longName = {P(longName)}, {valueAssignment};");
 
 			if (i == 0)
 			{
-				var edgeId = $"{currentParentRecordId.Replace(":", "_")}__attr_{EscapeString(attrKey)}";
-				var edgeParams = new Dictionary<string, object?>
-				{
-					["childKey"] = attrKey,
-					["edgeId"] = edgeId
-				};
-				await ExecuteAsync(
-					$"UPSERT has_attribute:⟨$edgeId⟩ SET in = {currentParentRecordId}, out = attribute:⟨$childKey⟩",
-					edgeParams, cancellationToken);
+				var edgeId = $"{typedRecordId.Replace(":", "_")}__attr_{EscapeString(attrKey)}";
+				sb.Append($"UPSERT has_attribute:⟨{P(edgeId)}⟩ SET in = {typedRecordId}, out = attribute:⟨{P(attrKey)}⟩;");
 			}
 			else
 			{
 				var prevAttrKey = $"{objKey}_{string.Join('`', attribute.Take(i))}";
 				var edgeId = $"attr_{EscapeString(prevAttrKey)}__attr_{EscapeString(attrKey)}";
-				var innerEdgeParams = new Dictionary<string, object?>
-				{
-					["parentKey"] = prevAttrKey,
-					["childKey"] = attrKey,
-					["edgeId"] = edgeId
-				};
-				await ExecuteAsync(
-					"UPSERT has_attribute:⟨$edgeId⟩ SET in = attribute:⟨$parentKey⟩, out = attribute:⟨$childKey⟩",
-					innerEdgeParams, cancellationToken);
+				sb.Append($"UPSERT has_attribute:⟨{P(edgeId)}⟩ SET in = attribute:⟨{P(prevAttrKey)}⟩, out = attribute:⟨{P(attrKey)}⟩;");
 			}
-
-			currentParentRecordId = $"attribute:⟨{attrKey}⟩";
-			lastAttrKey = attrKey;
 		}
 
-		if (lastAttrKey == null) return false;
-
-		// Every attribute node must have an owner — the leaf AND every branch parent auto-created
-		// along the path (e.g. setting FOO`BAR creates FOO, which must be owned too). Previously only
-		// the leaf was owned, so branch parents came back owner-less and any consumer that reads the
-		// owner (examine) tripped over the missing edge.
-		for (var level = 0; level < attribute.Length; level++)
+		// 2. Owner edge for EVERY level — leaf and every auto-created branch parent. Deleted-then-recreated
+		// so a re-set re-owns; because it is inside this transaction the swap is atomic to readers.
+		for (var i = 0; i < attribute.Length; i++)
 		{
-			var levelLongName = string.Join('`', attribute.Take(level + 1));
-			var levelAttrKey = $"{objKey}_{levelLongName}";
-			var ownerParams = new Dictionary<string, object?>
-			{
-				["attrKey"] = levelAttrKey,
-				["ownerKey"] = ownerKey
-			};
-
-			// Re-create the owner edge inside a transaction so the attribute is never observed
-			// owner-less between the DELETE and the RELATE (examine -> GetAttributeOwnerAsync returns
-			// null, then crashes) — the same guard as ReassignAttributeOwnerAsync.
-			await ExecuteAsync(
-				"BEGIN TRANSACTION;" +
-				"DELETE has_attribute_owner WHERE in = attribute:⟨$attrKey⟩;" +
-				"RELATE attribute:⟨$attrKey⟩->has_attribute_owner->player:$ownerKey;" +
-				"COMMIT TRANSACTION",
-				ownerParams, cancellationToken);
+			var attrKey = $"{objKey}_{string.Join('`', attribute.Take(i + 1))}";
+			sb.Append($"DELETE has_attribute_owner WHERE in = attribute:⟨{P(attrKey)}⟩;");
+			sb.Append($"RELATE attribute:⟨{P(attrKey)}⟩->has_attribute_owner->player:{P(ownerKey)};");
 		}
 
-	// Set branch flag on parent attribute nodes (not the root typed node)
-	for (var i = 0; i < attribute.Length - 1; i++)
-	{
-		var longName = string.Join('`', attribute.Take(i + 1));
-		var attrKey = $"{objKey}_{longName}";
-		var escapedAttrKey = EscapeRecordId(attrKey);
-		var branchParams = new Dictionary<string, object?>();
-		await ExecuteAsync(
-			$"RELATE attribute:⟨{escapedAttrKey}⟩->has_attribute_flag->(SELECT VALUE id FROM attribute_flag WHERE string::uppercase(name) = 'BRANCH' AND id NOT IN (SELECT VALUE out FROM has_attribute_flag WHERE in = attribute:⟨{escapedAttrKey}⟩) LIMIT 1)",
-			branchParams, cancellationToken);
-	}
-
-	for (var i = 0; i < attribute.Length; i++)
-	{
-		var longName = string.Join('`', attribute.Take(i + 1));
-		var attrEntry = await GetSharpAttributeEntry(longName, cancellationToken);
-		var flagNames = attrEntry?.DefaultFlags ?? [];
-
-		var attrKey = $"{objKey}_{longName}";
-		var escapedAttrKey = EscapeRecordId(attrKey);
-		foreach (var flagName in flagNames)
+		// 3. BRANCH flag on every parent node (not the leaf, not the root typed node).
+		for (var i = 0; i < attribute.Length - 1; i++)
 		{
-			var flagParams = new Dictionary<string, object?>
-			{
-				["flagName"] = flagName
-			};
-
-			await ExecuteAsync(
-				$"RELATE attribute:⟨{escapedAttrKey}⟩->has_attribute_flag->(SELECT VALUE id FROM attribute_flag WHERE string::uppercase(name) = string::uppercase($flagName) AND id NOT IN (SELECT VALUE out FROM has_attribute_flag WHERE in = attribute:⟨{escapedAttrKey}⟩) LIMIT 1)",
-				flagParams, cancellationToken);
+			var attrKey = $"{objKey}_{string.Join('`', attribute.Take(i + 1))}";
+			var escapedAttrKey = EscapeRecordId(attrKey);
+			sb.Append($"RELATE attribute:⟨{escapedAttrKey}⟩->has_attribute_flag->(SELECT VALUE id FROM attribute_flag WHERE string::uppercase(name) = 'BRANCH' AND id NOT IN (SELECT VALUE out FROM has_attribute_flag WHERE in = attribute:⟨{escapedAttrKey}⟩) LIMIT 1);");
 		}
-	}
 
-	return true;
+		// 4. Default flags configured for each level's attribute entry.
+		for (var i = 0; i < attribute.Length; i++)
+		{
+			var attrKey = $"{objKey}_{string.Join('`', attribute.Take(i + 1))}";
+			var escapedAttrKey = EscapeRecordId(attrKey);
+			foreach (var flagName in defaultFlagsPerLevel[i])
+			{
+				sb.Append($"RELATE attribute:⟨{escapedAttrKey}⟩->has_attribute_flag->(SELECT VALUE id FROM attribute_flag WHERE string::uppercase(name) = string::uppercase({P(flagName)}) AND id NOT IN (SELECT VALUE out FROM has_attribute_flag WHERE in = attribute:⟨{escapedAttrKey}⟩) LIMIT 1);");
+			}
+		}
+
+		sb.Append("COMMIT TRANSACTION");
+
+		await ExecuteAsync(sb.ToString(), txnParams, cancellationToken);
+		return true;
 	}
 
 	public async ValueTask<bool> SetAttributeFlagAsync(SharpObject dbref, string[] attribute, SharpAttributeFlag flag, CancellationToken cancellationToken = default)

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Attributes.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Attributes.cs
@@ -326,19 +326,28 @@ public partial class SurrealDatabase
 
 		if (lastAttrKey == null) return false;
 
-		var ownerParams = new Dictionary<string, object?>
+		// Every attribute node must have an owner — the leaf AND every branch parent auto-created
+		// along the path (e.g. setting FOO`BAR creates FOO, which must be owned too). Previously only
+		// the leaf was owned, so branch parents came back owner-less and any consumer that reads the
+		// owner (examine) tripped over the missing edge.
+		for (var level = 0; level < attribute.Length; level++)
 		{
-			["attrKey"] = lastAttrKey,
-			["ownerKey"] = ownerKey
-		};
+			var levelLongName = string.Join('`', attribute.Take(level + 1));
+			var levelAttrKey = $"{objKey}_{levelLongName}";
+			var ownerParams = new Dictionary<string, object?>
+			{
+				["attrKey"] = levelAttrKey,
+				["ownerKey"] = ownerKey
+			};
 
-		await ExecuteAsync(
-			"DELETE has_attribute_owner WHERE in = attribute:⟨$attrKey⟩",
-			ownerParams, cancellationToken);
+			await ExecuteAsync(
+				"DELETE has_attribute_owner WHERE in = attribute:⟨$attrKey⟩",
+				ownerParams, cancellationToken);
 
-		await ExecuteAsync(
-			"RELATE attribute:⟨$attrKey⟩->has_attribute_owner->player:$ownerKey",
-			ownerParams, cancellationToken);
+			await ExecuteAsync(
+				"RELATE attribute:⟨$attrKey⟩->has_attribute_owner->player:$ownerKey",
+				ownerParams, cancellationToken);
+		}
 
 	// Set branch flag on parent attribute nodes (not the root typed node)
 	for (var i = 0; i < attribute.Length - 1; i++)

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Channels.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Channels.cs
@@ -68,14 +68,15 @@ public partial class SurrealDatabase
 			["ownerKey"] = ownerObjKey
 		};
 
-		// Use deterministic record ID so repeated creates are idempotent under unique name index
+		// Deterministic record ID so repeated creates are idempotent under the unique name index.
+		// One transaction so the channel node and its owner/membership edges commit together —
+		// otherwise the channel is visible before its owner edge and GetChannelOwnerAsync throws.
 		await ExecuteAsync(
-			"UPSERT channel:⟨$name⟩ SET name = $name, markedUpName = $markedUpName, description = '', privs = $privs, joinLock = '', speakLock = '', seeLock = '', hideLock = '', modLock = '', buffer = 0, mogrifier = ''",
-			parameters, cancellationToken);
-
-		await ExecuteAsync(
+			"BEGIN TRANSACTION;" +
+			"UPSERT channel:⟨$name⟩ SET name = $name, markedUpName = $markedUpName, description = '', privs = $privs, joinLock = '', speakLock = '', seeLock = '', hideLock = '', modLock = '', buffer = 0, mogrifier = '';" +
 			"RELATE (SELECT VALUE id FROM channel WHERE name = $name LIMIT 1)->owner_of_channel->object:$ownerKey;" +
-			"RELATE object:$ownerKey->member_of_channel->(SELECT VALUE id FROM channel WHERE name = $name LIMIT 1) SET combine = false, gagged = false, hide = false, mute = false, title = ''",
+			"RELATE object:$ownerKey->member_of_channel->(SELECT VALUE id FROM channel WHERE name = $name LIMIT 1) SET combine = false, gagged = false, hide = false, mute = false, title = '';" +
+			"COMMIT TRANSACTION",
 			parameters, cancellationToken);
 	}
 
@@ -120,9 +121,13 @@ public partial class SurrealDatabase
 			["ownerKey"] = ownerObjKey
 		};
 
+		// One transaction so the channel is never momentarily owner-less between the DELETE and the
+		// RELATE (GetChannelOwnerAsync throws on a missing owner_of_channel edge).
 		await ExecuteAsync(
+			"BEGIN TRANSACTION;" +
 			"DELETE owner_of_channel WHERE in IN (SELECT VALUE id FROM channel WHERE name = $name);" +
-			"RELATE (SELECT VALUE id FROM channel WHERE name = $name LIMIT 1)->owner_of_channel->object:$ownerKey",
+			"RELATE (SELECT VALUE id FROM channel WHERE name = $name LIMIT 1)->owner_of_channel->object:$ownerKey;" +
+			"COMMIT TRANSACTION",
 			parameters, cancellationToken);
 	}
 
@@ -131,10 +136,13 @@ public partial class SurrealDatabase
 		var channelName = channel.Name.ToPlainText();
 		var parameters = new Dictionary<string, object?> { ["name"] = channelName };
 
+		// One transaction so the channel and its edges are torn down atomically.
 		await ExecuteAsync(
+			"BEGIN TRANSACTION;" +
 			"DELETE member_of_channel WHERE out IN (SELECT VALUE id FROM channel WHERE name = $name);" +
 			"DELETE owner_of_channel WHERE in IN (SELECT VALUE id FROM channel WHERE name = $name);" +
-			"DELETE channel WHERE name = $name",
+			"DELETE channel WHERE name = $name;" +
+			"COMMIT TRANSACTION",
 			parameters, cancellationToken);
 	}
 

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.FlagsAndPowers.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.FlagsAndPowers.cs
@@ -80,8 +80,10 @@ public partial class SurrealDatabase
 
 		var parameters = new Dictionary<string, object?> { ["name"] = name };
 		await ExecuteAsync(
+			"BEGIN TRANSACTION;" +
 			"DELETE has_flags WHERE out = object_flag:⟨$name⟩;" +
-			"DELETE object_flag:⟨$name⟩",
+			"DELETE object_flag:⟨$name⟩;" +
+			"COMMIT TRANSACTION",
 			parameters, cancellationToken);
 		return true;
 	}
@@ -225,8 +227,10 @@ public partial class SurrealDatabase
 
 		var parameters = new Dictionary<string, object?> { ["name"] = name };
 		await ExecuteAsync(
+			"BEGIN TRANSACTION;" +
 			"DELETE has_powers WHERE out = power:⟨$name⟩;" +
-			"DELETE power:⟨$name⟩",
+			"DELETE power:⟨$name⟩;" +
+			"COMMIT TRANSACTION",
 			parameters, cancellationToken);
 		return true;
 	}

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Mail.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Mail.cs
@@ -154,14 +154,15 @@ public partial class SurrealDatabase
 			["toKey"] = toKey
 		};
 
-		// Create mail using the same deterministic record ID used by later record-id-based operations
+		// Deterministic record ID used by later record-id-based operations. One transaction so the
+		// mail row and its received_mail/mail_sender edges commit together, matching ArangoDB's
+		// Exclusive=[Mails, ReceivedMail, SenderOfMail].
 		await ExecuteAsync(
-			"UPSERT mail:⟨$mailKey⟩ SET key = $mailKey, dateSent = $dateSent, fresh = $fresh, read = $read, tagged = $tagged, urgent = $urgent, forwarded = $forwarded, cleared = $cleared, folder = $folder, content = $content, subject = $subject",
-			parameters, cancellationToken);
-
-		await ExecuteAsync(
+			"BEGIN TRANSACTION;" +
+			"UPSERT mail:⟨$mailKey⟩ SET key = $mailKey, dateSent = $dateSent, fresh = $fresh, read = $read, tagged = $tagged, urgent = $urgent, forwarded = $forwarded, cleared = $cleared, folder = $folder, content = $content, subject = $subject;" +
 			"RELATE player:$toKey->received_mail->mail:⟨$mailKey⟩;" +
-			"RELATE mail:⟨$mailKey⟩->mail_sender->object:$fromKey",
+			"RELATE mail:⟨$mailKey⟩->mail_sender->object:$fromKey;" +
+			"COMMIT TRANSACTION",
 			parameters, cancellationToken);
 	}
 
@@ -196,10 +197,13 @@ public partial class SurrealDatabase
 		var mailKey = ExtractKeyString(mailId);
 		var parameters = new Dictionary<string, object?> { ["key"] = mailKey };
 
+		// One transaction so the mail row and its edges are torn down atomically.
 		await ExecuteAsync(
+			"BEGIN TRANSACTION;" +
 			"DELETE received_mail WHERE out = mail:⟨$key⟩;" +
 			"DELETE mail_sender WHERE in = mail:⟨$key⟩;" +
-			"DELETE mail:⟨$key⟩",
+			"DELETE mail:⟨$key⟩;" +
+			"COMMIT TRANSACTION",
 			parameters, cancellationToken);
 	}
 

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Navigation.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Navigation.cs
@@ -277,9 +277,14 @@ public partial class SurrealDatabase
 			["destKey"] = destKey
 		};
 
+		// One transaction so the object is never momentarily location-less between the DELETE and the
+		// RELATE — this is the hot object-movement path, and GetLocationForTypedAsync throws on a
+		// missing at_location edge, so an un-isolated gap here is a concurrent-read crash.
 		await ExecuteAsync(
+			$"BEGIN TRANSACTION;" +
 			$"DELETE at_location WHERE in = {srcTable}:$srcKey;" +
-			$"RELATE {srcTable}:$srcKey->at_location->{destTable}:$destKey",
+			$"RELATE {srcTable}:$srcKey->at_location->{destTable}:$destKey;" +
+			$"COMMIT TRANSACTION",
 			parameters, cancellationToken);
 	}
 

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Objects.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Objects.cs
@@ -635,9 +635,15 @@ public partial class SurrealDatabase
 			["ownerKey"] = ownerKey
 		};
 
+		// Replace the owner edge inside a single transaction so a concurrent reader never observes the
+		// object owner-less between the DELETE and the RELATE (GetObjectOwnerAsync throws on no owner).
+		// SurrealDB graph-edge in/out cannot be UPDATEd, so the edge must be re-created — the
+		// transaction is what makes that atomic to outside readers.
 		await ExecuteAsync(
+			"BEGIN TRANSACTION;" +
 			"DELETE has_owner WHERE in = object:$key;" +
-			"RELATE object:$key->has_owner->player:$ownerKey",
+			"RELATE object:$key->has_owner->player:$ownerKey;" +
+			"COMMIT TRANSACTION",
 			parameters, cancellationToken);
 	}
 

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Objects.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Objects.cs
@@ -44,13 +44,18 @@ public partial class SurrealDatabase
 			["homeKey"] = home.Number
 		};
 
+		// One transaction so the object and its is_object/has_owner/at_location/has_home edges commit
+		// together — otherwise the base record is visible before its owner/location/home edges, and a
+		// concurrent reader resolving .Owner/.Location/.Home (all throw on a missing edge) crashes.
 		await ExecuteAsync("""
+			BEGIN TRANSACTION;
 			CREATE object:$key SET key = $key, name = $name, type = 'PLAYER', creationTime = $now, modifiedTime = $now, locks = '{}', warnings = 0;
 			CREATE player:$key SET key = $key, passwordHash = $hash, passwordSalt = $salt, aliases = [], quota = $quota;
 			RELATE player:$key->is_object->object:$key;
 			RELATE object:$key->has_owner->player:$key;
 			RELATE player:$key->at_location->room:$locKey;
-			RELATE player:$key->has_home->room:$homeKey
+			RELATE player:$key->has_home->room:$homeKey;
+			COMMIT TRANSACTION
 			""", parameters, cancellationToken);
 
 		return new DBRef(nextKey, now);
@@ -70,11 +75,15 @@ public partial class SurrealDatabase
 			["ownerKey"] = creatorKey
 		};
 
+		// One transaction so the object and its is_object/has_owner edges commit together (a reader
+		// resolving .Owner throws on a missing has_owner edge).
 		await ExecuteAsync("""
+			BEGIN TRANSACTION;
 			CREATE object:$key SET key = $key, name = $name, type = 'ROOM', creationTime = $now, modifiedTime = $now, locks = '{}', warnings = 0;
 			CREATE room:$key SET key = $key, aliases = [];
 			RELATE room:$key->is_object->object:$key;
-			RELATE object:$key->has_owner->player:$ownerKey
+			RELATE object:$key->has_owner->player:$ownerKey;
+			COMMIT TRANSACTION
 			""", parameters, cancellationToken);
 
 		return new DBRef(nextKey, now);
@@ -103,13 +112,17 @@ public partial class SurrealDatabase
 			["emptyLocks"] = "{}"
 		};
 
+		// One transaction so the object and all its edges commit together — the has_owner edge is the
+		// last statement, so without this the object is visible and owner-less across the whole create.
 		await ExecuteAsync(
+			$"BEGIN TRANSACTION;" +
 			$"CREATE object:$key SET key = $key, name = $name, type = 'THING', creationTime = $now, modifiedTime = $now, locks = $emptyLocks, warnings = 0;" +
 			$"CREATE thing:$key SET key = $key, aliases = [];" +
 			$"RELATE thing:$key->is_object->object:$key;" +
 			$"RELATE thing:$key->at_location->{locTable}:$locKey;" +
 			$"RELATE thing:$key->has_home->{homeTable}:$homeKey;" +
-			$"RELATE object:$key->has_owner->player:$ownerKey",
+			$"RELATE object:$key->has_owner->player:$ownerKey;" +
+			$"COMMIT TRANSACTION",
 			parameters, cancellationToken);
 
 		return new DBRef(nextKey, now);
@@ -136,12 +149,15 @@ public partial class SurrealDatabase
 			["emptyLocks"] = "{}"
 		};
 
+		// One transaction so the object and all its edges commit together (has_owner is last).
 		await ExecuteAsync(
+			$"BEGIN TRANSACTION;" +
 			$"CREATE object:$key SET key = $key, name = $name, type = 'EXIT', creationTime = $now, modifiedTime = $now, locks = $emptyLocks, warnings = 0;" +
 			$"CREATE exit:$key SET key = $key, aliases = $aliases;" +
 			$"RELATE exit:$key->is_object->object:$key;" +
 			$"RELATE exit:$key->at_location->{locTable}:$locKey;" +
-			$"RELATE object:$key->has_owner->player:$ownerKey",
+			$"RELATE object:$key->has_owner->player:$ownerKey;" +
+			$"COMMIT TRANSACTION",
 			parameters, cancellationToken);
 
 		return new DBRef(nextKey, now);
@@ -552,9 +568,13 @@ public partial class SurrealDatabase
 			["homeKey"] = homeKey
 		};
 
+		// One transaction so the object is never momentarily home-less between DELETE and RELATE
+		// (GetHomeAsync throws on a missing has_home edge).
 		await ExecuteAsync(
+			$"BEGIN TRANSACTION;" +
 			$"DELETE has_home WHERE in = {srcTable}:$objKey;" +
-			$"RELATE {srcTable}:$objKey->has_home->{destTable}:$homeKey",
+			$"RELATE {srcTable}:$objKey->has_home->{destTable}:$homeKey;" +
+			$"COMMIT TRANSACTION",
 			parameters, cancellationToken);
 	}
 
@@ -571,9 +591,13 @@ public partial class SurrealDatabase
 			["locKey"] = locKey
 		};
 
+		// One transaction so the object is never momentarily location-less between DELETE and RELATE
+		// (GetLocationForTypedAsync throws on a missing at_location edge).
 		await ExecuteAsync(
+			$"BEGIN TRANSACTION;" +
 			$"DELETE at_location WHERE in = {srcTable}:$objKey;" +
-			$"RELATE {srcTable}:$objKey->at_location->{destTable}:$locKey",
+			$"RELATE {srcTable}:$objKey->at_location->{destTable}:$locKey;" +
+			$"COMMIT TRANSACTION",
 			parameters, cancellationToken);
 	}
 
@@ -582,20 +606,21 @@ public partial class SurrealDatabase
 		var objKey = obj.Object().Key;
 		var parameters = new Dictionary<string, object?> { ["key"] = objKey };
 
-		await ExecuteAsync("DELETE has_parent WHERE in = object:$key", parameters, cancellationToken);
-
-		if (parent != null)
+		if (parent == null)
 		{
-			var parentKey = parent.Object().Key;
-			var parentParams = new Dictionary<string, object?>
-			{
-				["key"] = objKey,
-				["parentKey"] = parentKey
-			};
-			await ExecuteAsync(
-				"RELATE object:$key->has_parent->object:$parentKey",
-				parentParams, cancellationToken);
+			await ExecuteAsync("DELETE has_parent WHERE in = object:$key", parameters, cancellationToken);
+			return;
 		}
+
+		// Replace the parent edge in one transaction so a concurrent reader never sees it detached
+		// between the DELETE and the RELATE.
+		parameters["parentKey"] = parent.Object().Key;
+		await ExecuteAsync(
+			"BEGIN TRANSACTION;" +
+			"DELETE has_parent WHERE in = object:$key;" +
+			"RELATE object:$key->has_parent->object:$parentKey;" +
+			"COMMIT TRANSACTION",
+			parameters, cancellationToken);
 	}
 
 	public async ValueTask UnsetObjectParent(AnySharpObject obj, CancellationToken cancellationToken = default)
@@ -606,20 +631,21 @@ public partial class SurrealDatabase
 		var objKey = obj.Object().Key;
 		var parameters = new Dictionary<string, object?> { ["key"] = objKey };
 
-		await ExecuteAsync("DELETE has_zone WHERE in = object:$key", parameters, cancellationToken);
-
-		if (zone != null)
+		if (zone == null)
 		{
-			var zoneKey = zone.Object().Key;
-			var zoneParams = new Dictionary<string, object?>
-			{
-				["key"] = objKey,
-				["zoneKey"] = zoneKey
-			};
-			await ExecuteAsync(
-				"RELATE object:$key->has_zone->object:$zoneKey",
-				zoneParams, cancellationToken);
+			await ExecuteAsync("DELETE has_zone WHERE in = object:$key", parameters, cancellationToken);
+			return;
 		}
+
+		// Replace the zone edge in one transaction so a concurrent reader never sees it detached
+		// between the DELETE and the RELATE.
+		parameters["zoneKey"] = zone.Object().Key;
+		await ExecuteAsync(
+			"BEGIN TRANSACTION;" +
+			"DELETE has_zone WHERE in = object:$key;" +
+			"RELATE object:$key->has_zone->object:$zoneKey;" +
+			"COMMIT TRANSACTION",
+			parameters, cancellationToken);
 	}
 
 	public async ValueTask UnsetObjectZone(AnySharpObject obj, CancellationToken cancellationToken = default)

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.cs
@@ -687,7 +687,7 @@ public partial class SurrealDatabase(
 			record.name,
 			flags,
 			null,
-			string.IsNullOrEmpty(record.longName) ? null : record.longName,
+			record.longName,
 			new AsyncLazy<IAsyncEnumerable<SharpAttribute>>(innerCt => Task.FromResult<IAsyncEnumerable<SharpAttribute>>(new FreshEnumerable<SharpAttribute>(() => GetTopLevelAttributesAsync(id, innerCt)))),
 			new AsyncLazy<SharpPlayer?>(async innerCt => await GetAttributeOwnerAsync(id, innerCt)),
 			new AsyncLazy<SharpAttributeEntry?>(async innerCt => await GetRelatedAttributeEntryAsync(id, innerCt)))
@@ -707,7 +707,7 @@ public partial class SurrealDatabase(
 			record.name,
 			flags,
 			null,
-			string.IsNullOrEmpty(record.longName) ? null : record.longName,
+			record.longName,
 			new AsyncLazy<IAsyncEnumerable<LazySharpAttribute>>(innerCt => Task.FromResult<IAsyncEnumerable<LazySharpAttribute>>(new FreshEnumerable<LazySharpAttribute>(() => GetTopLevelLazyAttributesAsync(id, innerCt)))),
 			new AsyncLazy<SharpPlayer?>(async innerCt => await GetAttributeOwnerAsync(id, innerCt)),
 			new AsyncLazy<SharpAttributeEntry?>(async innerCt => await GetRelatedAttributeEntryAsync(id, innerCt)),

--- a/SharpMUSH.Implementation/Handlers/Database/CommandAttributeScanner.cs
+++ b/SharpMUSH.Implementation/Handlers/Database/CommandAttributeScanner.cs
@@ -38,7 +38,7 @@ public static class CommandAttributeScanner
 			foreach (var attr in attrList)
 			{
 				if (attr.Flags.Any(f => f.Name == "no_inherit"))
-					noInheritPrefixes.Add((attr.LongName ?? "") + "`");
+					noInheritPrefixes.Add(attr.LongName + "`");
 			}
 		}
 
@@ -47,12 +47,12 @@ public static class CommandAttributeScanner
 		foreach (var attr in attrList)
 		{
 			if (attr.Flags.Any(flag => flag.Name == "no_command"))
-				localNoCommandPrefixes.Add((attr.LongName ?? "") + "`");
+				localNoCommandPrefixes.Add(attr.LongName + "`");
 		}
 
 		foreach (var attr in attrList)
 		{
-			var longName = attr.LongName ?? "";
+			var longName = attr.LongName;
 
 			// Skip if no_inherit (or descendant of no_inherit) and we're looking at parent attributes
 			if (!isLocal)

--- a/SharpMUSH.Implementation/Handlers/Database/GetCommandAttributesQueryHandler.cs
+++ b/SharpMUSH.Implementation/Handlers/Database/GetCommandAttributesQueryHandler.cs
@@ -76,7 +76,7 @@ public class GetCommandAttributesQueryHandler(
 	{
 		foreach (var cached in ancestorCommands)
 		{
-			var longName = cached.Attribute.LongName ?? "";
+			var longName = cached.Attribute.LongName;
 
 			// Child/parent attribute of the same name already won — ancestor is shadowed.
 			if (!seenNames.Add(longName))

--- a/SharpMUSH.Library/Models/SharpAttribute.cs
+++ b/SharpMUSH.Library/Models/SharpAttribute.cs
@@ -9,7 +9,7 @@ public record SharpAttribute(
 	string Name,
 	IEnumerable<SharpAttributeFlag> Flags,
 	int? CommandListIndex,
-	[property: JsonIgnore] string? LongName,
+	[property: JsonIgnore] string LongName,
 	[property: JsonIgnore] AsyncLazy<IAsyncEnumerable<SharpAttribute>> Leaves,
 	[property: JsonIgnore] AsyncLazy<SharpPlayer?> Owner,
 	[property: JsonIgnore] AsyncLazy<SharpAttributeEntry?> SharpAttributeEntry)
@@ -23,7 +23,7 @@ public record LazySharpAttribute(
 	string Name,
 	IEnumerable<SharpAttributeFlag> Flags,
 	int? CommandListIndex,
-	[property: JsonIgnore] string? LongName,
+	[property: JsonIgnore] string LongName,
 	[property: JsonIgnore] AsyncLazy<IAsyncEnumerable<LazySharpAttribute>> Leaves,
 	[property: JsonIgnore] AsyncLazy<SharpPlayer?> Owner,
 	[property: JsonIgnore] AsyncLazy<SharpAttributeEntry?> SharpAttributeEntry,

--- a/SharpMUSH.Library/Services/AttributeService.cs
+++ b/SharpMUSH.Library/Services/AttributeService.cs
@@ -541,7 +541,7 @@ public class AttributeService(
 
 		var filtered = results
 			.Where(x => !x.IsMortalDark()
-			             && !darkPrefixes.Any(dp => (x.LongName ?? "").StartsWith(dp, StringComparison.OrdinalIgnoreCase)));
+			             && !darkPrefixes.Any(dp => x.LongName.StartsWith(dp, StringComparison.OrdinalIgnoreCase)));
 
 		var permitted = new List<SharpAttribute>();
 		foreach (var attr in filtered)
@@ -594,7 +594,7 @@ public class AttributeService(
 
 		var filtered = results
 			.Where(x => !x.IsMortalDark()
-			             && !darkPrefixes.Any(dp => (x.LongName ?? "").StartsWith(dp, StringComparison.OrdinalIgnoreCase)))
+			             && !darkPrefixes.Any(dp => x.LongName.StartsWith(dp, StringComparison.OrdinalIgnoreCase)))
 			.OrderBy(x => x.LongName, _attributeSort);
 
 		foreach (var attr in filtered)

--- a/SharpMUSH.Tests/Commands/ExamineNullOwnerTests.cs
+++ b/SharpMUSH.Tests/Commands/ExamineNullOwnerTests.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using OneOf;
+using SharpMUSH.Library.DiscriminatedUnions;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Services.Interfaces;
+using SharpMUSH.Tests;
+
+namespace SharpMUSH.Tests.Commands;
+
+/// <summary>
+/// Every attribute must have an owner — the leaf and every branch parent auto-created along the
+/// path. The SurrealDB write path owned only the leaf, so branch parents came back owner-less;
+/// <c>examine</c> (which annotates each attribute with its owner) then hit a missing owner and
+/// dropped every attribute after the first owner-less one. On a bundled handler object (e.g. #8,
+/// whose FN/PM branches were owner-less) it listed a single attribute. This exercises the whole
+/// path through <c>examine</c>; the direct write assertion lives in
+/// <c>SurrealAttributeEnumerationTests</c>.
+/// </summary>
+public class ExamineNullOwnerTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactoryArg { get; init; }
+
+	private INotifyService NotifyService => WebAppFactoryArg.Services.GetRequiredService<INotifyService>();
+	private IConnectionService ConnectionService => WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
+	private IMUSHCodeParser Parser => WebAppFactoryArg.CommandParser;
+
+	[Test]
+	public async ValueTask Examine_RendersAllAttributes_EvenWhenABranchParentHasNoOwner()
+	{
+		var objDbRef = await TestIsolationHelpers.CreateTestThingAsync(Parser, ConnectionService, "ExamNullOwner");
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"&LEAFA {objDbRef}=leafa"));
+		// Setting only the child auto-creates BRANCHY as a parent with no owner of its own.
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"&BRANCHY`CHILD {objDbRef}=child"));
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"&LEAFZ {objDbRef}=leafz"));
+
+		NotifyService.ClearReceivedCalls();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"examine {objDbRef}"));
+
+		// Every top-level attribute must render — including the owner-less BRANCHY parent and LEAFZ
+		// (which, depending on enumeration order, may follow it). Before the fix, dereferencing the
+		// null owner threw NullReferenceException and aborted the listing partway.
+		foreach (var expected in new[] { "LEAFA", "BRANCHY", "LEAFZ" })
+		{
+			await NotifyService.Received().Notify(
+				Arg.Any<AnySharpObject>(),
+				Arg.Is<OneOf<MString, string>>(m => TestHelpers.MessageContains(m, expected)),
+				Arg.Any<AnySharpObject?>(),
+				Arg.Any<INotifyService.NotificationType>());
+		}
+	}
+}

--- a/SharpMUSH.Tests/Database/SurrealAttributeEnumerationTests.cs
+++ b/SharpMUSH.Tests/Database/SurrealAttributeEnumerationTests.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using DotNext.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using SharpMUSH.Database.SurrealDB;
@@ -10,10 +12,10 @@ using SurrealDb.Net;
 namespace SharpMUSH.Tests.Database;
 
 /// <summary>
-/// LongName is an invariant: a <see cref="SharpAttribute"/> is addressed by its fully-qualified
-/// backtick path, so every attribute — leaf, auto-created branch parent, or child — carries a
-/// non-empty LongName. The type is non-nullable and no read-time fallback masks a missing value;
-/// the write path must populate it. These tests pin that on the production (SurrealDB) provider.
+/// LongName is an invariant: an attribute is addressed by its fully-qualified backtick path, so
+/// every attribute — leaf or auto-created branch parent — carries a non-empty LongName on the
+/// production (SurrealDB) provider. (The separate <c>examine</c>-truncation bug, where a branch
+/// parent's null owner aborted the listing, is covered by <c>ExamineNullOwnerTests</c>.)
 /// </summary>
 public class SurrealAttributeEnumerationTests
 {
@@ -27,7 +29,7 @@ public class SurrealAttributeEnumerationTests
 		public ValueTask RehashPasswordAsync(SharpPlayer player, string plaintext) => ValueTask.CompletedTask;
 	}
 
-	private static async Task<SurrealDatabase> CreateFreshMigratedAsync(string dbName)
+	private static async Task<(SurrealDatabase Db, ISurrealDbClient Client)> CreateFreshMigratedAsync(string dbName)
 	{
 		var services = new ServiceCollection();
 		services.AddSurreal($"Endpoint=mem://;Namespace=sharpmush_attrenum;Database={dbName}")
@@ -36,30 +38,45 @@ public class SurrealAttributeEnumerationTests
 		await client.Connect();
 		var db = new SurrealDatabase(NullLogger<SurrealDatabase>.Instance, client, new NoopPasswordService());
 		await db.Migrate();
-		return db;
+		return (db, client);
+	}
+
+
+	[Test]
+	public async Task AutoCreatedBranchParent_HasAnOwner()
+	{
+		var (db, _) = await CreateFreshMigratedAsync("branchowner");
+		var god = (await db.GetObjectNodeAsync(new DBRef(1))).AsPlayer;
+		var godRef = new DBRef(god.Object.Key);
+
+		// Setting only the child auto-creates BRANCH as a parent node; it must be owned, like the leaf.
+		await db.SetAttributeAsync(godRef, ["BRANCH", "CHILD"], MModule.single("child"), god);
+
+		var obj = await db.GetObjectNodeAsync(godRef);
+		var branch = (await obj.Object()!.Attributes.Value.ToListAsync()).Single(a => a.Name == "BRANCH");
+		var owner = await branch.Owner.WithCancellation(CancellationToken.None);
+
+		await Assert.That(owner).IsNotNull()
+			.Because("every attribute, including an auto-created branch parent, must have an owner");
 	}
 
 	[Test]
 	public async Task EveryAttribute_LeafBranchParentAndChild_HasItsFullyQualifiedLongName()
 	{
-		var db = await CreateFreshMigratedAsync("longnameinvariant");
+		var (db, _) = await CreateFreshMigratedAsync("longnameinvariant");
 		var god = (await db.GetObjectNodeAsync(new DBRef(1))).AsPlayer;
 		var godRef = new DBRef(god.Object.Key);
 
 		await db.SetAttributeAsync(godRef, ["LEAFONE"], MModule.single("one"), god);
-		// Setting only the child auto-creates BRANCH as a parent node — it too must carry a longName.
 		await db.SetAttributeAsync(godRef, ["BRANCH", "CHILD"], MModule.single("child"), god);
 
 		var obj = await db.GetObjectNodeAsync(godRef);
 		var all = await db.GetAttributeAsync(godRef, ["BRANCH", "CHILD"])!.ToListAsync();
 		var topLevel = await obj.Object()!.Attributes.Value.ToListAsync();
 
-		// The full backtick path down to the child resolves, each hop non-empty and correct.
 		await Assert.That(all.Select(a => a.LongName)).IsEquivalentTo(new[] { "BRANCH", "BRANCH`CHILD" });
 
-		var leaf = topLevel.Single(a => a.Name == "LEAFONE");
 		var branch = topLevel.Single(a => a.Name == "BRANCH");
-		await Assert.That(leaf.LongName).IsEqualTo("LEAFONE");
 		await Assert.That(branch.LongName).IsEqualTo("BRANCH")
 			.Because("an auto-created branch parent must carry its own longName, never empty");
 	}

--- a/SharpMUSH.Tests/Database/SurrealAttributeEnumerationTests.cs
+++ b/SharpMUSH.Tests/Database/SurrealAttributeEnumerationTests.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using SharpMUSH.Database.SurrealDB;
+using SharpMUSH.Library.DiscriminatedUnions;
+using SharpMUSH.Library.Extensions;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.Services.Interfaces;
+using SurrealDb.Net;
+
+namespace SharpMUSH.Tests.Database;
+
+/// <summary>
+/// LongName is an invariant: a <see cref="SharpAttribute"/> is addressed by its fully-qualified
+/// backtick path, so every attribute — leaf, auto-created branch parent, or child — carries a
+/// non-empty LongName. The type is non-nullable and no read-time fallback masks a missing value;
+/// the write path must populate it. These tests pin that on the production (SurrealDB) provider.
+/// </summary>
+public class SurrealAttributeEnumerationTests
+{
+	private sealed class NoopPasswordService : IPasswordService
+	{
+		public string HashPassword(string user, string pw) => pw;
+		public bool PasswordIsValid(string user, string pw, string hash) => pw == hash;
+		public ValueTask SetPassword(SharpPlayer user, string hashedPassword) => ValueTask.CompletedTask;
+		public string GenerateRandomPassword() => "password";
+		public bool NeedsRehash(string hash) => false;
+		public ValueTask RehashPasswordAsync(SharpPlayer player, string plaintext) => ValueTask.CompletedTask;
+	}
+
+	private static async Task<SurrealDatabase> CreateFreshMigratedAsync(string dbName)
+	{
+		var services = new ServiceCollection();
+		services.AddSurreal($"Endpoint=mem://;Namespace=sharpmush_attrenum;Database={dbName}")
+			.AddInMemoryProvider();
+		var client = services.BuildServiceProvider().GetRequiredService<ISurrealDbClient>();
+		await client.Connect();
+		var db = new SurrealDatabase(NullLogger<SurrealDatabase>.Instance, client, new NoopPasswordService());
+		await db.Migrate();
+		return db;
+	}
+
+	[Test]
+	public async Task EveryAttribute_LeafBranchParentAndChild_HasItsFullyQualifiedLongName()
+	{
+		var db = await CreateFreshMigratedAsync("longnameinvariant");
+		var god = (await db.GetObjectNodeAsync(new DBRef(1))).AsPlayer;
+		var godRef = new DBRef(god.Object.Key);
+
+		await db.SetAttributeAsync(godRef, ["LEAFONE"], MModule.single("one"), god);
+		// Setting only the child auto-creates BRANCH as a parent node — it too must carry a longName.
+		await db.SetAttributeAsync(godRef, ["BRANCH", "CHILD"], MModule.single("child"), god);
+
+		var obj = await db.GetObjectNodeAsync(godRef);
+		var all = await db.GetAttributeAsync(godRef, ["BRANCH", "CHILD"])!.ToListAsync();
+		var topLevel = await obj.Object()!.Attributes.Value.ToListAsync();
+
+		// The full backtick path down to the child resolves, each hop non-empty and correct.
+		await Assert.That(all.Select(a => a.LongName)).IsEquivalentTo(new[] { "BRANCH", "BRANCH`CHILD" });
+
+		var leaf = topLevel.Single(a => a.Name == "LEAFONE");
+		var branch = topLevel.Single(a => a.Name == "BRANCH");
+		await Assert.That(leaf.LongName).IsEqualTo("LEAFONE");
+		await Assert.That(branch.LongName).IsEqualTo("BRANCH")
+			.Because("an auto-created branch parent must carry its own longName, never empty");
+	}
+}


### PR DESCRIPTION
## What & why

Started from a reported production bug — `examine #8` (a bundled HTTP-handler object) listed a single attribute instead of all eight — and expanded into the underlying invariant it exposed: **every attribute and object must always have a valid owner, and every multi-step write that maintains that must be atomic to concurrent readers.**

The reported crash was reproduced live on the SurrealDB provider (production runs SurrealDB, not ArangoDB): `examine`'s owner annotation deref (`attrOwner!.Object.DBRef.Number`) NRE'd because a bundled branch-parent attribute (`FN`, `PM`) had **no owner** — SurrealDB's attribute write owned only the leaf, not the auto-created branch parents. ArangoDB owns every level and never tripped, which is why the suite never caught it.

## Commits

1. **Make `SharpAttribute.LongName` non-nullable** — a standalone tidy-up, explicitly *not* the bug fix. LongName is a required value; the type was `string?` and the SurrealDB mapper manufactured `null` from an empty stored value, so readers coped with scattered `?? ""`. Removes the null-manufacturing and the dead guards.
2. **Own every attribute node on SurrealDB, including branch parents** — *the fix.* The write owned only the leaf; now it owns every level. Verified live: `examine #8` went from 1 attribute to all 8.
3. **Make SurrealDB owner re-assignment atomic** — the player-destruction re-owner sweep did `DELETE`-then-`RELATE` on the owner edge with no transaction, so a concurrent read landing in the gap saw a null/missing owner and crashed. Wrapped in `BEGIN TRANSACTION`.
4. **Transactional parity for SurrealDB (+ Memgraph branch-parent owners)** — audited all nine of ArangoDB's exclusive-transaction sites and brought SurrealDB in line: object creates, `MoveObject` (hot path), content location/home, the attribute owner assignment, channel create/owner, attribute delete cascades (crash-class), plus the transient ones (parent/zone, mail, account/channel/flag/power deletes) for full parity. Also fixes the Memgraph branch-parent-owner gap (owned only the leaf).

## Root causes, in one line each

- `examine` truncated because a branch-parent attribute had a **null owner** and the display deref assumed non-null.
- Branch parents were owner-less because the SurrealDB (and Memgraph) attribute write owned only the leaf.
- Owner-less states were also reachable transiently: SurrealDB's detach-then-reattach owner writes had no transaction, so a concurrent read could see the gap. (SurrealDB graph-edge `in`/`out` can't be `UPDATE`d, so edges are re-created — the transaction is what makes that atomic.)

## Testing

Reproduced and verified end-to-end against a live server on SurrealDB (`examine #8`: 1 → 8). Regression tests reproduce on the SurrealDB provider (fail without the fix, pass with it) and pass trivially on ArangoDB/Memgraph. Broad SurrealDB suite sweep green (attribute, object, movement, building, channel, communication, mail, wipe-cascade, player-destruction); Memgraph attribute-tree green. CI runs the whole suite on all three providers.

## Scope note

Closes every *per-operation* window — no reader will observe an owner-less/location-less object or attribute mid-write. It does **not** make the larger player-destruction *sweep* one transaction (deferred by choice), so a reader can still see a consistent partial state across the sweep — some possessions moved, some not — but never a crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed attribute listings so all attributes appear in `examine`, including those under automatically created branches.
  * Improved attribute ownership and fully qualified name handling.
  * Prevented temporary inconsistent states when creating, moving, updating, or deleting game objects, channels, mail, flags, powers, and attributes.
  * Made account and relationship cleanup more reliable during deletion.

* **Tests**
  * Added coverage for attribute enumeration, branch ownership, and fully qualified attribute names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->