### PR TITLE
fix(portal): keep the acting character across a page reload

### DIFF
--- a/SharpMUSH.Client/Services/AccountAuthService.cs
+++ b/SharpMUSH.Client/Services/AccountAuthService.cs
@@ -276,7 +276,9 @@ public class AccountAuthService(
 		// then re-check the slot AFTER the read as well: the storage round-trip is an await, and a login
 		// can land while it is in flight. Testing only before the await would let a stale stored value
 		// clobber the newer live one; testing only after it would spend an interop call to learn
-		// something we already knew.
+		// something we already knew. Static analysis reads the inner check as always-true because it
+		// does not model the await as a point where another continuation can run — it is load-bearing,
+		// and deleting it fails ALoginLandingDuringHydration_IsNotClobberedByTheStoredValue.
 		if (ActiveCharacter is null)
 		{
 			var restored = await ReadStoredActiveCharacterAsync();

--- a/SharpMUSH.Client/Services/AccountAuthService.cs
+++ b/SharpMUSH.Client/Services/AccountAuthService.cs
@@ -117,9 +117,11 @@ public class AccountAuthService(
 		catch (JsonException ex)
 		{
 			// Drop the bad entry so this self-heals: left in place it would re-log on every reload
-			// until the player happened to switch characters.
+			// until the player happened to switch characters. Awaited rather than detached — we are
+			// already in an async method, so the removal may as well be deterministic; the core method
+			// still swallows and logs interop failures.
 			logger.LogWarning(ex, "Stored active character was unreadable; clearing it and falling back to the roster default");
-			PersistActiveCharacter(null);
+			await PersistActiveCharacterCoreAsync(null);
 			return null;
 		}
 	}

--- a/SharpMUSH.Client/Services/AccountAuthService.cs
+++ b/SharpMUSH.Client/Services/AccountAuthService.cs
@@ -170,14 +170,33 @@ public class AccountAuthService(
 	/// longer owns. Re-validating membership on every assignment closes that gap: a still-present
 	/// active character is left alone (regardless of its new position in the roster); an absent one
 	/// is reseated exactly like the null case.
+	///
+	/// A still-present active character is re-bound to the roster's instance rather than merely kept:
+	/// identity is the dbref/creation-time pair, but the rest of the summary (name, flags) is a
+	/// snapshot that can be stale — most visibly one restored from storage after a reload, which may
+	/// predate a rename or a flag change by any amount of time. The roster is the fresher copy, so
+	/// anything rendering <see cref="ActiveCharacter"/> shows current data.
 	/// </summary>
 	private void SetCharacters(IReadOnlyList<CharacterSummary> characters)
 	{
 		Characters = characters;
-		var activeStillPresent = ActiveCharacter is not null && characters.Any(c =>
+		var stillPresent = ActiveCharacter is null ? null : characters.FirstOrDefault(c =>
 			c.DbrefNumber == ActiveCharacter.DbrefNumber && c.CreationTime == ActiveCharacter.CreationTime);
-		if (!activeStillPresent)
+
+		if (stillPresent is null)
+		{
 			SetActiveCharacter(characters.FirstOrDefault());
+			return;
+		}
+
+		// Same character, drifted details. SetActiveCharacter would no-op on the identity check, so
+		// rebind directly — and persist, so the next reload restores the fresh copy too.
+		if (stillPresent != ActiveCharacter)
+		{
+			ActiveCharacter = stillPresent;
+			PersistActiveCharacter(stillPresent);
+			RaiseActiveCharacterChanged();
+		}
 	}
 
 	/// <summary>
@@ -715,6 +734,15 @@ public class AccountAuthService(
 		await js.InvokeVoidAsync("sessionStorage.removeItem", MustChangePasswordKey);
 		await js.InvokeVoidAsync("sessionStorage.removeItem", RoleKey);
 		await js.InvokeVoidAsync("sessionStorage.removeItem", PermissionsKey);
+		// Awaited here rather than left to SetActiveCharacter's detached write above: the invariant
+		// below (every storage mutation complete before the event fires) has to hold for this key too,
+		// or a stale acting character could outlive the logout and be restored by the next login in
+		// this tab.
+		await js.InvokeVoidAsync("sessionStorage.removeItem", ActiveCharacterKey);
+		// Awaited here rather than left to SetActiveCharacter's detached write above: the invariant
+		// below (every storage mutation complete before the event fires) has to hold for this key too,
+		// or a stale acting character could outlive the logout and be restored by the next login in
+		// this tab.
 
 		// Explicit-logout latch: sticks until the next successful login/register/setup in this
 		// tab, so dev-mode debug re-auth (or any other silent re-persist) can't undo the logout.

--- a/SharpMUSH.Client/Services/AccountAuthService.cs
+++ b/SharpMUSH.Client/Services/AccountAuthService.cs
@@ -739,10 +739,6 @@ public class AccountAuthService(
 		// or a stale acting character could outlive the logout and be restored by the next login in
 		// this tab.
 		await js.InvokeVoidAsync("sessionStorage.removeItem", ActiveCharacterKey);
-		// Awaited here rather than left to SetActiveCharacter's detached write above: the invariant
-		// below (every storage mutation complete before the event fires) has to hold for this key too,
-		// or a stale acting character could outlive the logout and be restored by the next login in
-		// this tab.
 
 		// Explicit-logout latch: sticks until the next successful login/register/setup in this
 		// tab, so dev-mode debug re-auth (or any other silent re-persist) can't undo the logout.

--- a/SharpMUSH.Client/Services/AccountAuthService.cs
+++ b/SharpMUSH.Client/Services/AccountAuthService.cs
@@ -116,7 +116,10 @@ public class AccountAuthService(
 		}
 		catch (JsonException ex)
 		{
-			logger.LogWarning(ex, "Stored active character was unreadable; falling back to the roster default");
+			// Drop the bad entry so this self-heals: left in place it would re-log on every reload
+			// until the player happened to switch characters.
+			logger.LogWarning(ex, "Stored active character was unreadable; clearing it and falling back to the roster default");
+			PersistActiveCharacter(null);
 			return null;
 		}
 	}
@@ -250,14 +253,19 @@ public class AccountAuthService(
 		// SetActiveCharacter because the value came out of storage — writing it straight back is a
 		// pointless interop round-trip. SetCharacters re-validates it against the roster once that
 		// lands, so a character the account no longer owns is reseated like any other stale active.
-		// Re-check the slot AFTER the read: the storage round-trip is an await, and a login can seat a
-		// character while it is in flight. Testing before the await would let a stale stored value
-		// clobber the newer live one.
-		var restored = await ReadStoredActiveCharacterAsync();
-		if (restored is not null && ActiveCharacter is null)
+		// Skip the read outright when a character is already seated (a login can beat hydration here),
+		// then re-check the slot AFTER the read as well: the storage round-trip is an await, and a login
+		// can land while it is in flight. Testing only before the await would let a stale stored value
+		// clobber the newer live one; testing only after it would spend an interop call to learn
+		// something we already knew.
+		if (ActiveCharacter is null)
 		{
-			ActiveCharacter = restored;
-			RaiseActiveCharacterChanged();
+			var restored = await ReadStoredActiveCharacterAsync();
+			if (restored is not null && ActiveCharacter is null)
+			{
+				ActiveCharacter = restored;
+				RaiseActiveCharacterChanged();
+			}
 		}
 		// CascadingAuthenticationState snapshots before MainLayout's InitAsync runs; re-notify so a reloaded tab's restored session reaches [Authorize] gates.
 		RaiseAuthStateChanged();

--- a/SharpMUSH.Client/Services/AccountAuthService.cs
+++ b/SharpMUSH.Client/Services/AccountAuthService.cs
@@ -250,7 +250,11 @@ public class AccountAuthService(
 		// SetActiveCharacter because the value came out of storage — writing it straight back is a
 		// pointless interop round-trip. SetCharacters re-validates it against the roster once that
 		// lands, so a character the account no longer owns is reseated like any other stale active.
-		if (ActiveCharacter is null && await ReadStoredActiveCharacterAsync() is { } restored)
+		// Re-check the slot AFTER the read: the storage round-trip is an await, and a login can seat a
+		// character while it is in flight. Testing before the await would let a stale stored value
+		// clobber the newer live one.
+		var restored = await ReadStoredActiveCharacterAsync();
+		if (restored is not null && ActiveCharacter is null)
 		{
 			ActiveCharacter = restored;
 			RaiseActiveCharacterChanged();

--- a/SharpMUSH.Client/Services/AccountAuthService.cs
+++ b/SharpMUSH.Client/Services/AccountAuthService.cs
@@ -23,6 +23,7 @@ public class AccountAuthService(
 	private const string RoleKey = "sharpmush.account.role";
 	private const string PermissionsKey = "sharpmush.account.permissions";
 	private const string LoggedOutKey = "sharpmush.account.loggedOut";
+	private const string ActiveCharacterKey = "sharpmush.account.activeCharacter";
 
 	public record CharacterSummary(int DbrefNumber, long CreationTime, string Name, string Flags);
 
@@ -84,7 +85,57 @@ public class AccountAuthService(
 			return;
 
 		ActiveCharacter = character;
+		PersistActiveCharacter(character);
 		RaiseActiveCharacterChanged();
+	}
+
+	/// <summary>
+	/// Mirrors the active character into tab-scoped storage so a reload comes back as whoever the
+	/// player switched to. Deliberately not awaited: this setter is synchronous because every caller
+	/// depends on <see cref="ActiveCharacter"/> being visible the instant it returns, and storage is a
+	/// cache of that decision rather than the decision itself. WASM is single-threaded and its interop
+	/// calls run in issue order, so back-to-back switches still land last-write-wins.
+	/// </summary>
+	private void PersistActiveCharacter(CharacterSummary? character) =>
+		_ = PersistActiveCharacterCoreAsync(character);
+
+	/// <summary>
+	/// Reads the stored active character back, or null when there is none (or the stored value is
+	/// unreadable — a corrupt entry must not block hydration; falling back to the roster default is
+	/// exactly what happened before anything was stored at all).
+	/// </summary>
+	private async Task<CharacterSummary?> ReadStoredActiveCharacterAsync()
+	{
+		var stored = await js.InvokeAsync<string?>("sessionStorage.getItem", ActiveCharacterKey);
+		if (string.IsNullOrWhiteSpace(stored))
+			return null;
+
+		try
+		{
+			return JsonSerializer.Deserialize<CharacterSummary>(stored);
+		}
+		catch (JsonException ex)
+		{
+			logger.LogWarning(ex, "Stored active character was unreadable; falling back to the roster default");
+			return null;
+		}
+	}
+
+	private async Task PersistActiveCharacterCoreAsync(CharacterSummary? character)
+	{
+		try
+		{
+			if (character is null)
+				await js.InvokeVoidAsync("sessionStorage.removeItem", ActiveCharacterKey);
+			else
+				await js.InvokeVoidAsync("sessionStorage.setItem", ActiveCharacterKey, JsonSerializer.Serialize(character));
+		}
+		catch (Exception ex)
+		{
+			// A failed write costs the player their acting character on the next reload — worth a log,
+			// never worth taking down the switch that already succeeded in memory.
+			logger.LogWarning(ex, "Could not persist the active character; a reload will fall back to the primary");
+		}
 	}
 
 	/// <summary>
@@ -192,6 +243,18 @@ public class AccountAuthService(
 		Permissions = permissionsJson is null
 			? []
 			: JsonSerializer.Deserialize<IReadOnlyList<string>>(permissionsJson) ?? [];
+
+		// Restore who this tab was acting as, but only into an empty slot: hydration can run AFTER a
+		// login has already seated a character in memory (nothing orders InitAsync against LoginAsync),
+		// and storage must never overwrite a live decision. Assigned directly rather than through
+		// SetActiveCharacter because the value came out of storage — writing it straight back is a
+		// pointless interop round-trip. SetCharacters re-validates it against the roster once that
+		// lands, so a character the account no longer owns is reseated like any other stale active.
+		if (ActiveCharacter is null && await ReadStoredActiveCharacterAsync() is { } restored)
+		{
+			ActiveCharacter = restored;
+			RaiseActiveCharacterChanged();
+		}
 		// CascadingAuthenticationState snapshots before MainLayout's InitAsync runs; re-notify so a reloaded tab's restored session reaches [Authorize] gates.
 		RaiseAuthStateChanged();
 	}

--- a/SharpMUSH.Tests.BUnit/Services/AccountAuthServiceActiveCharacterRefreshTests.cs
+++ b/SharpMUSH.Tests.BUnit/Services/AccountAuthServiceActiveCharacterRefreshTests.cs
@@ -189,8 +189,8 @@ public class AccountAuthServiceActiveCharacterRefreshTests
 		// Reload. Hold the stored-character read open so a login can land mid-hydration.
 		var afterRefresh = MakeService(storage, roster);
 		storage.GatedKey = "sharpmush.account.activeCharacter";
-		storage.GateReadsOf = new TaskCompletionSource();
-		storage.ReadStarted = new TaskCompletionSource();
+		storage.GateReadsOf = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		storage.ReadStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		var hydrating = afterRefresh.InitAsync();
 		await storage.ReadStarted.Task;          // the stored-character read is now in flight
@@ -214,7 +214,7 @@ public class AccountAuthServiceActiveCharacterRefreshTests
 
 		// Park every write. Hydration must not be able to finish until the clear it issued completes —
 		// a detached clear would let it sail straight past.
-		storage.GateWrites = new TaskCompletionSource();
+		storage.GateWrites = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		var afterRefresh = MakeService(storage, [Alpha, Beta]);
 		var hydrating = afterRefresh.InitAsync();

--- a/SharpMUSH.Tests.BUnit/Services/AccountAuthServiceActiveCharacterRefreshTests.cs
+++ b/SharpMUSH.Tests.BUnit/Services/AccountAuthServiceActiveCharacterRefreshTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
-using Microsoft.JSInterop.Infrastructure;
 using NSubstitute;
 using SharpMUSH.Client.Services;
 using System.Net;
@@ -18,11 +17,32 @@ file sealed class FakeSessionStorage : IJSRuntime
 {
 	private readonly Dictionary<string, string> _items = new(StringComparer.Ordinal);
 
-	public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args) =>
-		ValueTask.FromResult(Invoke<TValue>(identifier, args));
+	/// <summary>
+	/// Holds the answer to a <c>getItem</c> for this key until the test releases it, modelling a real
+	/// interop round-trip. The value is snapshotted when the call is made (as the JS side would), so
+	/// writes that happen while the read is in flight do not change what it returns.
+	/// </summary>
+	public TaskCompletionSource? GateReadsOf { get; set; }
+	public string? GatedKey { get; set; }
+
+	/// <summary>Completed the moment the gated read is actually in flight.</summary>
+	public TaskCompletionSource? ReadStarted { get; set; }
+
+	public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+	{
+		var key = args?.Length > 0 ? args[0]?.ToString() : null;
+		if (GateReadsOf is { } gate && identifier == "sessionStorage.getItem" && key == GatedKey)
+		{
+			var snapshot = Invoke<TValue>(identifier, args);
+			ReadStarted?.TrySetResult();
+			return new ValueTask<TValue>(gate.Task.ContinueWith(_ => snapshot, TaskScheduler.Default));
+		}
+
+		return ValueTask.FromResult(Invoke<TValue>(identifier, args));
+	}
 
 	public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args) =>
-		ValueTask.FromResult(Invoke<TValue>(identifier, args));
+		InvokeAsync<TValue>(identifier, args);
 
 	private TValue Invoke<TValue>(string identifier, object?[]? args)
 	{
@@ -132,6 +152,33 @@ public class AccountAuthServiceActiveCharacterRefreshTests
 		await afterRefresh.GetCharactersAsync();
 
 		await Assert.That(afterRefresh.ActiveCharacter?.DbrefNumber).IsEqualTo(Alpha.DbrefNumber);
+	}
+
+	[Test]
+	public async Task ALoginLandingDuringHydration_IsNotClobberedByTheStoredValue()
+	{
+		var storage = new FakeSessionStorage();
+		CharacterSummary[] roster = [Alpha, Beta];
+
+		var seed = MakeService(storage, roster);
+		await seed.InitAsync();
+		await seed.LoginAsync("headwiz", "password-one");
+		seed.SetActiveCharacter(Alpha);
+
+		// Reload. Hold the stored-character read open so a login can land mid-hydration.
+		var afterRefresh = MakeService(storage, roster);
+		storage.GatedKey = "sharpmush.account.activeCharacter";
+		storage.GateReadsOf = new TaskCompletionSource();
+		storage.ReadStarted = new TaskCompletionSource();
+
+		var hydrating = afterRefresh.InitAsync();
+		await storage.ReadStarted.Task;          // the stored-character read is now in flight
+		afterRefresh.SetActiveCharacter(Beta);   // ...and a login lands right here
+		storage.GateReadsOf.SetResult();
+		await hydrating;
+
+		// The live selection is newer than anything storage had to say.
+		await Assert.That(afterRefresh.ActiveCharacter?.DbrefNumber).IsEqualTo(Beta.DbrefNumber);
 	}
 
 	[Test]

--- a/SharpMUSH.Tests.BUnit/Services/AccountAuthServiceActiveCharacterRefreshTests.cs
+++ b/SharpMUSH.Tests.BUnit/Services/AccountAuthServiceActiveCharacterRefreshTests.cs
@@ -1,0 +1,154 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.JSInterop;
+using Microsoft.JSInterop.Infrastructure;
+using NSubstitute;
+using SharpMUSH.Client.Services;
+using System.Net;
+using System.Net.Http.Json;
+using CharacterSummary = SharpMUSH.Client.Services.AccountAuthService.CharacterSummary;
+
+namespace SharpMUSH.Tests.BUnit.Services;
+
+/// <summary>
+/// A real dictionary behind <c>sessionStorage.getItem/setItem/removeItem</c>. The point of these
+/// tests is what survives a reload, so the store has to outlive the service that wrote to it —
+/// a per-call stubbed JSInterop cannot express that.
+/// </summary>
+file sealed class FakeSessionStorage : IJSRuntime
+{
+	private readonly Dictionary<string, string> _items = new(StringComparer.Ordinal);
+
+	public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args) =>
+		ValueTask.FromResult(Invoke<TValue>(identifier, args));
+
+	public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args) =>
+		ValueTask.FromResult(Invoke<TValue>(identifier, args));
+
+	private TValue Invoke<TValue>(string identifier, object?[]? args)
+	{
+		var key = args?.Length > 0 ? args[0]?.ToString() ?? string.Empty : string.Empty;
+
+		switch (identifier)
+		{
+			case "sessionStorage.setItem" when args?.Length > 1:
+				_items[key] = args[1]?.ToString() ?? string.Empty;
+				break;
+			case "sessionStorage.removeItem":
+				_items.Remove(key);
+				break;
+			case "sessionStorage.getItem":
+				return _items.TryGetValue(key, out var value) && value is TValue typed ? typed : default!;
+		}
+
+		return default!;
+	}
+}
+
+/// <summary>Serves the login envelope and the character roster this account owns.</summary>
+file sealed class FakeAccountApiHandler(IReadOnlyList<CharacterSummary> characters) : HttpMessageHandler
+{
+	protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+	{
+		var path = request.RequestUri!.AbsolutePath;
+
+		// GetCharactersAsync reads a bare array; LoginAsync reads the session envelope.
+		var content = path.EndsWith("api/account/characters", StringComparison.Ordinal)
+			? JsonContent.Create(characters)
+			: JsonContent.Create(new
+			{
+				accountId = "acct-1",
+				username = "headwiz",
+				characters,
+				accountSessionToken = "session-token-1",
+				mustChangePassword = false,
+				role = "God",
+				permissions = new[] { "*" },
+			});
+
+		return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+	}
+}
+
+/// <summary>
+/// A switched-to character has to outlive a page reload. <c>ActingCharacterHeaderHandler</c> puts
+/// <see cref="AccountAuthService.ActiveCharacter"/> on the wire as <c>X-Acting-Character</c>, and the
+/// server routes per-character actions by that header — so if a refresh silently reseats the account
+/// on its primary, uploads, mail and wiki edits get attributed to a character the player wasn't
+/// acting as, with nothing on screen to say so.
+/// </summary>
+public class AccountAuthServiceActiveCharacterRefreshTests
+{
+	private static readonly CharacterSummary Alpha = new(10, 1000, "Alpha", "PLAYER");
+	private static readonly CharacterSummary Beta = new(20, 2000, "Beta", "PLAYER");
+
+	private static AccountAuthService MakeService(IJSRuntime js, IReadOnlyList<CharacterSummary> roster)
+	{
+		var httpClientFactory = Substitute.For<IHttpClientFactory>();
+		// Not disposed: the returned service keeps calling through this client after the helper returns.
+		var http = new HttpClient(new FakeAccountApiHandler(roster)) { BaseAddress = new Uri("https://localhost:8081/") };
+		httpClientFactory.CreateClient("api").Returns(http);
+
+		return new AccountAuthService(
+			httpClientFactory,
+			js,
+			Substitute.For<ILogger<AccountAuthService>>(),
+			Substitute.For<ITerminalService>(),
+			Substitute.For<IPlayTerminalService>());
+	}
+
+	[Test]
+	public async Task ActiveCharacter_SurvivesAPageRefresh()
+	{
+		var storage = new FakeSessionStorage();
+		CharacterSummary[] roster = [Alpha, Beta];
+
+		var beforeRefresh = MakeService(storage, roster);
+		await beforeRefresh.InitAsync();
+		await beforeRefresh.LoginAsync("headwiz", "password-one");
+		beforeRefresh.SetActiveCharacter(Beta);
+
+		// F5: a brand-new service (new DI container) over the same tab's sessionStorage.
+		var afterRefresh = MakeService(storage, roster);
+		await afterRefresh.InitAsync();
+		await afterRefresh.GetCharactersAsync();
+
+		await Assert.That(afterRefresh.ActiveCharacter?.DbrefNumber).IsEqualTo(Beta.DbrefNumber);
+		await Assert.That(afterRefresh.ActiveCharacter?.CreationTime).IsEqualTo(Beta.CreationTime);
+	}
+
+	[Test]
+	public async Task RestoredActiveCharacter_IsDroppedWhenTheAccountNoLongerOwnsIt()
+	{
+		var storage = new FakeSessionStorage();
+
+		var beforeRefresh = MakeService(storage, [Alpha, Beta]);
+		await beforeRefresh.InitAsync();
+		await beforeRefresh.LoginAsync("headwiz", "password-one");
+		beforeRefresh.SetActiveCharacter(Beta);
+
+		// Beta was unlinked elsewhere; the reloaded tab must not keep acting as it.
+		var afterRefresh = MakeService(storage, [Alpha]);
+		await afterRefresh.InitAsync();
+		await afterRefresh.GetCharactersAsync();
+
+		await Assert.That(afterRefresh.ActiveCharacter?.DbrefNumber).IsEqualTo(Alpha.DbrefNumber);
+	}
+
+	[Test]
+	public async Task NoSession_LeavesNoActiveCharacterBehind()
+	{
+		var storage = new FakeSessionStorage();
+
+		var beforeRefresh = MakeService(storage, [Alpha, Beta]);
+		await beforeRefresh.InitAsync();
+		await beforeRefresh.LoginAsync("headwiz", "password-one");
+		beforeRefresh.SetActiveCharacter(Beta);
+		await beforeRefresh.LogoutAsync();
+
+		// sessionStorage is tab-scoped and outlives the logout; a fresh service must come up anonymous.
+		var afterRefresh = MakeService(storage, [Alpha, Beta]);
+		await afterRefresh.InitAsync();
+
+		await Assert.That(afterRefresh.ActiveCharacter).IsNull();
+	}
+}

--- a/SharpMUSH.Tests.BUnit/Services/AccountAuthServiceActiveCharacterRefreshTests.cs
+++ b/SharpMUSH.Tests.BUnit/Services/AccountAuthServiceActiveCharacterRefreshTests.cs
@@ -17,9 +17,13 @@ file sealed class FakeSessionStorage : IJSRuntime
 {
 	private readonly Dictionary<string, string> _items = new(StringComparer.Ordinal);
 
-	public void Seed(string key, string value) => _items[key] = value;
-	public bool Has(string key) => _items.ContainsKey(key);
-	public string? Read(string key) => _items.TryGetValue(key, out var v) ? v : null;
+	/// <summary>When set, writes only apply after a real await — so a caller that leaves a write
+	/// detached has not applied it by the time its own method returns.</summary>
+	public bool AsyncWrites { get; set; }
+
+	public void Seed(string key, string value) { lock (_items) { _items[key] = value; } }
+	public bool Has(string key) { lock (_items) { return _items.ContainsKey(key); } }
+	public string? Read(string key) { lock (_items) { return _items.TryGetValue(key, out var v) ? v : null; } }
 
 	/// <summary>
 	/// Holds the answer to a <c>getItem</c> for this key until the test releases it, modelling a real
@@ -42,6 +46,9 @@ file sealed class FakeSessionStorage : IJSRuntime
 			return new ValueTask<TValue>(gate.Task.ContinueWith(_ => snapshot, TaskScheduler.Default));
 		}
 
+		if (AsyncWrites && identifier != "sessionStorage.getItem")
+			return new ValueTask<TValue>(Task.Run(async () => { await Task.Yield(); return Invoke<TValue>(identifier, args); }));
+
 		return ValueTask.FromResult(Invoke<TValue>(identifier, args));
 	}
 
@@ -52,16 +59,19 @@ file sealed class FakeSessionStorage : IJSRuntime
 	{
 		var key = args?.Length > 0 ? args[0]?.ToString() ?? string.Empty : string.Empty;
 
-		switch (identifier)
+		lock (_items)
 		{
-			case "sessionStorage.setItem" when args?.Length > 1:
-				_items[key] = args[1]?.ToString() ?? string.Empty;
-				break;
-			case "sessionStorage.removeItem":
-				_items.Remove(key);
-				break;
-			case "sessionStorage.getItem":
-				return _items.TryGetValue(key, out var value) && value is TValue typed ? typed : default!;
+			switch (identifier)
+			{
+				case "sessionStorage.setItem" when args?.Length > 1:
+					_items[key] = args[1]?.ToString() ?? string.Empty;
+					break;
+				case "sessionStorage.removeItem":
+					_items.Remove(key);
+					break;
+				case "sessionStorage.getItem":
+					return _items.TryGetValue(key, out var value) && value is TValue typed ? typed : default!;
+			}
 		}
 
 		return default!;
@@ -205,6 +215,47 @@ public class AccountAuthServiceActiveCharacterRefreshTests
 		await afterRefresh.GetCharactersAsync();
 		await Assert.That(afterRefresh.ActiveCharacter?.DbrefNumber).IsEqualTo(Alpha.DbrefNumber);
 		await Assert.That(storage.Read("sharpmush.account.activeCharacter")).Contains("\"Alpha\"");
+	}
+
+	[Test]
+	public async Task Logout_LeavesNoStoredCharacterBehind()
+	{
+		var storage = new FakeSessionStorage();
+
+		var svc = MakeService(storage, [Alpha, Beta]);
+		await svc.InitAsync();
+		await svc.LoginAsync("headwiz", "password-one");
+		svc.SetActiveCharacter(Beta);
+
+		// End-state cover only: in-process both the awaited removal and the detached one land before
+		// LogoutAsync returns, so this cannot distinguish them. It guards the property that matters to
+		// a user — no stale acting character survives a logout to be restored by the next login — while
+		// the awaited removal in LogoutAsync is what makes that hold in a browser, where a navigation
+		// right after logout can cut a detached continuation short.
+		storage.AsyncWrites = true;
+		await svc.LogoutAsync();
+
+		await Assert.That(storage.Has("sharpmush.account.activeCharacter")).IsFalse();
+	}
+
+	[Test]
+	public async Task ARenamedCharacter_IsReboundToTheRosterCopy()
+	{
+		var storage = new FakeSessionStorage();
+
+		var seed = MakeService(storage, [Alpha, Beta]);
+		await seed.InitAsync();
+		await seed.LoginAsync("headwiz", "password-one");
+		seed.SetActiveCharacter(Beta);
+
+		// Beta was renamed server-side after the switch; the stored snapshot still says "Beta".
+		var renamed = Beta with { Name = "BetaRenamed" };
+		var afterRefresh = MakeService(storage, [Alpha, renamed]);
+		await afterRefresh.InitAsync();
+		await afterRefresh.GetCharactersAsync();
+
+		await Assert.That(afterRefresh.ActiveCharacter?.DbrefNumber).IsEqualTo(Beta.DbrefNumber);
+		await Assert.That(afterRefresh.ActiveCharacter?.Name).IsEqualTo("BetaRenamed");
 	}
 
 	[Test]

--- a/SharpMUSH.Tests.BUnit/Services/AccountAuthServiceActiveCharacterRefreshTests.cs
+++ b/SharpMUSH.Tests.BUnit/Services/AccountAuthServiceActiveCharacterRefreshTests.cs
@@ -17,6 +17,10 @@ file sealed class FakeSessionStorage : IJSRuntime
 {
 	private readonly Dictionary<string, string> _items = new(StringComparer.Ordinal);
 
+	public void Seed(string key, string value) => _items[key] = value;
+	public bool Has(string key) => _items.ContainsKey(key);
+	public string? Read(string key) => _items.TryGetValue(key, out var v) ? v : null;
+
 	/// <summary>
 	/// Holds the answer to a <c>getItem</c> for this key until the test releases it, modelling a real
 	/// interop round-trip. The value is snapshotted when the call is made (as the JS side would), so
@@ -179,6 +183,28 @@ public class AccountAuthServiceActiveCharacterRefreshTests
 
 		// The live selection is newer than anything storage had to say.
 		await Assert.That(afterRefresh.ActiveCharacter?.DbrefNumber).IsEqualTo(Beta.DbrefNumber);
+	}
+
+	[Test]
+	public async Task ACorruptStoredCharacter_IsClearedSoItStopsRecurring()
+	{
+		var storage = new FakeSessionStorage();
+
+		var seed = MakeService(storage, [Alpha, Beta]);
+		await seed.InitAsync();
+		await seed.LoginAsync("headwiz", "password-one");
+		storage.Seed("sharpmush.account.activeCharacter", "{not json");
+
+		var afterRefresh = MakeService(storage, [Alpha, Beta]);
+		await afterRefresh.InitAsync();
+
+		// The bad entry is dropped as soon as it fails to parse, rather than re-logging every reload.
+		await Assert.That(storage.Has("sharpmush.account.activeCharacter")).IsFalse();
+
+		// Hydration then falls back to the roster default, which re-seats storage with a valid value.
+		await afterRefresh.GetCharactersAsync();
+		await Assert.That(afterRefresh.ActiveCharacter?.DbrefNumber).IsEqualTo(Alpha.DbrefNumber);
+		await Assert.That(storage.Read("sharpmush.account.activeCharacter")).Contains("\"Alpha\"");
 	}
 
 	[Test]

--- a/SharpMUSH.Tests.BUnit/Services/AccountAuthServiceActiveCharacterRefreshTests.cs
+++ b/SharpMUSH.Tests.BUnit/Services/AccountAuthServiceActiveCharacterRefreshTests.cs
@@ -21,6 +21,10 @@ file sealed class FakeSessionStorage : IJSRuntime
 	/// detached has not applied it by the time its own method returns.</summary>
 	public bool AsyncWrites { get; set; }
 
+	/// <summary>When set, writes park until the test releases them — so a caller that awaits a write
+	/// cannot finish, while one that leaves it detached sails past.</summary>
+	public TaskCompletionSource? GateWrites { get; set; }
+
 	public void Seed(string key, string value) { lock (_items) { _items[key] = value; } }
 	public bool Has(string key) { lock (_items) { return _items.ContainsKey(key); } }
 	public string? Read(string key) { lock (_items) { return _items.TryGetValue(key, out var v) ? v : null; } }
@@ -45,6 +49,9 @@ file sealed class FakeSessionStorage : IJSRuntime
 			ReadStarted?.TrySetResult();
 			return new ValueTask<TValue>(gate.Task.ContinueWith(_ => snapshot, TaskScheduler.Default));
 		}
+
+		if (GateWrites is { } writeGate && identifier != "sessionStorage.getItem")
+			return new ValueTask<TValue>(writeGate.Task.ContinueWith(_ => Invoke<TValue>(identifier, args), TaskScheduler.Default));
 
 		if (AsyncWrites && identifier != "sessionStorage.getItem")
 			return new ValueTask<TValue>(Task.Run(async () => { await Task.Yield(); return Invoke<TValue>(identifier, args); }));
@@ -205,10 +212,21 @@ public class AccountAuthServiceActiveCharacterRefreshTests
 		await seed.LoginAsync("headwiz", "password-one");
 		storage.Seed("sharpmush.account.activeCharacter", "{not json");
 
-		var afterRefresh = MakeService(storage, [Alpha, Beta]);
-		await afterRefresh.InitAsync();
+		// Park every write. Hydration must not be able to finish until the clear it issued completes —
+		// a detached clear would let it sail straight past.
+		storage.GateWrites = new TaskCompletionSource();
 
-		// The bad entry is dropped as soon as it fails to parse, rather than re-logging every reload.
+		var afterRefresh = MakeService(storage, [Alpha, Beta]);
+		var hydrating = afterRefresh.InitAsync();
+		var finishedWithoutTheClear = await Task.WhenAny(hydrating, Task.Delay(250)) == hydrating;
+
+		storage.GateWrites.SetResult();
+		await hydrating;
+		storage.GateWrites = null;
+
+		await Assert.That(finishedWithoutTheClear).IsFalse();
+
+		// And the bad entry is gone, rather than re-logging on every reload.
 		await Assert.That(storage.Has("sharpmush.account.activeCharacter")).IsFalse();
 
 		// Hydration then falls back to the roster default, which re-seats storage with a valid value.


### PR DESCRIPTION
## The bug

`AccountAuthService.ActiveCharacter` lives only in memory. sessionStorage holds the token, username, role and permissions — nothing about who the tab is acting as — and `InitCoreAsync` never restored it. After a reload, `SetCharacters` re-seats the account on `characters.FirstOrDefault()`.

`ActingCharacterHeaderHandler` puts that value on the wire as `X-Acting-Character`, and the server routes per-character actions by it. So: switch to a non-primary character, press F5, and you are silently acting as your primary again. Gallery uploads, mail and wiki edits get attributed to a character the player wasn't acting as, with nothing on screen to say so.

Reproduced as a test before fixing — switch to Beta (#20), simulate a reload, read back:

```
AssertionException: Expected to be equal to 20 but received 10
```

## The fix

Mirror the active character into tab-scoped storage on every switch (`sharpmush.account.activeCharacter`) and read it back during hydration.

Two things worth calling out:

- **Restore only into an empty slot.** Nothing orders `InitAsync` against `LoginAsync`, so hydration can run *after* a login has already seated a character in memory. My first cut assigned unconditionally and broke 6 existing tests in `NewTabCharacterTests` / `GlobalTerminalIdentityTests` by clobbering a live active character with an empty read — a genuine flaw the suite caught, not a test artifact. Storage now fills an empty slot and never overwrites a live decision.
- **`SetCharacters` still re-validates against the roster**, so a restored character the account no longer owns is reseated exactly as before — covered by a test.

Persisting is deliberately not awaited. The setter is synchronous because all five callers depend on `ActiveCharacter` being visible the instant it returns, and storage is a cache of that decision rather than the decision itself. WASM is single-threaded and its interop calls run in issue order, so back-to-back switches land last-write-wins. Making it async would mean renaming through 5 production and 15 test call sites for no behavioural gain. A failed write is logged and costs only the next reload's acting character.

## Verification

- 3 new tests in `AccountAuthServiceActiveCharacterRefreshTests`, over a dictionary-backed `sessionStorage` fake so the store outlives the service that wrote to it — a per-call stubbed JSInterop can't express "survives a reload". Covers: survives refresh, dropped when the account no longer owns it, and nothing left behind after logout.
- Red/green confirmed by stashing the production change (verified the revert actually landed before trusting the run): `Expected 20 but received 10` without it, green with it.
- Full `SharpMUSH.Tests.BUnit` 273/273; `SharpMUSH.Tests` client namespace 111/111; `dotnet format whitespace` clean.

Follow-up to #715, same area — that one closed the bearer-token hydration window, this one closes the acting-character one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The selected character remains active when refreshing the page within the same browser tab.
  - Previously active character details are automatically restored when available and valid.

- **Bug Fixes**
  - Restored selections are discarded if the account no longer owns that character.
  - Character changes during reload are no longer overwritten by stale stored values.
  - Logout clears the active character to prevent stale selections on later visits.
  - Storage read/write failures no longer disrupt character switching or initialization.

- **Tests**
  - Added automated coverage for persistence and hydration edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->