### PR TITLE
feat(wiki): serve character biographies only from /character/{name}

### DIFF
--- a/SharpMUSH.Client/Components/Widgets/RecentWikiActivityWidget.razor
+++ b/SharpMUSH.Client/Components/Widgets/RecentWikiActivityWidget.razor
@@ -21,7 +21,7 @@
                     @(wp.Title.Length > 0 ? wp.Title[0].ToString().ToUpper() : "W")
                 </MudAvatar>
                 <div style="flex:1;min-width:0;">
-                    <MudLink Href="@($"/wiki/{wp.Namespace}/{wp.Category}/{wp.Slug}")" Style="color:var(--text);font-size:0.8125rem;font-weight:500;">@wp.Title</MudLink>
+                    <MudLink Href="@WikiRoutes.PathFor(wp.Namespace, wp.Category, wp.Slug)" Style="color:var(--text);font-size:0.8125rem;font-weight:500;">@wp.Title</MudLink>
                     <MudText Style="font-size:0.6875rem;color:var(--text-faint);">@wp.UpdatedAt.ToLocalTime().ToString("MMM d")</MudText>
                 </div>
             </div>

--- a/SharpMUSH.Client/Components/Widgets/WikiBodyWidget.razor
+++ b/SharpMUSH.Client/Components/Widgets/WikiBodyWidget.razor
@@ -2,14 +2,14 @@
 @using SharpMUSH.Client.Components
 @using SharpMUSH.Client.Models.Widgets
 
-@* Renders a character's free-form wiki biography (the page whose slug is the character name). The
-   character comes from the cascading ProfilePageContext when placed on the profile page; it falls
-   back to a "character" key in the widget config for standalone placements. *@
+@* Renders a character's free-form wiki biography: the Character-namespace page whose slug is the
+   character name. The character comes from the cascading ProfilePageContext when placed on the
+   profile page; it falls back to a "character" key in the widget config for standalone placements. *@
 
 @if (!string.IsNullOrWhiteSpace(_name))
 {
     <MudPaper Class="wiki-body-widget" Elevation="0" Style="padding:1.25rem;border-radius:var(--radius);border:1px solid var(--border);background:var(--surface);">
-        <WikiView Slug="@_name" Mode="WikiView.WikiMode.View" />
+        <WikiView Slug="@_name" Namespace="@WikiRoutes.CharacterNamespace" Mode="WikiView.WikiMode.View" />
     </MudPaper>
 }
 

--- a/SharpMUSH.Client/Components/Widgets/WikiIndexWidget.razor
+++ b/SharpMUSH.Client/Components/Widgets/WikiIndexWidget.razor
@@ -121,5 +121,5 @@
         => s.Length == 0 ? s : char.ToUpper(s[0]) + s[1..];
 
     private static string PageHref(WikiPageSummary page) =>
-        $"/wiki/{page.Namespace.ToLowerInvariant()}/{(page.Category ?? "general")}/{page.Slug}";
+        WikiRoutes.PathFor(page.Namespace, page.Category, page.Slug);
 }

--- a/SharpMUSH.Client/Components/WikiDirectiveBlock.razor
+++ b/SharpMUSH.Client/Components/WikiDirectiveBlock.razor
@@ -89,5 +89,5 @@
     };
 
     private static string LinkFor(PageDto page) =>
-        $"/wiki/{page.Namespace.ToLowerInvariant()}/{(page.Category ?? "general")}/{page.Slug}";
+        WikiRoutes.PathFor(page.Namespace, page.Category, page.Slug);
 }

--- a/SharpMUSH.Client/Components/WikiDisplay.razor
+++ b/SharpMUSH.Client/Components/WikiDisplay.razor
@@ -132,6 +132,13 @@ else
         "<a href=\"/wiki/([^\"#?]+)\">",
         RegexOptions.Compiled);
 
+    // Character biographies render as their /character/{slug} alias. HTML stored before that
+    // change still carries the /wiki/character/... form, which WikiLinkHref above still matches,
+    // so both shapes have to be recognised for redlink marking to survive the transition.
+    private static readonly Regex CharacterLinkHref = new(
+        "<a href=\"/character/([^\"#?/]+)\">",
+        RegexOptions.Compiled);
+
     private List<BodySegment> _segments = [];
     private List<TocEntry> _toc = [];
 
@@ -216,23 +223,36 @@ else
         return s.Trim('-');
     }
 
