### PR TITLE
Fix the portal Play sidebar and stop HTML markup leaking to plain telnet

### DIFF
--- a/SharpMUSH.ConnectionServer/Services/MarkupOutputRenderer.cs
+++ b/SharpMUSH.ConnectionServer/Services/MarkupOutputRenderer.cs
@@ -59,7 +59,11 @@ public sealed class MarkupOutputRenderer : IMarkupOutputRenderer
 		{
 			OutputFormat.Pueblo => ms.Render("pueblo"),
 			OutputFormat.Mxp => ApplyMxpLinePrefix(ms.Render("mxp")),
-			_ => ms.ToString()
+			// Explicitly the ANSI render, NOT ToString(): ToString() renders every markup in its
+			// own native form, so an HtmlMarkup span (every exit name is wrapped in <send>) went
+			// out as a literal tag to clients that negotiated neither Pueblo nor MXP. The ANSI
+			// render maps HtmlMarkup to its ANSI equivalent, or to plain text when it has none.
+			_ => ms.Render("ansi")
 		};
 
 		text = NormalizeLineEnding(text);

--- a/SharpMUSH.Contracts/Models/Packages/PackageRef.cs
+++ b/SharpMUSH.Contracts/Models/Packages/PackageRef.cs
@@ -58,6 +58,7 @@ public static class WellKnownRefs
 	public const string God = "god";
 	public const string PackageManager = "package_manager";
 	public const string HttpHandler = "http_handler";
+	public const string EventHandler = "event_handler";
 
 	/// <summary>All built-in well-known ref names (lowercase).</summary>
 	public static readonly IReadOnlySet<string> All = new HashSet<string>(StringComparer.Ordinal)
@@ -67,6 +68,7 @@ public static class WellKnownRefs
 		PlayerStart,
 		God,
 		PackageManager,
-		HttpHandler
+		HttpHandler,
+		EventHandler
 	};
 }

