### PR TITLE
fix(wiki): give character biographies one canonical URL

### DIFF
--- a/SharpMUSH.Client/Components/Widgets/RecentWikiActivityWidget.razor
+++ b/SharpMUSH.Client/Components/Widgets/RecentWikiActivityWidget.razor
@@ -21,7 +21,7 @@
                     @(wp.Title.Length > 0 ? wp.Title[0].ToString().ToUpper() : "W")
                 </MudAvatar>
                 <div style="flex:1;min-width:0;">
-                    <MudLink Href="@($"/wiki/{wp.Namespace}/{wp.Category}/{wp.Slug}")" Style="color:var(--text);font-size:0.8125rem;font-weight:500;">@wp.Title</MudLink>
+                    <MudLink Href="@WikiRoutes.PathFor(wp.Namespace, wp.Category, wp.Slug)" Style="color:var(--text);font-size:0.8125rem;font-weight:500;">@wp.Title</MudLink>
                     <MudText Style="font-size:0.6875rem;color:var(--text-faint);">@wp.UpdatedAt.ToLocalTime().ToString("MMM d")</MudText>
                 </div>
             </div>

--- a/SharpMUSH.Client/Components/Widgets/WikiBodyWidget.razor
+++ b/SharpMUSH.Client/Components/Widgets/WikiBodyWidget.razor
@@ -2,14 +2,14 @@
 @using SharpMUSH.Client.Components
 @using SharpMUSH.Client.Models.Widgets
 
-@* Renders a character's free-form wiki biography (the page whose slug is the character name). The
-   character comes from the cascading ProfilePageContext when placed on the profile page; it falls
-   back to a "character" key in the widget config for standalone placements. *@
+@* Renders a character's free-form wiki biography: the Character-namespace page whose slug is the
+   character name. The character comes from the cascading ProfilePageContext when placed on the
+   profile page; it falls back to a "character" key in the widget config for standalone placements. *@
 
 @if (!string.IsNullOrWhiteSpace(_name))
 {
     <MudPaper Class="wiki-body-widget" Elevation="0" Style="padding:1.25rem;border-radius:var(--radius);border:1px solid var(--border);background:var(--surface);">
-        <WikiView Slug="@_name" Mode="WikiView.WikiMode.View" />
+        <WikiView Slug="@_name" Namespace="@WikiRoutes.CharacterNamespace" Mode="WikiView.WikiMode.View" />
     </MudPaper>
 }
 

--- a/SharpMUSH.Client/Components/Widgets/WikiIndexWidget.razor
+++ b/SharpMUSH.Client/Components/Widgets/WikiIndexWidget.razor
@@ -121,5 +121,5 @@
         => s.Length == 0 ? s : char.ToUpper(s[0]) + s[1..];
 
     private static string PageHref(WikiPageSummary page) =>
-        $"/wiki/{page.Namespace.ToLowerInvariant()}/{(page.Category ?? "general")}/{page.Slug}";
+        WikiRoutes.PathFor(page.Namespace, page.Category, page.Slug);
 }

--- a/SharpMUSH.Client/Components/WikiDirectiveBlock.razor
+++ b/SharpMUSH.Client/Components/WikiDirectiveBlock.razor
@@ -89,5 +89,5 @@
     };
 
     private static string LinkFor(PageDto page) =>
-        $"/wiki/{page.Namespace.ToLowerInvariant()}/{(page.Category ?? "general")}/{page.Slug}";
+        WikiRoutes.PathFor(page.Namespace, page.Category, page.Slug);
 }

--- a/SharpMUSH.Client/Components/WikiDisplay.razor
+++ b/SharpMUSH.Client/Components/WikiDisplay.razor
@@ -132,6 +132,13 @@ else
         "<a href=\"/wiki/([^\"#?]+)\">",
         RegexOptions.Compiled);
 
+    // Character biographies render as their /character/{slug} alias. HTML stored before that
+    // change still carries the /wiki/character/... form, which WikiLinkHref above still matches,
+    // so both shapes have to be recognised for redlink marking to survive the transition.
+    private static readonly Regex CharacterLinkHref = new(
+        "<a href=\"/character/([^\"#?/]+)\">",
+        RegexOptions.Compiled);
+
     private List<BodySegment> _segments = [];
     private List<TocEntry> _toc = [];
 
@@ -216,23 +223,36 @@ else
         return s.Trim('-');
     }
 
+    /// <summary>An anchor found in rendered HTML: the href as written, and the wiki page
+    /// reference ("ns/category/slug") whose existence decides whether it is a redlink.</summary>
+    private readonly record struct LinkTarget(string Href, string Reference);
+
+    private static List<LinkTarget> FindLinkTargets(string html) =>
+        WikiLinkHref.Matches(html)
+            .Select(m => new LinkTarget($"/wiki/{m.Groups[1].Value}", m.Groups[1].Value))
+            .Concat(CharacterLinkHref.Matches(html)
+                .Select(m => new LinkTarget(
+                    $"/character/{m.Groups[1].Value}",
+                    $"character/general/{m.Groups[1].Value}")))
+            .DistinctBy(t => t.Href, StringComparer.Ordinal)
+            .ToList();
+
     private async Task<string> MarkRedlinksAsync(string html)
     {
-        var refs = WikiLinkHref.Matches(html)
-            .Select(m => m.Groups[1].Value)
-            .Distinct(StringComparer.Ordinal)
-            .ToList();
-        if (refs.Count == 0) return html;
+        var targets = FindLinkTargets(html);
+        if (targets.Count == 0) return html;
 
-        var exists = await Wiki.CheckExistsAsync(refs.Select(WebUtility.HtmlDecode)!);
-        foreach (var reference in refs)
+        var exists = await Wiki.CheckExistsAsync(
+            targets.Select(t => WebUtility.HtmlDecode(t.Reference)!).Distinct(StringComparer.Ordinal));
+
+        foreach (var target in targets)
         {
-            var decoded = WebUtility.HtmlDecode(reference);
+            var decoded = WebUtility.HtmlDecode(target.Reference);
             if (exists.TryGetValue(decoded, out var found) && !found)
             {
                 html = html.Replace(
-                    $"<a href=\"/wiki/{reference}\">",
-                    $"<a href=\"/wiki/{reference}\" class=\"wiki-redlink\">");
+                    $"<a href=\"{target.Href}\">",
+                    $"<a href=\"{target.Href}\" class=\"wiki-redlink\">");
             }
         }
 

--- a/SharpMUSH.Client/Components/WikiDisplay.razor
+++ b/SharpMUSH.Client/Components/WikiDisplay.razor
@@ -146,7 +146,7 @@ else
         string.IsNullOrWhiteSpace(Category) ? "General" : char.ToUpper(Category[0]) + Category[1..];
 
     private string HistoryHref =>