+    /// <summary>An anchor found in rendered HTML: the href as written, and the wiki page
+    /// reference ("ns/category/slug") whose existence decides whether it is a redlink.</summary>
+    private readonly record struct LinkTarget(string Href, string Reference);
+
+    private static List<LinkTarget> FindLinkTargets(string html) =>
+        WikiLinkHref.Matches(html)
+            .Select(m => new LinkTarget($"/wiki/{m.Groups[1].Value}", m.Groups[1].Value))
+            .Concat(CharacterLinkHref.Matches(html)
+                .Select(m => new LinkTarget(
+                    $"/character/{m.Groups[1].Value}",
+                    $"character/general/{m.Groups[1].Value}")))
+            .DistinctBy(t => t.Href, StringComparer.Ordinal)
+            .ToList();
+
     private async Task<string> MarkRedlinksAsync(string html)
     {
-        var refs = WikiLinkHref.Matches(html)
-            .Select(m => m.Groups[1].Value)
-            .Distinct(StringComparer.Ordinal)
-            .ToList();
-        if (refs.Count == 0) return html;
+        var targets = FindLinkTargets(html);
+        if (targets.Count == 0) return html;
 
-        var exists = await Wiki.CheckExistsAsync(refs.Select(WebUtility.HtmlDecode)!);
-        foreach (var reference in refs)
+        var exists = await Wiki.CheckExistsAsync(
+            targets.Select(t => WebUtility.HtmlDecode(t.Reference)!).Distinct(StringComparer.Ordinal));
+
+        foreach (var target in targets)
         {
-            var decoded = WebUtility.HtmlDecode(reference);
+            var decoded = WebUtility.HtmlDecode(target.Reference);
             if (exists.TryGetValue(decoded, out var found) && !found)
             {
                 html = html.Replace(
-                    $"<a href=\"/wiki/{reference}\">",
-                    $"<a href=\"/wiki/{reference}\" class=\"wiki-redlink\">");
+                    $"<a href=\"{target.Href}\">",
+                    $"<a href=\"{target.Href}\" class=\"wiki-redlink\">");
             }
         }
 

--- a/SharpMUSH.Client/Pages/Admin/AdminWiki.razor
+++ b/SharpMUSH.Client/Pages/Admin/AdminWiki.razor
@@ -276,7 +276,7 @@
     }
 
     private static string PageHref(WikiPageSummary page) =>
-        $"/wiki/{page.Namespace.ToLowerInvariant()}/{(page.Category ?? "general")}/{page.Slug}";
+        WikiRoutes.PathFor(page.Namespace, page.Category, page.Slug);
 
     private static string RefFor(WikiPageSummary page) =>
         $"{page.Namespace.ToLowerInvariant()}/{page.Category ?? "general"}/{page.Slug}";

--- a/SharpMUSH.Client/Pages/WikiPage.razor
+++ b/SharpMUSH.Client/Pages/WikiPage.razor
@@ -1,12 +1,34 @@
 @page "/wiki/{Ns}/{Category}/{Slug}"
 @using SharpMUSH.Client.Components
+@inject NavigationManager Nav
 
-<PageTitle>@Slug — Wiki — SharpMUSH</PageTitle>
+@if (!_redirecting)
+{
+    <PageTitle>@Slug — Wiki — SharpMUSH</PageTitle>
 
-<WikiView @key="@($"{Ns}:{Category}:{Slug}")" Slug="@Slug" Namespace="@Ns" Category="@Category" Mode="WikiView.WikiMode.View" />
+    <WikiView @key="@($"{Ns}:{Category}:{Slug}")" Slug="@Slug" Namespace="@Ns" Category="@Category" Mode="WikiView.WikiMode.View" />
+}
 
 @code {
     [Parameter] public required string Slug { get; set; }
     [Parameter] public required string Ns { get; set; }
     [Parameter] public required string Category { get; set; }
+
+    private bool _redirecting;
+
+    // Backstop for links this app no longer produces: bookmarks, external links, hand-typed URLs,
+    // and wiki markup rendered before character links became aliases. Cold loads are caught
+    // earlier by CanonicalUrlMiddleware's 301, but that never sees a client-side navigation, so
+    // the check has to exist here as well.
+    //
+    // replace: true keeps the wiki URL out of the history stack — otherwise Back lands on it and
+    // is bounced straight forward again, trapping the user on the profile.
+    protected override void OnParametersSet()
+    {
+        _redirecting = WikiRoutes.IsCharacterProfile(Ns, Category);
+        if (_redirecting)
+        {
+            Nav.NavigateTo(WikiRoutes.PathFor(Ns, Category, Slug), replace: true);
+        }
+    }
 }

--- a/SharpMUSH.Client/_Imports.razor
+++ b/SharpMUSH.Client/_Imports.razor
@@ -14,6 +14,7 @@
 @using SharpMUSH.Client.Models
 @using SharpMUSH.Client.Services
 @using SharpMUSH.Client.Components