--- a/SharpMUSH.Library/Services/PackageInstallService.cs
+++ b/SharpMUSH.Library/Services/PackageInstallService.cs
@@ -268,12 +268,18 @@ public class PackageInstallService(
 		await AddAsync(WellKnownRefs.PlayerStart, options.PlayerStart, 0);
 		await AddAsync(WellKnownRefs.PackageManager, options.PackageManager, 3);
 
-		// http_handler is optional (nullable, no fixed fallback) — only mapped
-		// when configured, so a package targeting {{$http_handler}} on a game
-		// without one fails to resolve rather than guessing a dbref.
+		// http_handler and event_handler are optional (nullable, no fixed fallback) — only
+		// mapped when configured, so a package targeting {{$http_handler}} or
+		// {{$event_handler}} on a game without one fails to resolve rather than guessing a
+		// dbref.
 		if (options.HttpHandler is > 0)
 		{
 			await AddAsync(WellKnownRefs.HttpHandler, options.HttpHandler, options.HttpHandler.Value);
+		}
+
+		if (options.EventHandler is > 0)
+		{
+			await AddAsync(WellKnownRefs.EventHandler, options.EventHandler, options.EventHandler.Value);
 		}
 
 		return map;
@@ -1435,5 +1441,5 @@ public class PackageInstallService(
 		name.Split(';', 2, StringSplitOptions.TrimEntries)[0];
 
 	private static string DecisionKey(string targetRef, string attribute) =>
-		$"{targetRef} {attribute.ToUpperInvariant()}";
+		$"{targetRef}\0{attribute.ToUpperInvariant()}";
 }

--- a/SharpMUSH.Server/Services/BundledHttpHooks.cs
+++ b/SharpMUSH.Server/Services/BundledHttpHooks.cs
@@ -1,5 +1,4 @@
 using System.Collections.Frozen;
-using System.Reflection;
 using SharpMUSH.Library.Services;
 
 namespace SharpMUSH.Server.Services;
@@ -25,14 +24,7 @@ public static class BundledHttpHooks
 	public static string Attribute(string name) => Attributes[name];
 
 	/// <summary>The raw YAML of one bundled package manifest.</summary>
-	public static string ManifestYaml(string packageId)
-	{
-		var resource = $"SharpMUSH.Server.BundledPackages.{packageId}.package.yaml";
-		using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resource)
-			?? throw new InvalidOperationException($"Bundled resource '{resource}' not found.");
-		using var reader = new StreamReader(stream);
-		return reader.ReadToEnd();
-	}
+	public static string ManifestYaml(string packageId) => BundledPackages.ManifestYaml(packageId);
 
 	private static FrozenDictionary<string, string> LoadAll()
 	{

--- a/SharpMUSH.Server/Services/BundledPackages.cs
+++ b/SharpMUSH.Server/Services/BundledPackages.cs
@@ -9,22 +9,37 @@ namespace SharpMUSH.Server.Services;
 /// each entry here is a bundled <c>examples/packages/&lt;id&gt;/package.yaml</c> embedded as a
 /// resource. Adding a default package is a one-line addition to <see cref="All"/>.
 /// </summary>
+/// <summary>The configured handler object a bundled attach-mode package needs.</summary>
+public enum BundledPackageHandler
+{
+	/// <summary>Create mode — installs regardless of handler configuration.</summary>
+	None,
+
+	/// <summary>Attaches to the configured <c>http_handler</c> object.</summary>
+	Http,
+
+	/// <summary>Attaches to the configured <c>event_handler</c> object.</summary>
+	Event
+}
+
 public static class BundledPackages
 {
 	/// <summary>
-	/// A bundled package and whether it attaches to the configured <c>http_handler</c> object
-	/// (attach-mode packages are skipped when no handler is configured; create-mode packages
-	/// always install).
+	/// A bundled package and the configured handler object it attaches to, if any. An
+	/// attach-mode package is skipped when its handler is not configured (there would be no
+	/// target to resolve <c>{{$http_handler}}</c> / <c>{{$event_handler}}</c> against);
+	/// create-mode packages always install.
 	/// </summary>
-	public readonly record struct Descriptor(string PackageId, bool RequiresHttpHandler);
+	public readonly record struct Descriptor(string PackageId, BundledPackageHandler Requires);
 
 	/// <summary>Bundled packages in dependency order (a dependency precedes its dependents).</summary>
 	public static readonly IReadOnlyList<Descriptor> All =
 	[
-		new("http-handler", RequiresHttpHandler: true),
-		new("profile-handler", RequiresHttpHandler: true),
-		new("common-functions", RequiresHttpHandler: false),
-		new("scene", RequiresHttpHandler: false),
+		new("http-handler", BundledPackageHandler.Http),
+		new("profile-handler", BundledPackageHandler.Http),
+		new("room-contents", BundledPackageHandler.Event),
+		new("common-functions", BundledPackageHandler.None),
+		new("scene", BundledPackageHandler.None),
 	];
 
 	/// <summary>The raw YAML of one bundled package manifest (embedded resource).</summary>

--- a/SharpMUSH.Server/Services/BundledPackages.cs
+++ b/SharpMUSH.Server/Services/BundledPackages.cs
@@ -2,13 +2,6 @@ using System.Reflection;
 
 namespace SharpMUSH.Server.Services;
 
-/// <summary>
-/// The default packages the server ships and installs at first boot (via
-/// <see cref="DefaultPackagesBootstrapService"/>), plus a loader for their embedded
-/// manifests. The package manager is the delivery mechanism for all default softcode —
-/// each entry here is a bundled <c>examples/packages/&lt;id&gt;/package.yaml</c> embedded as a
-/// resource. Adding a default package is a one-line addition to <see cref="All"/>.
-/// </summary>
 /// <summary>The configured handler object a bundled attach-mode package needs.</summary>
 public enum BundledPackageHandler
 {
@@ -22,6 +15,13 @@ public enum BundledPackageHandler
 	Event
 }
 
+/// <summary>
+/// The default packages the server ships and installs at first boot (via
+/// <see cref="DefaultPackagesBootstrapService"/>), plus a loader for their embedded
+/// manifests. The package manager is the delivery mechanism for all default softcode —
+/// each entry here is a bundled <c>examples/packages/&lt;id&gt;/package.yaml</c> embedded as a
+/// resource. Adding a default package is a one-line addition to <see cref="All"/>.
+/// </summary>
 public static class BundledPackages
 {
 	/// <summary>

--- a/SharpMUSH.Server/Services/DefaultPackagesBootstrapService.cs
+++ b/SharpMUSH.Server/Services/DefaultPackagesBootstrapService.cs
@@ -9,12 +9,14 @@ namespace SharpMUSH.Server.Services;
 /// <summary>
 /// Installs every bundled default package (see <see cref="BundledPackages.All"/>) at first boot,
 /// in dependency order, through the package manager — proving the package manager can own a core
-/// system's softcode (decision 20.3). Attach-mode packages (the HTTP verb routers / profile API)
-/// land on the configured <c>http_handler</c> object and are skipped when none is configured;
-/// create-mode packages (e.g. <c>common-functions</c>, <c>scene</c>) always install.
+/// system's softcode (decision 20.3). Attach-mode packages land on a configured handler object —
+/// the HTTP verb routers / profile API on <c>http_handler</c>, the room.contents OOB pushes on
+/// <c>event_handler</c> — and are skipped when that handler is not configured; create-mode
+/// packages (e.g. <c>common-functions</c>, <c>scene</c>) always install.
 ///
 /// Idempotent per package: an already-installed package is left to the package manager (so admins
-/// can upgrade/customize/uninstall independently), and pre-existing differing attributes resolve in
+/// can upgrade/customize/uninstall independently) unless this build ships a strictly newer version,
+/// in which case it is upgraded in place. Either way pre-existing differing attributes resolve in
 /// favor of the existing values (three-way merge protects local edits, nothing is clobbered).
 /// </summary>
 public class DefaultPackagesBootstrapService(
@@ -37,31 +39,55 @@ public class DefaultPackagesBootstrapService(
 			return;
 		}
 
-		var handler = options.CurrentValue.Database.HttpHandler;
+		var database = options.CurrentValue.Database;
 
 		foreach (var package in BundledPackages.All)
 		{
-			if (package.RequiresHttpHandler && handler is null or 0)
+			var handler = package.Requires switch
 			{
-				logger.LogDebug("No http_handler configured; skipping attach-mode package {PackageId}.", package.PackageId);
+				BundledPackageHandler.Http => database.HttpHandler,
+				BundledPackageHandler.Event => database.EventHandler,
+				_ => null
+			};
+
+			if (package.Requires is not BundledPackageHandler.None && handler is null or 0)
+			{
+				logger.LogDebug("No {Handler} configured; skipping attach-mode package {PackageId}.",
+					package.Requires is BundledPackageHandler.Http ? "http_handler" : "event_handler",
+					package.PackageId);
 				continue;
 			}
 
-			await InstallIfAbsentAsync(package.PackageId, cancellationToken);
+			await InstallOrUpgradeAsync(package.PackageId, cancellationToken);
 		}
 	}
 
-	private async Task InstallIfAbsentAsync(string packageId, CancellationToken cancellationToken)
+	private async Task InstallOrUpgradeAsync(string packageId, CancellationToken cancellationToken)
 	{
+		var parsedForVersion = manifests.ParseManifest(BundledPackages.ManifestYaml(packageId));
+		var bundledVersion = parsedForVersion.IsT0 ? parsedForVersion.AsT0.Manifest.Version : null;
+
 		var already = await registry.GetInstalledPackageAsync(packageId);
 		if (already.IsT0)
 		{
-			logger.LogDebug("Package {PackageId} already installed (v{Version}); leaving it to the package manager.",
-				packageId, already.AsT0.Version);
-			return;
+			// Already installed: only step in when this build ships a NEWER version than the
+			// game has. Without this a game that installed an older bundled package never sees
+			// later additions to it — the portal's "online now" list stayed empty on every game
+			// created before GET`ONLINE was added to profile-handler, with no upgrade path short
+			// of a manual reinstall. Same-or-newer installed (an admin upgrade, a local fork) is
+			// left alone, and the apply below still resolves conflicts in favour of local edits.
+			if (!IsNewer(bundledVersion, already.AsT0.Version))
+			{
+				logger.LogDebug("Package {PackageId} already installed (v{Version}); leaving it to the package manager.",
+					packageId, already.AsT0.Version);
+				return;
+			}
+
+			logger.LogInformation("Upgrading bundled {PackageId} v{Installed} → v{Bundled}.",
+				packageId, already.AsT0.Version, bundledVersion);
 		}
 
-		var parsed = manifests.ParseManifest(BundledPackages.ManifestYaml(packageId));
+		var parsed = parsedForVersion;
 		if (parsed.IsT1)
 		{
 			logger.LogError("Bundled {PackageId} manifest is invalid: {Issues}",
@@ -95,6 +121,16 @@ public class DefaultPackagesBootstrapService(
 				packageId, manifest.Version, ok.Revision),
 			error => logger.LogError("Failed to install {PackageId}: {Error}", packageId, error.Value));
 	}
+
+	/// <summary>
+	/// True when the bundled version is strictly newer than the installed one. An absent or
+	/// unparseable version on either side answers false: bootstrap only ever moves a game
+	/// forward on a comparison it is sure of, and leaves anything else to the package manager.
+	/// </summary>
+	public static bool IsNewer(PackageVersion? bundled, string? installed) =>
+		bundled is not null
+		&& PackageVersion.TryParse(installed, out var installedVersion)
+		&& bundled.CompareTo(installedVersion) > 0;
 
 	public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/SharpMUSH.Server/Services/DefaultPackagesBootstrapService.cs
+++ b/SharpMUSH.Server/Services/DefaultPackagesBootstrapService.cs
@@ -64,8 +64,19 @@ public class DefaultPackagesBootstrapService(
 
 	private async Task InstallOrUpgradeAsync(string packageId, CancellationToken cancellationToken)
 	{
-		var parsedForVersion = manifests.ParseManifest(BundledPackages.ManifestYaml(packageId));
-		var bundledVersion = parsedForVersion.IsT0 ? parsedForVersion.AsT0.Manifest.Version : null;
+		// Parse first and bail loudly on a bad manifest: an invalid embedded manifest is a build
+		// defect, and it must be reported whether or not the package happens to be installed
+		// already. Deciding the version gate first would swallow it on every game that has the
+		// package, because an unparsed manifest has no version to compare.
+		var parsed = manifests.ParseManifest(BundledPackages.ManifestYaml(packageId));
+		if (parsed.IsT1)
+		{
+			logger.LogError("Bundled {PackageId} manifest is invalid: {Issues}",
+				packageId, string.Join("; ", parsed.AsT1.Issues.Select(i => i.ToString())));
+			return;
+		}
+
+		var manifest = parsed.AsT0.Manifest;
 
 		var already = await registry.GetInstalledPackageAsync(packageId);
 		if (already.IsT0)
@@ -76,7 +87,7 @@ public class DefaultPackagesBootstrapService(
 			// created before GET`ONLINE was added to profile-handler, with no upgrade path short
 			// of a manual reinstall. Same-or-newer installed (an admin upgrade, a local fork) is
 			// left alone, and the apply below still resolves conflicts in favour of local edits.
-			if (!IsNewer(bundledVersion, already.AsT0.Version))
+			if (!IsNewer(manifest.Version, already.AsT0.Version))
 			{
 				logger.LogDebug("Package {PackageId} already installed (v{Version}); leaving it to the package manager.",
 					packageId, already.AsT0.Version);
@@ -84,18 +95,8 @@ public class DefaultPackagesBootstrapService(
 			}
 
 			logger.LogInformation("Upgrading bundled {PackageId} v{Installed} → v{Bundled}.",
-				packageId, already.AsT0.Version, bundledVersion);
+				packageId, already.AsT0.Version, manifest.Version);
 		}
-
-		var parsed = parsedForVersion;
-		if (parsed.IsT1)
-		{
-			logger.LogError("Bundled {PackageId} manifest is invalid: {Issues}",
-				packageId, string.Join("; ", parsed.AsT1.Issues.Select(i => i.ToString())));
-			return;
-		}
-
-		var manifest = parsed.AsT0.Manifest;
 
 		// Resolve any pre-existing conflicts in favor of what is already present (a game migrating
 		// off old hardcoded seeding) so the install never clobbers an admin's customizations.

--- a/SharpMUSH.Server/SharpMUSH.Server.csproj
+++ b/SharpMUSH.Server/SharpMUSH.Server.csproj
@@ -114,6 +114,10 @@
       <Link>BundledPackages\profile-handler.package.yaml</Link>
       <LogicalName>SharpMUSH.Server.BundledPackages.profile-handler.package.yaml</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="..\examples\packages\room-contents\package.yaml">
+      <Link>BundledPackages\room-contents.package.yaml</Link>
+      <LogicalName>SharpMUSH.Server.BundledPackages.room-contents.package.yaml</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="..\examples\packages\common-functions\package.yaml">
       <Link>BundledPackages\common-functions.package.yaml</Link>
       <LogicalName>SharpMUSH.Server.BundledPackages.common-functions.package.yaml</LogicalName>

--- a/SharpMUSH.Tests.Integration/Packages/BundledPackageUpgradeIntegrationTests.cs
+++ b/SharpMUSH.Tests.Integration/Packages/BundledPackageUpgradeIntegrationTests.cs
@@ -1,6 +1,9 @@
 using Microsoft.Extensions.DependencyInjection;
+using SharpMUSH.Configuration.Options;
 using SharpMUSH.Library;
+using SharpMUSH.Library.Models;
 using SharpMUSH.Library.Models.Packages;
+using SharpMUSH.Library.Services;
 using SharpMUSH.Library.Services.Interfaces;
 using SharpMUSH.Tests.Infrastructure;
 
@@ -15,6 +18,7 @@ namespace SharpMUSH.Tests.Integration.Packages;
 [ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
 public class BundledPackageUpgradeIntegrationTests(ServerWebAppFactory factory)
 {
+	private ISharpDatabase Database => factory.Services.GetRequiredService<ISharpDatabase>();
 	private IPackageManifestService Manifests => factory.Services.GetRequiredService<IPackageManifestService>();
 	private IPackageInstallService Installer => factory.Services.GetRequiredService<IPackageInstallService>();
 
@@ -23,7 +27,10 @@ public class BundledPackageUpgradeIntegrationTests(ServerWebAppFactory factory)
 
 	private const string PackageId = "upgrade-probe";
 
-	private static string Manifest(string version, string extraAttribute) => string.Join('\n',
+	/// <param name="version">Manifest version.</param>
+	/// <param name="originalValue">Value the manifest ships for PROBE`ORIGINAL.</param>
+	/// <param name="extraAttribute">Optional extra attribute lines (already indented).</param>
+	private static string Manifest(string version, string originalValue, string extraAttribute) => string.Join('\n',
 		"format: 1",
 		$"package: {PackageId}",
 		$"version: {version}",
@@ -38,11 +45,15 @@ public class BundledPackageUpgradeIntegrationTests(ServerWebAppFactory factory)
 		"    name: Upgrade Probe Object",
 		"    attributes:",
 		"      PROBE`ORIGINAL: |-",
-		"        first",
+		$"        {originalValue}",
 		extraAttribute);
 
-	/// <summary>Applies a manifest the way bootstrap does: plan, keep local edits, apply.</summary>
-	private async Task ApplyAsync(string yaml)
+	/// <summary>
+	/// Applies a manifest the way bootstrap does: plan, answer every conflict with KeepMine, apply.
+	/// Returns how many conflicts were resolved, so a test can prove the KeepMine path was actually
+	/// taken rather than passing because no conflict ever arose.
+	/// </summary>
+	private async Task<int> ApplyAsync(string yaml)
 	{
 		var manifest = Manifests.ParseManifest(yaml).AsT0.Manifest;
 		var plan = await Installer.PlanAsync(manifest);
@@ -56,14 +67,25 @@ public class BundledPackageUpgradeIntegrationTests(ServerWebAppFactory factory)
 			new Dictionary<string, string>(), decisions));
 
 		await Assert.That(result.IsT0).IsTrue().Because(result.IsT1 ? result.AsT1.Value : "applied");
+		return decisions.Count;
+	}
+
+	private DBRef ProbeDbref(IReadOnlyList<PackageObjectRecord> objects) =>
+		PackageInstallService.ParseObjid(objects.Single(o => o.Ref == "probe").Objid)!.Value;
+
+	private async Task<string> ReadAttributeAsync(DBRef dbref, string attribute)
+	{
+		var leaf = await Database.GetAttributeAsync(dbref, attribute.Split('`'), CancellationToken.None)
+			.LastOrDefaultAsync();
+		return leaf?.Value.ToPlainText() ?? "";
 	}
 
 	[Test]
-	public async Task ReapplyingANewerManifest_AddsTheNewAttributesAndRecordsTheNewVersion()
+	public async Task ReapplyingANewerManifest_AddsNewAttributes_KeepsLocalEdits_AndRecordsTheNewVersion()
 	{
 		try
 		{
-			await ApplyAsync(Manifest("1.0.0", string.Empty));
+			await ApplyAsync(Manifest("1.0.0", "first", string.Empty));
 
 			var installed = await Registry.GetInstalledPackageAsync(PackageId);
 			await Assert.That(installed.IsT0).IsTrue();
@@ -71,9 +93,24 @@ public class BundledPackageUpgradeIntegrationTests(ServerWebAppFactory factory)
 			await Assert.That((await Registry.GetManagedAttributesAsync(PackageId)).Select(m => m.Attribute))
 				.DoesNotContain("PROBE`ADDED");
 
-			// The v1.1.0 shape: same object, one route added — exactly what profile-handler 1.1.0 did
-			// when it gained GET`ONLINE, and what a game installed at 1.0.0 never received.
-			await ApplyAsync(Manifest("1.1.0", "      PROBE`ADDED: |-\n        second"));
+			// An admin edits the installed softcode in-game. The upgrade must not clobber it — that is
+			// the whole reason bootstrap answers every conflict with KeepMine.
+			var probe = ProbeDbref(await Registry.GetPackageObjectsAsync(PackageId));
+			var packageManager = factory.Services.GetRequiredService<IOptionsWrapper<SharpMUSHOptions>>()
+				.CurrentValue.Database.PackageManager ?? 7;
+			var owner = (await Database.GetObjectNodeAsync(new DBRef((int)packageManager)))
+				.Known.Match(player => player, _ => null!, _ => null!, _ => null!);
+			await Database.SetAttributeAsync(probe, ["PROBE", "ORIGINAL"], MModule.single("admin-edit"), owner);
+
+			// v1.1.0: adds a route AND changes the value the admin edited, so the upgrade produces both
+			// an Add and a ModifyModify conflict — exactly what profile-handler 1.1.0 did when it gained
+			// GET`ONLINE, and what a game installed at 1.0.0 never received.
+			var conflictsResolved = await ApplyAsync(Manifest("1.1.0", "second", "      PROBE`ADDED: |-\n        added"));
+
+			// Without this the KeepMine assertion below could pass simply because nothing conflicted.
+			await Assert.That(conflictsResolved)
+				.IsGreaterThan(0)
+				.Because("the edited attribute must reach the plan as a conflict for KeepMine to mean anything");
 
 			var upgraded = await Registry.GetInstalledPackageAsync(PackageId);
 			await Assert.That(upgraded.IsT0).IsTrue();
@@ -82,6 +119,11 @@ public class BundledPackageUpgradeIntegrationTests(ServerWebAppFactory factory)
 			var managed = (await Registry.GetManagedAttributesAsync(PackageId)).Select(m => m.Attribute).ToList();
 			await Assert.That(managed).Contains("PROBE`ADDED");
 			await Assert.That(managed).Contains("PROBE`ORIGINAL");
+
+			// The attribute the package gained is live...
+			await Assert.That(await ReadAttributeAsync(probe, "PROBE`ADDED")).IsEqualTo("added");
+			// ...and the admin's edit survived rather than being reset to the manifest's "second".
+			await Assert.That(await ReadAttributeAsync(probe, "PROBE`ORIGINAL")).IsEqualTo("admin-edit");
 		}
 		finally
 		{

--- a/SharpMUSH.Tests.Integration/Packages/BundledPackageUpgradeIntegrationTests.cs
+++ b/SharpMUSH.Tests.Integration/Packages/BundledPackageUpgradeIntegrationTests.cs
@@ -1,0 +1,91 @@
+using Microsoft.Extensions.DependencyInjection;
+using SharpMUSH.Library;
+using SharpMUSH.Library.Models.Packages;
+using SharpMUSH.Library.Services.Interfaces;
+using SharpMUSH.Tests.Infrastructure;
+
+namespace SharpMUSH.Tests.Integration.Packages;
+
+/// <summary>
+/// Boot-time bootstrap upgrades an already-installed bundled package when the build ships a newer
+/// version, instead of skipping it forever. This exercises the apply path that upgrade relies on:
+/// re-applying a newer manifest of an installed package must add the routes it gained, keep the
+/// admin's local edits, and move the recorded version forward.
+/// </summary>
+[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+public class BundledPackageUpgradeIntegrationTests(ServerWebAppFactory factory)
+{
+	private IPackageManifestService Manifests => factory.Services.GetRequiredService<IPackageManifestService>();
+	private IPackageInstallService Installer => factory.Services.GetRequiredService<IPackageInstallService>();
+
+	private IPackageRegistryService Registry =>
+		(IPackageRegistryService)factory.Services.GetRequiredService<ISharpDatabase>();
+
+	private const string PackageId = "upgrade-probe";
+
+	private static string Manifest(string version, string extraAttribute) => string.Join('\n',
+		"format: 1",
+		$"package: {PackageId}",
+		$"version: {version}",
+		"authors: [SharpMUSH]",
+		"description: \"Upgrade path probe.\"",
+		"license: MIT",
+		"requires_server: \">=0.1\"",
+		"",
+		"objects:",
+		"  - ref: probe",
+		"    type: thing",
+		"    name: Upgrade Probe Object",
+		"    attributes:",
+		"      PROBE`ORIGINAL: |-",
+		"        first",
+		extraAttribute);
+
+	/// <summary>Applies a manifest the way bootstrap does: plan, keep local edits, apply.</summary>
+	private async Task ApplyAsync(string yaml)
+	{
+		var manifest = Manifests.ParseManifest(yaml).AsT0.Manifest;
+		var plan = await Installer.PlanAsync(manifest);
+		var decisions = plan.Attributes
+			.Where(a => a.Action == PackageAttributeAction.Conflict)
+			.Select(a => new PackageConflictDecision(a.TargetRef, a.Attribute, PackageConflictResolution.KeepMine))
+			.ToList();
+
+		var result = await Installer.ApplyAsync(manifest, new PackageApplyRequest(
+			new PackageApplySource("bundled:sharpmush", PackageId, "bundled", null),
+			new Dictionary<string, string>(), decisions));
+
+		await Assert.That(result.IsT0).IsTrue().Because(result.IsT1 ? result.AsT1.Value : "applied");
+	}
+
+	[Test]
+	public async Task ReapplyingANewerManifest_AddsTheNewAttributesAndRecordsTheNewVersion()
+	{
+		try
+		{
+			await ApplyAsync(Manifest("1.0.0", string.Empty));
+
+			var installed = await Registry.GetInstalledPackageAsync(PackageId);
+			await Assert.That(installed.IsT0).IsTrue();
+			await Assert.That(installed.AsT0.Version).IsEqualTo("1.0.0");
+			await Assert.That((await Registry.GetManagedAttributesAsync(PackageId)).Select(m => m.Attribute))
+				.DoesNotContain("PROBE`ADDED");
+
+			// The v1.1.0 shape: same object, one route added — exactly what profile-handler 1.1.0 did
+			// when it gained GET`ONLINE, and what a game installed at 1.0.0 never received.
+			await ApplyAsync(Manifest("1.1.0", "      PROBE`ADDED: |-\n        second"));
+
+			var upgraded = await Registry.GetInstalledPackageAsync(PackageId);
+			await Assert.That(upgraded.IsT0).IsTrue();
+			await Assert.That(upgraded.AsT0.Version).IsEqualTo("1.1.0");
+
+			var managed = (await Registry.GetManagedAttributesAsync(PackageId)).Select(m => m.Attribute).ToList();
+			await Assert.That(managed).Contains("PROBE`ADDED");
+			await Assert.That(managed).Contains("PROBE`ORIGINAL");
+		}
+		finally
+		{
+			await Installer.UninstallAsync(PackageId, force: true);
+		}
+	}
+}

--- a/SharpMUSH.Tests.Integration/Packages/RoomContentsPackageTests.cs
+++ b/SharpMUSH.Tests.Integration/Packages/RoomContentsPackageTests.cs
@@ -1,0 +1,60 @@
+using Microsoft.Extensions.DependencyInjection;
+using SharpMUSH.Configuration.Options;
+using SharpMUSH.Library;
+using SharpMUSH.Library.Services.Interfaces;
+using SharpMUSH.Tests.Infrastructure;
+
+namespace SharpMUSH.Tests.Integration.Packages;
+
+/// <summary>
+/// The <c>room-contents</c> bundled package is what makes the portal's Play sidebar work: it
+/// attaches the <c>ROOM`CONTENTS</c> event handler that pushes <c>room.contents</c> /
+/// <c>room.exits</c> OOB frames to a room's connected occupants. It previously shipped as
+/// documentation only — nothing installed it — so a stock server emitted no OOB at all and the
+/// Here/Exits cards were permanently empty.
+/// </summary>
+[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+public class RoomContentsPackageTests(ServerWebAppFactory factory)
+{
+	private IPackageRegistryService Registry =>
+		(IPackageRegistryService)factory.Services.GetRequiredService<ISharpDatabase>();
+
+	[Test]
+	public async Task IsInstalledAtBoot_AsAnAttachPackageManagingTheHandlerAttributes()
+	{
+		var installed = await Registry.GetInstalledPackageAsync("room-contents");
+		await Assert.That(installed.IsT0).IsTrue();
+
+		// Attach mode: it manages attributes on the pre-seeded event_handler object and creates
+		// no objects of its own, so uninstalling leaves that object's other softcode intact.
+		await Assert.That((await Registry.GetPackageObjectsAsync("room-contents")).Count).IsEqualTo(0);
+
+		var managed = (await Registry.GetManagedAttributesAsync("room-contents"))
+			.Select(m => m.Attribute)
+			.ToList();
+
+		await Assert.That(managed).Contains("ROOM`CONTENTS");
+		await Assert.That(managed).Contains("FN`WHOROW");
+		await Assert.That(managed).Contains("FN`EXITROW");
+		await Assert.That(managed).Contains("FN`WHOVIS");
+	}
+
+	/// <summary>
+	/// The managed attributes must land on the configured event_handler object — that is the only
+	/// object <see cref="IEventService"/> reads handler attributes from. Asserted against the
+	/// configured dbref rather than a literal, because the seed numbering is config-driven and has
+	/// moved before.
+	/// </summary>
+	[Test]
+	public async Task ManagedAttributes_LandOnTheConfiguredEventHandler()
+	{
+		var configured = factory.Services
+			.GetRequiredService<IOptionsWrapper<SharpMUSHOptions>>()
+			.CurrentValue.Database.EventHandler;
+
+		var managed = await Registry.GetManagedAttributesAsync("room-contents");
+		var handler = managed.Single(m => m.Attribute == "ROOM`CONTENTS");
+
+		await Assert.That(handler.Objid).StartsWith($"#{configured}:");
+	}
+}

--- a/SharpMUSH.Tests/Packages/BundledPackageUpgradeTests.cs
+++ b/SharpMUSH.Tests/Packages/BundledPackageUpgradeTests.cs
@@ -1,0 +1,49 @@
+using SharpMUSH.Server.Services;
+using PackageVersion = SharpMUSH.Library.Models.Packages.PackageVersion;
+
+namespace SharpMUSH.Tests.Packages;
+
+/// <summary>
+/// The version gate that decides whether first-boot bootstrap upgrades an already-installed
+/// bundled package. Bootstrap used to skip every installed package unconditionally, so a game
+/// kept whatever version of a bundled package it first installed forever — additions like
+/// profile-handler's GET`ONLINE route (v1.1.0) never reached games created before it, and the
+/// portal's "online now" widget stayed empty with no upgrade path.
+/// </summary>
+public class BundledPackageUpgradeTests
+{
+	private static bool IsNewer(string bundled, string? installed) =>
+		DefaultPackagesBootstrapService.IsNewer(Parse(bundled), installed);
+
+	private static PackageVersion Parse(string text) =>
+		PackageVersion.TryParse(text, out var version) ? version : throw new ArgumentException(text);
+
+	[Test]
+	[Arguments("1.1.0", "1.0.0")]
+	[Arguments("1.0.1", "1.0.0")]
+	[Arguments("2.0.0", "1.9.9")]
+	[Arguments("1.0.0", "1.0.0-beta")]
+	public async Task NewerBundledVersion_Upgrades(string bundled, string installed)
+		=> await Assert.That(IsNewer(bundled, installed)).IsTrue();
+
+	[Test]
+	[Arguments("1.0.0", "1.0.0")]
+	[Arguments("1.0.0", "1.1.0")]
+	[Arguments("1.0.0", "2.0.0")]
+	public async Task SameOrOlderBundledVersion_IsLeftAlone(string bundled, string installed)
+		=> await Assert.That(IsNewer(bundled, installed)).IsFalse();
+
+	/// <summary>
+	/// An installed version the parser cannot read is left to the package manager rather than
+	/// overwritten on a guess.
+	/// </summary>
+	[Test]
+	[Arguments("")]
+	[Arguments("not-a-version")]
+	public async Task UnparseableInstalledVersion_IsLeftAlone(string installed)
+		=> await Assert.That(IsNewer("9.9.9", installed)).IsFalse();
+
+	[Test]
+	public async Task MissingBundledVersion_IsLeftAlone()
+		=> await Assert.That(DefaultPackagesBootstrapService.IsNewer(null, "1.0.0")).IsFalse();
+}

--- a/SharpMUSH.Tests/Packages/BundledPackagesTests.cs
+++ b/SharpMUSH.Tests/Packages/BundledPackagesTests.cs
@@ -1,0 +1,86 @@
+using SharpMUSH.Library.Models.Packages;
+using SharpMUSH.Library.Services;
+using SharpMUSH.Server.Services;
+
+namespace SharpMUSH.Tests.Packages;
+
+/// <summary>
+/// Guards the bundled-package wiring: every entry in <see cref="BundledPackages.All"/> must have
+/// its manifest embedded in the server assembly and parse cleanly, because a missing
+/// EmbeddedResource or a manifest typo only surfaces at first boot (as softcode that silently
+/// never installs).
+/// </summary>
+public class BundledPackagesTests
+{
+	private readonly PackageManifestService _manifests = new();
+
+	[Test]
+	public async Task EveryBundledPackage_HasAnEmbeddedManifestThatParses()
+	{
+		foreach (var descriptor in BundledPackages.All)
+		{
+			var yaml = BundledPackages.ManifestYaml(descriptor.PackageId);
+			var parsed = _manifests.ParseManifest(yaml);
+
+			await Assert.That(parsed.IsT0)
+				.IsTrue()
+				.Because($"bundled manifest '{descriptor.PackageId}' must parse");
+			await Assert.That(parsed.AsT0.Manifest.Name).IsEqualTo(descriptor.PackageId);
+		}
+	}
+
+	/// <summary>
+	/// room-contents is the softcode behind the portal's Play sidebar: it attaches the
+	/// ROOM`CONTENTS handler to the configured event_handler object. Before it was bundled the
+	/// handler shipped as documentation only, so a stock server emitted no room.contents /
+	/// room.exits pushes at all and the sidebar had no data source.
+	/// </summary>
+	[Test]
+	public async Task RoomContents_AttachesTheRoomContentsHandlerToTheEventHandler()
+	{
+		var parsed = _manifests.ParseManifest(BundledPackages.ManifestYaml("room-contents"));
+		await Assert.That(parsed.IsT0).IsTrue();
+
+		var handler = parsed.AsT0.Manifest.Objects.Single();
+		await Assert.That(handler.Target).IsEqualTo(new PackageRef(PackageRefKind.WellKnown, "event_handler"));
+		await Assert.That(handler.Attributes.Keys).Contains("ROOM`CONTENTS");
+	}
+
+	/// <summary>
+	/// An attach-mode bundled package must declare the handler it attaches to, or bootstrap
+	/// would try to install it on a game that has no target for its {{$...}} target ref.
+	/// </summary>
+	[Test]
+	public async Task AttachModePackages_DeclareTheHandlerTheyTarget()
+	{
+		foreach (var descriptor in BundledPackages.All)
+		{
+			var manifest = _manifests.ParseManifest(BundledPackages.ManifestYaml(descriptor.PackageId)).AsT0.Manifest;
+
+			var expected = descriptor.Requires switch
+			{
+				BundledPackageHandler.Http => WellKnownRefs.HttpHandler,
+				BundledPackageHandler.Event => WellKnownRefs.EventHandler,
+				_ => null
+			};
+
+			var wellKnownTargets = manifest.Objects
+				.Where(o => o.Target is { Kind: PackageRefKind.WellKnown })
+				.Select(o => o.Target!.Name)
+				.ToList();
+
+			if (expected is null)
+			{
+				await Assert.That(wellKnownTargets)
+					.DoesNotContain(WellKnownRefs.HttpHandler)
+					.And.DoesNotContain(WellKnownRefs.EventHandler);
+			}
+			else
+			{
+				await Assert.That(wellKnownTargets)
+					.Contains(expected)
+					.Because($"{descriptor.PackageId} is declared as attaching to {expected}");
+			}
+		}
+	}
+}

--- a/SharpMUSH.Tests/Packages/BundledPackagesTests.cs
+++ b/SharpMUSH.Tests/Packages/BundledPackagesTests.cs
@@ -55,7 +55,15 @@ public class BundledPackagesTests
 	{
 		foreach (var descriptor in BundledPackages.All)
 		{
-			var manifest = _manifests.ParseManifest(BundledPackages.ManifestYaml(descriptor.PackageId)).AsT0.Manifest;
+			// Assert the parse rather than assuming it: reaching AsT0 on a failed parse throws an
+			// opaque OneOf exception, and this test would silently depend on running after
+			// EveryBundledPackage_HasAnEmbeddedManifestThatParses to get a readable failure.
+			var parsed = _manifests.ParseManifest(BundledPackages.ManifestYaml(descriptor.PackageId));
+			await Assert.That(parsed.IsT0)
+				.IsTrue()
+				.Because($"bundled manifest '{descriptor.PackageId}' must parse");
+
+			var manifest = parsed.AsT0.Manifest;
 
 			var expected = descriptor.Requires switch
 			{

--- a/SharpMUSH.Tests/Services/MarkupOutputRendererTests.cs
+++ b/SharpMUSH.Tests/Services/MarkupOutputRendererTests.cs
@@ -1,7 +1,12 @@
 using SharpMUSH.ConnectionServer.ProtocolHandlers;
+using System.Collections.Immutable;
+using System.Drawing;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
+using ANSILibrary;
 using MarkupString;
+using MarkupString.MarkupImplementation;
 using SharpMUSH.ConnectionServer.Models;
 using SharpMUSH.ConnectionServer.Services;
 using SharpMUSH.Library.Definitions;
@@ -13,9 +18,14 @@ namespace SharpMUSH.Tests.Services;
 /// to ANSI/Pueblo/MXP for terminal connections (per <see cref="ProtocolCapabilities.Format"/>) and
 /// forwarded as a markup envelope for WebSocket (portal) connections.
 /// </summary>
-public class MarkupOutputRendererTests
+public partial class MarkupOutputRendererTests
 {
 	private const string Raw = "<send href=\"look\">Tom & \"Sue\"</send>";
+
+	private static string StripAnsi(string text) => AnsiEscape().Replace(text, string.Empty);
+
+	[GeneratedRegex("\u001b\\[[0-9;]*m")]
+	private static partial Regex AnsiEscape();
 
 	private static ConnectionServerService.ConnectionData Connection(
 		OutputFormat format = OutputFormat.Ansi,
@@ -65,6 +75,64 @@ public class MarkupOutputRendererTests
 
 		await Assert.That(result.ApplyOutputTransform).IsTrue();
 		await Assert.That(text).Contains(Raw);
+	}
+
+	/// <summary>
+	/// An HtmlMarkup span (what `look` wraps every exit name in) must not reach a client that
+	/// negotiated no Pueblo/MXP: a plain telnet client has no idea what &lt;send&gt; is and prints
+	/// the tag literally. Rendering an ANSI connection natively rather than as ANSI leaked the tags.
+	/// </summary>
+	[Test]
+	public async Task Ansi_StripsHtmlMarkupTags()
+	{
+		var send = HtmlMarkup.Create("send", "href=\"north\" hint=\"Go north\"");
+		var markup = MModule.serialize(MModule.MarkupSingle2(send, MModule.single("north")));
+
+		var result = new MarkupOutputRenderer().Render(markup, Connection(OutputFormat.Ansi));
+		var text = Encoding.UTF8.GetString(result.Data);
+
+		await Assert.That(text).DoesNotContain("<send");
+		await Assert.That(text).DoesNotContain("</send>");
+		// The trailing ANSI reset the ANSI strategy appends to any markup-bearing string is expected.
+		await Assert.That(StripAnsi(text)).IsEqualTo("north");
+	}
+
+	/// <summary>
+	/// The exits line as `look` actually builds it: an unmarked label followed by send-wrapped exit
+	/// names. The leading plain run means the first markup in the string is the HtmlMarkup, which is
+	/// what selected the native (tag-emitting) render strategy.
+	/// </summary>
+	[Test]
+	public async Task Ansi_StripsHtmlMarkupTagsInAMixedLine()
+	{
+		var send = HtmlMarkup.Create("send", "href=\"north\" hint=\"Go north\"");
+		var line = MModule.concat(
+			MModule.single("Obvious exits:\n"),
+			MModule.MarkupSingle2(send, MModule.single("north")));
+
+		var result = new MarkupOutputRenderer().Render(MModule.serialize(line), Connection(OutputFormat.Ansi));
+		var text = Encoding.UTF8.GetString(result.Data);
+
+		await Assert.That(text).DoesNotContain("<send");
+		await Assert.That(StripAnsi(text)).IsEqualTo("Obvious exits:\r\nnorth");
+	}
+
+	/// <summary>
+	/// Colour must survive the ANSI render — the fix must not turn styled output into plain text.
+	/// </summary>
+	[Test]
+	public async Task Ansi_KeepsAnsiMarkupAlongsideStrippedHtml()
+	{
+		var send = HtmlMarkup.Create("send", "href=\"north\"");
+		var red = AnsiMarkup.Create(foreground: new AnsiColor.RGB(Color.Red));
+		var line = MModule.MarkupSingleMulti(ImmutableArray.Create<IMarkup>(red, send), "north");
+
+		var result = new MarkupOutputRenderer().Render(MModule.serialize(line), Connection(OutputFormat.Ansi));
+		var text = Encoding.UTF8.GetString(result.Data);
+
+		await Assert.That(text).DoesNotContain("<send");
+		await Assert.That(text).Contains("\x1b[");
+		await Assert.That(text).Contains("north");
 	}
 
 	[Test]

--- a/docs/design/extensibility-overview.md
+++ b/docs/design/extensibility-overview.md
@@ -51,7 +51,8 @@ sensitive logic, integration with .NET libraries) but shouldn't live in the core
 The package manager installs **YAML packages** of game objects + attributes (and, with
 `@function`, global softcode functions) at runtime, with `@ainstall`/`@aupdate` lifecycle
 hooks and three-way-merge upgrades. Default packages are bundled and auto-installed at boot
-(`http-handler`, `profile-handler`, `common-functions`, `scene`). This is the home for
+(`http-handler`, `profile-handler`, `room-contents`, `common-functions`, `scene`), and are
+upgraded in place when a build ships a newer version of one. This is the home for
 **game policy** — who may do what, formatting, capture rules — written in MUSHcode by
 admins, no C# and no recompile.
 

--- a/docs/softcode/room-contents-handler.md
+++ b/docs/softcode/room-contents-handler.md
@@ -91,6 +91,10 @@ These are the attributes the `room-contents` package installs on the event
 handler object. The helpers keep the main handler readable; `me` is the event
 handler itself, since a handler runs with the handler object as its executor.
 
+Every example below targets `#9`, the default `event_handler`. The package
+resolves `{{$event_handler}}` from config at install time, so on a game that
+configures a different handler object, substitute its dbref throughout.
+
 ```mushcode
 &FN`WHOVIS #9=cand(not(hastype(%0,exit)),cor(not(isplayer(%0)),hasflag(%0,CONNECTED)))
 &FN`WHOROW #9=json(object,dbref,json(string,[num(%0)]),name,json(string,name(%0)),cmd,json(string,look [num(%0)]))

--- a/docs/softcode/room-contents-handler.md
+++ b/docs/softcode/room-contents-handler.md
@@ -111,7 +111,7 @@ Reading the main handler:
 
 Verify it is set:
 
-```
+```text
 > get #9/ROOM`CONTENTS
 ```
 
@@ -119,7 +119,7 @@ Verify it is set:
 
 ## Silencing the handler
 
-```
+```text
 &ROOM`CONTENTS #9=
 ```
 
@@ -128,7 +128,7 @@ An empty `&` sets the attribute to an empty string, which silences the handler
 remove it properly — attributes and registry records together — uninstall the
 package instead:
 
-```
+```text
 > @package uninstall room-contents
 ```
 

--- a/docs/softcode/room-contents-handler.md
+++ b/docs/softcode/room-contents-handler.md
@@ -1,18 +1,18 @@
-# WebSocket Support Package — Reference `ROOM`CONTENTS` Handler
+# WebSocket Support Package — the `ROOM`CONTENTS` Handler
 
-This document is part of the **WebSocket Support Package**. It provides a
-reference implementation of the `ROOM`CONTENTS` event handler that fans out
-structured OOB pushes to a room's connected occupants whenever the room's
-population changes (player movement, connect, or disconnect).
+This document is part of the **WebSocket Support Package**. It describes the
+`ROOM`CONTENTS` event handler that fans out structured OOB pushes to a room's
+connected occupants whenever the room's population changes (player movement,
+connect, or disconnect) — the data source behind the portal's Play sidebar.
 
-The handler below was verified end-to-end against a live server: installed on
-`#9`, fired by the real event path, and confirmed to populate the portal's
-Play sidebar.
-
-> **Packaging note:** The eventual home for this softcode is a SharpMUSH
-> package loadable via the `@package` command. Until the package-manager
-> integration ships as a follow-up, install the handler manually as shown
-> below.
+> **It ships installed.** The handler is the bundled **`room-contents`**
+> package (`examples/packages/room-contents/`), installed at first boot by
+> `DefaultPackagesBootstrapService` onto the configured `event_handler` object
+> (`{{$event_handler}}`, `#9` by default). Nothing below needs typing on a
+> stock game — it is here to explain what is installed and how to change it.
+> Manage it like any other package: `@package list`, `@package uninstall
+> room-contents`, or edit the attributes directly (the package's three-way
+> merge keeps local edits on the next upgrade).
 
 ---
 
@@ -85,22 +85,23 @@ These were learned the hard way; the reference handler relies on all of them:
 
 ---
 
-## Reference handler
+## The handler
 
-Install on the configured event handler object (default `#9`), one attribute
-at a time. The helper attributes keep the main handler readable.
+These are the attributes the `room-contents` package installs on the event
+handler object. The helpers keep the main handler readable; `me` is the event
+handler itself, since a handler runs with the handler object as its executor.
 
 ```mushcode
 &FN`WHOVIS #9=cand(not(hastype(%0,exit)),cor(not(isplayer(%0)),hasflag(%0,CONNECTED)))
 &FN`WHOROW #9=json(object,dbref,json(string,[num(%0)]),name,json(string,name(%0)),cmd,json(string,look [num(%0)]))
 &FN`EXITROW #9=json(object,name,json(string,name(%0)),cmd,json(string,goto [num(%0)]))
-&ROOM`CONTENTS #9=think oob(lcon(%0),room.contents,json(object,who,json_array(iter(filter(#9/FN`WHOVIS,lcon(%0)),u(#9/FN`WHOROW,itext(0)),%b,|),|)));think oob(lcon(%0),room.exits,json(object,exits,json_array(iter(lexits(%0),u(#9/FN`EXITROW,itext(0)),%b,|),|)))
+&ROOM`CONTENTS #9=think oob(lcon(%0),room.contents,json(object,who,json_array(iter(filter(me/FN`WHOVIS,lcon(%0)),u(me/FN`WHOROW,itext(0)),%b,|),|)));think oob(lcon(%0),room.exits,json(object,exits,json_array(iter(lexits(%0),u(me/FN`EXITROW,itext(0)),%b,|),|)))
 ```
 
 Reading the main handler:
 
-- `filter(#9/FN`WHOVIS,lcon(%0))` — the *who* set: non-exit occupants, players only when `CONNECTED` (disconnected / portal-only players are omitted, like PennMUSH); objects always show.
-- `iter(<set>, u(#9/FN`WHOROW,itext(0)), %b, |)` — build one JSON object per
+- `filter(me/FN`WHOVIS,lcon(%0))` — the *who* set: non-exit occupants, players only when `CONNECTED` (disconnected / portal-only players are omitted, like PennMUSH); objects always show.
+- `iter(<set>, u(me/FN`WHOROW,itext(0)), %b, |)` — build one JSON object per
   occupant (via the `FN`WHOROW` helper, `%0` = the occupant), joined with `|`.
 - `json_array(<that>, |)` — assemble those JSON objects into a JSON array.
 - `json(object, who, <array>)` — wrap as `{"who": [...]}`.
@@ -116,30 +117,39 @@ Verify it is set:
 
 ---
 
-## Removing the handler
+## Silencing the handler
 
 ```
 &ROOM`CONTENTS #9=
 ```
 
 An empty `&` sets the attribute to an empty string, which silences the handler
-(the engine still fires the event, but the attribute executes nothing).
+(the engine still fires the event, but the attribute executes nothing). To
+remove it properly — attributes and registry records together — uninstall the
+package instead:
+
+```
+> @package uninstall room-contents
+```
 
 ---
 
 ## Testing the handler
 
 `SharpMUSH.Tests/Services/RoomContentsHandlerReferenceTests.cs` installs the
-reference helpers + handler and triggers `ROOM`CONTENTS` via the **real event
-path** — `EventService.TriggerEventAsync(parser, SharpEvents.RoomContents, enactor, room, cause)` — not `@trigger`. The real path runs the handler with
-God (`#1`) as the executor — the elevated context the handler needs — whereas
-`@trigger` would run it as `#9` and the introspection calls would silently
-return nothing.
+helpers + handler and triggers `ROOM`CONTENTS` via the **real event path** —
+`EventService.TriggerEventAsync(parser, SharpEvents.RoomContents, enactor, room, cause)` —
+not `@trigger`. The event path runs the attribute with the event handler object
+as its executor (`me`, `%!`, `%@`) and the causing object as `%#`; seeded `#9`
+is a WIZARD, which is what lets the handler's introspection calls see the room.
 
 The test asserts the handler emits a **valid JSON `room.contents` payload**
 with the room's occupants — exercising `oob()`, `json_array()`, `iter()`,
-`filter()`, and the helper attributes together (the gap the previous,
-simplified test left open).
+`filter()`, and the helper attributes together.
+
+`SharpMUSH.Tests.Integration/Packages/RoomContentsPackageTests.cs` covers the
+delivery side: that the bundled `room-contents` package is installed at boot and
+that its attributes land on the configured event handler.
 
 ---
 

--- a/docs/softcode/room-contents-handler.md
+++ b/docs/softcode/room-contents-handler.md
@@ -1,7 +1,7 @@
-# WebSocket Support Package — the `ROOM`CONTENTS` Handler
+# WebSocket Support Package — the ``ROOM`CONTENTS`` Handler
 
 This document is part of the **WebSocket Support Package**. It describes the
-`ROOM`CONTENTS` event handler that fans out structured OOB pushes to a room's
+``ROOM`CONTENTS`` event handler that fans out structured OOB pushes to a room's
 connected occupants whenever the room's population changes (player movement,
 connect, or disconnect) — the data source behind the portal's Play sidebar.
 
@@ -18,7 +18,7 @@ connect, or disconnect) — the data source behind the portal's Play sidebar.
 
 ## What the handler does
 
-When `ROOM`CONTENTS` fires the handler receives:
+When ``ROOM`CONTENTS`` fires the handler receives:
 
 | Register | Value |
 |----------|-------|
@@ -66,9 +66,9 @@ These were learned the hard way; the reference handler relies on all of them:
    space delimiter would split it apart. The handler uses `|`:
    `iter(<list>, <expr>, %b, |)` then `json_array(<that>, |)`.
 
-5. **Filter with a stored attribute, not `#lambda`.** `filter(#9/FN`NOTEXIT,
-   lcon(%0))` is clean; the `#lambda/...` inline form mis-splits on commas
-   inside the lambda body (e.g. `hasflag(%0,connected)`) and needs escapes you
+5. **Filter with a stored attribute, not `#lambda`.** ``filter(me/FN`WHOVIS,
+   lcon(%0))`` is clean; the `#lambda/...` inline form mis-splits on commas
+   inside the lambda body (e.g. `hasflag(%0,CONNECTED)`) and needs escapes you
    should not have to think about.
 
 6. **`lcon(%0)` includes exits in this engine.** Filter them out of the *who*
@@ -77,7 +77,7 @@ These were learned the hard way; the reference handler relies on all of them:
 
 7. **Connected detection.** `hasflag(%0,CONNECTED)` reflects presence: true for a
    player with a live *play* session, false for a disconnected or portal-only
-   (background) connection. `FN`WHOVIS` uses it to keep asleep/portal players out
+   (background) connection. ``FN`WHOVIS`` uses it to keep asleep/portal players out
    of the *who* list. (`oob()`'s target filter independently governs *delivery*.)
 
 8. **`num(%0)` returns the `#N` dbref form** (e.g. `#76`), so don't prepend an
@@ -100,14 +100,14 @@ handler itself, since a handler runs with the handler object as its executor.
 
 Reading the main handler:
 
-- `filter(me/FN`WHOVIS,lcon(%0))` — the *who* set: non-exit occupants, players only when `CONNECTED` (disconnected / portal-only players are omitted, like PennMUSH); objects always show.
-- `iter(<set>, u(me/FN`WHOROW,itext(0)), %b, |)` — build one JSON object per
-  occupant (via the `FN`WHOROW` helper, `%0` = the occupant), joined with `|`.
+- ``filter(me/FN`WHOVIS,lcon(%0))`` — the *who* set: non-exit occupants, players only when `CONNECTED` (disconnected / portal-only players are omitted, like PennMUSH); objects always show.
+- ``iter(<set>, u(me/FN`WHOROW,itext(0)), %b, |)`` — build one JSON object per
+  occupant (via the ``FN`WHOROW`` helper, `%0` = the occupant), joined with `|`.
 - `json_array(<that>, |)` — assemble those JSON objects into a JSON array.
 - `json(object, who, <array>)` — wrap as `{"who": [...]}`.
 - `oob(lcon(%0), room.contents, <json>)` — send to every connected occupant of
   the room (non-players / non-connected are skipped automatically).
-- The second statement does the same for `room.exits` via `FN`EXITROW`/`lexits`.
+- The second statement does the same for `room.exits` via ``FN`EXITROW``/`lexits`.
 
 Verify it is set:
 
@@ -137,7 +137,7 @@ package instead:
 ## Testing the handler
 
 `SharpMUSH.Tests/Services/RoomContentsHandlerReferenceTests.cs` installs the
-helpers + handler and triggers `ROOM`CONTENTS` via the **real event path** —
+helpers + handler and triggers ``ROOM`CONTENTS`` via the **real event path** —
 `EventService.TriggerEventAsync(parser, SharpEvents.RoomContents, enactor, room, cause)` —
 not `@trigger`. The event path runs the attribute with the event handler object
 as its executor (`me`, `%!`, `%@`) and the causing object as `%#`; seeded `#9`

--- a/examples/packages/index.yaml
+++ b/examples/packages/index.yaml
@@ -27,6 +27,10 @@ packages:
     package: profile-handler
     version: 1.1.0
     description: Read-only character directory, online list + profile API (requires http-handler)
+  - path: room-contents/
+    package: room-contents
+    version: 1.0.0
+    description: room.contents/room.exits OOB pushes for the portal Play sidebar (bundled default)
   - path: chargen/
     package: chargen
     version: 1.0.0

--- a/examples/packages/room-contents/README.md
+++ b/examples/packages/room-contents/README.md
@@ -1,0 +1,35 @@
+# room-contents
+
+The `` ROOM`CONTENTS `` event handler, delivered as an attach-mode package
+(decision 20.3). It is what makes the web portal's **Play sidebar** (the *Here*
+and *Exits* cards) populate.
+
+The engine fires `` ROOM`CONTENTS `` room-scoped whenever a room's population
+changes — movement, connect, disconnect — with `%0` = the affected room and
+`%1` = the cause (`move-in`, `move-out`, `connect`, `disconnect`). This package
+supplies the attribute that turns that event into two OOB pushes to the room's
+connected occupants:
+
+- **`room.contents`** — `{"who": [ {dbref, name, cmd}, … ]}`, one entry per
+  non-exit occupant; players appear only while CONNECTED, matching PennMUSH.
+- **`room.exits`** — `{"exits": [ {name, cmd}, … ]}`, one entry per exit, with
+  the `goto` command a client issues to traverse it.
+
+The portal routes incoming OOB frames by package name into its per-connection
+channel store; the Play sidebar renders the `who` / `exits` entries and issues
+an entry's `cmd` on click. Without a handler attribute the engine emits nothing
+and the sidebar stays empty.
+
+It manages only these attributes on the configured `event_handler` object
+(`{{$event_handler}}`, #9) — it never creates or destroys the object, and
+uninstalling leaves the handler object's other softcode untouched.
+
+## Customising
+
+The helpers are the intended seam: `` FN`WHOVIS `` decides who is listed (add
+dark/visibility guards here), and `` FN`WHOROW `` / `` FN`EXITROW `` build one row
+each (`%0` = the occupant/exit). The engine imposes no policy.
+
+`oob(<targets>, <package>, <json>)` takes a target *list* and delivers only to
+targets that are players with a live WebSocket (or GMCP) connection, so the
+handler passes `lcon(%0)` and lets `oob()` do the filtering.

--- a/examples/packages/room-contents/README.md
+++ b/examples/packages/room-contents/README.md
@@ -21,8 +21,9 @@ an entry's `cmd` on click. Without a handler attribute the engine emits nothing
 and the sidebar stays empty.
 
 It manages only these attributes on the configured `event_handler` object
-(`{{$event_handler}}`, #9) — it never creates or destroys the object, and
-uninstalling leaves the handler object's other softcode untouched.
+(`{{$event_handler}}`, `#9` by default) — the target is resolved from config at
+install time, never a literal dbref. It never creates or destroys the object,
+and uninstalling leaves the handler object's other softcode untouched.
 
 ## Customising
 

--- a/examples/packages/room-contents/package.yaml
+++ b/examples/packages/room-contents/package.yaml
@@ -1,0 +1,45 @@
+format: 1
+package: room-contents
+version: 1.0.0
+authors: [SharpMUSH]
+description: "Pushes room.contents / room.exits OOB updates to a room's connected occupants, driving the portal's Play sidebar."
+license: MIT
+homepage: https://github.com/SharpMUSH/SharpMUSH-Packages
+keywords: [oob, websocket, portal, play, events]
+requires_server: ">=0.1"
+
+# Attach mode (decision 20.3): manages the ROOM`CONTENTS event handler and its
+# helpers on the existing event_handler object ({{$event_handler}}, #9 by
+# default). The engine fires ROOM`CONTENTS on movement, connect and disconnect;
+# without a handler attribute nothing is emitted and the Play sidebar has no
+# data source.
+objects:
+  - ref: handler
+    target: "{{$event_handler}}"
+    attributes:
+      # ── Helpers (me-relative; redefinable per game) ───────────────────────
+      # The "who" predicate (%0 = a room occupant). lcon() includes exits on this
+      # engine, so exits are filtered out here. Players are listed only while
+      # CONNECTED — a disconnected or portal-only (background) player is not
+      # present in the room for display purposes, matching PennMUSH; non-players
+      # always show.
+      FN`WHOVIS: |-
+        cand(not(hastype(%0,exit)),cor(not(isplayer(%0)),hasflag(%0,CONNECTED)))
+      # One occupant row (%0 = the occupant). cmd is what a client issues on click.
+      FN`WHOROW: |-
+        json(object,dbref,json(string,[num(%0)]),name,json(string,name(%0)),cmd,json(string,look [num(%0)]))
+      # One exit row (%0 = the exit).
+      FN`EXITROW: |-
+        json(object,name,json(string,name(%0)),cmd,json(string,goto [num(%0)]))
+
+      # ── The handler ──────────────────────────────────────────────────────
+      # %0 = the affected room, %1 = cause (move-in / move-out / connect / disconnect).
+      #
+      # oob(<targets>, <package>, <json>) takes a target LIST and delivers only to
+      # those that are players holding a live WebSocket/GMCP connection, so passing
+      # lcon(%0) (the whole room) needs no manual connected/player filtering.
+      #
+      # iter()/json_array() use "|" as their separator: a row like {"cmd":"look #1"}
+      # contains a space, and the default space separator would split it apart.
+      ROOM`CONTENTS: |-
+        think oob(lcon(%0),room.contents,json(object,who,json_array(iter(filter(me/FN`WHOVIS,lcon(%0)),u(me/FN`WHOROW,itext(0)),%b,|),|)));think oob(lcon(%0),room.exits,json(object,exits,json_array(iter(lexits(%0),u(me/FN`EXITROW,itext(0)),%b,|),|)))


### PR DESCRIPTION
Three defects behind "the Play sidebar is empty and exits print HTML". Each was reproduced against a live server (Server + ConnectionServer + NATS, real telnet and real browser) before being fixed.

## 1. `Here` / `Exits` never populated

The `ROOM`CONTENTS` handler that emits the `room.contents` / `room.exits` OOB packages existed **only as documentation** (`docs/softcode/room-contents-handler.md`, which said "install the handler manually; packaging is a follow-up"). Nothing installed it, so a stock server emitted no OOB frames at all and `Play.razor`'s sidebar had no data source. The engine side was already fine — the event fires room-scoped on move/connect/disconnect, `oob()` delivers, and the client's channel store works.

Evidence: zero OOB frames on a fresh game; correct payloads the moment the handler was pasted in by hand.

Fix — ship it as a bundled package:

- `examples/packages/room-contents/` — attach mode on `{{$event_handler}}`, helpers rewritten `me/`-relative instead of hardcoding `#9`
- added `event_handler` to `WellKnownRefs` and resolved it in `PackageInstallService.BuildWellKnownMapAsync` (only `http_handler` was resolvable before)
- registered in `BundledPackages.All` + embedded in the Server csproj; the attach gate is now per-handler (`BundledPackageHandler.Http/Event/None`) rather than a `RequiresHttpHandler` bool

## 2. Bundled packages had no upgrade path

`DefaultPackagesBootstrapService.InstallIfAbsentAsync` returned early for *any* already-installed package regardless of version. So a game kept whatever version of a bundled package it first installed, forever.

Concretely: `GET`ONLINE` / `FN`ONLINEVIS` only arrived in profile-handler **1.1.0** (be4c8dea). A game whose DB predates that keeps 1.0.0 → `/http/online` 404s → `CharacterDirectoryService` swallows the `HttpRequestException` and the "Online Now" widget renders its empty state, indistinguishable from genuinely nobody being connected.

Fix: bootstrap upgrades in place when the build ships a strictly newer version, reusing the existing `KeepMine` conflict resolution so local edits survive. Same-or-newer installed is still left to the package manager.

## 3. `<send>` tags reached non-Pueblo/non-MXP clients

`MarkupOutputRenderer.Render` used `ms.ToString()` for the ANSI case. That is not the ANSI render — it is `NativeToString()`, which renders **every markup span in its own native form**: `AnsiMarkup` → ANSI codes (fine), `HtmlMarkup` → the literal tag. Since `look` wraps every exit name in `WrapExitInSendTag`, a plain telnet client got:

```
Obvious exits:
<send href="north" hint="Go north">north</send>
```

Fix: use the ANSI render, which maps `HtmlMarkup` to its ANSI equivalent (`b`/`i`/`u`/`s`) or to bare text. Same client after the fix prints `north`; an MXP-negotiating client on the same build still gets its `<send>` tags behind the `ESC[0z` prefix.

This also covers `tagwrap()` in softcode (the other `HtmlMarkup` producer) and prompts, which share the renderer. For ANSI-only content the change is a no-op — the two strategies are identical when the first markup is an `AnsiMarkup`. Where they differ the ANSI render is also strictly better: it appends the standard trailing reset that the native path skipped whenever an `HtmlMarkup` came first, so a coloured exits line could previously bleed colour past its end.

## Why it wasn't caught

`PuebloMxpRenderTests` asserts `Render("ansi")` strips `<send>` — correct, but that tests the `MString` API, not the path the ConnectionServer takes. `MarkupOutputRendererTests.Ansi_KeepsRawText` fed it a plain string that merely *contains* the characters `<send …>`, with no markup runs. Nothing exercised a real `HtmlMarkup` run through the renderer.

## Tests added

- `MarkupOutputRendererTests` — a bare send span, the mixed `"Obvious exits:\n"` + send line as `look` builds it (the leading plain run is what makes the `HtmlMarkup` the *first* markup, which selected the native strategy), and a colour+send span asserting ANSI survives
- `BundledPackagesTests` — every entry in `BundledPackages.All` has an embedded manifest that parses, and attach-mode packages declare the handler they target (a missing `EmbeddedResource` was silent-at-boot)
- `BundledPackageUpgradeTests` — the version gate, including unparseable/missing versions
- `RoomContentsPackageTests` (integration) — the package installs at boot and its attributes land on the *configured* event handler
- `BundledPackageUpgradeIntegrationTests` — re-applying a newer manifest of an installed package really does add the new routes and move the recorded version forward

## Verification

Locally on this branch: unit **4690 passed / 198 skipped / 0 failed**, integration **246/246**, BUnit **263/263** (ArangoDB provider). Plus live checks: plain telnet shows `north`, MXP shows the tag, and the portal renders **Here** → God, Package Manager · **Exits** → north · **Online Now** → God with no manual softcode.

## Note on the docs

`docs/softcode/room-contents-handler.md` is rewritten to describe an installed package rather than a manual procedure, and its "the real path runs the handler with God (#1) as the executor" claim is corrected — `EventService` sets `Executor: handlerRef`, i.e. the handler object itself (`me`), which is why the packaged handler can use `me/FN`WHOVIS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the bundled `room-contents` package to keep the web portal sidebar updated with room occupants and exits.
  * Bundled packages can now attach via event-based handlers and resolve `event_handler` wiring.
* **Bug Fixes**
  * ANSI output now strips HTML `<send>` markup correctly while preserving ANSI styling.
  * Configured handler resolution no longer falls back to guessing when handlers are missing.
  * Bundled package upgrades now apply only for strictly newer versions, preserving local/admin customizations.
* **Documentation**
  * Updated extensibility overview and refreshed `room-contents` package/handler documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->