### PR TITLE
fix(portal): hydrate the account session before reading the bearer

### DIFF
--- a/.run/Start Server.run.xml
+++ b/.run/Start Server.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Start Server" type="docker-deploy" factoryName="docker-compose.yml" server-name="Podman">
+  <configuration default="false" name="Start Server" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
     <deployment type="docker-compose.yml">
       <settings>
         <option name="sourceFilePath" value="docker-compose.yml" />

--- a/.run/Start Server.run.xml
+++ b/.run/Start Server.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Start Server" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
+  <configuration default="false" name="Start Server" type="docker-deploy" factoryName="docker-compose.yml" server-name="Podman">
     <deployment type="docker-compose.yml">
       <settings>
         <option name="sourceFilePath" value="docker-compose.yml" />

--- a/SharpMUSH.Client/Services/AccountSessionBearerHandler.cs
+++ b/SharpMUSH.Client/Services/AccountSessionBearerHandler.cs
@@ -11,12 +11,24 @@ public sealed class AccountSessionBearerHandler(IAccountAuthState accountAuth) :
 {
 	private readonly IAccountAuthState _accountAuth = accountAuth;
 
-	protected override Task<HttpResponseMessage> SendAsync(
+	protected override async Task<HttpResponseMessage> SendAsync(
 		HttpRequestMessage request, CancellationToken cancellationToken)
 	{
-		if (request.Headers.Authorization is null && _accountAuth.AccountSessionToken is { } token)
-			request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		if (request.Headers.Authorization is null)
+		{
+			// Hydrate before reading the token. On a page refresh the session lives in sessionStorage
+			// until InitAsync copies it into memory, so a request issued inside that window would go out
+			// anonymous and come back 401. Today every authenticated caller happens to hydrate first —
+			// either behind an [Authorize] page (AuthorizeRouteView awaits AccountAuthStateProvider,
+			// which awaits InitAsync) or by calling InitAsync itself — but nothing enforces that, and a
+			// caller that forgets fails intermittently rather than loudly. Single-flight and JS-interop
+			// only: no HTTP, so this cannot re-enter the pipeline, and it is a no-op after the first call.
+			await _accountAuth.InitAsync();
 
-		return base.SendAsync(request, cancellationToken);
+			if (_accountAuth.AccountSessionToken is { } token)
+				request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		}
+
+		return await base.SendAsync(request, cancellationToken);
 	}
 }

--- a/SharpMUSH.Tests.BUnit/Services/AccountSessionBearerHandlerHydrationTests.cs
+++ b/SharpMUSH.Tests.BUnit/Services/AccountSessionBearerHandlerHydrationTests.cs
@@ -1,0 +1,91 @@
+using Bunit;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using SharpMUSH.Client.Services;
+using System.Net;
+
+namespace SharpMUSH.Tests.BUnit.Services;
+
+/// <summary>Captures the outgoing request so a test can assert what the handler forwarded.</summary>
+file sealed class CapturingHandler : HttpMessageHandler
+{
+	public HttpRequestMessage? LastRequest { get; private set; }
+
+	protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+	{
+		LastRequest = request;
+		return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+	}
+}
+
+/// <summary>
+/// The session token lives in sessionStorage until <see cref="AccountAuthService.InitAsync"/> copies
+/// it into memory, so a request issued during that window used to go out with no bearer and come back
+/// 401. Callers happen to hydrate first today — an <c>[Authorize]</c> page waits on
+/// <c>AccountAuthStateProvider</c>, which awaits <c>InitAsync</c>; <c>MainLayout</c>,
+/// <c>GlobalTerminal</c>, <c>Account</c> and <c>GetCharactersAsync</c> call it themselves — but that is
+/// convention, not enforcement, and a caller that forgets fails intermittently on refresh rather than
+/// loudly. These tests use the real <see cref="AccountAuthService"/> over bUnit's JSInterop so they
+/// exercise the actual storage read, not a fake that is already "hydrated".
+/// </summary>
+public class AccountSessionBearerHandlerHydrationTests : BunitContext
+{
+	private AccountAuthService ServiceWithStoredSession(string? storedToken)
+	{
+		JSInterop.Mode = JSRuntimeMode.Loose;
+		JSInterop.Setup<string?>("sessionStorage.getItem", "sharpmush.account.loggedOut").SetResult(null);
+		JSInterop.Setup<string?>("sessionStorage.getItem", "sharpmush.account.sessionToken").SetResult(storedToken);
+
+		return new AccountAuthService(
+			Substitute.For<IHttpClientFactory>(),
+			JSInterop.JSRuntime,
+			NullLogger<AccountAuthService>.Instance,
+			Substitute.For<ITerminalService>(),
+			Substitute.For<IPlayTerminalService>());
+	}
+
+	private static async Task<HttpRequestMessage?> SendAsync(IAccountAuthState auth, string url)
+	{
+		var inner = new CapturingHandler();
+		using var handler = new AccountSessionBearerHandler(auth) { InnerHandler = inner };
+		using var invoker = new HttpMessageInvoker(handler);
+		await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), CancellationToken.None);
+		return inner.LastRequest;
+	}
+
+	[Test]
+	public async Task SendAsync_WithoutPriorInitAsync_HydratesAndAttachesStoredToken()
+	{
+		var auth = ServiceWithStoredSession("stored-session-token");
+
+		// Nobody has awaited InitAsync — this is a request racing a page refresh's hydration.
+		var sent = await SendAsync(auth, "https://localhost/api/mail");
+
+		await Assert.That(sent!.Headers.Authorization?.Scheme).IsEqualTo("Bearer");
+		await Assert.That(sent.Headers.Authorization?.Parameter).IsEqualTo("stored-session-token");
+	}
+
+	[Test]
+	public async Task SendAsync_WithHydrationAlreadyInFlight_StillAttachesToken()
+	{
+		var auth = ServiceWithStoredSession("stored-session-token");
+
+		// CascadingAuthenticationState kicks hydration off without anyone awaiting it; the handler must
+		// join that in-flight single-flight task rather than read the not-yet-populated token.
+		_ = auth.InitAsync();
+		var sent = await SendAsync(auth, "https://localhost/api/mail");
+
+		await Assert.That(sent!.Headers.Authorization?.Parameter).IsEqualTo("stored-session-token");
+	}
+
+	[Test]
+	public async Task SendAsync_NoStoredSession_StaysAnonymous()
+	{
+		var auth = ServiceWithStoredSession(null);
+
+		var sent = await SendAsync(auth, "https://localhost/api/wiki");
+
+		// Hydrating must not invent a credential for an anonymous visitor.
+		await Assert.That(sent!.Headers.Authorization).IsNull();
+	}
+}