+@using SharpMUSH.Library.Services
 @using SharpMUSH.Library.Services.Interfaces
 @using MudBlazor
 @using BlazorMonaco

--- a/SharpMUSH.Contracts/Services/WikiLinkExtension.cs
+++ b/SharpMUSH.Contracts/Services/WikiLinkExtension.cs
@@ -19,6 +19,13 @@ public sealed class WikiLinkInline : LeafInline
 	public required string Slug { get; init; }
 
 	/// <summary>
+	/// The portal path this link points at. Character biographies resolve to their
+	/// <c>/character/{slug}</c> alias rather than the wiki route they are stored under;
+	/// see <see cref="WikiRoutes.PathFor"/>.
+	/// </summary>
+	public required string Href { get; init; }
+
+	/// <summary>
 	/// The human-readable title of the target page (derived from the slug if not specified).
 	/// </summary>
 	public required string Title { get; init; }
@@ -108,6 +115,7 @@ internal sealed class WikiLinkParser : InlineParser
 		{
 			// Canonical path identity: namespace/category/slug.
 			Slug = $"{ns}/{category}/{slug}",
+			Href = WikiRoutes.PathFor(ns, category, slug),
 			Title = title,
 			DisplayText = displayText,
 		};
@@ -146,16 +154,14 @@ internal sealed class WikiLinkParser : InlineParser
 }
 
 /// <summary>