-        $"/wiki/{(Namespace ?? "main").ToLowerInvariant()}/{(string.IsNullOrWhiteSpace(Category) ? "general" : Category)}/{Slug}/history";
+        $"{WikiRoutes.WikiPathFor(Namespace, Category, Slug)}/history";
 
     protected override async Task OnParametersSetAsync()
     {

--- a/SharpMUSH.Client/Pages/Admin/AdminWiki.razor
+++ b/SharpMUSH.Client/Pages/Admin/AdminWiki.razor
@@ -138,7 +138,7 @@
                     <div style="display:flex;gap:0.125rem;">
                         <MudTooltip Text="Edit">
                             <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small"
-                                           Href="@($"{PageHref(context.Item)}/edit")" />
+                                           Href="@($"{WikiHref(context.Item)}/edit")" />
                         </MudTooltip>
                         <MudTooltip Text="@Loc["WikiEditMetadata"]">
                             <MudIconButton Icon="@Icons.Material.Filled.Tune" Size="Size.Small"
@@ -146,7 +146,7 @@
                         </MudTooltip>
                         <MudTooltip Text="History">
                             <MudIconButton Icon="@Icons.Material.Filled.History" Size="Size.Small"
-                                           Href="@($"{PageHref(context.Item)}/history")" />
+                                           Href="@($"{WikiHref(context.Item)}/history")" />
                         </MudTooltip>
                     </div>
                 </CellTemplate>
@@ -275,8 +275,14 @@
         return new GridData<WikiPageSummary> { Items = items, TotalItems = total };
     }
 
+    /// <summary>Where the page is read — the profile alias for character biographies.</summary>
     private static string PageHref(WikiPageSummary page) =>
         WikiRoutes.PathFor(page.Namespace, page.Category, page.Slug);
+
+    /// <summary>Base for the management actions. /edit and /history exist only under /wiki,
+    /// so these must not be built from a page's profile alias.</summary>
+    private static string WikiHref(WikiPageSummary page) =>
+        WikiRoutes.WikiPathFor(page.Namespace, page.Category, page.Slug);
 
     private static string RefFor(WikiPageSummary page) =>
         $"{page.Namespace.ToLowerInvariant()}/{page.Category ?? "general"}/{page.Slug}";

--- a/SharpMUSH.Client/Pages/Admin/AdminWiki.razor
+++ b/SharpMUSH.Client/Pages/Admin/AdminWiki.razor
@@ -276,7 +276,7 @@
     }
 
     private static string PageHref(WikiPageSummary page) =>
-        $"/wiki/{page.Namespace.ToLowerInvariant()}/{(page.Category ?? "general")}/{page.Slug}";
+        WikiRoutes.PathFor(page.Namespace, page.Category, page.Slug);
 
     private static string RefFor(WikiPageSummary page) =>
         $"{page.Namespace.ToLowerInvariant()}/{page.Category ?? "general"}/{page.Slug}";

--- a/SharpMUSH.Client/Pages/WikiPage.razor
+++ b/SharpMUSH.Client/Pages/WikiPage.razor
@@ -1,12 +1,34 @@
 @page "/wiki/{Ns}/{Category}/{Slug}"
 @using SharpMUSH.Client.Components
+@inject NavigationManager Nav
 
-<PageTitle>@Slug — Wiki — SharpMUSH</PageTitle>
+@if (!_redirecting)
+{
+    <PageTitle>@Slug — Wiki — SharpMUSH</PageTitle>
 
-<WikiView @key="@($"{Ns}:{Category}:{Slug}")" Slug="@Slug" Namespace="@Ns" Category="@Category" Mode="WikiView.WikiMode.View" />
+    <WikiView @key="@($"{Ns}:{Category}:{Slug}")" Slug="@Slug" Namespace="@Ns" Category="@Category" Mode="WikiView.WikiMode.View" />
+}
 
 @code {
     [Parameter] public required string Slug { get; set; }
     [Parameter] public required string Ns { get; set; }
     [Parameter] public required string Category { get; set; }
+
+    private bool _redirecting;
+
+    // Backstop for links this app no longer produces: bookmarks, external links, hand-typed URLs,
+    // and wiki markup rendered before character links became aliases. Cold loads are caught
+    // earlier by CanonicalUrlMiddleware's 301, but that never sees a client-side navigation, so
+    // the check has to exist here as well.
+    //
+    // replace: true keeps the wiki URL out of the history stack — otherwise Back lands on it and
+    // is bounced straight forward again, trapping the user on the profile.
+    protected override void OnParametersSet()
+    {
+        _redirecting = WikiRoutes.IsCharacterProfile(Ns, Category);
+        if (_redirecting)
+        {
+            Nav.NavigateTo(WikiRoutes.PathFor(Ns, Category, Slug), replace: true);
+        }
+    }
 }

--- a/SharpMUSH.Client/Pages/WikiPageHistory.razor
+++ b/SharpMUSH.Client/Pages/WikiPageHistory.razor
@@ -10,7 +10,7 @@
 <PageTitle>History: @Slug — SharpMUSH</PageTitle>
 
 <div class="wikihist">
-    <a class="wikihist-back" href="@($"/wiki/{Ns}/{Category}/{Slug}")">
+    <a class="wikihist-back" href="@WikiRoutes.PathFor(Ns, Category, Slug)">
         <MudIcon Icon="@Icons.Material.Filled.ChevronLeft" Style="font-size:0.875rem;" /> @_displayTitle
     </a>
     <div class="wikihist-head">
@@ -206,7 +206,7 @@
             _ =>
             {
                 Snackbar.Add($"Restored to revision {rev.RevisionNumber}.", Severity.Success);
-                Nav.NavigateTo($"/wiki/{Ns}/{Category}/{Slug}");
+                Nav.NavigateTo(WikiRoutes.PathFor(Ns, Category, Slug));
             },
             err => Snackbar.Add($"Restore failed: {err}", Severity.Error)
         );

--- a/SharpMUSH.Client/_Imports.razor
+++ b/SharpMUSH.Client/_Imports.razor
@@ -14,6 +14,7 @@
 @using SharpMUSH.Client.Models
 @using SharpMUSH.Client.Services
 @using SharpMUSH.Client.Components
+@using SharpMUSH.Library.Services
 @using SharpMUSH.Library.Services.Interfaces
 @using MudBlazor
 @using BlazorMonaco

--- a/SharpMUSH.Contracts/Services/WikiLinkExtension.cs
+++ b/SharpMUSH.Contracts/Services/WikiLinkExtension.cs
@@ -19,6 +19,13 @@ public sealed class WikiLinkInline : LeafInline
 	public required string Slug { get; init; }
 
 	/// <summary>
+	/// The portal path this link points at. Character biographies resolve to their
+	/// <c>/character/{slug}</c> alias rather than the wiki route they are stored under;
+	/// see <see cref="WikiRoutes.PathFor"/>.
+	/// </summary>
+	public required string Href { get; init; }
+
+	/// <summary>
 	/// The human-readable title of the target page (derived from the slug if not specified).
 	/// </summary>
 	public required string Title { get; init; }
@@ -108,6 +115,7 @@ internal sealed class WikiLinkParser : InlineParser
 		{
 			// Canonical path identity: namespace/category/slug.
 			Slug = $"{ns}/{category}/{slug}",
+			Href = WikiRoutes.PathFor(ns, category, slug),
 			Title = title,
 			DisplayText = displayText,
 		};
@@ -146,16 +154,14 @@ internal sealed class WikiLinkParser : InlineParser
 }
 
 /// <summary>
