### PR TITLE
chore(deps): collate Dependabot NuGet bumps (#701–#705)

### DIFF
--- a/SharpMUSH.Benchmarks/SharpMUSH.Benchmarks.csproj
+++ b/SharpMUSH.Benchmarks/SharpMUSH.Benchmarks.csproj
@@ -11,7 +11,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />

--- a/SharpMUSH.Client/SharpMUSH.Client.csproj
+++ b/SharpMUSH.Client/SharpMUSH.Client.csproj
@@ -33,9 +33,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="BlazorMonaco" Version="3.5.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.9" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.10" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.7" />
 		<PackageReference Include="MudBlazor" Version="9.4.0" />

--- a/SharpMUSH.Server/SharpMUSH.Server.csproj
+++ b/SharpMUSH.Server/SharpMUSH.Server.csproj
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.10" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.11.0-beta.1" />
@@ -41,7 +41,7 @@
 		     normally trimmed from output. The McMaster plugin loader eagerly walks the shared SharpMUSH.Library
 		     reference closure and resolves each referenced assembly against the host's default load context,
 		     so FSharp.Core must be present beside the host binary for plugin loading to succeed. -->
-		<PackageReference Include="FSharp.Core" Version="10.1.301" />
+		<PackageReference Include="FSharp.Core" Version="10.1.302" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.7" />
 		<PackageReference Include="Testcontainers.ArangoDb" Version="4.11.0" />
 
@@ -91,7 +91,7 @@
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Mvc" Version="10.0.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
     <None Include="..\SharpMUSH.Documentation\Helpfiles\SharpMUSH\*.md">
       <Link>TextFiles\help\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/SharpMUSH.Tests.Integration/SharpMUSH.Tests.Integration.csproj
+++ b/SharpMUSH.Tests.Integration/SharpMUSH.Tests.Integration.csproj
@@ -23,7 +23,7 @@
 		     assembly against the host's default load context — so FSharp.Core must be present beside the
 		     host binary for plugin loading to succeed. A host that loads plugins must carry its full
 		     dependency closure; this reference materializes FSharp.Core into the test host output. -->
-		<PackageReference Include="FSharp.Core" Version="10.1.301" />
+		<PackageReference Include="FSharp.Core" Version="10.1.302" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Collates the five open Dependabot NuGet PRs into one change so the ASP.NET Core 10.0.10 family moves together and CI runs once instead of five times.

## Bumps from the Dependabot PRs
| Package | From | To | Project(s) | PR |
|---|---|---|---|---|
| FSharp.Core | 10.1.301 | 10.1.302 | Server | #701 |
| Microsoft.AspNetCore.Authentication.JwtBearer | 10.0.9 | 10.0.10 | Server | #702 |
| Microsoft.AspNetCore.Components.WebAssembly | 10.0.9 | 10.0.10 | Benchmarks, Client | #703 |
| Microsoft.AspNetCore.Components.WebAssembly.Authentication | 10.0.9 | 10.0.10 | Client | #704 |
| Microsoft.AspNetCore.Components.WebAssembly.DevServer | 10.0.9 | 10.0.10 | Client | #705 |

(The `SharpMUSH.Benchmarks` bump is part of #703 — Dependabot bumped that package in both `SharpMUSH.Benchmarks` and `SharpMUSH.Client` in the same PR.)

## Lockstep bumps Dependabot can't see
Dependabot edits one `.csproj` per PR, so it never sees the cross-project effects of its own bumps. Two references have to move with them:

- **`Microsoft.AspNetCore.Components.WebAssembly.Server` 10.0.9 → 10.0.10 in `SharpMUSH.Server`** — the Blazor host package (`UseBlazorFrameworkFiles()`), same ASP.NET Core patch family as the client packages.
- **`FSharp.Core` 10.1.301 → 10.1.302 in `SharpMUSH.Tests.Integration`** — without it, restore fails with `NU1605` (`SharpMUSH.Tests.Integration -> SharpMUSH.Tests.Infrastructure -> SharpMUSH.Server -> FSharp.Core (>= 10.1.302)` downgraded to 10.1.301). Unlike the redundant pins dropped in #699, this one is deliberate and documented in the csproj: it materializes `FSharp.Core` beside the test host so the McMaster plugin loader can resolve `SharpMUSH.Library`'s full reference closure. So it's bumped, not removed.

## Dropped from #703
#703 also tried to *add* a plain `Microsoft.AspNetCore.Components.WebAssembly` reference to `SharpMUSH.Server`. Omitted, same as in #699 and #669 — the Server project hosts Blazor through the `.Server` package and does not consume the client WASM package.

## Verification
`dotnet restore` clean (no `NU1605`); `dotnet build` 0 errors. The remaining warnings (CS0067 unused test events, MSB3277 conflicts in the plugin fixtures) are pre-existing and unrelated to the bumps.

Closes #701, closes #702, closes #703, closes #704, closes #705.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvopbATVT2fY4m2JrAWukR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application framework, authentication, WebAssembly, and F# runtime components to newer patch versions.
  * Applied consistent dependency updates across client, server, benchmark, and integration testing projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