-/// Markdig HTML renderer that converts <see cref="WikiLinkInline"/> nodes into
-/// HTML anchor tags pointing to <c>/wiki/{ns}/{slug}</c>.
+/// Markdig HTML renderer that converts <see cref="WikiLinkInline"/> nodes into HTML anchor
+/// tags pointing at the node's canonical portal path (see <see cref="WikiLinkInline.Href"/>).
 /// </summary>
 internal sealed class WikiLinkHtmlRenderer : HtmlObjectRenderer<WikiLinkInline>
 {
 	protected override void Write(HtmlRenderer renderer, WikiLinkInline obj)
 	{
-		// Build href from full slug (which already includes namespace prefix if any)
-		// e.g. "main/page_name", "help/getting_started"
-		var href = $"/wiki/{obj.Slug}";
+		var href = obj.Href;
 		var cssClass = obj.IsRedLink ? " class=\"wiki-redlink\"" : string.Empty;
 		var text = obj.DisplayText ?? obj.Title;
 		// C-5: Use WriteEscapeUrl for the href so slug characters like '"' and '>'

--- a/SharpMUSH.Contracts/Services/WikiRoutes.cs
+++ b/SharpMUSH.Contracts/Services/WikiRoutes.cs
@@ -1,0 +1,38 @@
+namespace SharpMUSH.Library.Services;
+
+/// <summary>
+/// Maps a wiki page's identity to the portal path that page is canonically served from.
+/// Shared by the client's link producers, the sitemap, and the redirect backstops so every
+/// surface agrees on one answer.
+/// </summary>
+public static class WikiRoutes
+{
+	/// <summary>The namespace whose pages are character biographies.</summary>
+	public const string CharacterNamespace = "character";
+
+	/// <summary>
+	/// True when (<paramref name="ns"/>, <paramref name="category"/>) identifies a character
+	/// biography, which the portal serves from <c>/character/{slug}</c> rather than the wiki.
+	/// <para>
+	/// The category must be the default one: <c>/character/{name}</c> carries no category segment,
+	/// so both the API alias and the bot prerenderer resolve it against <see cref="WikiHelpers.DefaultCategory"/>.
+	/// A character-namespace page filed under any other category would not round-trip through that
+	/// URL, so it keeps its wiki path.
+	/// </para>
+	/// </summary>
+	public static bool IsCharacterProfile(string? ns, string? category) =>
+		string.Equals(ns?.Trim(), CharacterNamespace, StringComparison.OrdinalIgnoreCase)
+		&& WikiHelpers.NormalizeCategory(category) == WikiHelpers.DefaultCategory;
+
+	/// <summary>
+	/// The canonical portal path for a wiki page: <c>/character/{slug}</c> for character
+	/// biographies, <c>/wiki/{ns}/{category}/{slug}</c> for everything else.
+	/// </summary>
+	public static string PathFor(string? ns, string? category, string slug)
+	{
+		var normalizedSlug = WikiHelpers.Slugify(slug);
+		return IsCharacterProfile(ns, category)
+			? $"/character/{normalizedSlug}"
+			: $"/wiki/{(ns ?? "main").Trim().ToLowerInvariant()}/{WikiHelpers.NormalizeCategory(category)}/{normalizedSlug}";
+	}
+}

--- a/SharpMUSH.Server/Controllers/SeoController.cs
+++ b/SharpMUSH.Server/Controllers/SeoController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SharpMUSH.Library.Models.Wiki;
+using SharpMUSH.Library.Services;
 using SharpMUSH.Library.Services.Interfaces;
 using System.Security;
 using System.Text;
@@ -89,11 +90,7 @@ public class SeoController(
 
 	/// <summary>Maps a wiki page to its public portal path based on its namespace.</summary>
 	private static string PathFor(WikiPage page) =>
-		page.Namespace.ToLowerInvariant() switch
-		{
-			"character" => $"/character/{page.Slug}",
-			var ns => $"/wiki/{ns}/{page.Category ?? "general"}/{page.Slug}",
-		};
+		WikiRoutes.PathFor(page.Namespace, page.Category, page.Slug);
 
 	private static void AppendUrl(StringBuilder sb, string loc, string lastmod)
 	{

--- a/SharpMUSH.Server/Middleware/CanonicalUrlMiddleware.cs
+++ b/SharpMUSH.Server/Middleware/CanonicalUrlMiddleware.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using SharpMUSH.Library.Services;
 using SharpMUSH.Server.Helpers;
 
 namespace SharpMUSH.Server.Middleware;
@@ -11,6 +12,7 @@ namespace SharpMUSH.Server.Middleware;
 /// - Spaces in path segments → underscores  (301)
 /// - Wrong case on known path prefixes → lowercase prefix  (301)
 /// - Trailing slash on non-root paths → stripped  (301)
+/// - Character biographies reached through the wiki → their /character/{slug} alias  (301)
 /// API, hub, and static asset routes are exempted.
 /// </summary>
 public sealed partial class CanonicalUrlMiddleware(RequestDelegate next, ILogger<CanonicalUrlMiddleware> logger)
@@ -68,6 +70,7 @@ public sealed partial class CanonicalUrlMiddleware(RequestDelegate next, ILogger
 	/// 1. Lowercase the first path segment prefix (e.g. /Wiki → /wiki).
 	/// 2. Percent-decode then replace spaces with underscores in each segment.
 	/// 3. Strip trailing slash (except root "/").
+	/// 4. Rewrite a character biography's wiki route to its /character/{slug} alias.
 	/// </summary>
 	public static string BuildCanonical(string path)
 	{
@@ -93,8 +96,28 @@ public sealed partial class CanonicalUrlMiddleware(RequestDelegate next, ILogger
 			segments[i] = noSpaces;
 		}
 
-		return string.Join('/', segments);
+		return CharacterAliasFor(segments) ?? string.Join('/', segments);
 	}
+
+	/// <summary>
+	/// The <c>/character/{slug}</c> alias for <c>/wiki/character/general/{slug}</c>, or
+	/// <c>null</c> when the path is not a character biography's wiki view route.
+	/// <para>
+	/// Deliberately narrow. Only the bare view route is aliased: the <c>/history</c>,
+	/// <c>/diff</c> and <c>/edit</c> siblings have no equivalent under <c>/character</c> and
+	/// keep working where they are — which is also what stops the profile page's own history
+	/// link from bouncing. And only the default category is aliased, because
+	/// <c>/character/{slug}</c> carries no category segment to round-trip a different one
+	/// through.
+	/// </para>
+	/// </summary>
+	private static string? CharacterAliasFor(string[] segments) =>
+		// ["", "wiki", ns, category, slug] — exactly five, so /history and friends do not match.
+		segments is ["", "wiki", var ns, var category, var slug]
+		&& !string.IsNullOrEmpty(slug)
+		&& WikiRoutes.IsCharacterProfile(ns, category)
+			? WikiRoutes.PathFor(ns, category, slug)
+			: null;
 
 	[GeneratedRegex(@"\.[a-zA-Z0-9]+$")]
 	private static partial Regex FileExtensionRegex();

--- a/SharpMUSH.Tests.BUnit/Pages/WikiRoutePageTests.cs
+++ b/SharpMUSH.Tests.BUnit/Pages/WikiRoutePageTests.cs
@@ -1,4 +1,6 @@
 using Bunit;
+using Bunit.TestDoubles;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -251,6 +253,62 @@ public class WikiPageRouteTests : BunitContext
         await Assert.That(wikiView.Instance.Slug).IsEqualTo("magic_system");
         await Assert.That(wikiView.Instance.Mode).IsEqualTo(WikiView.WikiMode.Edit);
     }
+
+    /// <summary>
+    /// The client-side half of the character alias. CanonicalUrlMiddleware 301s cold loads, but
+    /// never sees a client-side navigation, so the route page has to catch those itself.
+    /// </summary>
+    [TUnit.Core.Test]
+    public async Task WikiPage_CharacterNamespace_RedirectsToProfileAlias()
+    {
+        var nav = (BunitNavigationManager)Services.GetRequiredService<NavigationManager>();
+
+        var cut = Render<SharpMUSH.Client.Pages.WikiPage>(p => p
+            .Add(c => c.Slug, "mercutio")
+            .Add(c => c.Ns, "character")
+            .Add(c => c.Category, "general"));
+
+        await Assert.That(nav.Uri).IsEqualTo(nav.BaseUri + "character/mercutio");
+
+        // The wiki view must not render behind the redirect — a flash of the wrong page.
+        await Assert.That(cut.FindComponents<WikiView>().Count).IsEqualTo(0);
+    }
+
+    /// <summary>
+    /// replace: true keeps the wiki URL out of the history stack. Without it, Back returns to
+    /// the wiki route and is bounced forward again, trapping the user on the profile.
+    /// </summary>
+    [TUnit.Core.Test]
+    public async Task WikiPage_CharacterRedirect_ReplacesHistoryEntry()
+    {
+        var nav = (BunitNavigationManager)Services.GetRequiredService<NavigationManager>();
+
+        Render<SharpMUSH.Client.Pages.WikiPage>(p => p
+            .Add(c => c.Slug, "mercutio")
+            .Add(c => c.Ns, "character")
+            .Add(c => c.Category, "general"));
+
+        await Assert.That(nav.History.Single().Options.ReplaceHistoryEntry).IsTrue();
+    }
+
+    /// <summary>
+    /// /character/{slug} has no category segment, so a character page filed elsewhere cannot
+    /// round-trip through it. It renders as an ordinary wiki page instead of redirecting.
+    /// </summary>
+    [TUnit.Core.Test]
+    public async Task WikiPage_CharacterNamespaceOtherCategory_RendersNormally()
+    {
+        var nav = (BunitNavigationManager)Services.GetRequiredService<NavigationManager>();
+        var startingUri = nav.Uri;
+
+        var cut = Render<SharpMUSH.Client.Pages.WikiPage>(p => p
+            .Add(c => c.Slug, "mercutio")
+            .Add(c => c.Ns, "character")
+            .Add(c => c.Category, "npcs"));
+
+        await Assert.That(nav.Uri).IsEqualTo(startingUri);
+        await Assert.That(cut.FindComponent<WikiView>().Instance.Slug).IsEqualTo("mercutio");
+    }
 }
 
 /// <summary>
@@ -315,6 +373,10 @@ public class CharacterRouteTests : BunitContext
         await Assert.That(wikiView).IsNotNull();
         await Assert.That(wikiView.Instance.Slug).IsEqualTo("Gandalf");
         await Assert.That(wikiView.Instance.Mode).IsEqualTo(WikiView.WikiMode.View);
+
+        // Biographies live in the Character namespace — that is what SeoController and
+        // BotPrerenderMiddleware read, and what makes the wiki-route alias identifiable.
+        await Assert.That(wikiView.Instance.Namespace).IsEqualTo(WikiRoutes.CharacterNamespace);
     }
 }
 

--- a/SharpMUSH.Tests/Server/Middleware/CanonicalUrlMiddlewareTests.cs
+++ b/SharpMUSH.Tests/Server/Middleware/CanonicalUrlMiddlewareTests.cs
@@ -183,4 +183,95 @@ public class CanonicalUrlMiddlewareTests
         await Assert.That((int)response.StatusCode).IsEqualTo(301);
         await Assert.That(response.Headers.Location?.ToString()).IsEqualTo("/wiki/Page_Name?search=foo");
     }