-/// Markdig HTML renderer that converts <see cref="WikiLinkInline"/> nodes into
-/// HTML anchor tags pointing to <c>/wiki/{ns}/{slug}</c>.
+/// Markdig HTML renderer that converts <see cref="WikiLinkInline"/> nodes into HTML anchor
+/// tags pointing at the node's canonical portal path (see <see cref="WikiLinkInline.Href"/>).
 /// </summary>
 internal sealed class WikiLinkHtmlRenderer : HtmlObjectRenderer<WikiLinkInline>
 {
 	protected override void Write(HtmlRenderer renderer, WikiLinkInline obj)
 	{
-		// Build href from full slug (which already includes namespace prefix if any)
-		// e.g. "main/page_name", "help/getting_started"
-		var href = $"/wiki/{obj.Slug}";
+		var href = obj.Href;
 		var cssClass = obj.IsRedLink ? " class=\"wiki-redlink\"" : string.Empty;
 		var text = obj.DisplayText ?? obj.Title;
 		// C-5: Use WriteEscapeUrl for the href so slug characters like '"' and '>'

--- a/SharpMUSH.Contracts/Services/WikiRoutes.cs
+++ b/SharpMUSH.Contracts/Services/WikiRoutes.cs
@@ -25,14 +25,24 @@ public static class WikiRoutes
 		&& WikiHelpers.NormalizeCategory(category) == WikiHelpers.DefaultCategory;
 
 	/// <summary>
-	/// The canonical portal path for a wiki page: <c>/character/{slug}</c> for character
-	/// biographies, <c>/wiki/{ns}/{category}/{slug}</c> for everything else.
+	/// The canonical portal path for reading a wiki page: <c>/character/{slug}</c> for character
+	/// biographies, <c>/wiki/{ns}/{category}/{slug}</c> for everything else. This is what links
+	/// pointing <em>at</em> a page should use.
 	/// </summary>
-	public static string PathFor(string? ns, string? category, string slug)
+	public static string PathFor(string? ns, string? category, string slug) =>
+		IsCharacterProfile(ns, category)
+			? $"/character/{WikiHelpers.Slugify(slug)}"
+			: WikiPathFor(ns, category, slug);
+
+	/// <summary>
+	/// The wiki route a page is stored under, never the profile alias. Use this — not
+	/// <see cref="PathFor"/> — when appending <c>/edit</c>, <c>/history</c> or <c>/diff</c>:
+	/// those sub-routes exist only under <c>/wiki</c>, so building them from a
+	/// <c>/character/{slug}</c> alias produces URLs that do not resolve.
+	/// </summary>
+	public static string WikiPathFor(string? ns, string? category, string slug)
 	{
-		var normalizedSlug = WikiHelpers.Slugify(slug);
-		return IsCharacterProfile(ns, category)
-			? $"/character/{normalizedSlug}"
-			: $"/wiki/{(ns ?? "main").Trim().ToLowerInvariant()}/{WikiHelpers.NormalizeCategory(category)}/{normalizedSlug}";
+		var normalizedNs = string.IsNullOrWhiteSpace(ns) ? "main" : ns.Trim().ToLowerInvariant();
+		return $"/wiki/{normalizedNs}/{WikiHelpers.NormalizeCategory(category)}/{WikiHelpers.Slugify(slug)}";
 	}
 }

--- a/SharpMUSH.Contracts/Services/WikiRoutes.cs
+++ b/SharpMUSH.Contracts/Services/WikiRoutes.cs
@@ -1,0 +1,38 @@
+namespace SharpMUSH.Library.Services;
+
+/// <summary>
+/// Maps a wiki page's identity to the portal path that page is canonically served from.
+/// Shared by the client's link producers, the sitemap, and the redirect backstops so every
+/// surface agrees on one answer.
+/// </summary>
+public static class WikiRoutes
+{
+	/// <summary>The namespace whose pages are character biographies.</summary>
+	public const string CharacterNamespace = "character";
+
+	/// <summary>
+	/// True when (<paramref name="ns"/>, <paramref name="category"/>) identifies a character
+	/// biography, which the portal serves from <c>/character/{slug}</c> rather than the wiki.
+	/// <para>
+	/// The category must be the default one: <c>/character/{name}</c> carries no category segment,
+	/// so both the API alias and the bot prerenderer resolve it against <see cref="WikiHelpers.DefaultCategory"/>.
+	/// A character-namespace page filed under any other category would not round-trip through that
+	/// URL, so it keeps its wiki path.
+	/// </para>
+	/// </summary>
+	public static bool IsCharacterProfile(string? ns, string? category) =>
+		string.Equals(ns?.Trim(), CharacterNamespace, StringComparison.OrdinalIgnoreCase)
+		&& WikiHelpers.NormalizeCategory(category) == WikiHelpers.DefaultCategory;
+
+	/// <summary>
+	/// The canonical portal path for a wiki page: <c>/character/{slug}</c> for character
+	/// biographies, <c>/wiki/{ns}/{category}/{slug}</c> for everything else.
+	/// </summary>
+	public static string PathFor(string? ns, string? category, string slug)
+	{
+		var normalizedSlug = WikiHelpers.Slugify(slug);
+		return IsCharacterProfile(ns, category)
+			? $"/character/{normalizedSlug}"
+			: $"/wiki/{(ns ?? "main").Trim().ToLowerInvariant()}/{WikiHelpers.NormalizeCategory(category)}/{normalizedSlug}";
+	}
+}

--- a/SharpMUSH.Database.ArangoDB/ArangoDatabase.Wiki.cs
+++ b/SharpMUSH.Database.ArangoDB/ArangoDatabase.Wiki.cs
@@ -19,6 +19,7 @@ public partial class ArangoDatabase : IWikiService
 	{
 		var nsStr = ns.ToString().ToLowerInvariant();
 		var cat = WikiHelpers.NormalizeCategory(category);
+		var normalizedSlug = Slugify(slug);
 		var result = await arangoDb.Query.ExecuteAsync<JsonElement>(handle,
 			"FOR p IN @@c FILTER p.Namespace == @ns AND p.Category == @cat AND p.Slug == @slug RETURN p",
 			bindVars: new Dictionary<string, object>
@@ -26,7 +27,7 @@ public partial class ArangoDatabase : IWikiService
 				{ "@c", DatabaseConstants.WikiPages },
 				{ "ns", nsStr },
 				{ "cat", cat },
-				{ "slug", slug }
+				{ "slug", normalizedSlug }
 			});
 
 		return result.FirstOrDefault() is { ValueKind: not JsonValueKind.Undefined } elem

--- a/SharpMUSH.Database.Memgraph/MemgraphDatabase.Wiki.cs
+++ b/SharpMUSH.Database.Memgraph/MemgraphDatabase.Wiki.cs
@@ -17,10 +17,11 @@ public partial class MemgraphDatabase : IWikiService
 	{
 		var nsStr = ns.ToString().ToLowerInvariant();
 		var cat = WikiHelpers.NormalizeCategory(category);
+		var normalizedSlug = Slugify(slug);
 		await using var session = driver.AsyncSession();
 		var result = await session.RunAsync(
 			"MATCH (p:WikiPage {namespace: $ns, category: $cat, slug: $slug}) RETURN p",
-			new { ns = nsStr, cat, slug });
+			new { ns = nsStr, cat, slug = normalizedSlug });
 
 		var records = await result.ToListAsync();
 		if (records.Count == 0) return new NotFound();

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Wiki.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Wiki.cs
@@ -65,7 +65,7 @@ public partial class SurrealDatabase : IWikiService
     {
         var nsStr = ns.ToString().ToLowerInvariant();
         var cat = WikiHelpers.NormalizeCategory(category);
-        var parameters = new Dictionary<string, object?> { ["ns"] = nsStr, ["cat"] = cat, ["slug"] = slug };
+        var parameters = new Dictionary<string, object?> { ["ns"] = nsStr, ["cat"] = cat, ["slug"] = Slugify(slug) };
         var response = await ExecuteAsync(
             $"SELECT {WikiPageFields} FROM wiki_page WHERE namespace = $ns AND category = $cat AND slug = $slug",
             parameters);

--- a/SharpMUSH.Library/Services/InMemoryWikiService.cs
+++ b/SharpMUSH.Library/Services/InMemoryWikiService.cs
@@ -33,7 +33,7 @@ public sealed class InMemoryWikiService : IWikiService
 
 	public Task<OneOf<WikiPage, NotFound>> GetBySlugAsync(string slug, string? category, WikiNamespace ns = WikiNamespace.Main)
 	{
-		var key = SlugKey(ns, category, slug);
+		var key = SlugKey(ns, category, Slugify(slug));
 		if (_slugIndex.TryGetValue(key, out var id) && _pagesById.TryGetValue(id, out var page))
 			return Task.FromResult<OneOf<WikiPage, NotFound>>(page);
 		return Task.FromResult<OneOf<WikiPage, NotFound>>(new NotFound());

--- a/SharpMUSH.Library/Services/Interfaces/IWikiService.cs
+++ b/SharpMUSH.Library/Services/Interfaces/IWikiService.cs
@@ -18,7 +18,10 @@ public interface IWikiService
 {
 	/// <summary>
 	/// Retrieves a wiki page by its (namespace, category, slug) identity.
-	/// <paramref name="category"/> is normalised (null/blank → <c>general</c>).
+	/// <paramref name="category"/> is normalised (null/blank → <c>general</c>) and
+	/// <paramref name="slug"/> is normalised the same way <see cref="CreateAsync"/> derives it from
+	/// a title (see <c>WikiHelpers.Slugify</c>), so callers may pass a display name such as
+	/// <c>"Mannaz Byron"</c> and reach the page stored as <c>mannaz_byron</c>.
 	/// Returns <c>NotFound</c> if no matching page exists.
 	/// </summary>
 	Task<OneOf<WikiPage, NotFound>> GetBySlugAsync(string slug, string? category, WikiNamespace ns = WikiNamespace.Main);

--- a/SharpMUSH.Server/Controllers/SeoController.cs
+++ b/SharpMUSH.Server/Controllers/SeoController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SharpMUSH.Library.Models.Wiki;
+using SharpMUSH.Library.Services;
 using SharpMUSH.Library.Services.Interfaces;
 using System.Security;
 using System.Text;
@@ -89,11 +90,7 @@ public class SeoController(
 
 	/// <summary>Maps a wiki page to its public portal path based on its namespace.</summary>
 	private static string PathFor(WikiPage page) =>
-		page.Namespace.ToLowerInvariant() switch
-		{
-			"character" => $"/character/{page.Slug}",
-			var ns => $"/wiki/{ns}/{page.Category ?? "general"}/{page.Slug}",
-		};
+		WikiRoutes.PathFor(page.Namespace, page.Category, page.Slug);
 
 	private static void AppendUrl(StringBuilder sb, string loc, string lastmod)
 	{

--- a/SharpMUSH.Server/Middleware/CanonicalUrlMiddleware.cs
+++ b/SharpMUSH.Server/Middleware/CanonicalUrlMiddleware.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using SharpMUSH.Library.Services;
 using SharpMUSH.Server.Helpers;
 
 namespace SharpMUSH.Server.Middleware;
@@ -11,6 +12,7 @@ namespace SharpMUSH.Server.Middleware;
 /// - Spaces in path segments → underscores  (301)
 /// - Wrong case on known path prefixes → lowercase prefix  (301)
 /// - Trailing slash on non-root paths → stripped  (301)
+/// - Character biographies reached through the wiki → their /character/{slug} alias  (301)
 /// API, hub, and static asset routes are exempted.
 /// </summary>
 public sealed partial class CanonicalUrlMiddleware(RequestDelegate next, ILogger<CanonicalUrlMiddleware> logger)
@@ -68,6 +70,7 @@ public sealed partial class CanonicalUrlMiddleware(RequestDelegate next, ILogger
 	/// 1. Lowercase the first path segment prefix (e.g. /Wiki → /wiki).
 	/// 2. Percent-decode then replace spaces with underscores in each segment.
 	/// 3. Strip trailing slash (except root "/").
+	/// 4. Rewrite a character biography's wiki route to its /character/{slug} alias.
 	/// </summary>
 	public static string BuildCanonical(string path)
 	{
@@ -93,8 +96,28 @@ public sealed partial class CanonicalUrlMiddleware(RequestDelegate next, ILogger
 			segments[i] = noSpaces;
 		}
 
-		return string.Join('/', segments);
+		return CharacterAliasFor(segments) ?? string.Join('/', segments);
 	}
+
+	/// <summary>
+	/// The <c>/character/{slug}</c> alias for <c>/wiki/character/general/{slug}</c>, or
+	/// <c>null</c> when the path is not a character biography's wiki view route.
+	/// <para>
+	/// Deliberately narrow. Only the bare view route is aliased: the <c>/history</c>,
+	/// <c>/diff</c> and <c>/edit</c> siblings have no equivalent under <c>/character</c> and
+	/// keep working where they are — which is also what stops the profile page's own history
+	/// link from bouncing. And only the default category is aliased, because
+	/// <c>/character/{slug}</c> carries no category segment to round-trip a different one
+	/// through.
+	/// </para>
+	/// </summary>
+	private static string? CharacterAliasFor(string[] segments) =>
+		// ["", "wiki", ns, category, slug] — exactly five, so /history and friends do not match.
+		segments is ["", "wiki", var ns, var category, var slug]
+		&& !string.IsNullOrEmpty(slug)
+		&& WikiRoutes.IsCharacterProfile(ns, category)
+			? WikiRoutes.PathFor(ns, category, slug)
+			: null;
 
 	[GeneratedRegex(@"\.[a-zA-Z0-9]+$")]
 	private static partial Regex FileExtensionRegex();

--- a/SharpMUSH.Tests.BUnit/Pages/WikiRoutePageTests.cs
+++ b/SharpMUSH.Tests.BUnit/Pages/WikiRoutePageTests.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging.Abstractions;
+using MudBlazor;
 using MudBlazor.Services;
 using NSubstitute;
 using SharpMUSH.Client.Components;
@@ -59,6 +60,15 @@ file sealed class InMemoryWikiHandler(IWikiService wikiService) : HttpMessageHan
             return result.Match(
                 page => Json(ToDto(page)),
                 _ => new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+
+        // The wiki admin grid's server-side data source.
+        if (request.Method == HttpMethod.Get && path == "api/wiki/pages")
+        {
+            var pages = await wikiService.GetAllPagesAsync(skip: 0, take: 2000);
+            var response = Json(pages.Select(ToDto).ToList());
+            response.Headers.Add("X-Total-Count", pages.Count.ToString());
+            return response;
         }
 
         // Refs use URL-path form: "ns/category/slug".
@@ -406,5 +416,48 @@ public class HelpRouteTests : BunitContext
         var wikiView = cut.FindComponent<WikiView>();
         await Assert.That(wikiView).IsNotNull();
         await Assert.That(wikiView.Instance.Slug).IsEqualTo("commands");
+    }
+}
+
+/// <summary>
+/// The wiki admin grid offers three links per row: the title (where the page is read) and the
+/// edit / history management actions. Character biographies read from /character/{slug} but are
+/// still edited and audited through their wiki route, so the two must be built from different
+/// bases — appending "/edit" to the profile alias yields a URL that does not resolve.
+/// </summary>
+public class AdminWikiLinkTests : BunitContext
+{
+    public AdminWikiLinkTests()
+    {
+        this.AddWikiTestServices();
+        Services.AddSingleton<ISnackbar>(Substitute.For<ISnackbar>());
+        AddAuthorization().SetAuthorized("admin").SetPolicies("wiki.admin");
+    }
+
+    [TUnit.Core.Test]
+    public async Task AdminWiki_CharacterPage_ReadsFromAliasButManagesThroughWikiRoute()
+    {
+        var wikiSvc = Services.GetRequiredService<IWikiService>();
+        await wikiSvc.CreateAsync("Mercutio", "A bio.", "#1", WikiNamespace.Character);
+
+        // MudDataGrid's column menus need a popover host present in the render tree.
+        Render<MudPopoverProvider>();
+
+        var cut = Render<SharpMUSH.Client.Pages.Admin.AdminWiki>();
+
+        cut.WaitForAssertion(() =>
+        {
+            if (!cut.Markup.Contains("/character/mercutio"))
+                throw new InvalidOperationException("grid rows not loaded yet");
+        }, TimeSpan.FromSeconds(5));
+
+        // Title link: the canonical reading path.
+        await Assert.That(cut.Markup).Contains("href=\"/character/mercutio\"");
+
+        // Management actions: real routes, not aliases with a suffix bolted on.
+        await Assert.That(cut.Markup).Contains("/wiki/character/general/mercutio/edit");
+        await Assert.That(cut.Markup).Contains("/wiki/character/general/mercutio/history");
+        await Assert.That(cut.Markup).DoesNotContain("/character/mercutio/edit");
+        await Assert.That(cut.Markup).DoesNotContain("/character/mercutio/history");
     }
 }

--- a/SharpMUSH.Tests.BUnit/Pages/WikiRoutePageTests.cs
+++ b/SharpMUSH.Tests.BUnit/Pages/WikiRoutePageTests.cs
@@ -1,4 +1,6 @@
 using Bunit;
+using Bunit.TestDoubles;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -251,6 +253,62 @@ public class WikiPageRouteTests : BunitContext
         await Assert.That(wikiView.Instance.Slug).IsEqualTo("magic_system");
         await Assert.That(wikiView.Instance.Mode).IsEqualTo(WikiView.WikiMode.Edit);
     }
+
+    /// <summary>
+    /// The client-side half of the character alias. CanonicalUrlMiddleware 301s cold loads, but
+    /// never sees a client-side navigation, so the route page has to catch those itself.
+    /// </summary>
+    [TUnit.Core.Test]
+    public async Task WikiPage_CharacterNamespace_RedirectsToProfileAlias()
+    {
+        var nav = (BunitNavigationManager)Services.GetRequiredService<NavigationManager>();
+
+        var cut = Render<SharpMUSH.Client.Pages.WikiPage>(p => p
+            .Add(c => c.Slug, "mercutio")
+            .Add(c => c.Ns, "character")
+            .Add(c => c.Category, "general"));
+
+        await Assert.That(nav.Uri).IsEqualTo(nav.BaseUri + "character/mercutio");
+
+        // The wiki view must not render behind the redirect — a flash of the wrong page.
+        await Assert.That(cut.FindComponents<WikiView>().Count).IsEqualTo(0);
+    }
+
+    /// <summary>
+    /// replace: true keeps the wiki URL out of the history stack. Without it, Back returns to
+    /// the wiki route and is bounced forward again, trapping the user on the profile.
+    /// </summary>
+    [TUnit.Core.Test]
+    public async Task WikiPage_CharacterRedirect_ReplacesHistoryEntry()
+    {
+        var nav = (BunitNavigationManager)Services.GetRequiredService<NavigationManager>();
+
+        Render<SharpMUSH.Client.Pages.WikiPage>(p => p
+            .Add(c => c.Slug, "mercutio")
+            .Add(c => c.Ns, "character")
+            .Add(c => c.Category, "general"));
+
+        await Assert.That(nav.History.Single().Options.ReplaceHistoryEntry).IsTrue();
+    }
+
+    /// <summary>
+    /// /character/{slug} has no category segment, so a character page filed elsewhere cannot
+    /// round-trip through it. It renders as an ordinary wiki page instead of redirecting.
+    /// </summary>
+    [TUnit.Core.Test]
+    public async Task WikiPage_CharacterNamespaceOtherCategory_RendersNormally()
+    {
+        var nav = (BunitNavigationManager)Services.GetRequiredService<NavigationManager>();
+        var startingUri = nav.Uri;
+
+        var cut = Render<SharpMUSH.Client.Pages.WikiPage>(p => p
+            .Add(c => c.Slug, "mercutio")
+            .Add(c => c.Ns, "character")
+            .Add(c => c.Category, "npcs"));
+
+        await Assert.That(nav.Uri).IsEqualTo(startingUri);
+        await Assert.That(cut.FindComponent<WikiView>().Instance.Slug).IsEqualTo("mercutio");
+    }
 }
 
 /// <summary>
@@ -315,6 +373,10 @@ public class CharacterRouteTests : BunitContext
         await Assert.That(wikiView).IsNotNull();
         await Assert.That(wikiView.Instance.Slug).IsEqualTo("Gandalf");
         await Assert.That(wikiView.Instance.Mode).IsEqualTo(WikiView.WikiMode.View);
+
+        // Biographies live in the Character namespace — that is what SeoController and
+        // BotPrerenderMiddleware read, and what makes the wiki-route alias identifiable.
+        await Assert.That(wikiView.Instance.Namespace).IsEqualTo(WikiRoutes.CharacterNamespace);
     }
 }
 

--- a/SharpMUSH.Tests.Integration/Wiki/WikiServiceIntegrationTests.cs
+++ b/SharpMUSH.Tests.Integration/Wiki/WikiServiceIntegrationTests.cs
@@ -153,6 +153,36 @@ public class WikiServiceIntegrationTests
         await Assert.That(result.AsT0.Id).IsEqualTo(created.Id);
     }
 
+    /// <summary>
+    /// The page identity is the slugified title, but callers look pages up by the name the user
+    /// sees — "/character/Mercutio" hands the profile widget "Mercutio", not "mercutio". The
+    /// service normalizes the incoming slug so the lookup lands on the stored page.
+    /// </summary>
+    [Test]
+    public async Task GetBySlugAsync_NormalizesTitleCasedLookup()
+    {
+        var uid = Guid.NewGuid().ToString("N")[..8];
+        var title = $"Mercutio {uid}";
+        var created = await CreatePageAsync(title);
+
+        var result = await Wiki.GetBySlugAsync(title, "general", WikiNamespace.Main);
+
+        await Assert.That(result.IsT0).IsTrue();
+        await Assert.That(result.AsT0.Id).IsEqualTo(created.Id);
+    }
+
+    [Test]
+    public async Task GetBySlugAsync_NormalizesUpperCasedLookup()
+    {
+        var uid = Guid.NewGuid().ToString("N")[..8];
+        var created = await CreatePageAsync($"Mercutio {uid}");
+
+        var result = await Wiki.GetBySlugAsync(created.Slug.ToUpperInvariant(), "general", WikiNamespace.Main);
+
+        await Assert.That(result.IsT0).IsTrue();
+        await Assert.That(result.AsT0.Id).IsEqualTo(created.Id);
+    }
+
     [Test]
     public async Task GetBySlugAsync_MissingSlug_ReturnsNotFound()
     {

--- a/SharpMUSH.Tests/Server/Middleware/CanonicalUrlMiddlewareTests.cs
+++ b/SharpMUSH.Tests/Server/Middleware/CanonicalUrlMiddlewareTests.cs
@@ -183,4 +183,95 @@ public class CanonicalUrlMiddlewareTests
         await Assert.That((int)response.StatusCode).IsEqualTo(301);
         await Assert.That(response.Headers.Location?.ToString()).IsEqualTo("/wiki/Page_Name?search=foo");
     }
+
+    // --- Character biography aliasing -------------------------------------------------
+    // /wiki/character/general/{slug} is the storage route; /character/{slug} is the one the
+    // portal serves. The middleware aliases the former to the latter so bookmarks and external
+    // links land on the canonical page.
+
+    [Test]
+    public async Task BuildCanonical_CharacterViewRoute_AliasedToProfile()
+    {
+        await Assert.That(CanonicalUrlMiddleware.BuildCanonical("/wiki/character/general/mercutio"))
+            .IsEqualTo("/character/mercutio");
+    }
+
+    [Test]
+    public async Task BuildCanonical_CharacterViewRouteWithSpaces_AliasedAndSlugified()
+    {
+        await Assert.That(CanonicalUrlMiddleware.BuildCanonical("/wiki/character/general/Mannaz Byron"))
+            .IsEqualTo("/character/mannaz_byron");
+    }
+
+    /// <summary>
+    /// History, diff and edit have no equivalent under /character, so they stay on the wiki
+    /// routes. This is also what stops the profile page's own history link from bouncing.
+    /// </summary>
+    [Test]
+    [Arguments("history")]
+    [Arguments("diff")]
+    [Arguments("edit")]
+    public async Task BuildCanonical_CharacterSubRoutes_NotAliased(string subRoute)
+    {
+        var path = $"/wiki/character/general/mercutio/{subRoute}";
+
+        await Assert.That(CanonicalUrlMiddleware.BuildCanonical(path)).IsEqualTo(path);
+    }
+
+    /// <summary>
+    /// /character/{slug} carries no category segment, so a character page filed elsewhere
+    /// cannot round-trip through it and keeps its wiki path.
+    /// </summary>
+    [Test]
+    public async Task BuildCanonical_CharacterPageInOtherCategory_NotAliased()
+    {
+        await Assert.That(CanonicalUrlMiddleware.BuildCanonical("/wiki/character/npcs/mercutio"))
+            .IsEqualTo("/wiki/character/npcs/mercutio");
+    }
+
+    [Test]
+    [Arguments("/wiki/main/general/mercutio")]
+    [Arguments("/wiki/help/general/markdown_guide")]
+    public async Task BuildCanonical_OtherNamespaces_NotAliased(string path)
+    {
+        await Assert.That(CanonicalUrlMiddleware.BuildCanonical(path)).IsEqualTo(path);
+    }
+
+    /// <summary>The alias must not loop: the target is already canonical.</summary>
+    [Test]
+    public async Task BuildCanonical_ProfileAlias_IsAFixedPoint()
+    {
+        var once = CanonicalUrlMiddleware.BuildCanonical("/wiki/character/general/mercutio");
+
+        await Assert.That(CanonicalUrlMiddleware.BuildCanonical(once)).IsEqualTo(once);
+    }
+
+    [Test]
+    public async Task Request_CharacterWikiRoute_Returns301ToProfile()
+    {
+        await using var app = await BuildAndStartAsync();
+        using var client = new HttpClient(app.GetTestServer().CreateHandler())
+        {
+            BaseAddress = new Uri("http://localhost")
+        };
+
+        var response = await client.GetAsync("/wiki/character/general/mercutio");
+
+        await Assert.That((int)response.StatusCode).IsEqualTo(301);
+        await Assert.That(response.Headers.Location?.ToString()).IsEqualTo("/character/mercutio");
+    }
+
+    [Test]
+    public async Task Request_CharacterHistoryRoute_IsNotRedirected()
+    {
+        await using var app = await BuildAndStartAsync();
+        using var client = new HttpClient(app.GetTestServer().CreateHandler())
+        {
+            BaseAddress = new Uri("http://localhost")
+        };
+
+        var response = await client.GetAsync("/wiki/character/general/mercutio/history");
+
+        await Assert.That((int)response.StatusCode).IsEqualTo(200);
+    }
 }