--- a/SharpMUSH.Tests.BUnit/Services/AccountSessionBearerHandlerHydrationTests.cs
+++ b/SharpMUSH.Tests.BUnit/Services/AccountSessionBearerHandlerHydrationTests.cs
@@ -49,7 +49,8 @@ public class AccountSessionBearerHandlerHydrationTests : BunitContext
 		var inner = new CapturingHandler();
 		using var handler = new AccountSessionBearerHandler(auth) { InnerHandler = inner };
 		using var invoker = new HttpMessageInvoker(handler);
-		using var response = await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), CancellationToken.None);
+		using var request = new HttpRequestMessage(HttpMethod.Get, url);
+		using var response = await invoker.SendAsync(request, CancellationToken.None);
 		return inner.LastRequest;
 	}
 

--- a/SharpMUSH.Tests.BUnit/Services/AccountSessionBearerHandlerHydrationTests.cs
+++ b/SharpMUSH.Tests.BUnit/Services/AccountSessionBearerHandlerHydrationTests.cs
@@ -3,17 +3,22 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using SharpMUSH.Client.Services;
 using System.Net;
+using System.Net.Http.Headers;
 
 namespace SharpMUSH.Tests.BUnit.Services;
 
-/// <summary>Captures the outgoing request so a test can assert what the handler forwarded.</summary>
+/// <summary>
+/// Captures what the handler forwarded. Records the header value rather than keeping the
+/// <see cref="HttpRequestMessage"/> alive, so the request can be disposed the moment the send
+/// completes and no assertion ever reads a disposed object.
+/// </summary>
 file sealed class CapturingHandler : HttpMessageHandler
 {
-	public HttpRequestMessage? LastRequest { get; private set; }
+	public AuthenticationHeaderValue? LastAuthorization { get; private set; }
 
 	protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
 	{
-		LastRequest = request;
+		LastAuthorization = request.Headers.Authorization;
 		return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
 	}
 }