+
+    // --- Character biography aliasing -------------------------------------------------
+    // /wiki/character/general/{slug} is the storage route; /character/{slug} is the one the
+    // portal serves. The middleware aliases the former to the latter so bookmarks and external
+    // links land on the canonical page.
+
+    [Test]
+    public async Task BuildCanonical_CharacterViewRoute_AliasedToProfile()
+    {
+        await Assert.That(CanonicalUrlMiddleware.BuildCanonical("/wiki/character/general/mercutio"))
+            .IsEqualTo("/character/mercutio");
+    }
+
+    [Test]
+    public async Task BuildCanonical_CharacterViewRouteWithSpaces_AliasedAndSlugified()
+    {
+        await Assert.That(CanonicalUrlMiddleware.BuildCanonical("/wiki/character/general/Mannaz Byron"))
+            .IsEqualTo("/character/mannaz_byron");
+    }
+
+    /// <summary>
+    /// History, diff and edit have no equivalent under /character, so they stay on the wiki
+    /// routes. This is also what stops the profile page's own history link from bouncing.
+    /// </summary>
+    [Test]
+    [Arguments("history")]
+    [Arguments("diff")]
+    [Arguments("edit")]
+    public async Task BuildCanonical_CharacterSubRoutes_NotAliased(string subRoute)
+    {
+        var path = $"/wiki/character/general/mercutio/{subRoute}";
+
+        await Assert.That(CanonicalUrlMiddleware.BuildCanonical(path)).IsEqualTo(path);
+    }
+
+    /// <summary>
+    /// /character/{slug} carries no category segment, so a character page filed elsewhere
+    /// cannot round-trip through it and keeps its wiki path.
+    /// </summary>
+    [Test]
+    public async Task BuildCanonical_CharacterPageInOtherCategory_NotAliased()
+    {
+        await Assert.That(CanonicalUrlMiddleware.BuildCanonical("/wiki/character/npcs/mercutio"))
+            .IsEqualTo("/wiki/character/npcs/mercutio");
+    }
+
+    [Test]
+    [Arguments("/wiki/main/general/mercutio")]
+    [Arguments("/wiki/help/general/markdown_guide")]
+    public async Task BuildCanonical_OtherNamespaces_NotAliased(string path)
+    {
+        await Assert.That(CanonicalUrlMiddleware.BuildCanonical(path)).IsEqualTo(path);
+    }
+
+    /// <summary>The alias must not loop: the target is already canonical.</summary>
+    [Test]
+    public async Task BuildCanonical_ProfileAlias_IsAFixedPoint()
+    {
+        var once = CanonicalUrlMiddleware.BuildCanonical("/wiki/character/general/mercutio");
+
+        await Assert.That(CanonicalUrlMiddleware.BuildCanonical(once)).IsEqualTo(once);
+    }
+
+    [Test]
+    public async Task Request_CharacterWikiRoute_Returns301ToProfile()
+    {
+        await using var app = await BuildAndStartAsync();
+        using var client = new HttpClient(app.GetTestServer().CreateHandler())
+        {
+            BaseAddress = new Uri("http://localhost")
+        };
+
+        var response = await client.GetAsync("/wiki/character/general/mercutio");
+
+        await Assert.That((int)response.StatusCode).IsEqualTo(301);
+        await Assert.That(response.Headers.Location?.ToString()).IsEqualTo("/character/mercutio");
+    }
+
+    [Test]
+    public async Task Request_CharacterHistoryRoute_IsNotRedirected()
+    {
+        await using var app = await BuildAndStartAsync();
+        using var client = new HttpClient(app.GetTestServer().CreateHandler())
+        {
+            BaseAddress = new Uri("http://localhost")
+        };
+
+        var response = await client.GetAsync("/wiki/character/general/mercutio/history");
+
+        await Assert.That((int)response.StatusCode).IsEqualTo(200);
+    }
 }