--- a/SharpMUSH.Tests/Wiki/InMemoryWikiServiceTests.cs
+++ b/SharpMUSH.Tests/Wiki/InMemoryWikiServiceTests.cs
@@ -174,6 +174,35 @@ public class InMemoryWikiServiceTests
 	}
 
 	[Test]
+	[Arguments("Mercutio")]
+	[Arguments("MERCUTIO")]
+	[Arguments("mercutio")]
+	public async Task GetBySlugAsync_NormalizesSlugCase(string lookup)
+	{
+		var svc = BuildService();
+		var created = await CreatePageAsync(svc, title: "Mercutio");
+
+		var result = await svc.GetBySlugAsync(lookup, "general", WikiNamespace.Main);
+
+		await Assert.That(result.IsT0).IsTrue();
+		await Assert.That(result.AsT0.Id).IsEqualTo(created.Id);
+	}
+
+	[Test]
+	[Arguments("Mannaz Byron")]
+	[Arguments("mannaz_byron")]
+	public async Task GetBySlugAsync_NormalizesSpacesToUnderscores(string lookup)
+	{
+		var svc = BuildService();
+		var created = await CreatePageAsync(svc, title: "Mannaz Byron");
+
+		var result = await svc.GetBySlugAsync(lookup, "general", WikiNamespace.Main);
+
+		await Assert.That(result.IsT0).IsTrue();
+		await Assert.That(result.AsT0.Id).IsEqualTo(created.Id);
+	}
+
+	[Test]
 	public async Task GetBySlugAsync_MissingSlug_ReturnsNotFound()
 	{
 		var svc = BuildService();

--- a/SharpMUSH.Tests/Wiki/WikiMarkdigPipelineTests.cs
+++ b/SharpMUSH.Tests/Wiki/WikiMarkdigPipelineTests.cs
@@ -219,6 +219,7 @@ public class WikiMarkdigPipelineTests
 		var node = new WikiLinkInline
 		{
 			Slug = "missing_page",
+			Href = "/wiki/missing_page",
 			Title = "Missing Page",
 			IsRedLink = true,
 		};
@@ -245,6 +246,31 @@ public class WikiMarkdigPipelineTests
 		var html = Pipeline().RenderToHtml("[[Help:Getting Started]]");
 
 		await Assert.That(html).Contains("href=\"/wiki/help/general/getting_started\"");
+	}
+
+	/// <summary>
+	/// [[Character:Mercutio]] → href="/character/mercutio". Character biographies are served
+	/// from their alias, so wiki markup links straight there instead of via a redirect.
+	/// </summary>
+	[Test]
+	public async Task WikiLinkExtension_CharacterPage_LinksToProfileAlias()
+	{
+		var html = Pipeline().RenderToHtml("[[Character:Mannaz Byron]]");
+
+		await Assert.That(html).Contains("href=\"/character/mannaz_byron\"");
+		await Assert.That(html).DoesNotContain("/wiki/character/");
+	}
+
+	/// <summary>
+	/// A character-namespace page in a non-default category has no /character URL to round-trip
+	/// through (that route carries no category segment), so it keeps its wiki path.
+	/// </summary>
+	[Test]
+	public async Task WikiLinkExtension_CharacterPageInOtherCategory_KeepsWikiPath()
+	{
+		var html = Pipeline().RenderToHtml("[[Character:NPCs:Mercutio]]");
+
+		await Assert.That(html).Contains("href=\"/wiki/character/npcs/mercutio\"");
 	}
 
 	/// <summary>