@@ -44,14 +49,14 @@ public class AccountSessionBearerHandlerHydrationTests : BunitContext
 			Substitute.For<IPlayTerminalService>());
 	}
 
-	private static async Task<HttpRequestMessage?> SendAsync(IAccountAuthState auth, string url)
+	private static async Task<AuthenticationHeaderValue?> SendAsync(IAccountAuthState auth, string url)
 	{
 		var inner = new CapturingHandler();
 		using var handler = new AccountSessionBearerHandler(auth) { InnerHandler = inner };
 		using var invoker = new HttpMessageInvoker(handler);
 		using var request = new HttpRequestMessage(HttpMethod.Get, url);
 		using var response = await invoker.SendAsync(request, CancellationToken.None);
-		return inner.LastRequest;
+		return inner.LastAuthorization;
 	}
 
 	[Test]
@@ -62,8 +67,8 @@ public class AccountSessionBearerHandlerHydrationTests : BunitContext
 		// Nobody has awaited InitAsync — this is a request racing a page refresh's hydration.
 		var sent = await SendAsync(auth, "https://localhost/api/mail");
 
-		await Assert.That(sent!.Headers.Authorization?.Scheme).IsEqualTo("Bearer");
-		await Assert.That(sent.Headers.Authorization?.Parameter).IsEqualTo("stored-session-token");
+		await Assert.That(sent?.Scheme).IsEqualTo("Bearer");
+		await Assert.That(sent?.Parameter).IsEqualTo("stored-session-token");
 	}
 
 	[Test]
@@ -76,7 +81,7 @@ public class AccountSessionBearerHandlerHydrationTests : BunitContext
 		_ = auth.InitAsync();
 		var sent = await SendAsync(auth, "https://localhost/api/mail");
 
-		await Assert.That(sent!.Headers.Authorization?.Parameter).IsEqualTo("stored-session-token");
+		await Assert.That(sent?.Parameter).IsEqualTo("stored-session-token");
 	}
 
 	[Test]
@@ -87,6 +92,6 @@ public class AccountSessionBearerHandlerHydrationTests : BunitContext
 		var sent = await SendAsync(auth, "https://localhost/api/wiki");
 
 		// Hydrating must not invent a credential for an anonymous visitor.
-		await Assert.That(sent!.Headers.Authorization).IsNull();
+		await Assert.That(sent).IsNull();
 	}
 }

--- a/SharpMUSH.Tests.BUnit/Services/AccountSessionBearerHandlerHydrationTests.cs
+++ b/SharpMUSH.Tests.BUnit/Services/AccountSessionBearerHandlerHydrationTests.cs
@@ -49,7 +49,7 @@ public class AccountSessionBearerHandlerHydrationTests : BunitContext
 		var inner = new CapturingHandler();
 		using var handler = new AccountSessionBearerHandler(auth) { InnerHandler = inner };
 		using var invoker = new HttpMessageInvoker(handler);
-		await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), CancellationToken.None);
+		using var response = await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), CancellationToken.None);
 		return inner.LastRequest;
 	}
 

--- a/SharpMUSH.Tests.BUnit/Services/AccountSessionBearerHandlerTests.cs
+++ b/SharpMUSH.Tests.BUnit/Services/AccountSessionBearerHandlerTests.cs
@@ -31,14 +31,18 @@ file sealed class FakeAccountAuthState : IAccountAuthState
 	}
 }
 