--- a/SharpMUSH.Tests/Wiki/WikiMarkdigPipelineTests.cs
+++ b/SharpMUSH.Tests/Wiki/WikiMarkdigPipelineTests.cs
@@ -219,6 +219,7 @@ public class WikiMarkdigPipelineTests
 		var node = new WikiLinkInline
 		{
 			Slug = "missing_page",
+			Href = "/wiki/missing_page",
 			Title = "Missing Page",
 			IsRedLink = true,
 		};
@@ -245,6 +246,31 @@ public class WikiMarkdigPipelineTests
 		var html = Pipeline().RenderToHtml("[[Help:Getting Started]]");
 
 		await Assert.That(html).Contains("href=\"/wiki/help/general/getting_started\"");
+	}
+
+	/// <summary>
+	/// [[Character:Mercutio]] → href="/character/mercutio". Character biographies are served
+	/// from their alias, so wiki markup links straight there instead of via a redirect.
+	/// </summary>
+	[Test]
+	public async Task WikiLinkExtension_CharacterPage_LinksToProfileAlias()
+	{
+		var html = Pipeline().RenderToHtml("[[Character:Mannaz Byron]]");
+
+		await Assert.That(html).Contains("href=\"/character/mannaz_byron\"");
+		await Assert.That(html).DoesNotContain("/wiki/character/");
+	}
+
+	/// <summary>
+	/// A character-namespace page in a non-default category has no /character URL to round-trip
+	/// through (that route carries no category segment), so it keeps its wiki path.
+	/// </summary>
+	[Test]
+	public async Task WikiLinkExtension_CharacterPageInOtherCategory_KeepsWikiPath()
+	{
+		var html = Pipeline().RenderToHtml("[[Character:NPCs:Mercutio]]");
+
+		await Assert.That(html).Contains("href=\"/wiki/character/npcs/mercutio\"");
 	}
 
 	/// <summary>