--- a/SharpMUSH.Tests/Wiki/WikiRoutesTests.cs
+++ b/SharpMUSH.Tests/Wiki/WikiRoutesTests.cs
@@ -1,0 +1,75 @@
+using SharpMUSH.Library.Services;
+
+namespace SharpMUSH.Tests.Wiki;
+
+/// <summary>
+/// Unit tests for <see cref="WikiRoutes"/>, the single answer to "where does this page live"
+/// shared by the client link producers, the sitemap, and the redirect backstops.
+/// </summary>
+public class WikiRoutesTests
+{
+	[Test]
+	[Arguments("character", "general")]
+	[Arguments("Character", "general")]
+	[Arguments("character", null)]
+	[Arguments("character", "")]
+	public async Task IsCharacterProfile_CharacterNamespaceInDefaultCategory_IsTrue(string ns, string? category)
+	{
+		await Assert.That(WikiRoutes.IsCharacterProfile(ns, category)).IsTrue();
+	}
+
+	/// <summary>
+	/// /character/{name} carries no category segment, so a character page filed under a
+	/// non-default category cannot round-trip through that URL and keeps its wiki path.
+	/// </summary>
+	[Test]
+	public async Task IsCharacterProfile_CharacterNamespaceInOtherCategory_IsFalse()
+	{
+		await Assert.That(WikiRoutes.IsCharacterProfile("character", "npcs")).IsFalse();
+	}
+
+	[Test]
+	[Arguments("main")]
+	[Arguments("help")]
+	[Arguments("system")]
+	public async Task IsCharacterProfile_OtherNamespaces_IsFalse(string ns)
+	{
+		await Assert.That(WikiRoutes.IsCharacterProfile(ns, "general")).IsFalse();
+	}
+
+	[Test]
+	public async Task PathFor_CharacterProfile_UsesCharacterAlias()
+	{
+		await Assert.That(WikiRoutes.PathFor("character", "general", "mercutio"))
+			.IsEqualTo("/character/mercutio");
+	}
+
+	[Test]
+	public async Task PathFor_CharacterInOtherCategory_KeepsWikiPath()
+	{
+		await Assert.That(WikiRoutes.PathFor("character", "npcs", "mercutio"))
+			.IsEqualTo("/wiki/character/npcs/mercutio");
+	}
+
+	[Test]
+	public async Task PathFor_OrdinaryPage_UsesWikiPath()
+	{
+		await Assert.That(WikiRoutes.PathFor("help", "general", "markdown_guide"))
+			.IsEqualTo("/wiki/help/general/markdown_guide");
+	}
+
+	[Test]
+	public async Task PathFor_NormalizesNamespaceCaseAndMissingCategory()
+	{
+		await Assert.That(WikiRoutes.PathFor("Help", null, "markdown_guide"))
+			.IsEqualTo("/wiki/help/general/markdown_guide");
+	}
+
+	/// <summary>Display names reach the same path as the stored slug, per <c>WikiHelpers.Slugify</c>.</summary>
+	[Test]
+	public async Task PathFor_SlugifiesDisplayNames()
+	{
+		await Assert.That(WikiRoutes.PathFor("character", "general", "Mannaz Byron"))
+			.IsEqualTo("/character/mannaz_byron");
+	}
+}