-/// <summary>Captures the outgoing request so a test can assert what the handler forwarded.</summary>
+/// <summary>
+/// Captures what the handler forwarded. Records the header value rather than keeping the
+/// <see cref="HttpRequestMessage"/> alive, so the request can be disposed the moment the send
+/// completes and no assertion ever reads a disposed object.
+/// </summary>
 file sealed class CapturingInnerHandler : HttpMessageHandler
 {
-	public HttpRequestMessage? LastRequest { get; private set; }
+	public AuthenticationHeaderValue? LastAuthorization { get; private set; }
 
 	protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
 	{
-		LastRequest = request;
+		LastAuthorization = request.Headers.Authorization;
 		return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
 	}
 }
@@ -52,14 +56,17 @@ file sealed class CapturingInnerHandler : HttpMessageHandler
 /// </summary>
 public class AccountSessionBearerHandlerTests
 {
-	private static async Task<HttpRequestMessage?> SendAsync(
+	private static async Task<AuthenticationHeaderValue?> SendAsync(
 		IAccountAuthState auth, HttpRequestMessage request)
 	{
-		var inner = new CapturingInnerHandler();
-		using var handler = new AccountSessionBearerHandler(auth) { InnerHandler = inner };
-		using var invoker = new HttpMessageInvoker(handler);
-		using var response = await invoker.SendAsync(request, CancellationToken.None);
-		return inner.LastRequest;
+		using (request)
+		{
+			var inner = new CapturingInnerHandler();
+			using var handler = new AccountSessionBearerHandler(auth) { InnerHandler = inner };
+			using var invoker = new HttpMessageInvoker(handler);
+			using var response = await invoker.SendAsync(request, CancellationToken.None);
+			return inner.LastAuthorization;
+		}
 	}
 
 	[Test]
@@ -69,8 +76,8 @@ public class AccountSessionBearerHandlerTests
 
 		var sent = await SendAsync(auth, new HttpRequestMessage(HttpMethod.Get, "https://localhost/api/mail"));
 
-		await Assert.That(sent!.Headers.Authorization?.Scheme).IsEqualTo("Bearer");
-		await Assert.That(sent.Headers.Authorization?.Parameter).IsEqualTo("session-token-1");
+		await Assert.That(sent?.Scheme).IsEqualTo("Bearer");
+		await Assert.That(sent?.Parameter).IsEqualTo("session-token-1");
 	}
 
 	[Test]
@@ -81,7 +88,7 @@ public class AccountSessionBearerHandlerTests
 		var sent = await SendAsync(auth, new HttpRequestMessage(HttpMethod.Get, "https://localhost/api/wiki"));
 
 		// Anonymous browsing (public wiki, character directory) must keep working — no header added.
-		await Assert.That(sent!.Headers.Authorization).IsNull();
+		await Assert.That(sent).IsNull();
 	}
 
 	[Test]
@@ -96,7 +103,7 @@ public class AccountSessionBearerHandlerTests
 		var sent = await SendAsync(auth, request);
 
 		// A call that set its own header on purpose wins; the handler must not clobber it.
-		await Assert.That(sent!.Headers.Authorization?.Parameter).IsEqualTo("explicit-token");
+		await Assert.That(sent?.Parameter).IsEqualTo("explicit-token");
 	}
 
 	[Test]
@@ -109,8 +116,9 @@ public class AccountSessionBearerHandlerTests
 
 		// Log in AFTER the handler exists (it is a long-lived singleton built once at startup).
 		auth.AccountSessionToken = "logged-in-later";
-		using var response = await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, "https://localhost/api/mail"), CancellationToken.None);
+		using var request = new HttpRequestMessage(HttpMethod.Get, "https://localhost/api/mail");
+		using var response = await invoker.SendAsync(request, CancellationToken.None);
 
-		await Assert.That(inner.LastRequest!.Headers.Authorization?.Parameter).IsEqualTo("logged-in-later");
+		await Assert.That(inner.LastAuthorization?.Parameter).IsEqualTo("logged-in-later");
 	}
 }

--- a/SharpMUSH.Tests.BUnit/Services/AccountSessionBearerHandlerTests.cs
+++ b/SharpMUSH.Tests.BUnit/Services/AccountSessionBearerHandlerTests.cs
@@ -58,7 +58,7 @@ public class AccountSessionBearerHandlerTests
 		var inner = new CapturingInnerHandler();
 		using var handler = new AccountSessionBearerHandler(auth) { InnerHandler = inner };
 		using var invoker = new HttpMessageInvoker(handler);