--- a/SharpMUSH.Tests/Wiki/WikiRoutesTests.cs
+++ b/SharpMUSH.Tests/Wiki/WikiRoutesTests.cs
@@ -1,0 +1,75 @@
+using SharpMUSH.Library.Services;
+
+namespace SharpMUSH.Tests.Wiki;
+
+/// <summary>
+/// Unit tests for <see cref="WikiRoutes"/>, the single answer to "where does this page live"
+/// shared by the client link producers, the sitemap, and the redirect backstops.
+/// </summary>
+public class WikiRoutesTests
+{
+	[Test]
+	[Arguments("character", "general")]
+	[Arguments("Character", "general")]
+	[Arguments("character", null)]
+	[Arguments("character", "")]
+	public async Task IsCharacterProfile_CharacterNamespaceInDefaultCategory_IsTrue(string ns, string? category)
+	{
+		await Assert.That(WikiRoutes.IsCharacterProfile(ns, category)).IsTrue();
+	}
+
+	/// <summary>
+	/// /character/{name} carries no category segment, so a character page filed under a
+	/// non-default category cannot round-trip through that URL and keeps its wiki path.
+	/// </summary>
+	[Test]
+	public async Task IsCharacterProfile_CharacterNamespaceInOtherCategory_IsFalse()
+	{
+		await Assert.That(WikiRoutes.IsCharacterProfile("character", "npcs")).IsFalse();
+	}
+
+	[Test]
+	[Arguments("main")]
+	[Arguments("help")]
+	[Arguments("system")]
+	public async Task IsCharacterProfile_OtherNamespaces_IsFalse(string ns)
+	{
+		await Assert.That(WikiRoutes.IsCharacterProfile(ns, "general")).IsFalse();
+	}
+
+	[Test]
+	public async Task PathFor_CharacterProfile_UsesCharacterAlias()
+	{
+		await Assert.That(WikiRoutes.PathFor("character", "general", "mercutio"))
+			.IsEqualTo("/character/mercutio");
+	}
+
+	[Test]
+	public async Task PathFor_CharacterInOtherCategory_KeepsWikiPath()
+	{
+		await Assert.That(WikiRoutes.PathFor("character", "npcs", "mercutio"))
+			.IsEqualTo("/wiki/character/npcs/mercutio");
+	}
+
+	[Test]
+	public async Task PathFor_OrdinaryPage_UsesWikiPath()
+	{
+		await Assert.That(WikiRoutes.PathFor("help", "general", "markdown_guide"))
+			.IsEqualTo("/wiki/help/general/markdown_guide");
+	}
+
+	[Test]
+	public async Task PathFor_NormalizesNamespaceCaseAndMissingCategory()
+	{
+		await Assert.That(WikiRoutes.PathFor("Help", null, "markdown_guide"))
+			.IsEqualTo("/wiki/help/general/markdown_guide");
+	}
+
+	/// <summary>Display names reach the same path as the stored slug, per <c>WikiHelpers.Slugify</c>.</summary>
+	[Test]
+	public async Task PathFor_SlugifiesDisplayNames()
+	{
+		await Assert.That(WikiRoutes.PathFor("character", "general", "Mannaz Byron"))
+			.IsEqualTo("/character/mannaz_byron");
+	}
+}

--- a/docs/design/url-strategy.md
+++ b/docs/design/url-strategy.md
@@ -76,6 +76,31 @@ non-API routes (standard WASM hosting pattern).
 - Character profiles get the alias `/character/Name` → resolves to
   `Character:Name` wiki page internally
 
+### Character Biographies
+
+A character's biography is the Character-namespace page whose slug is the
+character name, and `/character/{name}` is its **only** canonical URL. The
+wiki route it is stored under is an implementation detail:
+
+- Nothing in the portal links to `/wiki/character/general/{slug}`. Every link
+  producer — the wiki index, recent-changes, directive blocks, the wiki admin
+  grid, `[[wiki links]]` in markup, and the sitemap — goes through
+  `WikiRoutes.PathFor`, which returns the alias for these pages.
+- `CanonicalUrlMiddleware` 301s the wiki route to the alias, catching
+  bookmarks, external links, and markup rendered before that change.
+- `WikiPage.razor` performs the same redirect for client-side navigations,
+  which never reach the server. It replaces the history entry rather than
+  pushing one, so Back does not land on a URL that immediately bounces.
+
+Two deliberate limits on the alias:
+
+- **View route only.** `/history`, `/diff` and `/edit` have no equivalent under
+  `/character` and keep working where they are. This is also what stops the
+  profile page's own history link from bouncing.
+- **Default category only.** `/character/{name}` carries no category segment,
+  so a Character-namespace page filed under any other category cannot round-trip
+  through the alias and keeps its wiki path.
+
 ### Scene Permalinks
 
 - `/scenes/42` — numeric ID, never changes