--- a/SharpMUSH.Tests/Wiki/WikiRoutesTests.cs
+++ b/SharpMUSH.Tests/Wiki/WikiRoutesTests.cs
@@ -72,4 +72,47 @@ public class WikiRoutesTests
 		await Assert.That(WikiRoutes.PathFor("character", "general", "Mannaz Byron"))
 			.IsEqualTo("/character/mannaz_byron");
 	}
+
+	/// <summary>
+	/// A blank namespace must fall back to main like a null one does. Wiki markup can supply an
+	/// empty prefix (<c>[[ :Page]]</c>), and an empty segment would build <c>/wiki//general/x</c>.
+	/// </summary>
+	[Test]
+	[Arguments(null)]
+	[Arguments("")]
+	[Arguments("   ")]
+	public async Task PathFor_BlankNamespace_FallsBackToMain(string? ns)
+	{
+		await Assert.That(WikiRoutes.PathFor(ns, "general", "page_name"))
+			.IsEqualTo("/wiki/main/general/page_name");
+	}
+
+	// --- WikiPathFor: the storage route, for tooling links ------------------------------
+	// /edit, /history and /diff hang off the wiki route and have no alias equivalent, so
+	// anything appending them must not start from the profile alias.
+
+	[Test]
+	public async Task WikiPathFor_CharacterProfile_KeepsWikiRoute()
+	{
+		await Assert.That(WikiRoutes.WikiPathFor("character", "general", "mercutio"))
+			.IsEqualTo("/wiki/character/general/mercutio");
+	}
+
+	[Test]
+	public async Task WikiPathFor_OrdinaryPage_MatchesPathFor()
+	{
+		await Assert.That(WikiRoutes.WikiPathFor("help", "general", "markdown_guide"))
+			.IsEqualTo(WikiRoutes.PathFor("help", "general", "markdown_guide"));
+	}
+
+	/// <summary>Sub-routes appended to the tooling path must land on real routes.</summary>
+	[Test]
+	[Arguments("edit")]
+	[Arguments("history")]
+	[Arguments("diff")]
+	public async Task WikiPathFor_CharacterProfile_SupportsSubRoutes(string subRoute)
+	{
+		await Assert.That($"{WikiRoutes.WikiPathFor("character", "general", "mercutio")}/{subRoute}")
+			.IsEqualTo($"/wiki/character/general/mercutio/{subRoute}");
+	}
 }