-		await invoker.SendAsync(request, CancellationToken.None);
+		using var response = await invoker.SendAsync(request, CancellationToken.None);
 		return inner.LastRequest;
 	}
 
@@ -109,7 +109,7 @@ public class AccountSessionBearerHandlerTests
 
 		// Log in AFTER the handler exists (it is a long-lived singleton built once at startup).
 		auth.AccountSessionToken = "logged-in-later";
-		await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, "https://localhost/api/mail"), CancellationToken.None);
+		using var response = await invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get, "https://localhost/api/mail"), CancellationToken.None);
 
 		await Assert.That(inner.LastRequest!.Headers.Authorization?.Parameter).IsEqualTo("logged-in-later");
 	}


### PR DESCRIPTION
## The gap

`AccountSessionBearerHandler` reads `AccountSessionToken` straight off `IAccountAuthState`. On a page refresh that token sits in `sessionStorage` until `AccountAuthService.InitAsync` copies it into memory, so a request issued inside that window goes out with **no** `Authorization` header and comes back 401 — intermittently, depending on timing.

Proven, not assumed. Against `main` as-is, a request racing an un-awaited `InitAsync()` sends nothing:

```
Expected to be equal to "Bearer" but received ""
```

## Is it reachable today?

No — I swept for a caller that could land in the window and found none:

- **`[Authorize]` pages are safe by ordering.** `AuthorizeRouteView` won't instantiate the page until `AccountAuthStateProvider.GetAuthenticationStateAsync` resolves, and that awaits `InitAsync` first (`AccountAuthStateProvider.cs:31`, whose comment names this exact race). `/mail` → `MailController [Authorize]` is the representative case.
- **Account-data callers hydrate themselves**: `GetCharactersAsync` (`AccountAuthService.cs:482`), `GlobalTerminal.razor:221`, `MainLayout.razor:173`, `Account.razor:179`.
- **Un-gated first-render components hit anonymous endpoints**: `SceneController` is `[AllowAnonymous]` wholesale, `GET /api/layouts/{scope}` is `[AllowAnonymous]`, likewise wiki reads and server info. The home-page widgets (`ActiveScene`, `WikiIndex`, `RecentWikiActivity`, `Stats`, `OnlineCharacters`, `CharacterDirectory`) stay inside that set.

So the invariant holds by **convention**. Nothing enforces it, and a future authenticated caller that forgets doesn't fail loudly — it 401s on some refreshes and not others.

## The change

`await _accountAuth.InitAsync()` before reading the token. Hydration is single-flight and JS-interop only (no HTTP), so it cannot re-enter the pipeline, and it's a no-op after the first call. The existing skip-when-caller-set-its-own-header and no-token-stays-anonymous behaviour is unchanged.

Not touched: `ActingCharacterHeaderHandler` reads `ActiveCharacter`, which `InitCoreAsync` does not restore from storage (it's set by `SetCharacters`/`SwitchCharacterAsync`), so it isn't the same hydration concern and this change doesn't claim to fix it.

## Verification

- 3 new tests in `SharpMUSH.Tests.BUnit/Services/AccountSessionBearerHandlerHydrationTests.cs`, using the **real** `AccountAuthService` over bUnit's JSInterop so they exercise the actual storage read: no prior `InitAsync`, hydration already in flight, and no stored session at all.
- Red/green confirmed by reverting the handler in place: 2 of the 3 fail without it, all pass with it.
- Full `SharpMUSH.Tests.BUnit` 270/270; `SharpMUSH.Tests` client namespace 111/111. `dotnet format whitespace` clean on both touched projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session handling so outgoing requests reliably hydrate account state before attaching an access token.
  * Requests now include the bearer token restored from saved session storage, even when initialization is already in progress.
  * Requests remain anonymous when no saved session token is available.
* **Tests**
  * Added new bUnit coverage for token hydration from session storage, concurrent initialization scenarios, and anonymous behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->