@@ -158,4 +183,6 @@ Bots get a 403 or a generic "Login required" page. No content leak.
   - `/wiki/Page Name` (space) → `/wiki/Page_Name` (301 redirect)
   - `/Wiki/Page_Name` (capital W) → `/wiki/Page_Name` (301 redirect)
   - `/character/Name/` (trailing slash) → `/character/Name` (301 redirect)
+  - `/wiki/character/general/Name` → `/character/Name` (301 redirect;
+    see "Character Biographies" above)
 - `<link rel="canonical">` included in pre-rendered pages


### PR DESCRIPTION
> **Stacked on #708.** Base is `fix/wiki-slug-normalization`; GitHub retargets this to `main` when that merges. The diff shown here is this change alone.

A character's biography is a Character-namespace wiki page — but the portal had two URLs for it and no agreement on which one was real.

## The disagreement

`WikiBodyWidget` read and wrote bios in the **Main** namespace. `SeoController.PathFor` and `BotPrerenderMiddleware` both looked in **Character**. So the sitemap and every crawler pointed at pages the portal never wrote, and the pages the portal did write were invisible to both.

`docs/design/url-strategy.md:76` already settled it — *"Character profiles get the alias `/character/Name` → resolves to `Character:Name` wiki page internally"* — so the widget was simply wrong. One line fixes it, and fixing it makes character pages **identifiable**, which is what lets the rest of this work.

## `/character/{name}` becomes the only URL

**`WikiRoutes.PathFor`** — one answer to "where does this page live", in `SharpMUSH.Contracts` beside `WikiHelpers`, shared by the client, the sitemap, and the redirect backstops. Six link producers adopt it:

| Producer | Was |
|---|---|
| `WikiIndexWidget` | inline `$"/wiki/{ns}/{cat}/{slug}"` |
| `RecentWikiActivityWidget` | inline |
| `WikiDirectiveBlock` | inline |
| `AdminWiki` | inline |
| `WikiLinkExtension` (`[[wiki links]]`) | inline |
| `SeoController.PathFor` | a private near-duplicate of this function — deleted |

The app no longer emits a `/wiki/character/…` link anywhere. The redirect is a safety net, not a routine bounce with visible flicker.

**Server 301** — a rule in `CanonicalUrlMiddleware`, which already owned the case / space / trailing-slash 301s for these prefixes. It sits ten lines ahead of `BotPrerenderMiddleware`, so a crawler is redirected and then prerendered through the character branch — right result for free.

**Client redirect** — `WikiPage.razor` repeats it for client-side navigations, which never reach the server. `replace: true` keeps the wiki URL out of the history stack; pushing it would leave Back landing on a URL that immediately bounces forward again.

## Three guards against weirdness

- **View route only.** `/history`, `/diff`, `/edit` have no equivalent under `/character` and keep working where they are — a list-pattern match on exactly five segments. This is also what stops the profile page's own history link from bouncing.
- **Default category only.** `/character/{name}` carries no category segment, so a Character-namespace page filed elsewhere can't round-trip through the alias and keeps its wiki path.
- **The alias is a fixed point.** Tested explicitly — `BuildCanonical` applied twice returns the same path, so no redirect chain is reachable.

## Redlinks survive the transition

`RenderedHtml` is stored per page, so HTML written before this change still carries `/wiki/character/…` hrefs. Matching only the new alias would have silently stopped marking those links red until each page was re-saved. `WikiDisplay` now recognises both shapes and maps either back to the `character/general/{slug}` reference for the existence check.

## No migration

A bio already saved under `main/general` isn't deleted — it stops appearing on the profile and stays readable at its own wiki URL, which does *not* redirect. Re-saving it on the profile files it under Character. Per your call; the alternative was a startup migration keyed off `GetAllPlayersAsync`.

## Verification

- `WikiRoutesTests` — 13 cases over the path rules.
- `CanonicalUrlMiddlewareTests` — alias fires on the view route; does not fire on `/history`, `/diff`, `/edit`, on other categories, or on other namespaces; is a fixed point; end-to-end 301 through `TestServer`.
- `WikiMarkdigPipelineTests` — `[[Character:Mannaz Byron]]` renders `/character/mannaz_byron` and emits no `/wiki/character/`; `[[Character:NPCs:Mercutio]]` keeps its wiki path.
- bUnit — profile requests the Character namespace; `WikiPage` redirects with a replaced history entry and renders no `WikiView` behind it; the non-default-category case renders normally without navigating.
- Suites: **4705** unit passed (198 skipped), **266** bUnit, **245** integration on ArangoDB. Build 0 errors.

`docs/design/url-strategy.md` gains a "Character Biographies" section and the new 301 in the canonical-URL list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvopbATVT2fY4m2JrAWukR