--- a/docs/design/url-strategy.md
+++ b/docs/design/url-strategy.md
@@ -76,6 +76,31 @@ non-API routes (standard WASM hosting pattern).
 - Character profiles get the alias `/character/Name` → resolves to
   `Character:Name` wiki page internally
 
+### Character Biographies
+
+A character's biography is the Character-namespace page whose slug is the
+character name, and `/character/{name}` is its **only** canonical URL. The
+wiki route it is stored under is an implementation detail:
+
+- Nothing in the portal links to `/wiki/character/general/{slug}`. Every link
+  producer — the wiki index, recent-changes, directive blocks, the wiki admin
+  grid, `[[wiki links]]` in markup, and the sitemap — goes through
+  `WikiRoutes.PathFor`, which returns the alias for these pages.
+- `CanonicalUrlMiddleware` 301s the wiki route to the alias, catching
+  bookmarks, external links, and markup rendered before that change.
+- `WikiPage.razor` performs the same redirect for client-side navigations,
+  which never reach the server. It replaces the history entry rather than
+  pushing one, so Back does not land on a URL that immediately bounces.
+
+Two deliberate limits on the alias:
+
+- **View route only.** `/history`, `/diff` and `/edit` have no equivalent under
+  `/character` and keep working where they are. This is also what stops the
+  profile page's own history link from bouncing.
+- **Default category only.** `/character/{name}` carries no category segment,
+  so a Character-namespace page filed under any other category cannot round-trip
+  through the alias and keeps its wiki path.
+
 ### Scene Permalinks
 
 - `/scenes/42` — numeric ID, never changes
@@ -158,4 +183,6 @@ Bots get a 403 or a generic "Login required" page. No content leak.
   - `/wiki/Page Name` (space) → `/wiki/Page_Name` (301 redirect)
   - `/Wiki/Page_Name` (capital W) → `/wiki/Page_Name` (301 redirect)
   - `/character/Name/` (trailing slash) → `/character/Name` (301 redirect)
+  - `/wiki/character/general/Name` → `/character/Name` (301 redirect;
+    see "Character Biographies" above)
 - `<link rel="canonical">` included in pre-rendered pages


### PR DESCRIPTION
Two changes, both about character biographies having one honest URL. #709 was merged into this branch, so it carries both.

## 1. Slug normalization on lookup

Editing a character bio, saving, and reloading made it vanish; saving again failed with

```
Create failed (409): {"error":"A wiki page with slug 'mercutio' already exists in namespace 'main' category 'general'."}
```

`CreateAsync` derives a page's identity slug from its title with `WikiHelpers.Slugify` (lower-cased, spaces → underscores). `GetBySlugAsync` compared the caller's string against the stored slug **verbatim** — namespace and category were normalized on the way in, slug was not.

That splits the round-trip in two:

| Step | Slug used | Result |
|---|---|---|
| Profile renders `/character/Mercutio` | `Mercutio` | GET → 404 |
| Widget offers to create the bio, user saves | title → `mercutio` | created, shown in-session |
| Reload | `Mercutio` | 404 again — the bio is gone |
| User re-saves | `CreateAsync` slugifies → `mercutio` | duplicate check **hits** → 409 |

The lookup and the duplicate check disagreed about what the slug is, so the page was simultaneously invisible and un-creatable. Same failure for any name with a space, and for `BotPrerenderMiddleware`, which passes the raw URL segment straight through.

**Fix:** normalize the slug at the service boundary in all four `IWikiService` implementations, alongside the `NormalizeCategory` call already there. `Slugify` is idempotent, so already-normalized callers are unaffected and no future caller can get it wrong.

**The dev double was hiding this.** `InMemoryWikiService` keys its slug index with `StringComparer.OrdinalIgnoreCase`, so it tolerated the case mismatch that ArangoDB, Memgraph and SurrealDB all reject. Unit tests passed while production failed. Its lookup is normalized now too.

## 2. One canonical URL for a biography

A bio is a Character-namespace wiki page — but the portal had two URLs for it and no agreement on which was real. `WikiBodyWidget` read and wrote in **Main**; `SeoController` and `BotPrerenderMiddleware` both read from **Character**. The sitemap and every crawler pointed at pages the portal never wrote.

`docs/design/url-strategy.md:76` already settled it — *"Character profiles get the alias `/character/Name`"* — so the widget was simply wrong. Fixing it makes character pages **identifiable**, which is what lets the rest work.

**`WikiRoutes`** — two functions, two questions:

- `PathFor` — where a page is *read*. The alias for biographies. For links pointing at a page.
- `WikiPathFor` — the wiki route it is *stored* under, never the alias. For anything appending `/edit`, `/history`, `/diff`.

Six link producers adopt `PathFor`: the wiki index, recent changes, directive blocks, the admin grid's title link, `[[wiki links]]`, and `SeoController.PathFor` — a private near-duplicate of this function, now deleted. The app no longer emits a `/wiki/character/…` link anywhere.

**Server 301** — a rule in `CanonicalUrlMiddleware`, which already owned the case / space / trailing-slash 301s for these prefixes. It sits ahead of `BotPrerenderMiddleware`, so crawlers are redirected and then prerendered through the character branch.

**Client redirect** — `WikiPage.razor` repeats it for client-side navigations, which never reach the server. `replace: true` keeps the wiki URL out of the history stack; pushing it would leave Back landing on a URL that bounces forward again.

### Three guards against weirdness

- **View route only.** `/history`, `/diff`, `/edit` have no equivalent under `/character` and keep working where they are. This is also what stops the profile's own history link from bouncing.
- **Default category only.** `/character/{name}` carries no category segment, so a Character-namespace page filed elsewhere can't round-trip through the alias.
- **The alias is a fixed point.** Tested explicitly — `BuildCanonical` applied twice returns the same path, so no redirect chain is reachable.

### Redlinks survive the transition

`RenderedHtml` is stored per page, so HTML written before this still carries `/wiki/character/…` hrefs. Matching only the new alias would have silently stopped marking those links red until each page was re-saved. `WikiDisplay` recognises both shapes and maps either back to the same reference for the existence check.

## No migration

A bio already saved under `main/general` isn't deleted — it stops appearing on the profile and stays readable at its own wiki URL, which does *not* redirect. Re-saving it on the profile files it under Character. Deliberate call; the alternative was a startup migration keyed off `GetAllPlayersAsync`.

## Verification

- `WikiRoutesTests` — 21 cases over both path helpers, including blank/whitespace namespaces and sub-route composition.
- `CanonicalUrlMiddlewareTests` — alias fires on the view route; not on `/history`, `/diff`, `/edit`, other categories, or other namespaces; is a fixed point; end-to-end 301 through `TestServer`.
- `WikiMarkdigPipelineTests` — `[[Character:Mannaz Byron]]` → `/character/mannaz_byron`; `[[Character:NPCs:Mercutio]]` keeps its wiki path.
- `AdminWikiLinkTests` — renders the admin grid and asserts the title link uses the alias while edit/history use the wiki route. Verified failing before the fix.
- bUnit — profile requests the Character namespace; `WikiPage` redirects with a replaced history entry and renders no `WikiView` behind it.
- Integration — slug normalization verified failing-then-passing against ArangoDB, then green on all three providers.
- Suites: **4713** unit passed (198 skipped), **267** bUnit, **245** integration on ArangoDB. Build 0 errors.

`docs/design/url-strategy.md` gains a "Character Biographies" section and the new 301 in the canonical-URL list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvopbATVT2fY4m2JrAWukR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Character biography pages now use canonical `/character/{name}` URLs.
  * Wiki links automatically route to the appropriate canonical page.
* **Bug Fixes**
  * Added redirects from legacy character wiki URLs to canonical profile URLs, including history behavior.
  * Redlink detection now recognizes both wiki and character link aliases.
  * Wiki slug lookups are now normalized (case/spacing) across storage and services.
* **Documentation**
  * Updated URL strategy and canonical URL guidance for character biographies.
* **Tests**
  * Expanded route, redirect, and URL normalization coverage for wiki routing and admin links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->