### PR TITLE
Give silent command branches their PennMUSH notifications

### DIFF
--- a/SharpMUSH.Database.ArangoDB/ArangoDatabase.Navigation.cs
+++ b/SharpMUSH.Database.ArangoDB/ArangoDatabase.Navigation.cs
@@ -105,6 +105,31 @@ public partial class ArangoDatabase
 			_ => throw new Exception("Invalid Location found"));
 	}
 
+	/// <summary>
+	/// An exit's destination. Unlike every other type's home, this edge is absent on a freshly
+	/// <c>@open</c>ed or an <c>@unlink</c>ed exit, so the result is optional.
+	/// </summary>
+	private async ValueTask<AnyOptionalSharpContainer> GetExitDestinationAsync(string id, CancellationToken ct = default)
+	{
+		var destinationResult = await arangoDb.Query.ExecuteAsync<string>(handle,
+			$"FOR v IN 1..1 OUTBOUND {id} GRAPH {DatabaseConstants.GraphHomes} RETURN v._id", cache: true,
+			cancellationToken: ct);
+
+		if (!destinationResult.Any())
+		{
+			return new None();
+		}
+
+		var destinationObject = await GetObjectNodeAsync(destinationResult.First(), ct);
+
+		return destinationObject.Match<AnyOptionalSharpContainer>(
+			player => player,
+			room => room,
+			_ => new None(),
+			thing => thing,
+			_ => new None());
+	}
+
 	private async ValueTask<AnyOptionalSharpContainer> GetDropToAsync(string id, CancellationToken ct = default)
 	{
 		var dropToResult = await arangoDb.Query.ExecuteAsync<string>(handle,
@@ -322,7 +347,7 @@ public partial class ArangoDatabase
 				Id = id, Object = sharpObject,
 				Aliases = typedVertex.GetProperty("Aliases").EnumerateArray().Select(x => x.GetString()!).ToArray(),
 				Location = new(async ct => await mediator.Send(new GetCertainLocationQuery(id, sharpObject.Id!), ct)),
-				Home = new(async ct => await GetHomeAsync(id, ct))
+				Home = new(async ct => await GetExitDestinationAsync(id, ct))
 			},
 			_ => throw new ArgumentException($"Invalid Object Type found: '{objectVertex.GetProperty("Type").GetString()}'"),
 		};

--- a/SharpMUSH.Database.ArangoDB/ArangoDatabase.Objects.cs
+++ b/SharpMUSH.Database.ArangoDB/ArangoDatabase.Objects.cs
@@ -183,6 +183,8 @@ public partial class ArangoDatabase
 
 	public async ValueTask<bool> LinkExitAsync(SharpExit exit, AnySharpContainer location, CancellationToken ct = default)
 	{
+		// Relinking must replace the destination, not accumulate a second HasHome edge.
+		await UnlinkExitAsync(exit, ct);
 		await arangoDb.Graph.Edge.CreateAsync(handle, DatabaseConstants.GraphHomes, DatabaseConstants.HasHome,
 			new SharpEdgeCreateRequest(exit.Id!, location.Id), cancellationToken: ct);
 		return true;
@@ -191,7 +193,8 @@ public partial class ArangoDatabase
 	public async ValueTask<bool> UnlinkExitAsync(SharpExit exit, CancellationToken ct = default)
 	{
 		var result = await arangoDb.Query.ExecuteAsync<SharpEdgeQueryResult>(handle,
-			$"FOR v, e IN 1..1 INBOUND {exit.Id} GRAPH {DatabaseConstants.GraphHomes} RETURN e", cancellationToken: ct);
+			// HasHome edges go FROM the exit TO its destination, so traverse OUTBOUND from the exit.
+			$"FOR v, e IN 1..1 OUTBOUND {exit.Id} GRAPH {DatabaseConstants.GraphHomes} RETURN e", cancellationToken: ct);
 
 		if (!result.Any())
 		{
@@ -270,8 +273,8 @@ public partial class ArangoDatabase
 				new SharpEdgeCreateRequest(exit.Id, obj.Id), cancellationToken: ct);
 			await arangoDb.Graph.Edge.CreateAsync(transaction, DatabaseConstants.GraphLocations, DatabaseConstants.AtLocation,
 				new SharpEdgeCreateRequest(exit.Id, location.Id), cancellationToken: ct);
-			await arangoDb.Graph.Edge.CreateAsync(transaction, DatabaseConstants.GraphHomes, DatabaseConstants.HasHome,
-				new SharpEdgeCreateRequest(exit.Id, location.Id), cancellationToken: ct);
+			// No HasHome edge: a new exit is unlinked until @link points it somewhere, matching PennMUSH's
+			// Destination() == NOTHING. Seeding it to the source room made every exit look self-linked.
 			await arangoDb.Graph.Edge.CreateAsync(transaction, DatabaseConstants.GraphObjectOwners, DatabaseConstants.HasObjectOwner,
 				new SharpEdgeCreateRequest(obj.Id, creator.Id!), cancellationToken: ct);
 
@@ -509,7 +512,7 @@ public partial class ArangoDatabase
 				Object = convertObject,
 				Aliases = res.Aliases,
 				Location = new(async ct => await mediator.Send(new GetCertainLocationQuery(id, convertObject.Id!), ct)),
-				Home = new(async ct => await GetHomeAsync(id, ct))
+				Home = new(async ct => await GetExitDestinationAsync(id, ct))
 			},
 			_ => throw new ArgumentException($"Invalid Object Type found: '{obj.Type}'")
 		};
@@ -570,7 +573,7 @@ public partial class ArangoDatabase
 			{
 				Id = id, Object = convertObject, Aliases = res.GetProperty("Aliases").EnumerateArray().Select(x => x.GetString()!).ToArray(),
 				Location = new(async ct => await mediator.Send(new GetCertainLocationQuery(id, convertObject.Id!), ct)),
-				Home = new(async ct => await GetHomeAsync(id, ct))
+				Home = new(async ct => await GetExitDestinationAsync(id, ct))
 			},
 			_ => new None(),
 		};

--- a/SharpMUSH.Database.Memgraph/MemgraphDatabase.Objects.cs
+++ b/SharpMUSH.Database.Memgraph/MemgraphDatabase.Objects.cs
@@ -116,6 +116,8 @@ CREATE (o)-[:HAS_OWNER]->(owner)
 		var exitKey = ExtractKey(exit.Id!);
 		var destKey = ExtractKey(location.Id);
 		var destLabel = ExtractTypedLabel(location.Id);
+		// Relinking must replace the destination, not accumulate a second HAS_HOME edge.
+		await UnlinkExitAsync(exit, cancellationToken);
 		await ExecuteWithRetryAsync("""
 MATCH (e:Exit {key: $exitKey}), (dest:%DEST_LABEL% {key: $destKey})
 CREATE (e)-[:HAS_HOME]->(dest)

--- a/SharpMUSH.Database.Memgraph/MemgraphDatabase.cs
+++ b/SharpMUSH.Database.Memgraph/MemgraphDatabase.cs
@@ -324,7 +324,7 @@ RETURN c.value AS nextKey
 			Object = sharpObj,
 			Aliases = aliases,
 			Location = new(async ct => await GetLocationForTypedAsync(id, ct)),
-			Home = new(async ct => await GetHomeAsync(id, ct))
+			Home = new(async ct => await GetExitDestinationAsync(id, ct))
 		};
 	}
 
@@ -372,6 +372,34 @@ RETURN destObj
 		_ => throw new Exception("Invalid home: Exit"),
 		thing => thing,
 		_ => throw new Exception("No home found"));
+	}
+
+	/// <summary>
+	/// An exit's destination. Absent on a freshly @open'd or an @unlink'd exit, hence optional.
+	/// </summary>
+	private async ValueTask<AnyOptionalSharpContainer> GetExitDestinationAsync(string typedId, CancellationToken ct)
+	{
+		var key = ExtractKey(typedId);
+		var typedLabel = ExtractTypedLabel(typedId);
+		var result = await ExecuteWithRetryAsync("""
+MATCH (src:%LABEL% {key: $key})-[:HAS_HOME]->(dest)
+MATCH (dest)-[:IS_OBJECT]->(destObj:Object)
+RETURN destObj
+""".Replace("%LABEL%", typedLabel), new { key }, ct);
+
+		if (result.Result.Count == 0)
+		{
+			return new None();
+		}
+
+		var destObjNode = result.Result[0]["destObj"].As<INode>();
+		var destination = await BuildTypedObjectFromObjectNode(destObjNode, ct);
+		return destination.Match<AnyOptionalSharpContainer>(
+			player => player,
+			room => room,
+			_ => new None(),
+			thing => thing,
+			_ => new None());
 	}
 
 	private async ValueTask<AnyOptionalSharpContainer> GetDropToAsync(string roomId, CancellationToken ct)

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Objects.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Objects.cs
@@ -179,6 +179,8 @@ public partial class SurrealDatabase
 			["destKey"] = destKey
 		};
 
+		// Relinking must replace the destination, not accumulate a second has_home edge.
+		await UnlinkExitAsync(exit, cancellationToken);
 		await ExecuteAsync(
 			$"RELATE exit:$exitKey->has_home->{destTable}:$destKey",
 			parameters, cancellationToken);

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Objects.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Objects.cs
@@ -179,10 +179,14 @@ public partial class SurrealDatabase
 			["destKey"] = destKey
 		};
 
-		// Relinking must replace the destination, not accumulate a second has_home edge.
-		await UnlinkExitAsync(exit, cancellationToken);
+		// Relinking must replace the destination rather than accumulate a second has_home edge, and must
+		// do so in one transaction like every other edge replacement here — otherwise a concurrent reader
+		// can catch the exit detached, and a failure between the two statements strands it unlinked.
 		await ExecuteAsync(
-			$"RELATE exit:$exitKey->has_home->{destTable}:$destKey",
+			$"BEGIN TRANSACTION;" +
+			$"DELETE has_home WHERE in = exit:$exitKey;" +
+			$"RELATE exit:$exitKey->has_home->{destTable}:$destKey;" +
+			$"COMMIT TRANSACTION",
 			parameters, cancellationToken);
 		return true;
 	}

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.cs
@@ -400,7 +400,7 @@ public partial class SurrealDatabase(
 			Object = sharpObj,
 			Aliases = exitRecord.aliases,
 			Location = new(async ct => await GetLocationForTypedAsync(id, ct)),
-			Home = new(async ct => await GetHomeAsync(id, ct))
+			Home = new(async ct => await GetExitDestinationAsync(id, ct))
 		};
 	}
 
@@ -448,6 +448,33 @@ public partial class SurrealDatabase(
 			_ => throw new InvalidOperationException($"Invalid home for {typedId}: Exit objects cannot be homes"),
 			thing => thing,
 			_ => throw new InvalidOperationException($"No home found for {typedId}"));
+	}
+
+	/// <summary>
+	/// An exit's destination. Absent on a freshly @open'd or an @unlink'd exit, hence optional.
+	/// </summary>
+	private async ValueTask<AnyOptionalSharpContainer> GetExitDestinationAsync(string typedId, CancellationToken ct)
+	{
+		var key = ExtractKey(typedId);
+		var table = ExtractTable(typedId);
+		var parameters = new Dictionary<string, object?> { ["key"] = key };
+		var result = await ExecuteAsync(
+			$"SELECT VALUE out.key FROM has_home WHERE in = {table}:$key",
+			parameters, ct);
+
+		var destKeys = result.GetValue<List<int>>(0)!;
+		if (destKeys.Count == 0)
+		{
+			return new None();
+		}
+
+		var destination = await BuildTypedObjectFromKey(destKeys[0], ct);
+		return destination.Match<AnyOptionalSharpContainer>(
+			player => player,
+			room => room,
+			_ => new None(),
+			thing => thing,
+			_ => new None());
 	}
 
 	private async ValueTask<AnyOptionalSharpContainer> GetDropToAsync(string roomId, CancellationToken ct)

--- a/SharpMUSH.Implementation/Commands/BuildingCommands.cs
+++ b/SharpMUSH.Implementation/Commands/BuildingCommands.cs
@@ -667,23 +667,15 @@ public partial class Commands
 										shouldNotify: true);
 							}
 
-							var destinationRoom = destObj.AsContainer;
+							var destination = destObj.AsContainer;
 
-							bool canLink = await PermissionService!.Controls(executor, destObj);
-
-							if (!canLink)
+							if (!await CanLinkTo(executor, destObj))
 							{
-								var destFlags = await destinationRoom.Object().Flags.Value.ToArrayAsync();
-								var hasLinkOk = destFlags.Any(f => f.Name.Equals("LINK_OK", StringComparison.OrdinalIgnoreCase));
-
-								if (!hasLinkOk)
-								{
-									return await NotifyService!.NotifyAndReturn(
-										executor.Object().DBRef,
-										errorReturn: ErrorMessages.Returns.PermissionDenied,
-										notifyMessage: ErrorMessages.Notifications.CantLinkToThat,
-										shouldNotify: true);
-								}
+								return await NotifyService!.NotifyAndReturn(
+									executor.Object().DBRef,
+									errorReturn: ErrorMessages.Returns.PermissionDenied,
+									notifyMessage: ErrorMessages.Notifications.CantLinkToThat,
+									shouldNotify: true);
 							}
 
 							var exitOwner = await exitObj.Object().Owner.WithCancellation(CancellationToken.None);
@@ -729,9 +721,9 @@ public partial class Commands
 
 							await AttributeService!.SetAttributeAsync(executor, exitObj, AttrLinkType, MModule.empty());
 
-							await Mediator!.Send(new LinkExitCommand(exitObj.AsExit, destinationRoom));
+							await Mediator!.Send(new LinkExitCommand(exitObj.AsExit, destination));
 
-							await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.LinkedExitToRoom), executor, exitObj.Object().DBRef.Number, destinationRoom.Object().DBRef.Number);
+							await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.LinkedExitToRoom), executor, exitObj.Object().DBRef.Number, destination.Object().DBRef.Number);
 							return CallState.Empty;
 						}
 					);
@@ -1233,6 +1225,23 @@ public partial class Commands
 		);
 	}
 
+	/// <summary>
+	/// PennMUSH <c>can_link_to</c> (<c>mushdb.h:87</c>): you may point an exit at somewhere you control,
+	/// or at somewhere flagged LINK_OK. Both <c>@link</c> and <c>@open</c> gate on this — without it,
+	/// accepting any container as a destination would let anyone link an exit into someone else's object.
+	/// </summary>
+	private static async ValueTask<bool> CanLinkTo(AnySharpObject executor, AnySharpObject destination)
+	{
+		if (await PermissionService!.Controls(executor, destination))
+		{
+			return true;
+		}
+
+		var destinationFlags = await destination.Object().Flags.Value.ToArrayAsync();
+
+		return destinationFlags.Any(f => f.Name.Equals("LINK_OK", StringComparison.OrdinalIgnoreCase));
+	}
+
 	[SharpCommand(Name = "@OPEN", Switches = [], Behavior = CB.Default | CB.EqSplit | CB.RSArgs | CB.NoGagged,
 		MinArgs = 1, MaxArgs = 5, ParameterNames = ["exit", "destination"])]
 	public static async ValueTask<Option<CallState>> Open(IMUSHCodeParser parser, SharpCommandAttribute _2)
@@ -1305,8 +1314,10 @@ public partial class Commands
 			}
 
 			// An exit may lead to any container — room, player or thing (PennMUSH can_link_to). Anything
-			// else is reported rather than leaving the exit silently unlinked.
-			if (!locateResult.AsSharpObject.IsContainer)
+			// else, or anywhere the executor may not link into, is reported rather than leaving the exit
+			// silently unlinked.
+			if (!locateResult.AsSharpObject.IsContainer
+					|| !await CanLinkTo(executor, locateResult.AsSharpObject))
 			{
 				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.CantLinkToThat), executor);
 				return new CallState(exitDbRef.ToString());

--- a/SharpMUSH.Implementation/Commands/BuildingCommands.cs
+++ b/SharpMUSH.Implementation/Commands/BuildingCommands.cs
@@ -656,7 +656,9 @@ public partial class Commands
 						executor, executor, destName, LocateFlags.All,
 						async destObj =>
 						{
-							if (!destObj.IsRoom)
+							// An exit may lead to any container — room, player or thing (PennMUSH can_link_to).
+							// Only another exit is not a place you can end up.
+							if (!destObj.IsContainer)
 							{
 								return await NotifyService!.NotifyAndReturn(
 										executor.Object().DBRef,
@@ -665,13 +667,13 @@ public partial class Commands
 										shouldNotify: true);
 							}
 
-							var destinationRoom = destObj.AsRoom;
+							var destinationRoom = destObj.AsContainer;
 
 							bool canLink = await PermissionService!.Controls(executor, destObj);
 
 							if (!canLink)
 							{
-								var destFlags = await destinationRoom.Object.Flags.Value.ToArrayAsync();
+								var destFlags = await destinationRoom.Object().Flags.Value.ToArrayAsync();
 								var hasLinkOk = destFlags.Any(f => f.Name.Equals("LINK_OK", StringComparison.OrdinalIgnoreCase));
 
 								if (!hasLinkOk)
@@ -729,7 +731,7 @@ public partial class Commands
 
 							await Mediator!.Send(new LinkExitCommand(exitObj.AsExit, destinationRoom));
 
-							await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.LinkedExitToRoom), executor, exitObj.Object().DBRef.Number, destinationRoom.Object.DBRef.Number);
+							await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.LinkedExitToRoom), executor, exitObj.Object().DBRef.Number, destinationRoom.Object().DBRef.Number);
 							return CallState.Empty;
 						}
 					);
@@ -1296,12 +1298,23 @@ public partial class Commands
 			var locateResult = await LocateService!.LocateAndNotifyIfInvalidWithCallState(parser,
 				executor, executor, destName, LocateFlags.All);
 
-			if (!locateResult.IsError && locateResult.AsSharpObject.IsRoom)
+			if (locateResult.IsError)
 			{
-				var exitObj = await Mediator.Send(new GetObjectNodeQuery(exitDbRef));
-				await Mediator.Send(new LinkExitCommand(exitObj.AsExit, locateResult.AsSharpObject.AsRoom));
-				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.LinkedToNameFormat), executor, destName);
+				// LocateAndNotifyIfInvalidWithCallState has already said why.
+				return new CallState(exitDbRef.ToString());
 			}
+
+			// An exit may lead to any container — room, player or thing (PennMUSH can_link_to). Anything
+			// else is reported rather than leaving the exit silently unlinked.
+			if (!locateResult.AsSharpObject.IsContainer)
+			{
+				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.CantLinkToThat), executor);
+				return new CallState(exitDbRef.ToString());
+			}
+
+			var exitObj = await Mediator.Send(new GetObjectNodeQuery(exitDbRef));
+			await Mediator.Send(new LinkExitCommand(exitObj.AsExit, locateResult.AsSharpObject.AsContainer));
+			await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.LinkedToNameFormat), executor, destName);
 		}
 
 		return new CallState(exitDbRef.ToString());

--- a/SharpMUSH.Implementation/Commands/GeneralCommands.cs
+++ b/SharpMUSH.Implementation/Commands/GeneralCommands.cs
@@ -222,12 +222,13 @@ public partial class Commands
 	{
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 
-		if (parser.CurrentState.Arguments.Count <= 0)
-		{
-			return new None();
-		}
+		// PennMUSH cmd_think (cmds.c:1769) is an unconditional notify, so a bare `think` prints a
+		// blank line rather than nothing at all.
+		var thought = parser.CurrentState.Arguments.Count <= 0
+			? string.Empty
+			: parser.CurrentState.Arguments["0"].Message!.ToString();
 
-		await NotifyService!.Notify(executor, parser.CurrentState.Arguments["0"].Message!.ToString(), executor);
+		await NotifyService!.Notify(executor, thought, executor);
 		return parser.CurrentState.Arguments["0"];
 	}
 
@@ -569,10 +570,20 @@ public partial class Commands
 
 		AnyOptionalSharpObject viewing = new None();
 
-		if (lookOutside && executor.IsContent)
+		if (lookOutside)
 		{
-			var container = await executor.AsContent.Location();
-			viewing = container.WithRoomOption().Match<AnyOptionalSharpObject>(
+			// PennMUSH do_look_at (look.c:611): looking outside shows the location OF your location, so
+			// there is nothing to see when you are standing in a room or inside an opaque container.
+			var container = executor.IsContent ? await executor.AsContent.Location() : null;
+
+			if (container is null || container.IsRoom || await container.WithExitOption().IsOpaque())
+			{
+				await NotifyService!.NotifyLocalized(executor,
+					nameof(ErrorMessages.Notifications.CantSeeThroughThat), executor);
+				return new CallState(ErrorMessages.Returns.CantSeeThroughThat);
+			}
+
+			viewing = (await container.Location()).WithRoomOption().Match<AnyOptionalSharpObject>(
 				player => player,
 				room => room,
 				exit => exit,
@@ -793,8 +804,10 @@ public partial class Commands
 					foreach (var exit in visibleExits)
 					{
 						var exitObj = exit.WithRoomOption().Object();
-						var destination = exit.IsExit ? await exit.AsExit.Home.WithCancellation(CancellationToken.None) : null;
-						var destName = destination != null ? destination.Object().Name : "*UNLINKED*";
+						var destination = exit.IsExit
+							? await exit.AsExit.Home.WithCancellation(CancellationToken.None)
+							: new AnyOptionalSharpContainer(new None());
+						var destName = destination.IsNone ? "*UNLINKED*" : destination.WithoutNone().Object().Name;
 
 						var exitMString = WrapExitInSendTag(exitObj.Name);
 
@@ -827,8 +840,10 @@ public partial class Commands
 					foreach (var exit in visibleExits)
 					{
 						var exitObj = exit.WithRoomOption().Object();
-						var destination = exit.IsExit ? await exit.AsExit.Home.WithCancellation(CancellationToken.None) : null;
-						var destName = destination != null ? destination.Object().Name : "*UNLINKED*";
+						var destination = exit.IsExit
+							? await exit.AsExit.Home.WithCancellation(CancellationToken.None)
+							: new AnyOptionalSharpContainer(new None());
+						var destName = destination.IsNone ? "*UNLINKED*" : destination.WithoutNone().Object().Name;
 
 						var exitMString = WrapExitInSendTag(exitObj.Name);
 
@@ -1162,14 +1177,23 @@ public partial class Commands
 				var homeContainer = await viewingKnown.MinusRoom().Home();
 				var locationContainer = await viewingKnown.AsContent.Location();
 
-				var homeObject = homeContainer.Object();
 				var locationObject = locationContainer.Object();
-				var homeFlags = await homeObject.Flags.Value.ToArrayAsync();
 				var locationFlags = await locationObject.Flags.Value.ToArrayAsync();
-
-				var homeFlagStr = string.Join(string.Empty, homeFlags.Select(x => x.Symbol));
 				var locationFlagStr = string.Join(string.Empty, locationFlags.Select(x => x.Symbol));
-				await NotifyService.Notify(enactor, Format($"Home: {homeObject.Name.Hilight()}(#{homeObject.DBRef.Number}{homeFlagStr})"), enactor);
+
+				// An unlinked exit has no destination to report; PennMUSH shows #-1 for NOTHING.
+				if (homeContainer.IsNone)
+				{
+					await NotifyService.Notify(enactor, Format($"Home: #-1"), enactor);
+				}
+				else
+				{
+					var homeObject = homeContainer.WithoutNone().Object();
+					var homeFlags = await homeObject.Flags.Value.ToArrayAsync();
+					var homeFlagStr = string.Join(string.Empty, homeFlags.Select(x => x.Symbol));
+					await NotifyService.Notify(enactor, Format($"Home: {homeObject.Name.Hilight()}(#{homeObject.DBRef.Number}{homeFlagStr})"), enactor);
+				}
+
 				await NotifyService.Notify(enactor, Format($"Location: {locationObject.Name.Hilight()}(#{locationObject.DBRef.Number}{locationFlagStr})"), enactor);
 			}
 		}
@@ -1177,7 +1201,8 @@ public partial class Commands
 		return new CallState(obj.DBRef.ToString());
 	}
 
-	[SharpCommand(Name = "@PEMIT", Behavior = CB.Default | CB.EqSplit, MinArgs = 1, MaxArgs = 2, ParameterNames = ["target", "message"])]
+	[SharpCommand(Name = "@PEMIT", Switches = ["LIST", "SILENT", "NOISY", "NOEVAL"], Behavior = CB.Default | CB.EqSplit,
+		MinArgs = 1, MaxArgs = 2, ParameterNames = ["target", "message"])]
 	public static async ValueTask<Option<CallState>> PrivateEmit(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
 		var args = parser.CurrentState.Arguments;
@@ -1194,7 +1219,7 @@ public partial class Commands
 
 		var enactor = await parser.CurrentState.KnownEnactorObject(Mediator!);
 
-		await CommunicationService!.SendToMultipleObjectsAsync(
+		var notified = await CommunicationService!.SendToMultipleObjectsAsync(
 			parser,
 			executor,
 			enactor,
@@ -1203,7 +1228,90 @@ public partial class Commands
 			INotifyService.NotificationType.Announce,
 			notifyOnPermissionFailure: true);
 
+		await EchoEmitToSender(executor, parser.CurrentState.Switches, notified, notification);
+
 		return new None();
+	}
+
+	/// <summary>
+	/// PennMUSH <c>do_pemit</c> (<c>speech.c:595</c>): unless <c>/silent</c>, the sender is told what
+	/// they sent — naming the single recipient, or counting them when there was more than one. Pemitting
+	/// only to yourself says nothing, since you already saw the message.
+	/// </summary>
+	private static async ValueTask EchoEmitToSender(
+		AnySharpObject executor, IEnumerable<string> switches, IReadOnlyList<AnySharpObject> notified, string message)
+	{
+		if (switches.Contains("SILENT") || notified.Count == 0)
+		{
+			return;
+		}
+
+		if (notified.Count > 1)
+		{
+			await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.YouPemitToCountFormat),
+				executor, message, notified.Count);
+			return;
+		}
+
+		var only = notified[0];
+		if (only.Object().DBRef == executor.Object().DBRef)
+		{
+			return;
+		}
+
+		await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.YouPemitToObjectFormat),
+			executor, message, only.Object().Name);
+	}
+
+	/// <summary>
+	/// PennMUSH <c>fail_lock</c> (<c>lock.c:832</c>) for an exit's basic lock: the exit's
+	/// <c>@fail</c> replaces the default message, <c>@ofail</c> goes to the rest of the room, and
+	/// <c>@afail</c> runs as the exit.
+	/// </summary>
+	private static async ValueTask<Option<CallState>> FailToGoThatWay(
+		IMUSHCodeParser parser, AnySharpObject executor, SharpExit exit)
+	{
+		var exitObject = new AnySharpObject(exit);
+
+		var failAttr = await AttributeService!.GetAttributeAsync(
+			executor, exitObject, "FAILURE", IAttributeService.AttributeMode.Read, true);
+
+		if (failAttr.IsAttribute && failAttr.AsAttribute.Length > 0
+				&& !string.IsNullOrEmpty(failAttr.AsAttribute[0].Value.ToPlainText()))
+		{
+			await NotifyService!.Notify(executor, failAttr.AsAttribute[0].Value, executor);
+		}
+		else
+		{
+			await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.CantGoThatWay), executor);
+		}
+
+		var ofailAttr = await AttributeService!.GetAttributeAsync(
+			executor, exitObject, "OFAILURE", IAttributeService.AttributeMode.Read, true);
+
+		if (ofailAttr.IsAttribute && ofailAttr.AsAttribute.Length > 0
+				&& !string.IsNullOrEmpty(ofailAttr.AsAttribute[0].Value.ToPlainText()))
+		{
+			await CommunicationService!.SendToRoomAsync(
+				executor,
+				await executor.Where(),
+				_ => ofailAttr.AsAttribute[0].Value,
+				INotifyService.NotificationType.Emit,
+				excludeObjects: [executor]);
+		}
+
+		var afailAttr = await AttributeService!.GetAttributeAsync(
+			executor, exitObject, "AFAILURE", IAttributeService.AttributeMode.Read, true);
+
+		if (afailAttr.IsAttribute && afailAttr.AsAttribute.Length > 0
+				&& !string.IsNullOrEmpty(afailAttr.AsAttribute[0].Value.ToPlainText()))
+		{
+			await parser.With(
+				state => state with { Executor = exit.Object.DBRef, Caller = state.Executor },
+				async p => await p.CommandParse(afailAttr.AsAttribute[0].Value));
+		}
+
+		return CallState.Empty;
 	}
 
 	[SharpCommand(Name = "GOTO", Behavior = CB.Default, MinArgs = 1, MaxArgs = 1, ParameterNames = ["destination"])]
@@ -1217,7 +1325,7 @@ public partial class Commands
 			return CallState.Empty;
 		}
 
-		var exit = await LocateService!.LocateAndNotifyIfInvalid(
+		var exit = await LocateService!.Locate(
 			parser,
 			executor,
 			executor,
@@ -1228,14 +1336,26 @@ public partial class Commands
 			| LocateFlags.OnlyMatchTypePreference
 			| LocateFlags.FailIfNotPreferred);
 
-		if (!exit.IsValid())
+		// PennMUSH do_move (move.c:432) answers a failed exit match with "You can't go that way.",
+		// not with the generic locate failure.
+		if (!exit.IsValid() || !exit.IsExit)
 		{
+			await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.CantGoThatWay), executor);
 			return CallState.Empty;
 		}
 
 		var exitObj = exit.AsExit;
 
-		var homeLocation = await exitObj.Home.WithCancellation(CancellationToken.None);
+		var maybeDestination = await exitObj.Home.WithCancellation(CancellationToken.None);
+
+		// PennMUSH could_doit() (predicat.c:75) refuses an exit with no destination before the basic
+		// lock is even evaluated, so do_move falls through to fail_lock.
+		if (maybeDestination.IsNone)
+		{
+			return await FailToGoThatWay(parser, executor, exitObj);
+		}
+
+		var homeLocation = maybeDestination.WithoutNone();
 		AnySharpContainer destination;
 
 		if (homeLocation.Object().DBRef.Number == -1)
@@ -1279,8 +1399,7 @@ public partial class Commands
 
 		if (!await PermissionService!.CanGoto(executor, exitObj, destination))
 		{
-			await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.CantGoThatWay), executor);
-			return CallState.Empty;
+			return await FailToGoThatWay(parser, executor, exitObj);
 		}
 
 		if (await MoveService!.WouldCreateLoop(executor.AsContent, destination))
@@ -1340,14 +1459,22 @@ public partial class Commands
 		if (validDestination.IsExit)
 		{
 			var exitObj = validDestination.AsExit;
-			var homeLocation = await exitObj.Home.WithCancellation(CancellationToken.None);
+			var maybeHomeLocation = await exitObj.Home.WithCancellation(CancellationToken.None);
+
+			const string exitUnlinkedMsg = "That exit doesn't go anywhere.";
+
+			if (maybeHomeLocation.IsNone)
+			{
+				await NotifyService!.Notify(executor, exitUnlinkedMsg, executor);
+				return CallState.Empty;
+			}
+
+			var homeLocation = maybeHomeLocation.WithoutNone();
 
 			if (homeLocation.Object().DBRef.Number == -1)
 			{
 				var destAttr = await AttributeService!.GetAttributeAsync(
 					executor, exitObj, "DESTINATION", IAttributeService.AttributeMode.Read, false);
-
-				const string exitUnlinkedMsg = "That exit doesn't go anywhere.";
 
 				if (destAttr.IsNone || destAttr.IsError)
 				{
@@ -2954,8 +3081,11 @@ public partial class Commands
 			LocateFlags.All,
 			async target =>
 			{
+				// PennMUSH do_one_remit (speech.c:1263): only containers hold anything.
 				if (!target.IsContainer)
 				{
+					await NotifyService!.NotifyLocalized(executor,
+						nameof(ErrorMessages.Notifications.ThereCantBeAnythingInThat), executor);
 					return CallState.Empty;
 				}
 
@@ -2966,10 +3096,34 @@ public partial class Commands
 					_ => message,
 					notificationType);
 
+				await EchoRemitToSender(executor, parser.CurrentState.Switches, target, message);
+
 				return CallState.Empty;
 			});
 
 		return CallState.Empty;
+	}
+
+	/// <summary>
+	/// PennMUSH <c>do_one_remit</c> (<c>speech.c:1273</c>): tell the sender what they remitted, unless
+	/// <c>/silent</c> or they are standing in the target room and already saw it.
+	/// </summary>
+	private static async ValueTask EchoRemitToSender(
+		AnySharpObject executor, IEnumerable<string> switches, AnySharpObject target, MString message)
+	{
+		if (switches.Contains("SILENT"))
+		{
+			return;
+		}
+
+		var executorLocation = await executor.Where();
+		if (executorLocation.Object().DBRef == target.Object().DBRef)
+		{
+			return;
+		}
+
+		await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.YouRemitInFormat),
+			executor, message.ToPlainText(), $"{target.Object().Name}(#{target.Object().DBRef.Number})");
 	}
 
 	[SharpCommand(Name = "@PROMPT", Switches = ["SILENT", "NOISY", "NOEVAL", "SPOOF"],
@@ -4028,13 +4182,45 @@ public partial class Commands
 		var executorLocation = await executor.OutermostWhere();
 		var message = args["0"].Message!;
 
+		// PennMUSH do_lemit (speech.c:1334) requires the absolute location to be a room.
+		if (!executorLocation.IsRoom)
+		{
+			await NotifyService!.NotifyLocalized(executor,
+				nameof(ErrorMessages.Notifications.LemitTooManyContainers), executor);
+			return new CallState(ErrorMessages.Returns.NothingToDo);
+		}
+
 		await CommunicationService!.SendToRoomAsync(
 			executor,
 			executorLocation,
 			_ => message,
 			INotifyService.NotificationType.Emit);
 
+		await EchoLemitToSender(executor, parser.CurrentState.Switches, executorLocation, message);
+
 		return CallState.Empty;
+	}
+
+	/// <summary>
+	/// PennMUSH <c>do_lemit</c> (<c>speech.c:1343</c>): echoed only when the sender is not directly in the
+	/// room they lemitted to — otherwise they already saw the emit.
+	/// </summary>
+	private static async ValueTask EchoLemitToSender(
+		AnySharpObject executor, IEnumerable<string> switches, AnySharpContainer room, MString message)
+	{
+		if (switches.Contains("SILENT"))
+		{
+			return;
+		}
+
+		var executorLocation = await executor.Where();
+		if (executorLocation.Object().DBRef == room.Object().DBRef)
+		{
+			return;
+		}
+
+		await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.YouLemitFormat),
+			executor, message.ToPlainText());
 	}
 
 	[SharpCommand(Name = "@NSLEMIT", Switches = ["NOEVAL", "NOISY", "SILENT"],
@@ -4055,6 +4241,15 @@ public partial class Commands
 			: INotifyService.NotificationType.Emit;
 
 		var executorLocation = await executor.OutermostWhere();
+
+		// PennMUSH do_lemit (speech.c:1334) requires the absolute location to be a room.
+		if (!executorLocation.IsRoom)
+		{
+			await NotifyService!.NotifyLocalized(executor,
+				nameof(ErrorMessages.Notifications.LemitTooManyContainers), executor);
+			return new CallState(ErrorMessages.Returns.NothingToDo);
+		}
+
 		var contents = executorLocation.Content(Mediator!);
 		var message = args["0"].Message!;
 
@@ -4068,6 +4263,8 @@ public partial class Commands
 				executor,
 				spoofType);
 		}
+
+		await EchoLemitToSender(executor, parser.CurrentState.Switches, executorLocation, message);
 
 		return CallState.Empty;
 	}
@@ -4100,6 +4297,14 @@ public partial class Commands
 			LocateFlags.All,
 			async zone =>
 			{
+				// PennMUSH do_zemit (speech.c:1405) requires control of the zone object.
+				if (!await PermissionService!.Controls(executor, zone))
+				{
+					await NotifyService!.NotifyLocalized(executor,
+						nameof(ErrorMessages.Notifications.PermissionDenied), executor);
+					return CallState.Empty;
+				}
+
 				var zoneObjects = Mediator!.CreateStream(new GetObjectsByZoneQuery(zone));
 
 				var rooms = zoneObjects.Where(obj => obj.Type == DatabaseConstants.TypeRoom);
@@ -4112,6 +4317,8 @@ public partial class Commands
 						await NotifyService!.Notify(content.WithRoomOption(), message, executor, notificationType);
 					}
 				}
+
+				await EchoZemitToSender(executor, parser.CurrentState.Switches, zone, message);
 
 				return CallState.Empty;
 			});
@@ -4649,6 +4856,14 @@ public partial class Commands
 			LocateFlags.All,
 			async zone =>
 			{
+				// PennMUSH do_zemit (speech.c:1405) requires control of the zone object.
+				if (!await PermissionService!.Controls(executor, zone))
+				{
+					await NotifyService!.NotifyLocalized(executor,
+						nameof(ErrorMessages.Notifications.PermissionDenied), executor);
+					return CallState.Empty;
+				}
+
 				var zoneObjects = Mediator!.CreateStream(new GetObjectsByZoneQuery(zone));
 
 				var rooms = zoneObjects.Where(obj => obj.Type == DatabaseConstants.TypeRoom);
@@ -4662,10 +4877,28 @@ public partial class Commands
 					}
 				}
 
+				await EchoZemitToSender(executor, parser.CurrentState.Switches, zone, message);
+
 				return CallState.Empty;
 			});
 
 		return CallState.Empty;
+	}
+
+	/// <summary>
+	/// PennMUSH <c>do_zemit</c> (<c>speech.c:1419</c>): tell the sender what they zemitted, unless
+	/// <c>/silent</c>.
+	/// </summary>
+	private static async ValueTask EchoZemitToSender(
+		AnySharpObject executor, IEnumerable<string> switches, AnySharpObject zone, MString message)
+	{
+		if (switches.Contains("SILENT"))
+		{
+			return;
+		}
+
+		await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.YouZemitInZoneFormat),
+			executor, message.ToPlainText(), $"{zone.Object().Name}(#{zone.Object().DBRef.Number})");
 	}
 
 	[SharpCommand(Name = "@CHANNEL",
@@ -5286,8 +5519,11 @@ public partial class Commands
 				LocateFlags.All,
 				async target =>
 				{
+					// PennMUSH do_one_remit (speech.c:1263): only containers hold anything.
 					if (!target.IsContainer)
 					{
+						await NotifyService!.NotifyLocalized(executor,
+							nameof(ErrorMessages.Notifications.ThereCantBeAnythingInThat), executor);
 						return CallState.Empty;
 					}
 
@@ -5296,6 +5532,8 @@ public partial class Commands
 						target.AsContainer,
 						_ => message,
 						INotifyService.NotificationType.Emit);
+
+					await EchoRemitToSender(executor, parser.CurrentState.Switches, target, message);
 
 					return CallState.Empty;
 				});
@@ -6127,6 +6365,8 @@ public partial class Commands
 			? INotifyService.NotificationType.NSAnnounce
 			: INotifyService.NotificationType.Announce;
 
+		var switches = parser.CurrentState.Switches;
+
 		if (IsIntegerList(recipients))
 		{
 			var ports = recipients.Split(' ', StringSplitOptions.RemoveEmptyEntries)
@@ -6134,10 +6374,20 @@ public partial class Commands
 				.ToArray();
 
 			await CommunicationService!.SendToPortsAsync(executor, ports, _ => message, notificationType);
+
+			// PennMUSH bsd.c:5133 reports port pemits by connection count.
+			if (!switches.Contains("SILENT") && ports.Length > 0)
+			{
+				await NotifyService!.NotifyLocalized(executor,
+					nameof(ErrorMessages.Notifications.YouPemitToConnectionsFormat), executor,
+					message.ToPlainText(), ports.Length);
+			}
+
 			return CallState.Empty;
 		}
 
 		var recipientList = ArgHelpers.NameList(recipients);
+		var notified = new List<AnySharpObject>();
 
 		foreach (var recipient in recipientList)
 		{
@@ -6154,11 +6404,14 @@ public partial class Commands
 					if (await PermissionService.CanInteract(executor, target, InteractType.Hear))
 					{
 						await NotifyService!.Notify(target, message, executor, notificationType);
+						notified.Add(target);
 					}
 
 					return CallState.Empty;
 				});
 		}
+
+		await EchoEmitToSender(executor, switches, notified, message.ToPlainText());
 
 		return CallState.Empty;
 	}

--- a/SharpMUSH.Implementation/Commands/GeneralCommands.cs
+++ b/SharpMUSH.Implementation/Commands/GeneralCommands.cs
@@ -1461,63 +1461,17 @@ public partial class Commands
 		AnySharpContainer destinationContainer;
 		if (validDestination.IsExit)
 		{
-			var exitObj = validDestination.AsExit;
-			var maybeHomeLocation = await exitObj.Home.WithCancellation(CancellationToken.None);
-
-			const string exitUnlinkedMsg = "That exit doesn't go anywhere.";
+			// Teleporting to an exit means going where it leads. GetExitDestinationAsync yields either a
+			// real object or None, so there is no sentinel dbref to test for here.
+			var maybeHomeLocation = await validDestination.AsExit.Home.WithCancellation(CancellationToken.None);
 
 			if (maybeHomeLocation.IsNone)
 			{
-				await NotifyService!.Notify(executor, exitUnlinkedMsg, executor);
+				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.ExitGoesNowhere), executor);
 				return CallState.Empty;
 			}
 
-			var homeLocation = maybeHomeLocation.WithoutNone();
-
-			if (homeLocation.Object().DBRef.Number == -1)
-			{
-				var destAttr = await AttributeService!.GetAttributeAsync(
-					executor, exitObj, "DESTINATION", IAttributeService.AttributeMode.Read, false);
-
-				if (destAttr.IsNone || destAttr.IsError)
-				{
-					await NotifyService!.Notify(executor, exitUnlinkedMsg, executor);
-					return CallState.Empty;
-				}
-
-				var destValue = destAttr.AsAttribute.Last().Value.ToPlainText();
-				if (string.IsNullOrWhiteSpace(destValue))
-				{
-					await NotifyService!.Notify(executor, exitUnlinkedMsg, executor);
-					return CallState.Empty;
-				}
-
-				var located = await LocateService!.LocateAndNotifyIfInvalid(
-					parser,
-					executor,
-					executor,
-					destValue,
-					LocateFlags.All);
-
-				if (!located.IsValid())
-				{
-					await NotifyService!.Notify(executor, exitUnlinkedMsg, executor);
-					return CallState.Empty;
-				}
-
-				var locatedObj = located.WithoutError().WithoutNone();
-				if (!locatedObj.IsContainer)
-				{
-					await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.ExitDestinationInvalid), executor);
-					return CallState.Empty;
-				}
-
-				destinationContainer = locatedObj.AsContainer;
-			}
-			else
-			{
-				destinationContainer = homeLocation;
-			}
+			destinationContainer = maybeHomeLocation.WithoutNone();
 		}
 		else
 		{

--- a/SharpMUSH.Implementation/Commands/GeneralCommands.cs
+++ b/SharpMUSH.Implementation/Commands/GeneralCommands.cs
@@ -223,13 +223,16 @@ public partial class Commands
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 
 		// PennMUSH cmd_think (cmds.c:1769) is an unconditional notify, so a bare `think` prints a
-		// blank line rather than nothing at all.
-		var thought = parser.CurrentState.Arguments.Count <= 0
-			? string.Empty
-			: parser.CurrentState.Arguments["0"].Message!.ToString();
+		// blank line rather than nothing at all. A bare `think` has no "0" argument at all, so the
+		// return has to come off the same check as the notify.
+		if (!parser.CurrentState.Arguments.TryGetValue("0", out var thought))
+		{
+			await NotifyService!.Notify(executor, string.Empty, executor);
+			return CallState.Empty;
+		}
 
-		await NotifyService!.Notify(executor, thought, executor);
-		return parser.CurrentState.Arguments["0"];
+		await NotifyService!.Notify(executor, thought.Message!.ToString(), executor);
+		return thought;
 	}
 
 	[SharpCommand(Name = "HUH_COMMAND", Behavior = CB.Default, MinArgs = 0, MaxArgs = 1, ParameterNames = [])]

--- a/SharpMUSH.Implementation/Commands/GeneralCommands.cs
+++ b/SharpMUSH.Implementation/Commands/GeneralCommands.cs
@@ -1317,6 +1317,145 @@ public partial class Commands
 		return CallState.Empty;
 	}
 
+	/// <summary>
+	/// How the exit was linked. PennMUSH stores HOME and AMBIGUOUS directly in Destination(); SharpMUSH
+	/// records them in a <c>_LINKTYPE</c> attribute instead, which is the convention <c>loc()</c> already
+	/// reads to answer <c>#-3</c> and <c>#-2</c>.
+	/// </summary>
+	private static async ValueTask<string?> LinkTypeOf(AnySharpObject executor, AnySharpObject exitObject)
+	{
+		var linkTypeAttr = await AttributeService!.GetAttributeAsync(
+			executor, exitObject, AttrLinkType, IAttributeService.AttributeMode.Read, false);
+
+		if (!linkTypeAttr.IsAttribute || linkTypeAttr.AsAttribute.Length == 0)
+		{
+			return null;
+		}
+
+		var linkType = linkTypeAttr.AsAttribute[0].Value.ToPlainText().Trim();
+
+		return string.IsNullOrEmpty(linkType) ? null : linkType.ToLowerInvariant();
+	}
+
+	/// <summary>
+	/// Why an exit could not say where it leads.
+	/// </summary>
+	private enum ExitDestinationFailure
+	{
+		/// <summary>No destination at all — never linked, or <c>@unlink</c>ed.</summary>
+		Unlinked,
+
+		/// <summary>A variable exit failed to resolve one, and has already told the executor why.</summary>
+		AlreadyReported
+	}
+
+	/// <summary>
+	/// Where an exit leads for a particular mover. <c>goto</c> and <c>@teleport</c> both need this and
+	/// must not drift apart: a variable exit computes its destination from <c>@DESTINATION</c>, a
+	/// home-linked exit sends the mover to <em>their own</em> home — which is why the mover is a separate
+	/// parameter from the executor — and otherwise it is the stored destination edge.
+	/// </summary>
+	private static async ValueTask<OneOf<AnySharpContainer, ExitDestinationFailure>> ResolveExitDestination(
+		IMUSHCodeParser parser, AnySharpObject executor, AnySharpObject mover, SharpExit exitObj, string typedName)
+	{
+		var exitObject = new AnySharpObject(exitObj);
+		var linkType = await LinkTypeOf(executor, exitObject);
+
+		if (linkType == LinkTypeVariable)
+		{
+			var variableDestination = await FindVariableDestination(parser, executor, exitObject, typedName);
+
+			return variableDestination is null
+				? ExitDestinationFailure.AlreadyReported
+				: variableDestination;
+		}
+
+		if (linkType == LinkTypeHome)
+		{
+			// PennMUSH do_move (move.c:451): an exit linked to HOME sends the mover to their own home.
+			if (!mover.IsContent)
+			{
+				return ExitDestinationFailure.Unlinked;
+			}
+
+			var moverHome = await mover.AsContent.Home();
+
+			return moverHome.IsNone
+				? ExitDestinationFailure.Unlinked
+				: moverHome.WithoutNone();
+		}
+
+		var maybeDestination = await exitObj.Home.WithCancellation(CancellationToken.None);
+
+		return maybeDestination.IsNone
+			? ExitDestinationFailure.Unlinked
+			: maybeDestination.WithoutNone();
+	}
+
+	/// <summary>
+	/// PennMUSH <c>find_var_dest</c> (<c>move.c:360</c>): a variable exit works out where it leads at move
+	/// time by evaluating its <c>DESTINATION</c> attribute — with <c>%0</c> set to the exit name or alias
+	/// the mover typed — falling back to <c>EXITTO</c>. The result is parsed as an objid, so it must name
+	/// an object rather than merely matching something nearby.
+	/// <para>Returns <c>null</c> after notifying the mover when no usable destination comes back.</para>
+	/// </summary>
+	private static async ValueTask<AnySharpContainer?> FindVariableDestination(
+		IMUSHCodeParser parser, AnySharpObject executor, AnySharpObject exitObject, string typedName)
+	{
+		var attributeArgs = new Dictionary<string, CallState> { { "0", new CallState(typedName) } };
+
+		var resolved = await AttributeHelpers.EvaluateFormatAttribute(
+			AttributeService!, parser, executor, exitObject, "DESTINATION", attributeArgs, MModule.empty());
+
+		if (MModule.getLength(resolved) == 0)
+		{
+			resolved = await AttributeHelpers.EvaluateFormatAttribute(
+				AttributeService!, parser, executor, exitObject, "EXITTO", attributeArgs, MModule.empty());
+		}
+
+		var destinationText = resolved.ToPlainText().Trim();
+		var located = DBRef.TryParse(destinationText, out var destinationRef)
+			? await Mediator!.Send(new GetObjectNodeQuery(destinationRef!.Value))
+			: new AnyOptionalSharpObject(new None());
+
+		// PennMUSH only permits a variable destination the exit itself could have been linked to
+		// (move.c:457), and an exit is not somewhere you can end up.
+		if (located.IsNone() || !located.Known().IsContainer
+				|| !await ExitCanLinkTo(exitObject, located.Known()))
+		{
+			await NotifyService!.NotifyLocalized(executor,
+				nameof(ErrorMessages.Notifications.VariableExitDestinationInvalidFormat), executor,
+				located.IsNone() ? "#-1" : located.Known().Object().DBRef.Number.ToString());
+
+			return null;
+		}
+
+		return located.Known().AsContainer;
+	}
+
+	/// <summary>
+	/// PennMUSH <c>can_link_to</c> (<c>mushdb.h:87</c>), asked of the exit rather than of the player: the
+	/// exit controls the destination, is allowed to link anywhere, or the destination is LINK_OK and the
+	/// exit passes its link lock.
+	/// </summary>
+	private static async ValueTask<bool> ExitCanLinkTo(AnySharpObject exitObject, AnySharpObject destination)
+	{
+		if (await PermissionService!.Controls(exitObject, destination))
+		{
+			return true;
+		}
+
+		if (await exitObject.HasPower("Link_Anywhere"))
+		{
+			return true;
+		}
+
+		var destinationFlags = await destination.Object().Flags.Value.ToArrayAsync();
+
+		return destinationFlags.Any(f => f.Name.Equals("LINK_OK", StringComparison.OrdinalIgnoreCase))
+					 && LockService!.Evaluate(LockType.Link, destination, exitObject);
+	}
+
 	[SharpCommand(Name = "GOTO", Behavior = CB.Default, MinArgs = 1, MaxArgs = 1, ParameterNames = ["destination"])]
 	public static async ValueTask<Option<CallState>> GoTo(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
@@ -1348,57 +1487,27 @@ public partial class Commands
 		}
 
 		var exitObj = exit.AsExit;
+		var exitObject = new AnySharpObject(exitObj);
 
-		var maybeDestination = await exitObj.Home.WithCancellation(CancellationToken.None);
+		// The exit name or alias actually typed: args["1"] when the visitor routed a bare exit command
+		// here, otherwise the argument to an explicit `goto`.
+		var typedName = args.TryGetValue("1", out var typedArg)
+			? typedArg.Message!.ToPlainText()
+			: args["0"].Message!.ToPlainText();
 
-		// PennMUSH could_doit() (predicat.c:75) refuses an exit with no destination before the basic
-		// lock is even evaluated, so do_move falls through to fail_lock.
-		if (maybeDestination.IsNone)
+		var resolved = await ResolveExitDestination(parser, executor, executor, exitObj, typedName);
+
+		if (!resolved.IsT0)
 		{
-			return await FailToGoThatWay(parser, executor, exitObj);
+			// PennMUSH could_doit() (predicat.c:75) refuses an exit with no destination before the basic
+			// lock is even evaluated, so do_move falls through to fail_lock. A variable exit that could
+			// not work out where it leads has already reported that itself.
+			return resolved.AsT1 == ExitDestinationFailure.Unlinked
+				? await FailToGoThatWay(parser, executor, exitObj)
+				: CallState.Empty;
 		}
 
-		var homeLocation = maybeDestination.WithoutNone();
-		AnySharpContainer destination;
-
-		if (homeLocation.Object().DBRef.Number == -1)
-		{
-			var destAttr = await AttributeService!.GetAttributeAsync(
-				executor, exitObj, "DESTINATION", IAttributeService.AttributeMode.Read, false);
-
-			if (destAttr.IsNone || destAttr.IsError)
-			{
-				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.ExitDestinationInvalid), executor);
-				return CallState.Empty;
-			}
-
-			var destValue = destAttr.AsAttribute.Last().Value.ToPlainText();
-			var located = await LocateService!.LocateAndNotifyIfInvalid(
-				parser,
-				executor,
-				executor,
-				destValue!,
-				LocateFlags.All);
-
-			if (!located.IsValid())
-			{
-				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.ExitDestinationInvalid), executor);
-				return CallState.Empty;
-			}
-
-			var locatedObj = located.WithoutError().WithoutNone();
-			if (!locatedObj.IsContainer)
-			{
-				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.ExitNoValidLocationDetail), executor);
-				return CallState.Empty;
-			}
-
-			destination = locatedObj.AsContainer;
-		}
-		else
-		{
-			destination = homeLocation;
-		}
+		var destination = resolved.AsT0;
 
 		if (!await PermissionService!.CanGoto(executor, exitObj, destination))
 		{
@@ -1458,25 +1567,10 @@ public partial class Commands
 
 		var validDestination = destination.WithoutError().WithoutNone();
 
-		AnySharpContainer destinationContainer;
-		if (validDestination.IsExit)
-		{
-			// Teleporting to an exit means going where it leads. GetExitDestinationAsync yields either a
-			// real object or None, so there is no sentinel dbref to test for here.
-			var maybeHomeLocation = await validDestination.AsExit.Home.WithCancellation(CancellationToken.None);
-
-			if (maybeHomeLocation.IsNone)
-			{
-				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.ExitGoesNowhere), executor);
-				return CallState.Empty;
-			}
-
-			destinationContainer = maybeHomeLocation.WithoutNone();
-		}
-		else
-		{
-			destinationContainer = validDestination.AsContainer;
-		}
+		// Teleporting to an exit means going where it leads. That is resolved per target inside the loop,
+		// because a home-linked exit leads somewhere different for each mover.
+		var destinationExit = validDestination.IsExit ? validDestination.AsExit : null;
+		var fixedDestination = destinationExit is null ? validDestination.AsContainer : null;
 
 		foreach (var obj in toTeleportStringList)
 		{
@@ -1502,6 +1596,30 @@ public partial class Commands
 			{
 				await NotifyService!.Notify(executor, ErrorMessages.Returns.CannotTeleport, executor);
 				continue;
+			}
+
+			AnySharpContainer destinationContainer;
+
+			if (destinationExit is null)
+			{
+				destinationContainer = fixedDestination!;
+			}
+			else
+			{
+				var resolvedExit = await ResolveExitDestination(
+					parser, executor, target, destinationExit, destinationString);
+
+				if (!resolvedExit.IsT0)
+				{
+					if (resolvedExit.AsT1 == ExitDestinationFailure.Unlinked)
+					{
+						await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.ExitGoesNowhere), executor);
+					}
+
+					continue;
+				}
+
+				destinationContainer = resolvedExit.AsT0;
 			}
 
 			// Zone teleport restriction: check if the source room blocks teleporting out.

--- a/SharpMUSH.Implementation/Commands/MoreCommands.cs
+++ b/SharpMUSH.Implementation/Commands/MoreCommands.cs
@@ -769,14 +769,10 @@ public partial class Commands
 
 		if (viewingKnown.IsPlayer || viewingKnown.IsThing)
 		{
-			var homeObj = await viewingKnown.MinusRoom().Home();
+			var homeObj = (await viewingKnown.MinusRoom().Home()).WithoutNone();
 			outputSections.Add(MModule.single($"Home: {homeObj.Object().Name}(#{homeObj.Object().DBRef.Number})"));
 
-			var locationObj = await viewingKnown.Match(
-				async player => await player.Location.WithCancellation(CancellationToken.None),
-				async room => await ValueTask.FromResult<AnySharpContainer>(room),
-				async exit => await exit.Home.WithCancellation(CancellationToken.None),
-				async thing => await thing.Location.WithCancellation(CancellationToken.None));
+			var locationObj = await viewingKnown.Where();
 			outputSections.Add(MModule.single($"Location: {locationObj.Object().Name}(#{locationObj.Object().DBRef.Number})"));
 		}
 
@@ -975,17 +971,9 @@ public partial class Commands
 
 		var objectToDrop = locateResult.WithoutError().WithoutNone();
 
-		var executorLocation = await executor.Match(
-			async player => await player.Location.WithCancellation(CancellationToken.None),
-			async room => await ValueTask.FromResult<AnySharpContainer>(room),
-			async exit => await exit.Home.WithCancellation(CancellationToken.None),
-			async thing => await thing.Location.WithCancellation(CancellationToken.None));
+		var executorLocation = await executor.Where();
 
-		var objectLocation = await objectToDrop.Match(
-			async player => await player.Location.WithCancellation(CancellationToken.None),
-			async room => await ValueTask.FromResult<AnySharpContainer>(room),
-			async exit => await exit.Home.WithCancellation(CancellationToken.None),
-			async thing => await thing.Location.WithCancellation(CancellationToken.None));
+		var objectLocation = await objectToDrop.Where();
 
 		bool isCarrying = objectLocation.Match(
 			player => player.Object.DBRef.Equals(executor.Object().DBRef),
@@ -1129,17 +1117,9 @@ public partial class Commands
 			return CallState.Empty;
 		}
 
-		var executorLocation = await executor.Match(
-			async player => await player.Location.WithCancellation(CancellationToken.None),
-			async room => await ValueTask.FromResult<AnySharpContainer>(room),
-			async exit => await exit.Home.WithCancellation(CancellationToken.None),
-			async thing => await thing.Location.WithCancellation(CancellationToken.None));
+		var executorLocation = await executor.Where();
 
-		var objectLocation = await objectToEmpty.Match(
-			async player => await player.Location.WithCancellation(CancellationToken.None),
-			async room => await ValueTask.FromResult<AnySharpContainer>(room),
-			async exit => await exit.Home.WithCancellation(CancellationToken.None),
-			async thing => await thing.Location.WithCancellation(CancellationToken.None));
+		var objectLocation = await objectToEmpty.Where();
 
 		bool isHolding = objectLocation.Match(
 			player => player.Object.DBRef.Equals(executor.Object().DBRef),
@@ -1415,11 +1395,7 @@ public partial class Commands
 		}
 
 		// Get old location for %0 substitution
-		var oldLocation = await executor.Match(
-			async player => await player.Location.WithCancellation(CancellationToken.None),
-			async room => await ValueTask.FromResult<AnySharpContainer>(room),
-			async exit => await exit.Home.WithCancellation(CancellationToken.None),
-			async thing => await thing.Location.WithCancellation(CancellationToken.None));
+		var oldLocation = await executor.Where();
 
 		// Move executor into object using MoveService for proper hook triggering
 		var executorAsContent = executor.AsContent;
@@ -1594,11 +1570,7 @@ public partial class Commands
 		else
 		{
 			objectName = fullArg;
-			sourceLocation = await executor.Match<ValueTask<AnySharpContainer>>(
-				async player => await player.Location.WithCancellation(CancellationToken.None),
-				room => ValueTask.FromResult<AnySharpContainer>(room),
-				async exit => await exit.Home.WithCancellation(CancellationToken.None),
-				async thing => await thing.Location.WithCancellation(CancellationToken.None));
+			sourceLocation = await executor.Where();
 		}
 
 		var locateResult = await LocateService!.LocateAndNotifyIfInvalid(parser, executor, sourceLocation.WithExitOption(), objectName, LocateFlags.All);
@@ -1611,11 +1583,7 @@ public partial class Commands
 
 		var objectToGet = locateResult.WithoutError().WithoutNone();
 
-		var objectLocation = await objectToGet.Match<ValueTask<AnySharpContainer>>(
-			async player => await player.Location.WithCancellation(CancellationToken.None),
-			room => ValueTask.FromResult<AnySharpContainer>(room),
-			async exit => await exit.Home.WithCancellation(CancellationToken.None),
-			async thing => await thing.Location.WithCancellation(CancellationToken.None));
+		var objectLocation = await objectToGet.Where();
 
 		var alreadyCarrying = objectLocation.Match(
 			player => player.Object.DBRef.Equals(executor.Object().DBRef),
@@ -1757,11 +1725,7 @@ public partial class Commands
 
 		var objectToGive = objectResult.WithoutError().WithoutNone();
 
-		var objectLocation = await objectToGive.Match<ValueTask<AnySharpContainer>>(
-			async player => await player.Location.WithCancellation(CancellationToken.None),
-			room => ValueTask.FromResult<AnySharpContainer>(room),
-			async exit => await exit.Home.WithCancellation(CancellationToken.None),
-			async thing => await thing.Location.WithCancellation(CancellationToken.None));
+		var objectLocation = await objectToGive.Where();
 
 		var isCarrying = objectLocation.Match(
 			player => player.Object.DBRef.Equals(executor.Object().DBRef),
@@ -1922,7 +1886,8 @@ public partial class Commands
 			return CallState.Empty;
 		}
 
-		var homeLocation = await executor.MinusRoom().Home();
+		// Guarded above: only players and things reach here, and both always have a home.
+		var homeLocation = (await executor.MinusRoom().Home()).WithoutNone();
 		var homeObj = homeLocation.Object();
 
 		if (homeObj.DBRef.Number < 0)
@@ -1931,11 +1896,7 @@ public partial class Commands
 			return CallState.Empty;
 		}
 
-		var currentLocation = await executor.Match(
-			async player => await player.Location.WithCancellation(CancellationToken.None),
-			async room => await ValueTask.FromResult<AnySharpContainer>(room),
-			async exit => await exit.Home.WithCancellation(CancellationToken.None),
-			async thing => await thing.Location.WithCancellation(CancellationToken.None));
+		var currentLocation = await executor.Where();
 
 		if (currentLocation.Object().DBRef.Equals(homeObj.DBRef))
 		{
@@ -2009,11 +1970,7 @@ public partial class Commands
 			return CallState.Empty;
 		}
 
-		var currentLocation = await executor.Match(
-			async player => await player.Location.WithCancellation(CancellationToken.None),
-			async room => await ValueTask.FromResult<AnySharpContainer>(room),
-			async exit => await exit.Home.WithCancellation(CancellationToken.None),
-			async thing => await thing.Location.WithCancellation(CancellationToken.None));
+		var currentLocation = await executor.Where();
 
 		if (!currentLocation.IsThing && !currentLocation.IsPlayer)
 		{

--- a/SharpMUSH.Implementation/Functions/DbrefFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/DbrefFunctions.cs
@@ -67,15 +67,13 @@ public partial class Functions
 					}
 				}
 
-				try
-				{
-					var destination = await exit.Location.WithCancellation(CancellationToken.None);
-					return destination.Object().DBRef;
-				}
-				catch (InvalidOperationException)
-				{
-					return "#-1";
-				}
+				// PennMUSH fun_loc (fundb.c:1459) returns Location(it), which for an exit is where it
+				// leads. The room it sits in is what where() reports.
+				var destination = await exit.Home.WithCancellation(CancellationToken.None);
+
+				return destination.IsNone
+					? "#-1"
+					: destination.WithoutNone().Object().DBRef;
 			},
 			async thing => (await thing.Location.WithCancellation(CancellationToken.None)).Object().DBRef
 		);

--- a/SharpMUSH.Implementation/Functions/DbrefFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/DbrefFunctions.cs
@@ -392,7 +392,8 @@ public partial class Functions
 					thing => thing.Object.DBRef.ToString(),
 					_ => "#-1");
 			},
-			async exit => (await exit.Home.WithCancellation(CancellationToken.None)).Object().DBRef,
+			// PennMUSH fun_home (fundb.c:1672) returns Source() for an exit — the room it sits in.
+			async exit => (await exit.Location.WithCancellation(CancellationToken.None)).Object().DBRef,
 			async thing => (await thing.Home.WithCancellation(CancellationToken.None)).Object().DBRef
 		);
 	}
@@ -1575,7 +1576,7 @@ public partial class Functions
 					else if (current.IsExit)
 					{
 						// Exits' location is their source room
-						var location = await current.AsExit.Home.WithCancellation(CancellationToken.None);
+						var location = await current.AsExit.Location.WithCancellation(CancellationToken.None);
 						current = location.WithRoomOption();
 					}
 					else

--- a/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
+++ b/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
@@ -954,7 +954,7 @@ public class SharpMUSHParserVisitor(
 				if (locate.IsExit)
 				{
 					var exit = locate.AsExit;
-					return await HandleGoCommandPattern(parser, exit);
+					return await HandleGoCommandPattern(parser, exit, command);
 				}
 			}
 
@@ -1192,14 +1192,20 @@ public class SharpMUSHParserVisitor(
 		return CallState.Empty;
 	}
 
-	private static async ValueTask<Option<CallState>> HandleGoCommandPattern(IMUSHCodeParser prs, SharpExit exit)
+	/// <param name="typedName">
+	/// The exit name or alias the player actually typed. PennMUSH passes this to a variable exit's
+	/// DESTINATION attribute as %0 (move.c:369), so one exit can route differently per alias.
+	/// </param>
+	private static async ValueTask<Option<CallState>> HandleGoCommandPattern(
+		IMUSHCodeParser prs, SharpExit exit, string typedName)
 	{
 		var newParser = prs.Push(prs.CurrentState with
 		{
 			Command = "GOTO",
 			Arguments = new Dictionary<string, CallState>
 			{
-				{ "0", new CallState(exit.Object.DBRef.ToString(), 0) }
+				{ "0", new CallState(exit.Object.DBRef.ToString(), 0) },
+				{ "1", new CallState(typedName, 0) }
 			},
 			Function = null
 		});

--- a/SharpMUSH.Library/Definitions/ErrorMessages.cs
+++ b/SharpMUSH.Library/Definitions/ErrorMessages.cs
@@ -620,6 +620,7 @@ public static class ErrorMessages
 
 		public const string CantGoThatWay = "You can't go that way.";
 		public const string CantSeeThroughThat = "You can't see through that.";
+		public const string ExitGoesNowhere = "That exit doesn't go anywhere.";
 		public const string ExitNoValidLocation = "That exit doesn't go to a valid location.";
 		public const string CantGoThatWayContainmentLoop = "You can't go that way - it would create a containment loop.";
 		public const string YouHaveBeenTeleported = "You have been teleported.";

--- a/SharpMUSH.Library/Definitions/ErrorMessages.cs
+++ b/SharpMUSH.Library/Definitions/ErrorMessages.cs
@@ -622,6 +622,9 @@ public static class ErrorMessages
 		public const string CantSeeThroughThat = "You can't see through that.";
 		public const string ExitGoesNowhere = "That exit doesn't go anywhere.";
 		public const string ExitNoValidLocation = "That exit doesn't go to a valid location.";
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string VariableExitDestinationInvalidFormat =
+			"Variable exit destination #{0} is invalid or not permitted.";
 		public const string CantGoThatWayContainmentLoop = "You can't go that way - it would create a containment loop.";
 		public const string YouHaveBeenTeleported = "You have been teleported.";
 

--- a/SharpMUSH.Library/Definitions/ErrorMessages.cs
+++ b/SharpMUSH.Library/Definitions/ErrorMessages.cs
@@ -110,6 +110,7 @@ public static class ErrorMessages
 		public const string NothingToEvaluate = "#-1 NOTHING TO EVALUATE";
 		public const string NothingToDo = "#-1 NOTHING TO DO";
 		public const string ExitsCannotContainThings = "#-1 EXITS CANNOT CONTAIN THINGS";
+		public const string CantSeeThroughThat = "#-1 CANNOT SEE THROUGH THAT";
 		public const string ParentLoop = "#-1 PARENT LOOP DETECTED";
 		public const string NotSupported = "#-1 BEHAVIOR NOT SUPPORTED BY SHARPMUSH";
 		public const string SafeObject = "#-1 OBJECT IS SAFE";
@@ -618,9 +619,26 @@ public static class ErrorMessages
 		public const string TryingToLink = "Trying to link...";
 
 		public const string CantGoThatWay = "You can't go that way.";
+		public const string CantSeeThroughThat = "You can't see through that.";
 		public const string ExitNoValidLocation = "That exit doesn't go to a valid location.";
 		public const string CantGoThatWayContainmentLoop = "You can't go that way - it would create a containment loop.";
 		public const string YouHaveBeenTeleported = "You have been teleported.";
+
+		// Emit-family sender echoes, suppressed by /silent (PennMUSH speech.c, bsd.c).
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string YouPemitToObjectFormat = "You pemit \"{0}\" to {1}.";
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string YouPemitToCountFormat = "You pemit \"{0}\" to {1} objects.";
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string YouPemitToConnectionsFormat = "You pemit \"{0}\" to {1} connections.";
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string YouRemitInFormat = "You remit, \"{0}\" in {1}";
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string YouLemitFormat = "You lemit: \"{0}\"";
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string YouZemitInZoneFormat = "You zemit, \"{0}\" in zone {1}";
+		public const string ThereCantBeAnythingInThat = "There can't be anything in that!";
+		public const string LemitTooManyContainers = "Too many containers.";
 
 		public const string DontYouHaveAnythingToSay = "Don't you have anything to say?";
 		public const string HuhTypeHelp = "Huh?  (Type \"help\" for help.)";

--- a/SharpMUSH.Library/DiscriminatedUnions/AnySharpContent.cs
+++ b/SharpMUSH.Library/DiscriminatedUnions/AnySharpContent.cs
@@ -50,10 +50,14 @@ public class AnySharpContent : OneOfBase<SharpPlayer, SharpExit, SharpThing>
 		);
 
 
-	public async ValueTask<AnySharpContainer> Home()
-		=> await Match(
-			async player => await player.Home.WithCancellation(CancellationToken.None),
+	/// <summary>
+	/// Where this content goes home to. Players and things always have one; for an exit this is its
+	/// destination, which is absent until <c>@link</c> gives it one.
+	/// </summary>
+	public async ValueTask<AnyOptionalSharpContainer> Home()
+		=> await Match<ValueTask<AnyOptionalSharpContainer>>(
+			async player => (await player.Home.WithCancellation(CancellationToken.None)).WithNoneOption(),
 			async exit => await exit.Home.WithCancellation(CancellationToken.None),
-			async thing => await thing.Home.WithCancellation(CancellationToken.None)
+			async thing => (await thing.Home.WithCancellation(CancellationToken.None)).WithNoneOption()
 		);
 }

--- a/SharpMUSH.Library/Extensions/OneOfExtensions.cs
+++ b/SharpMUSH.Library/Extensions/OneOfExtensions.cs
@@ -104,17 +104,8 @@ public static class OneOfExtensions
 			_ => throw new ArgumentException("Cannot convert an Error to a non-Error value.")
 		);
 
-	public static async ValueTask<AnySharpContainer> Home(this AnySharpContent thing)
-		=> await thing.Match(
-			async player => await player.Home.WithCancellation(CancellationToken.None),
-			async exit => await exit.Location.WithCancellation(CancellationToken.None),
-			async thing2 => await thing2.Home.WithCancellation(CancellationToken.None));
-
-	public static async ValueTask<AnySharpContainer> Location(this AnySharpContent thing)
-		=> await thing.Match(
-			async player => await player.Location.WithCancellation(CancellationToken.None),
-			async exit => await exit.Home.WithCancellation(CancellationToken.None),
-			async thing2 => await thing2.Location.WithCancellation(CancellationToken.None));
+	// AnySharpContent.Home()/Location() are instance methods, so same-signature extensions here were
+	// unreachable — and had the exit's source/destination edges the wrong way round.
 
 	public static AnySharpObject Known(this AnyOptionalSharpObject union) =>
 		union.Match<AnySharpObject>(

--- a/SharpMUSH.Library/Models/SharpExit.cs
+++ b/SharpMUSH.Library/Models/SharpExit.cs
@@ -13,9 +13,18 @@ public class SharpExit
 
 	public required SharpObject Object { get; set; }
 
+	/// <summary>
+	/// The room the exit sits in — PennMUSH's <c>Source()</c>. Backed by the AtLocation edge, which is
+	/// also what makes the exit show up in that room's contents.
+	/// </summary>
 	[JsonIgnore]
-	public required AsyncLazy<AnySharpContainer> Location { get; set; } // DESTINATION
+	public required AsyncLazy<AnySharpContainer> Location { get; set; }
 
+	/// <summary>
+	/// Where the exit leads — PennMUSH's <c>Destination()</c>. Backed by the HasHome edge, which
+	/// <c>@link</c> writes and <c>@unlink</c> removes, so a freshly <c>@open</c>ed or <c>@unlink</c>ed
+	/// exit has none.
+	/// </summary>
 	[JsonIgnore]
-	public required AsyncLazy<AnySharpContainer> Home { get; set; } // SOURCE ROOM
+	public required AsyncLazy<AnyOptionalSharpContainer> Home { get; set; }
 }

--- a/SharpMUSH.Library/Models/SharpExit.cs
+++ b/SharpMUSH.Library/Models/SharpExit.cs
@@ -14,8 +14,9 @@ public class SharpExit
 	public required SharpObject Object { get; set; }
 
 	/// <summary>
-	/// The room the exit sits in — PennMUSH's <c>Source()</c>. Backed by the AtLocation edge, which is
-	/// also what makes the exit show up in that room's contents.
+	/// The container the exit sits in — PennMUSH's <c>Source()</c>. Usually a room, but exits can also
+	/// live on a player or a thing. Backed by the AtLocation edge, which is also what makes the exit show
+	/// up in that container's contents.
 	/// </summary>
 	[JsonIgnore]
 	public required AsyncLazy<AnySharpContainer> Location { get; set; }

--- a/SharpMUSH.Library/Resources/Notifications.resx
+++ b/SharpMUSH.Library/Resources/Notifications.resx
@@ -710,6 +710,9 @@
   <data name="CantSeeThroughThat" xml:space="preserve">
     <value>You can't see through that.</value>
   </data>
+  <data name="VariableExitDestinationInvalidFormat" xml:space="preserve">
+    <value>Variable exit destination #{0} is invalid or not permitted.</value>
+  </data>
   <data name="ExitGoesNowhere" xml:space="preserve">
     <value>That exit doesn't go anywhere.</value>
   </data>

--- a/SharpMUSH.Library/Resources/Notifications.resx
+++ b/SharpMUSH.Library/Resources/Notifications.resx
@@ -710,6 +710,9 @@
   <data name="CantSeeThroughThat" xml:space="preserve">
     <value>You can't see through that.</value>
   </data>
+  <data name="ExitGoesNowhere" xml:space="preserve">
+    <value>That exit doesn't go anywhere.</value>
+  </data>
   <data name="ExitNoValidLocation" xml:space="preserve">
     <value>That exit doesn't go to a valid location.</value>
   </data>

--- a/SharpMUSH.Library/Resources/Notifications.resx
+++ b/SharpMUSH.Library/Resources/Notifications.resx
@@ -678,8 +678,37 @@
   </data>
 
   <!-- Navigation -->
+  <!-- Emit-family sender echoes -->
+  <data name="YouPemitToObjectFormat" xml:space="preserve">
+    <value>You pemit "{0}" to {1}.</value>
+  </data>
+  <data name="YouPemitToCountFormat" xml:space="preserve">
+    <value>You pemit "{0}" to {1} objects.</value>
+  </data>
+  <data name="YouPemitToConnectionsFormat" xml:space="preserve">
+    <value>You pemit "{0}" to {1} connections.</value>
+  </data>
+  <data name="YouRemitInFormat" xml:space="preserve">
+    <value>You remit, "{0}" in {1}</value>
+  </data>
+  <data name="YouLemitFormat" xml:space="preserve">
+    <value>You lemit: "{0}"</value>
+  </data>
+  <data name="YouZemitInZoneFormat" xml:space="preserve">
+    <value>You zemit, "{0}" in zone {1}</value>
+  </data>
+  <data name="ThereCantBeAnythingInThat" xml:space="preserve">
+    <value>There can't be anything in that!</value>
+  </data>
+  <data name="LemitTooManyContainers" xml:space="preserve">
+    <value>Too many containers.</value>
+  </data>
+
   <data name="CantGoThatWay" xml:space="preserve">
     <value>You can't go that way.</value>
+  </data>
+  <data name="CantSeeThroughThat" xml:space="preserve">
+    <value>You can't see through that.</value>
   </data>
   <data name="ExitNoValidLocation" xml:space="preserve">
     <value>That exit doesn't go to a valid location.</value>

--- a/SharpMUSH.Library/Services/CommunicationService.cs
+++ b/SharpMUSH.Library/Services/CommunicationService.cs
@@ -94,7 +94,7 @@ public class CommunicationService(
 		}
 	}
 
-	public async ValueTask<AnySharpObject?> SendToObjectAsync(
+	public async ValueTask<OneOf<AnySharpObject, DeliveryFailure>> SendToObjectAsync(
 		IMUSHCodeParser parser,
 		AnySharpObject executor,
 		AnySharpObject enactor,
@@ -109,7 +109,7 @@ public class CommunicationService(
 		if (maybeLocateTarget.IsError)
 		{
 			await notifyService.Notify(executor, maybeLocateTarget.AsError.Message!);
-			return null;
+			return new DeliveryFailure(DeliveryFailure.Cause.TargetNotFound);
 		}
 
 		var target = maybeLocateTarget.AsSharpObject;
@@ -121,7 +121,7 @@ public class CommunicationService(
 				await notifyService.Notify(executor, $"{target.Object().Name} does not want to hear from you.");
 			}
 
-			return null;
+			return new DeliveryFailure(DeliveryFailure.Cause.TargetWillNotHear);
 		}
 
 		var message = messageFunc(target);
@@ -143,12 +143,12 @@ public class CommunicationService(
 		await foreach (var target in targets)
 		{
 			var targetString = target.Match(dbref => dbref.ToString(), str => str);
-			var recipient = await SendToObjectAsync(parser, executor, enactor, targetString, messageFunc,
+			var delivery = await SendToObjectAsync(parser, executor, enactor, targetString, messageFunc,
 				notificationType, notifyOnPermissionFailure);
 
-			if (recipient is not null)
+			if (delivery.IsT0)
 			{
-				notified.Add(recipient);
+				notified.Add(delivery.AsT0);
 			}
 		}
 

--- a/SharpMUSH.Library/Services/CommunicationService.cs
+++ b/SharpMUSH.Library/Services/CommunicationService.cs
@@ -94,7 +94,7 @@ public class CommunicationService(
 		}
 	}
 
-	public async ValueTask<bool> SendToObjectAsync(
+	public async ValueTask<AnySharpObject?> SendToObjectAsync(
 		IMUSHCodeParser parser,
 		AnySharpObject executor,
 		AnySharpObject enactor,
@@ -109,7 +109,7 @@ public class CommunicationService(
 		if (maybeLocateTarget.IsError)
 		{
 			await notifyService.Notify(executor, maybeLocateTarget.AsError.Message!);
-			return false;
+			return null;
 		}
 
 		var target = maybeLocateTarget.AsSharpObject;
@@ -121,15 +121,15 @@ public class CommunicationService(
 				await notifyService.Notify(executor, $"{target.Object().Name} does not want to hear from you.");
 			}
 
-			return false;
+			return null;
 		}
 
 		var message = messageFunc(target);
 		await notifyService.Notify(target, message, executor, notificationType);
-		return true;
+		return target;
 	}
 
-	public async ValueTask SendToMultipleObjectsAsync(
+	public async ValueTask<IReadOnlyList<AnySharpObject>> SendToMultipleObjectsAsync(
 		IMUSHCodeParser parser,
 		AnySharpObject executor,
 		AnySharpObject enactor,
@@ -138,11 +138,20 @@ public class CommunicationService(
 		INotifyService.NotificationType notificationType,
 		bool notifyOnPermissionFailure = true)
 	{
+		var notified = new List<AnySharpObject>();
+
 		await foreach (var target in targets)
 		{
 			var targetString = target.Match(dbref => dbref.ToString(), str => str);
-			await SendToObjectAsync(parser, executor, enactor, targetString, messageFunc, notificationType,
-				notifyOnPermissionFailure);
+			var recipient = await SendToObjectAsync(parser, executor, enactor, targetString, messageFunc,
+				notificationType, notifyOnPermissionFailure);
+
+			if (recipient is not null)
+			{
+				notified.Add(recipient);
+			}
 		}
+
+		return notified;
 	}
 }

--- a/SharpMUSH.Library/Services/Interfaces/ICommunicationService.cs
+++ b/SharpMUSH.Library/Services/Interfaces/ICommunicationService.cs
@@ -55,8 +55,8 @@ public interface ICommunicationService
 	/// <param name="messageFunc">Function that takes the target and base message, returns the final message to send</param>
 	/// <param name="notificationType">The type of notification to send</param>
 	/// <param name="notifyOnPermissionFailure">Whether to notify executor if permission check fails</param>
-	/// <returns>True if message was sent successfully, false otherwise</returns>
-	ValueTask<bool> SendToObjectAsync(
+	/// <returns>The object that received the message, or null if it could not be delivered.</returns>
+	ValueTask<AnySharpObject?> SendToObjectAsync(
 		IMUSHCodeParser parser,
 		AnySharpObject executor,
 		AnySharpObject enactor,
@@ -75,8 +75,8 @@ public interface ICommunicationService
 	/// <param name="messageFunc">Function that takes the target and base message, returns the final message to send</param>
 	/// <param name="notificationType">The type of notification to send</param>
 	/// <param name="notifyOnPermissionFailure">Whether to notify executor if permission check fails</param>
-	/// <returns>Task representing the async operation</returns>
-	ValueTask SendToMultipleObjectsAsync(
+	/// <returns>The objects that actually received the message, in the order they were notified.</returns>
+	ValueTask<IReadOnlyList<AnySharpObject>> SendToMultipleObjectsAsync(
 		IMUSHCodeParser parser,
 		AnySharpObject executor,
 		AnySharpObject enactor,

--- a/SharpMUSH.Library/Services/Interfaces/ICommunicationService.cs
+++ b/SharpMUSH.Library/Services/Interfaces/ICommunicationService.cs
@@ -9,6 +9,20 @@ namespace SharpMUSH.Library.Services.Interfaces;
 /// Service for handling communication functions like pemit, emit, etc.
 /// Centralizes the logic for sending messages to players, rooms, and ports.
 /// </summary>
+/// <summary>
+/// Why a message could not be delivered to a target: the name did not resolve, or the target declined
+/// to hear from the executor. Distinguishes "nobody received this" from a successful delivery without
+/// resorting to a nullable service return.
+/// </summary>
+public readonly record struct DeliveryFailure(DeliveryFailure.Cause Reason)
+{
+	public enum Cause
+	{
+		TargetNotFound,
+		TargetWillNotHear
+	}
+}
+
 public interface ICommunicationService
 {
 	/// <summary>
@@ -55,8 +69,11 @@ public interface ICommunicationService
 	/// <param name="messageFunc">Function that takes the target and base message, returns the final message to send</param>
 	/// <param name="notificationType">The type of notification to send</param>
 	/// <param name="notifyOnPermissionFailure">Whether to notify executor if permission check fails</param>
-	/// <returns>The object that received the message, or null if it could not be delivered.</returns>
-	ValueTask<AnySharpObject?> SendToObjectAsync(
+	/// <returns>
+	/// The object that received the message, or <see cref="DeliveryFailure"/> when it could not be
+	/// delivered — the target could not be located, or it declined to hear from the executor.
+	/// </returns>
+	ValueTask<OneOf<AnySharpObject, DeliveryFailure>> SendToObjectAsync(
 		IMUSHCodeParser parser,
 		AnySharpObject executor,
 		AnySharpObject enactor,

--- a/SharpMUSH.Library/Services/LocateService.cs
+++ b/SharpMUSH.Library/Services/LocateService.cs
@@ -193,7 +193,9 @@ public partial class LocateService(
 		}
 		else if (where.IsExit)
 		{
-			location = await where.MinusRoom().Home();
+			// Search the exit's destination; an unlinked exit has none, so fall back to the room it sits in.
+			var destination = await where.MinusRoom().Home();
+			location = destination.IsNone ? await FriendlyWhereIs(where) : destination.WithoutNone();
 		}
 		else
 		{
@@ -599,9 +601,13 @@ public partial class LocateService(
 	{
 		if (thing.IsRoom) return null;
 		var minusRoom = thing.MinusRoom();
-		return thing.IsExit
-			? (await minusRoom.Home()).Object().DBRef
-			: (await minusRoom.Location()).Object().DBRef;
+		if (!thing.IsExit)
+		{
+			return (await minusRoom.Location()).Object().DBRef;
+		}
+
+		var destination = await minusRoom.Home();
+		return destination.IsNone ? null : destination.WithoutNone().Object().DBRef;
 	}
 
 	public async ValueTask<AnySharpContainer> Room(AnySharpObject content)
@@ -637,7 +643,7 @@ public partial class LocateService(
 	public static async ValueTask<AnySharpContainer> FriendlyWhereIs(AnySharpObject obj) => await obj.Match(
 		async player => await player.Location.WithCancellation(CancellationToken.None),
 		async room => await ValueTask.FromResult<AnySharpContainer>(room),
-		async exit => await exit.Home.WithCancellation(CancellationToken.None),
+		async exit => await exit.Location.WithCancellation(CancellationToken.None),
 		async thing => await thing.Location.WithCancellation(CancellationToken.None)
 	);
 

--- a/SharpMUSH.Library/Services/LockService.cs
+++ b/SharpMUSH.Library/Services/LockService.cs
@@ -113,6 +113,21 @@ public class LockService(IFusionCache cache, IBooleanExpressionParser bep, IMedi
 		return lockee.Object().Locks.GetValueOrDefault(standardType.ToString(), defaultLockData).LockString;
 	}
 
+	/// <summary>
+	/// The lock exactly as stored, or <c>null</c> when the object has none — the distinction
+	/// <see cref="Get"/> erases by defaulting to <c>#TRUE</c>.
+	/// <para>
+	/// An unset lock passes everybody, which is the right default for gates like @lock/enter but the
+	/// wrong one for a permission check: evaluating an absent control lock would hand control of every
+	/// unlocked object to everyone. PennMUSH <c>controls()</c> (<c>predicat.c:416</c>) reads the raw
+	/// boolexp and skips it when it is <c>TRUE_BOOLEXP</c> for exactly this reason.
+	/// </para>
+	/// </summary>
+	public static string? GetIfSet(LockType standardType, AnySharpObject lockee)
+		=> lockee.Object().Locks.TryGetValue(standardType.ToString(), out var lockData)
+			? lockData.LockString
+			: null;
+
 	public bool Evaluate(
 		string lockString,
 		AnySharpObject gated,

--- a/SharpMUSH.Library/Services/PermissionService.cs
+++ b/SharpMUSH.Library/Services/PermissionService.cs
@@ -214,7 +214,13 @@ public class PermissionService(ILockService lockService, IOptionsMonitor<SharpMU
 			}
 		}
 
-		return lockService.Evaluate(LockType.Control, target, who);
+		// PennMUSH controls() (predicat.c:416) reads the control lock raw and skips it when unset, rather
+		// than evaluating it: an unset lock passes everybody, so evaluating it here would grant control of
+		// every object without an explicit control lock to everyone. Only a lock that was actually set,
+		// and that `who` passes, grants control.
+		var controlLock = LockService.GetIfSet(LockType.Control, target);
+
+		return controlLock is not null && lockService.Evaluate(controlLock, target, who);
 	}
 
 	public async ValueTask<bool> CanExamine(AnySharpObject examiner, AnySharpObject examinee)

--- a/SharpMUSH.Library/Services/WarningService.cs
+++ b/SharpMUSH.Library/Services/WarningService.cs
@@ -303,11 +303,12 @@ public class WarningService(
 					var destination = await exit.Home.WithCancellation(CancellationToken.None);
 
 					// An @open'd or @unlink'd exit has no destination edge at all; a linked one may still
-					// point at NOTHING (-1) or an invalid dbref.
-					if (destination.IsNone || destination.WithoutNone().Object().DBRef.Number <= 0)
+					// point at NOTHING. #0 is the master room, a real destination, so only negative
+					// dbrefs are invalid.
+					if (destination.IsNone || destination.WithoutNone().Object().DBRef.Number < 0)
 					{
 						await Complain(checker, target, "exit-unlinked",
-							"Exit is unlinked (destination is NOTHING). This exit can be stolen.");
+							"Exit is unlinked (no destination set). This exit can be stolen.");
 						hasWarnings = true;
 					}
 				}
@@ -391,7 +392,7 @@ public class WarningService(
 					var destObj = destination.Object();
 					var sourceObj = source.Object();
 
-					if (destObj.DBRef.Number > 0 && sourceObj.DBRef.Number > 0)
+					if (destObj.DBRef.Number >= 0 && sourceObj.DBRef.Number >= 0)
 					{
 						var returnExitsQuery = mediator.CreateStream(new GetExitsQuery(destination));
 						var returnExitCount = 0;

--- a/SharpMUSH.Library/Services/WarningService.cs
+++ b/SharpMUSH.Library/Services/WarningService.cs
@@ -300,15 +300,11 @@ public class WarningService(
 				var exit = target.AsExit;
 				try
 				{
-					var destination = await exit.Location.WithCancellation(CancellationToken.None);
-					var destObj = destination.Match(
-						player => player.Object,
-						room => room.Object,
-						thing => thing.Object
-					);
+					var destination = await exit.Home.WithCancellation(CancellationToken.None);
 
-					// Check if destination DBRef is -1 (NOTHING) or 0 (invalid)
-					if (destObj.DBRef.Number <= 0)
+					// An @open'd or @unlink'd exit has no destination edge at all; a linked one may still
+					// point at NOTHING (-1) or an invalid dbref.
+					if (destination.IsNone || destination.WithoutNone().Object().DBRef.Number <= 0)
 					{
 						await Complain(checker, target, "exit-unlinked",
 							"Exit is unlinked (destination is NOTHING). This exit can be stolen.");
@@ -328,8 +324,8 @@ public class WarningService(
 				// DESTINATION or EXITTO attributes to dynamically determine the target
 				try
 				{
-					var exitLocation = await target.AsExit.Location.WithCancellation(CancellationToken.None);
-					if (exitLocation.Object().DBRef.Number == -1)
+					var exitDestination = await target.AsExit.Home.WithCancellation(CancellationToken.None);
+					if (!exitDestination.IsNone && exitDestination.WithoutNone().Object().DBRef.Number == -1)
 					{
 						var destAttr = await attributeService.GetAttributeAsync(checker, target, "DESTINATION", IAttributeService.AttributeMode.Read, false);
 						var exitToAttr = await attributeService.GetAttributeAsync(checker, target, "EXITTO", IAttributeService.AttributeMode.Read, false);
@@ -385,61 +381,50 @@ public class WarningService(
 			var exit = target.AsExit;
 			try
 			{
-				var destination = await exit.Location.WithCancellation(CancellationToken.None);
-				var source = await exit.Home.WithCancellation(CancellationToken.None);
+				var maybeDestination = await exit.Home.WithCancellation(CancellationToken.None);
+				var source = await exit.Location.WithCancellation(CancellationToken.None);
 
-				var destObj = destination.Match(
-					player => player.Object,
-					room => room.Object,
-					thing => thing.Object
-				);
-
-				var sourceObj = source.Match(
-					player => player.Object,
-					room => room.Object,
-					thing => thing.Object
-				);
-
-				// Only check if we have valid source and destination (not NOTHING)
-				if (destObj.DBRef.Number > 0 && sourceObj.DBRef.Number > 0)
+				// An unlinked exit has no topology to analyse: it is neither one-way nor duplicated.
+				if (!maybeDestination.IsNone)
 				{
-					var returnExitsQuery = mediator.CreateStream(new GetExitsQuery(destination));
-					var returnExitCount = 0;
+					var destination = maybeDestination.WithoutNone();
+					var destObj = destination.Object();
+					var sourceObj = source.Object();
 
-					await foreach (var returnExit in returnExitsQuery)
+					if (destObj.DBRef.Number > 0 && sourceObj.DBRef.Number > 0)
 					{
-						try
-						{
-							var returnDest = await returnExit.Location.WithCancellation(CancellationToken.None);
-							var returnDestObj = returnDest.Match(
-								player => player.Object,
-								room => room.Object,
-								thing => thing.Object
-							);
+						var returnExitsQuery = mediator.CreateStream(new GetExitsQuery(destination));
+						var returnExitCount = 0;
 
-							if (returnDestObj.DBRef.Equals(sourceObj.DBRef))
+						await foreach (var returnExit in returnExitsQuery)
+						{
+							try
 							{
-								returnExitCount++;
+								var returnDest = await returnExit.Home.WithCancellation(CancellationToken.None);
+								if (!returnDest.IsNone && returnDest.WithoutNone().Object().DBRef.Equals(sourceObj.DBRef))
+								{
+									returnExitCount++;
+								}
+							}
+							catch
+							{
+								// Ignore exits we can't check
 							}
 						}
-						catch
+
+						if (warnings.HasFlag(WarningType.ExitOneway) && returnExitCount == 0)
 						{
-							// Ignore exits we can't check
+							await Complain(checker, target, "exit-oneway",
+								"Exit has no return path from destination back to source.");
+							hasWarnings = true;
 						}
-					}
 
-					if (warnings.HasFlag(WarningType.ExitOneway) && returnExitCount == 0)
-					{
-						await Complain(checker, target, "exit-oneway",
-							"Exit has no return path from destination back to source.");
-						hasWarnings = true;
-					}
-
-					if (warnings.HasFlag(WarningType.ExitMultiple) && returnExitCount > 1)
-					{
-						await Complain(checker, target, "exit-multiple",
-							$"Exit has {returnExitCount} return paths from destination back to source.");
-						hasWarnings = true;
+						if (warnings.HasFlag(WarningType.ExitMultiple) && returnExitCount > 1)
+						{
+							await Complain(checker, target, "exit-multiple",
+								$"Exit has {returnExitCount} return paths from destination back to source.");
+							hasWarnings = true;
+						}
 					}
 				}
 			}

--- a/SharpMUSH.Tests.Infrastructure/TestHelpers.cs
+++ b/SharpMUSH.Tests.Infrastructure/TestHelpers.cs
@@ -227,4 +227,29 @@ public static class TestHelpers
 				 (c.GetArguments().Length >= 3 &&
 					((c.GetArguments()[2] is AnySharpObject sObj && sObj.Object().DBRef == senderDbRef) ||
 					 (c.GetArguments()[2] is DBRef sd && sd == senderDbRef)))));
+
+	/// <summary>
+	/// Like <see cref="ReceivedNotifyLocalizedWithKey"/>, but also renders the message so the format
+	/// arguments are checked. Asserting the key alone passes even when the command formats it with the
+	/// wrong values — a recipient count, say.
+	/// </summary>
+	public static bool ReceivedNotifyLocalizedRendering(
+		INotifyService notifyService,
+		string key,
+		string expectedText,
+		DBRef? receiverDbRef = null)
+	{
+		var localization = new SharpMUSH.Library.Services.LocalizationService();
+
+		return notifyService.ReceivedCalls()
+			.Where(c =>
+				c.GetMethodInfo().Name == "NotifyLocalized" &&
+				c.GetArguments().Length >= 2 &&
+				c.GetArguments()[1] is string k && k == key &&
+				(receiverDbRef == null ||
+				 (c.GetArguments()[0] is AnySharpObject obj && obj.Object().DBRef == receiverDbRef) ||
+				 (c.GetArguments()[0] is DBRef d && d == receiverDbRef)))
+			.Select(c => c.GetArguments()[^1] as object[] ?? [])
+			.Any(args => localization.Format(key, null, args) == expectedText);
+	}
 }

--- a/SharpMUSH.Tests/Commands/BuildingCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/BuildingCommandTests.cs
@@ -448,21 +448,27 @@ public class BuildingCommandTests
 	}
 
 	[Test]
-	[DependsOn(nameof(RecycleObject))]
-	[Category("NotImplemented")]
-	[Skip("Not Yet Implemented")]
 	public async ValueTask UnlinkExit()
 	{
 		var executor = WebAppFactoryArg.ExecutorDBRef;
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@dig Unlink Room"));
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@open Unlink Exit=#14"));
 
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@unlink Unlink Exit"));
+		var roomName = TestIsolationHelpers.GenerateUniqueName("UnlinkRoom");
+		var digResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {roomName}"));
+		var roomDbRef = digResult.Message!.ToPlainText()!.Trim();
 
-		await NotifyService
-			.Received(1)
-			.Notify(TestHelpers.MatchingObject(executor), Arg.Is<OneOf<MString, string>>(msg =>
-				TestHelpers.MessageContains(msg, "Unlinked")), TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
+		var exitName = TestIsolationHelpers.GenerateUniqueName("UnlinkExit");
+		var openResult = await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"@open {exitName}={roomDbRef}"));
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@unlink {exitName}"));
+
+		DBRef.TryParse(openResult.Message!.ToPlainText()!.Trim(), out var exitRef);
+		var exit = await Mediator.Send(new GetObjectNodeQuery(exitRef!.Value));
+		var destination = await exit.AsExit.Home.WithCancellation(CancellationToken.None);
+
+		await Assert.That(destination.IsNone).IsTrue();
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.UnlinkedExit), executor, executor)).IsTrue();
 	}
 
 	[Test]

--- a/SharpMUSH.Tests/Commands/CommunicationCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/CommunicationCommandTests.cs
@@ -445,10 +445,40 @@ public class CommunicationCommandTests
 	{
 		var executor = WebAppFactoryArg.ExecutorDBRef;
 		var targetName = TestIsolationHelpers.GenerateUniqueName("PemitSilentTarget");
-		await Parser.CommandParse(1, ConnectionService, MModule.single($"@create {targetName}"));
+		var createResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@create {targetName}"));
+		var targetDbRef = DBRef.Parse(createResult.Message!.ToPlainText()!);
 
 		NotifyService.ClearReceivedCalls();
 		await Parser.CommandParse(1, ConnectionService, MModule.single($"@pemit/silent {targetName}=Quietly"));
+
+		// /silent suppresses the sender's echo, not the delivery — without this a no-op would pass.
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(targetDbRef), Arg.Is<OneOf<MString, string>>(msg =>
+					TestHelpers.MessagePlainTextEquals(msg, "Quietly")),
+				TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.YouPemitToObjectFormat), executor, executor)).IsFalse();
+	}
+
+	/// <summary>
+	/// PennMUSH <c>speech.c:599</c> skips the echo when the only recipient was the sender, who has
+	/// already seen the message.
+	/// </summary>
+	[Test]
+	public async ValueTask PemitToYourselfDoesNotEchoBack()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+
+		NotifyService.ClearReceivedCalls();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@pemit #{executor.Number}=Talking to myself"));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor), Arg.Is<OneOf<MString, string>>(msg =>
+					TestHelpers.MessagePlainTextEquals(msg, "Talking to myself")),
+				TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
 
 		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
 			NotifyService, nameof(ErrorMessages.Notifications.YouPemitToObjectFormat), executor, executor)).IsFalse();
@@ -469,8 +499,10 @@ public class CommunicationCommandTests
 		await Parser.CommandParse(1, ConnectionService,
 			MModule.single($"@pemit/list {firstName} {secondName}=Group message"));
 
-		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
-			NotifyService, nameof(ErrorMessages.Notifications.YouPemitToCountFormat), executor, executor)).IsTrue();
+		// The key alone would pass even if the command counted the recipients wrong.
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedRendering(
+			NotifyService, nameof(ErrorMessages.Notifications.YouPemitToCountFormat),
+			"You pemit \"Group message\" to 2 objects.", executor)).IsTrue();
 	}
 
 	/// <summary>

--- a/SharpMUSH.Tests/Commands/CommunicationCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/CommunicationCommandTests.cs
@@ -5,6 +5,7 @@ using OneOf;
 using SharpMUSH.Library;
 using SharpMUSH.Library.Commands.Database;
 using SharpMUSH.Library.Definitions;
+using SharpMUSH.Library.Extensions;
 using SharpMUSH.Library.DiscriminatedUnions;
 using SharpMUSH.Library.Models;
 using SharpMUSH.Library.ParserInterfaces;
@@ -420,5 +421,165 @@ public class CommunicationCommandTests
 		await Parser.CommandParse(1, ConnectionService, MModule.single(command));
 
 		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(NotifyService, nameof(ErrorMessages.Notifications.YouHaveNoChannelAliases), executor, executor)).IsTrue();
+	}
+
+	/// <summary>
+	/// PennMUSH <c>do_pemit</c> (<c>speech.c:595</c>) echoes the message back to the sender unless
+	/// <c>/silent</c> is given and the target is not the sender itself.
+	/// </summary>
+	[Test]
+	public async ValueTask PemitEchoesTheMessageBackToTheSender()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var targetName = TestIsolationHelpers.GenerateUniqueName("PemitEchoTarget");
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@create {targetName}"));
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@pemit {targetName}=Hello there"));
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.YouPemitToObjectFormat), executor, executor)).IsTrue();
+	}
+
+	[Test]
+	public async ValueTask PemitSilentSuppressesTheSenderEcho()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var targetName = TestIsolationHelpers.GenerateUniqueName("PemitSilentTarget");
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@create {targetName}"));
+
+		NotifyService.ClearReceivedCalls();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@pemit/silent {targetName}=Quietly"));
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.YouPemitToObjectFormat), executor, executor)).IsFalse();
+	}
+
+	/// <summary>
+	/// PennMUSH <c>speech.c:596</c>: more than one recipient collapses the echo into a count.
+	/// </summary>
+	[Test]
+	public async ValueTask PemitListEchoesTheRecipientCount()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var firstName = TestIsolationHelpers.GenerateUniqueName("PemitListA");
+		var secondName = TestIsolationHelpers.GenerateUniqueName("PemitListB");
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@create {firstName}"));
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@create {secondName}"));
+
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"@pemit/list {firstName} {secondName}=Group message"));
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.YouPemitToCountFormat), executor, executor)).IsTrue();
+	}
+
+	/// <summary>
+	/// PennMUSH <c>do_one_remit</c> (<c>speech.c:1263</c>): an exit cannot hold anything.
+	/// </summary>
+	[Test]
+	public async ValueTask RemitToAnExitReportsThatNothingCanBeInIt()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var roomName = TestIsolationHelpers.GenerateUniqueName("RemitExitRoom");
+		var digResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {roomName}"));
+		var roomDbRef = digResult.Message!.ToPlainText()!.Trim();
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("RemitExit");
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@open {exitName}={roomDbRef}"));
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@remit {exitName}=Nobody hears this"));
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.ThereCantBeAnythingInThat), executor, executor)).IsTrue();
+	}
+
+	/// <summary>
+	/// PennMUSH <c>speech.c:1273</c>: the sender is told what they remitted, but only when they are not
+	/// standing in the target room themselves.
+	/// </summary>
+	[Test]
+	public async ValueTask RemitEchoesToTheSenderWhenTheyAreElsewhere()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var roomName = TestIsolationHelpers.GenerateUniqueName("RemitEchoRoom");
+		var digResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {roomName}"));
+		var roomDbRef = digResult.Message!.ToPlainText()!.Trim();
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@remit {roomDbRef}=Anyone there?"));
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.YouRemitInFormat), executor, executor)).IsTrue();
+	}
+
+	[Test]
+	public async ValueTask RemitSilentSuppressesTheSenderEcho()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var roomName = TestIsolationHelpers.GenerateUniqueName("RemitSilentRoom");
+		var digResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {roomName}"));
+		var roomDbRef = digResult.Message!.ToPlainText()!.Trim();
+
+		NotifyService.ClearReceivedCalls();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@remit/silent {roomDbRef}=Hush"));
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.YouRemitInFormat), executor, executor)).IsFalse();
+	}
+
+	/// <summary>
+	/// PennMUSH <c>do_lemit</c> (<c>speech.c:1343</c>): echoed only when the sender is not directly in the
+	/// outermost room, i.e. when they are inside a container.
+	/// </summary>
+	[Test]
+	public async ValueTask LemitEchoesToTheSenderFromInsideAContainer()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "LemitEcho");
+
+		var boxName = TestIsolationHelpers.GenerateUniqueName("LemitBox");
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@create {boxName}"));
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@set {boxName}=ENTER_OK"));
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={boxName}"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single("@lemit Anyone outside?"));
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.YouLemitFormat), player.DbRef, player.DbRef)).IsTrue();
+	}
+
+	/// <summary>
+	/// PennMUSH <c>do_zemit</c> (<c>speech.c:1405</c>) requires control of the zone object.
+	/// </summary>
+	[Test]
+	public async ValueTask ZemitRequiresControlOfTheZone()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "ZemitNoControl");
+
+		// God is the one object a mortal provably cannot control, so this isolates the new permission
+		// branch from the Control-lock default that governs ordinary objects.
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}=#0"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single("@zemit #1=Not mine"));
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.PermissionDenied), player.DbRef, player.DbRef)).IsTrue();
+	}
+
+	/// <summary>
+	/// PennMUSH <c>speech.c:1419</c>: the sender is told what they zemitted.
+	/// </summary>
+	[Test]
+	public async ValueTask ZemitEchoesToTheSender()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var zmoName = TestIsolationHelpers.GenerateUniqueName("ZemitEchoZMO");
+		var zmoResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@create {zmoName}"));
+		var zmoDbRef = zmoResult.Message!.ToPlainText()!.Trim();
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@zemit {zmoDbRef}=Zone wide"));
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.YouZemitInZoneFormat), executor, executor)).IsTrue();
 	}
 }

--- a/SharpMUSH.Tests/Commands/GeneralCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/GeneralCommandTests.cs
@@ -816,4 +816,70 @@ public class GeneralCommandTests
 		await Assert.That(destination.IsNone).IsFalse();
 		await Assert.That(destination.WithoutNone().Object().DBRef.ToString()).IsEqualTo(thingDbRef);
 	}
+
+	/// <summary>
+	/// PennMUSH <c>do_open</c> hands the destination to <c>parse_linkable_room</c>, which refuses it
+	/// unless <c>can_link_to</c> passes (<c>create.c:61</c>, <c>mushdb.h:87</c>). Widening <c>@open</c> to
+	/// accept any container must not also let a player link an exit into somewhere they do not control.
+	/// </summary>
+	[Test]
+	public async ValueTask OpenCannotLinkAnExitToAContainerTheExecutorDoesNotControl()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "OpenNoLinkPerm");
+
+		var roomName = TestIsolationHelpers.GenerateUniqueName("OpenNoLinkPermRoom");
+		var digResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {roomName}"));
+		var roomDbRef = digResult.Message!.ToPlainText()!.Trim();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={roomDbRef}"));
+
+		// God's thing, not LINK_OK, brought within reach so the locate succeeds and only permission decides.
+		var thingName = TestIsolationHelpers.GenerateUniqueName("OpenNoLinkPermThing");
+		var thingResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@create {thingName}"));
+		var thingDbRef = thingResult.Message!.ToPlainText()!.Trim();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {thingDbRef}={roomDbRef}"));
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("OpenNoLinkPermExit");
+		var exitResult = await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"@open {exitName}={thingDbRef}"));
+
+		DBRef.TryParse(exitResult.Message!.ToPlainText()!.Trim(), out var exitRef);
+		var exit = await Mediator.Send(new GetObjectNodeQuery(exitRef!.Value));
+		var destination = await exit.AsExit.Home.WithCancellation(CancellationToken.None);
+
+		await Assert.That(destination.IsNone).IsTrue()
+			.Because("the exit must be left unlinked when the executor cannot link to the destination");
+	}
+
+	/// <summary>
+	/// The complement: LINK_OK on the destination is what lets someone else link into it.
+	/// </summary>
+	[Test]
+	public async ValueTask OpenCanLinkAnExitToALinkOkContainerTheExecutorDoesNotControl()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "OpenLinkOk");
+
+		var roomName = TestIsolationHelpers.GenerateUniqueName("OpenLinkOkRoom");
+		var digResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {roomName}"));
+		var roomDbRef = digResult.Message!.ToPlainText()!.Trim();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={roomDbRef}"));
+
+		var thingName = TestIsolationHelpers.GenerateUniqueName("OpenLinkOkThing");
+		var thingResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@create {thingName}"));
+		var thingDbRef = thingResult.Message!.ToPlainText()!.Trim();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {thingDbRef}={roomDbRef}"));
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@set {thingDbRef}=LINK_OK"));
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("OpenLinkOkExit");
+		var exitResult = await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"@open {exitName}={thingDbRef}"));
+
+		DBRef.TryParse(exitResult.Message!.ToPlainText()!.Trim(), out var exitRef);
+		var exit = await Mediator.Send(new GetObjectNodeQuery(exitRef!.Value));
+		var destination = await exit.AsExit.Home.WithCancellation(CancellationToken.None);
+
+		await Assert.That(destination.IsNone).IsFalse();
+		await Assert.That(destination.WithoutNone().Object().DBRef.ToString()).IsEqualTo(thingDbRef);
+	}
 }

--- a/SharpMUSH.Tests/Commands/GeneralCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/GeneralCommandTests.cs
@@ -4,6 +4,7 @@ using NSubstitute;
 using OneOf;
 using SharpMUSH.Library.Definitions;
 using SharpMUSH.Library.DiscriminatedUnions;
+using SharpMUSH.Library.Extensions;
 using SharpMUSH.Library.Models;
 using SharpMUSH.Library.ParserInterfaces;
 using SharpMUSH.Library.Queries.Database;
@@ -676,5 +677,136 @@ public class GeneralCommandTests
 			.Received(1)
 			.Notify(TestHelpers.MatchingObject(executor), Arg.Is<OneOf<MString, string>>(msg =>
 				TestHelpers.MessagePlainTextEquals(msg, "Fruit: orange")), TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
+	}
+
+	/// <summary>
+	/// PennMUSH <c>do_look_at</c> (<c>look.c:611</c>): <c>look/outside</c> from a room — or any opaque
+	/// location — has nothing to see out of.
+	/// </summary>
+	[Test]
+	public async ValueTask LookOutsideFromARoomReportsYouCantSeeThroughThat()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "LookOutsideRoom");
+
+		var roomName = TestIsolationHelpers.GenerateUniqueName("LookOutsideRoomDest");
+		var digResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {roomName}"));
+		var roomDbRef = digResult.Message!.ToPlainText()!.Trim();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={roomDbRef}"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single("look/outside"));
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.CantSeeThroughThat), player.DbRef, player.DbRef)).IsTrue();
+	}
+
+	/// <summary>
+	/// PennMUSH <c>look.c:618</c>: from inside a container you see that container's own location, not the
+	/// container itself.
+	/// </summary>
+	[Test]
+	public async ValueTask LookOutsideFromInsideAContainerShowsTheContainersRoom()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "LookOutsideBox");
+
+		var roomName = TestIsolationHelpers.GenerateUniqueName("LookOutsideOuter");
+		var digResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {roomName}"));
+		var roomDbRef = digResult.Message!.ToPlainText()!.Trim();
+
+		var boxName = TestIsolationHelpers.GenerateUniqueName("LookOutsideContainer");
+		var createResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@create {boxName}"));
+		var boxDbRef = createResult.Message!.ToPlainText()!.Trim();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@set {boxName}=ENTER_OK"));
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {boxDbRef}={roomDbRef}"));
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={boxDbRef}"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single("look/outside"));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(player.DbRef), Arg.Is<OneOf<MString, string>>(msg =>
+					TestHelpers.MessagePlainTextContains(msg, roomName)),
+				TestHelpers.MatchingObject(player.DbRef), INotifyService.NotificationType.Announce);
+	}
+
+	/// <summary>
+	/// PennMUSH <c>cmd_think</c> (<c>cmds.c:1769</c>) is an unconditional notify, so a bare
+	/// <c>think</c> still emits an (empty) line.
+	/// </summary>
+	[Test]
+	public async ValueTask ThinkWithNoArgumentStillNotifiesTheExecutor()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "ThinkEmpty");
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single("think"));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(player.DbRef), Arg.Is<OneOf<MString, string>>(msg =>
+					TestHelpers.MessagePlainTextEquals(msg, string.Empty)),
+				TestHelpers.MatchingObject(player.DbRef), INotifyService.NotificationType.Announce);
+	}
+
+	/// <summary>
+	/// PennMUSH <c>do_open</c> hands the destination to <c>do_link</c>, which reports a destination it
+	/// cannot link to instead of quietly leaving the exit unlinked. An exit is the one thing you cannot
+	/// end up inside.
+	/// </summary>
+	[Test]
+	public async ValueTask OpenWithAnUnlinkableDestinationReportsTheFailure()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "OpenBadDest");
+
+		var roomName = TestIsolationHelpers.GenerateUniqueName("OpenBadDestRoom");
+		var digResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {roomName}"));
+		var roomDbRef = digResult.Message!.ToPlainText()!.Trim();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={roomDbRef}"));
+
+		var decoyName = TestIsolationHelpers.GenerateUniqueName("OpenBadDestDecoy");
+		var decoyResult = await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"@open {decoyName}={roomDbRef}"));
+		var decoyDbRef = decoyResult.Message!.ToPlainText()!.Trim();
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("OpenBadDestExit");
+		await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"@open {exitName}={decoyDbRef}"));
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.CantLinkToThat), player.DbRef, player.DbRef)).IsTrue();
+	}
+
+	/// <summary>
+	/// An exit may lead to any container, not just a room — PennMUSH <c>can_link_to</c> accepts things
+	/// and players too, which is how "enter the wardrobe" exits are built.
+	/// </summary>
+	[Test]
+	public async ValueTask OpenCanLinkAnExitToAThing()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "OpenThingDest");
+
+		var roomName = TestIsolationHelpers.GenerateUniqueName("OpenThingDestRoom");
+		var digResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {roomName}"));
+		var roomDbRef = digResult.Message!.ToPlainText()!.Trim();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={roomDbRef}"));
+
+		var thingName = TestIsolationHelpers.GenerateUniqueName("OpenThingDestThing");
+		var thingResult = await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"@create {thingName}"));
+		var thingDbRef = thingResult.Message!.ToPlainText()!.Trim();
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("OpenThingDestExit");
+		var exitResult = await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"@open {exitName}={thingDbRef}"));
+
+		DBRef.TryParse(exitResult.Message!.ToPlainText()!.Trim(), out var exitRef);
+		var exit = await Mediator.Send(new GetObjectNodeQuery(exitRef!.Value));
+		var destination = await exit.AsExit.Home.WithCancellation(CancellationToken.None);
+
+		await Assert.That(destination.IsNone).IsFalse();
+		await Assert.That(destination.WithoutNone().Object().DBRef.ToString()).IsEqualTo(thingDbRef);
 	}
 }

--- a/SharpMUSH.Tests/Commands/GeneralCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/GeneralCommandTests.cs
@@ -761,7 +761,7 @@ public class GeneralCommandTests
 			WebAppFactoryArg.Services, Mediator, ConnectionService, "OpenBadDest");
 
 		var roomName = TestIsolationHelpers.GenerateUniqueName("OpenBadDestRoom");
-		var digResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {roomName}"));
+		var digResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {roomName}"));
 		var roomDbRef = digResult.Message!.ToPlainText()!.Trim();
 		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={roomDbRef}"));
 
@@ -789,7 +789,7 @@ public class GeneralCommandTests
 			WebAppFactoryArg.Services, Mediator, ConnectionService, "OpenThingDest");
 
 		var roomName = TestIsolationHelpers.GenerateUniqueName("OpenThingDestRoom");
-		var digResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {roomName}"));
+		var digResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {roomName}"));
 		var roomDbRef = digResult.Message!.ToPlainText()!.Trim();
 		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={roomDbRef}"));
 

--- a/SharpMUSH.Tests/Commands/GeneralCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/GeneralCommandTests.cs
@@ -740,13 +740,20 @@ public class GeneralCommandTests
 		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
 			WebAppFactoryArg.Services, Mediator, ConnectionService, "ThinkEmpty");
 
-		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single("think"));
+		var result = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single("think"));
 
 		await NotifyService
 			.Received(1)
 			.Notify(TestHelpers.MatchingObject(player.DbRef), Arg.Is<OneOf<MString, string>>(msg =>
 					TestHelpers.MessagePlainTextEquals(msg, string.Empty)),
 				TestHelpers.MatchingObject(player.DbRef), INotifyService.NotificationType.Announce);
+
+		// The notify happens before the return, so asserting on it alone would not have caught the
+		// command indexing a "0" argument that a bare `think` does not have. The resulting
+		// KeyNotFoundException is swallowed upstream and surfaces only as a null Message.
+		await Assert.That(result).IsNotNull();
+		await Assert.That(result.Message).IsNotNull();
+		await Assert.That(result.Message!.ToPlainText()).IsEqualTo(string.Empty);
 	}
 
 	/// <summary>

--- a/SharpMUSH.Tests/Commands/MovementCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/MovementCommandTests.cs
@@ -1,8 +1,12 @@
 using Mediator;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
+using OneOf;
+using SharpMUSH.Library.Definitions;
 using SharpMUSH.Library.DiscriminatedUnions;
+using SharpMUSH.Library.Extensions;
 using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Queries.Database;
 using SharpMUSH.Library.Services.Interfaces;
 
 namespace SharpMUSH.Tests.Commands;
@@ -25,17 +29,128 @@ public class MovementCommandTests
 		TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
 			WebAppFactoryArg.Services, Mediator, ConnectionService, namePrefix);
 
+	/// <summary>
+	/// PennMUSH <c>do_move</c> (<c>move.c:435</c>): when nothing matches as an exit the answer is
+	/// "You can't go that way.", not a generic "I don't see that here."
+	/// </summary>
 	[Test]
-	[Category("NotImplemented")]
-	[Skip("Not Yet Implemented")]
-	public async ValueTask GotoCommand()
+	public async ValueTask GotoSomethingThatIsNotAnExitReportsCantGoThatWay()
 	{
-		var executor = WebAppFactoryArg.ExecutorDBRef;
-		await Parser.CommandParse(1, ConnectionService, MModule.single("goto #0"));
+		var player = await CreateTestPlayerAsync("GotoNonExit");
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single("goto #0"));
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.CantGoThatWay), player.DbRef, player.DbRef)).IsTrue();
+	}
+
+	/// <summary>
+	/// PennMUSH <c>move.c:449</c> → <c>predicat.c:75</c>: <c>could_doit</c> fails when an exit has no
+	/// destination, so <c>do_move</c> falls through to
+	/// <c>fail_lock(..., "You can't go that way.")</c>.
+	/// </summary>
+	[Test]
+	public async ValueTask WalkingAnExitWithNoDestinationReportsCantGoThatWay()
+	{
+		var player = await CreateTestPlayerAsync("NoDestWalker");
+
+		var roomName = TestIsolationHelpers.GenerateUniqueName("NoDestRoom");
+		var digResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {roomName}"));
+		var roomDbRef = digResult.Message!.ToPlainText()!.Trim();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={roomDbRef}"));
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("NoDestExit");
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@open {exitName}"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single(exitName));
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.CantGoThatWay), player.DbRef, player.DbRef)).IsTrue();
+	}
+
+	/// <summary>
+	/// PennMUSH routes the failure through <c>fail_lock</c>, so the exit's own <c>@fail</c> replaces the
+	/// default message rather than being ignored.
+	/// </summary>
+	[Test]
+	public async ValueTask WalkingAnExitWithNoDestinationUsesTheExitsFailureAttribute()
+	{
+		var player = await CreateTestPlayerAsync("NoDestFailAttr");
+
+		var roomName = TestIsolationHelpers.GenerateUniqueName("FailAttrRoom");
+		var digResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {roomName}"));
+		var roomDbRef = digResult.Message!.ToPlainText()!.Trim();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={roomDbRef}"));
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("FailAttrExit");
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@open {exitName}"));
+		await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"&FAILURE {exitName}=The door is bricked up."));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single(exitName));
 
 		await NotifyService
 			.Received(1)
-			.Notify(TestHelpers.MatchingObject(executor), "You can't go that way.", TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
+			.Notify(TestHelpers.MatchingObject(player.DbRef), Arg.Is<OneOf<MString, string>>(msg =>
+					TestHelpers.MessagePlainTextContains(msg, "The door is bricked up.")),
+				TestHelpers.MatchingObject(player.DbRef), INotifyService.NotificationType.Announce);
+	}
+
+	/// <summary>
+	/// <c>@unlink</c> removes the destination edge entirely. Walking the exit afterwards must report the
+	/// same PennMUSH failure rather than throwing out of the database layer.
+	/// </summary>
+	[Test]
+	public async ValueTask WalkingAnUnlinkedExitReportsCantGoThatWay()
+	{
+		var player = await CreateTestPlayerAsync("UnlinkWalker");
+
+		var sourceName = TestIsolationHelpers.GenerateUniqueName("UnlinkSource");
+		var sourceResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {sourceName}"));
+		var sourceDbRef = sourceResult.Message!.ToPlainText()!.Trim();
+
+		var destName = TestIsolationHelpers.GenerateUniqueName("UnlinkDest");
+		var destResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {destName}"));
+		var destDbRef = destResult.Message!.ToPlainText()!.Trim();
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={sourceDbRef}"));
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("UnlinkExitWalk");
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@open {exitName}={destDbRef}"));
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@unlink {exitName}"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single(exitName));
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.CantGoThatWay), player.DbRef, player.DbRef)).IsTrue();
+	}
+
+	/// <summary>
+	/// A linked exit still has to work: this pins the destination edge the other three tests depend on.
+	/// </summary>
+	[Test]
+	public async ValueTask WalkingALinkedExitMovesThePlayerToTheDestination()
+	{
+		var player = await CreateTestPlayerAsync("LinkedWalker");
+
+		var sourceName = TestIsolationHelpers.GenerateUniqueName("LinkedSource");
+		var sourceResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {sourceName}"));
+		var sourceDbRef = sourceResult.Message!.ToPlainText()!.Trim();
+
+		var destName = TestIsolationHelpers.GenerateUniqueName("LinkedDest");
+		var destResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {destName}"));
+		var destDbRef = destResult.Message!.ToPlainText()!.Trim();
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={sourceDbRef}"));
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("LinkedExitWalk");
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@open {exitName}={destDbRef}"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single(exitName));
+
+		var location = await Mediator.Send(new GetLocationQuery(player.DbRef));
+
+		await Assert.That(location.WithExitOption().Known().Object().DBRef.ToString()).IsEqualTo(destDbRef);
 	}
 
 	[Test]

--- a/SharpMUSH.Tests/Commands/MovementCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/MovementCommandTests.cs
@@ -55,7 +55,7 @@ public class MovementCommandTests
 		var player = await CreateTestPlayerAsync("NoDestWalker");
 
 		var roomName = TestIsolationHelpers.GenerateUniqueName("NoDestRoom");
-		var digResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {roomName}"));
+		var digResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {roomName}"));
 		var roomDbRef = digResult.Message!.ToPlainText()!.Trim();
 		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={roomDbRef}"));
 
@@ -78,7 +78,7 @@ public class MovementCommandTests
 		var player = await CreateTestPlayerAsync("NoDestFailAttr");
 
 		var roomName = TestIsolationHelpers.GenerateUniqueName("FailAttrRoom");
-		var digResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {roomName}"));
+		var digResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {roomName}"));
 		var roomDbRef = digResult.Message!.ToPlainText()!.Trim();
 		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={roomDbRef}"));
 
@@ -106,11 +106,11 @@ public class MovementCommandTests
 		var player = await CreateTestPlayerAsync("UnlinkWalker");
 
 		var sourceName = TestIsolationHelpers.GenerateUniqueName("UnlinkSource");
-		var sourceResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {sourceName}"));
+		var sourceResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {sourceName}"));
 		var sourceDbRef = sourceResult.Message!.ToPlainText()!.Trim();
 
 		var destName = TestIsolationHelpers.GenerateUniqueName("UnlinkDest");
-		var destResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {destName}"));
+		var destResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {destName}"));
 		var destDbRef = destResult.Message!.ToPlainText()!.Trim();
 
 		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={sourceDbRef}"));
@@ -134,11 +134,11 @@ public class MovementCommandTests
 		var player = await CreateTestPlayerAsync("LinkedWalker");
 
 		var sourceName = TestIsolationHelpers.GenerateUniqueName("LinkedSource");
-		var sourceResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {sourceName}"));
+		var sourceResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {sourceName}"));
 		var sourceDbRef = sourceResult.Message!.ToPlainText()!.Trim();
 
 		var destName = TestIsolationHelpers.GenerateUniqueName("LinkedDest");
-		var destResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@dig {destName}"));
+		var destResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {destName}"));
 		var destDbRef = destResult.Message!.ToPlainText()!.Trim();
 
 		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={sourceDbRef}"));

--- a/SharpMUSH.Tests/Commands/MovementCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/MovementCommandTests.cs
@@ -315,4 +315,251 @@ public class MovementCommandTests
 
 		await Assert.That(result).IsNotNull();
 	}
+
+	/// <summary>
+	/// PennMUSH variable exits: <c>@link &lt;exit&gt;=variable</c> leaves the destination unresolved, and
+	/// <c>find_var_dest</c> (<c>move.c:360</c>) reads it from the exit's <c>DESTINATION</c> attribute at
+	/// move time.
+	/// </summary>
+	[Test]
+	public async ValueTask VariableExitMovesToTheDestinationAttribute()
+	{
+		var player = await CreateTestPlayerAsync("VarDestPlain");
+
+		var sourceName = TestIsolationHelpers.GenerateUniqueName("VarDestSource");
+		var sourceResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {sourceName}"));
+		var sourceDbRef = sourceResult.Message!.ToPlainText()!.Trim();
+
+		var destName = TestIsolationHelpers.GenerateUniqueName("VarDestTarget");
+		var destResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {destName}"));
+		var destDbRef = destResult.Message!.ToPlainText()!.Trim();
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={sourceDbRef}"));
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("VarDestExit");
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@open {exitName}"));
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@link {exitName}=variable"));
+		await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"&DESTINATION {exitName}={destDbRef}"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single(exitName));
+
+		var location = await Mediator.Send(new GetLocationQuery(player.DbRef));
+
+		await Assert.That(location.WithExitOption().Known().Object().DBRef.ToString()).IsEqualTo(destDbRef);
+	}
+
+	/// <summary>
+	/// PennMUSH <c>find_var_dest</c> uses <c>call_attrib</c>, so <c>DESTINATION</c> is softcode that is
+	/// evaluated — that is the whole point of a variable exit.
+	/// </summary>
+	[Test]
+	public async ValueTask VariableExitEvaluatesTheDestinationAttribute()
+	{
+		var player = await CreateTestPlayerAsync("VarDestEval");
+
+		var sourceName = TestIsolationHelpers.GenerateUniqueName("VarEvalSource");
+		var sourceResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {sourceName}"));
+		var sourceDbRef = sourceResult.Message!.ToPlainText()!.Trim();
+
+		var destName = TestIsolationHelpers.GenerateUniqueName("VarEvalTarget");
+		var destResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {destName}"));
+		var destDbRef = destResult.Message!.ToPlainText()!.Trim();
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={sourceDbRef}"));
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("VarEvalExit");
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@open {exitName}"));
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@link {exitName}=variable"));
+		await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"&DESTINATION {exitName}=[first({destDbRef} {sourceDbRef})]"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single(exitName));
+
+		var location = await Mediator.Send(new GetLocationQuery(player.DbRef));
+
+		await Assert.That(location.WithExitOption().Known().Object().DBRef.ToString()).IsEqualTo(destDbRef);
+	}
+
+	/// <summary>
+	/// PennMUSH <c>move.c:377</c> falls back to <c>EXITTO</c> when <c>DESTINATION</c> is absent, "for
+	/// portability".
+	/// </summary>
+	[Test]
+	public async ValueTask VariableExitFallsBackToTheExitToAttribute()
+	{
+		var player = await CreateTestPlayerAsync("VarDestExitTo");
+
+		var sourceName = TestIsolationHelpers.GenerateUniqueName("VarExitToSource");
+		var sourceResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {sourceName}"));
+		var sourceDbRef = sourceResult.Message!.ToPlainText()!.Trim();
+
+		var destName = TestIsolationHelpers.GenerateUniqueName("VarExitToTarget");
+		var destResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {destName}"));
+		var destDbRef = destResult.Message!.ToPlainText()!.Trim();
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={sourceDbRef}"));
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("VarExitToExit");
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@open {exitName}"));
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@link {exitName}=variable"));
+		await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"&EXITTO {exitName}={destDbRef}"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single(exitName));
+
+		var location = await Mediator.Send(new GetLocationQuery(player.DbRef));
+
+		await Assert.That(location.WithExitOption().Known().Object().DBRef.ToString()).IsEqualTo(destDbRef);
+	}
+
+	/// <summary>
+	/// PennMUSH <c>move.c:369</c> passes the exit name or alias the player actually typed as <c>%0</c>,
+	/// so one exit can route differently per alias.
+	/// </summary>
+	[Test]
+	public async ValueTask VariableExitPassesTheUsedExitNameAsPercentZero()
+	{
+		var player = await CreateTestPlayerAsync("VarDestArg");
+
+		var sourceName = TestIsolationHelpers.GenerateUniqueName("VarArgSource");
+		var sourceResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {sourceName}"));
+		var sourceDbRef = sourceResult.Message!.ToPlainText()!.Trim();
+
+		var northName = TestIsolationHelpers.GenerateUniqueName("VarArgNorth");
+		var northResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {northName}"));
+		var northDbRef = northResult.Message!.ToPlainText()!.Trim();
+
+		var southName = TestIsolationHelpers.GenerateUniqueName("VarArgSouth");
+		var southResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {southName}"));
+		var southDbRef = southResult.Message!.ToPlainText()!.Trim();
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={sourceDbRef}"));
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("VarArgExit");
+		await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"@open {exitName};{exitName}North;{exitName}South"));
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@link {exitName}=variable"));
+		await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"&DESTINATION {exitName}=[switch(%0,*South,{southDbRef},{northDbRef})]"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"{exitName}South"));
+
+		var location = await Mediator.Send(new GetLocationQuery(player.DbRef));
+
+		await Assert.That(location.WithExitOption().Known().Object().DBRef.ToString()).IsEqualTo(southDbRef);
+	}
+
+	/// <summary>
+	/// PennMUSH <c>do_move</c> (<c>move.c:451</c>): an exit linked to HOME sends the mover to their own
+	/// home, not to a fixed room.
+	/// </summary>
+	[Test]
+	public async ValueTask HomeLinkedExitSendsTheMoverToTheirOwnHome()
+	{
+		var player = await CreateTestPlayerAsync("HomeLinkWalker");
+
+		var homeName = TestIsolationHelpers.GenerateUniqueName("HomeLinkHome");
+		var homeResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {homeName}"));
+		var homeDbRef = homeResult.Message!.ToPlainText()!.Trim();
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@link me={homeDbRef}"));
+
+		var sourceName = TestIsolationHelpers.GenerateUniqueName("HomeLinkSource");
+		var sourceResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {sourceName}"));
+		var sourceDbRef = sourceResult.Message!.ToPlainText()!.Trim();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={sourceDbRef}"));
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("HomeLinkExit");
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@open {exitName}"));
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@link {exitName}=home"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single(exitName));
+
+		var location = await Mediator.Send(new GetLocationQuery(player.DbRef));
+
+		await Assert.That(location.WithExitOption().Known().Object().DBRef.ToString()).IsEqualTo(homeDbRef);
+	}
+
+	/// <summary>
+	/// PennMUSH <c>move.c:459</c> names the offending dbref rather than giving the generic exit failure.
+	/// </summary>
+	[Test]
+	public async ValueTask VariableExitWithNoDestinationAttributeReportsAnInvalidDestination()
+	{
+		var player = await CreateTestPlayerAsync("VarDestMissing");
+
+		var sourceName = TestIsolationHelpers.GenerateUniqueName("VarMissingSource");
+		var sourceResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {sourceName}"));
+		var sourceDbRef = sourceResult.Message!.ToPlainText()!.Trim();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={sourceDbRef}"));
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("VarMissingExit");
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@open {exitName}"));
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@link {exitName}=variable"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single(exitName));
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.VariableExitDestinationInvalidFormat),
+			player.DbRef, player.DbRef)).IsTrue();
+	}
+
+	/// <summary>
+	/// SharpMUSH lets <c>@teleport</c> target an exit, meaning "go where it leads". That has to agree with
+	/// what walking the exit does, so a variable exit must resolve its DESTINATION here too.
+	/// </summary>
+	[Test]
+	public async ValueTask TeleportToAVariableExitUsesTheDestinationAttribute()
+	{
+		var player = await CreateTestPlayerAsync("TelVarDest");
+
+		var sourceName = TestIsolationHelpers.GenerateUniqueName("TelVarSource");
+		var sourceResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {sourceName}"));
+		var sourceDbRef = sourceResult.Message!.ToPlainText()!.Trim();
+
+		var destName = TestIsolationHelpers.GenerateUniqueName("TelVarTarget");
+		var destResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {destName}"));
+		var destDbRef = destResult.Message!.ToPlainText()!.Trim();
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={sourceDbRef}"));
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("TelVarExit");
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@open {exitName}"));
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@link {exitName}=variable"));
+		await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"&DESTINATION {exitName}={destDbRef}"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@tel {exitName}"));
+
+		var location = await Mediator.Send(new GetLocationQuery(player.DbRef));
+
+		await Assert.That(location.WithExitOption().Known().Object().DBRef.ToString()).IsEqualTo(destDbRef);
+	}
+
+	/// <summary>
+	/// A home-linked exit resolves against whoever is moving, not against whoever typed the command — so
+	/// teleporting someone else through one must send them to <em>their</em> home.
+	/// </summary>
+	[Test]
+	public async ValueTask TeleportToAHomeLinkedExitSendsTheTargetToTheirOwnHome()
+	{
+		var player = await CreateTestPlayerAsync("TelHomeTarget");
+
+		var homeName = TestIsolationHelpers.GenerateUniqueName("TelHomeTargetHome");
+		var homeResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {homeName}"));
+		var homeDbRef = homeResult.Message!.ToPlainText()!.Trim();
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@link me={homeDbRef}"));
+
+		// Opened where God stands, so God can see it to teleport the player through it.
+		var exitName = TestIsolationHelpers.GenerateUniqueName("TelHomeExit");
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@open {exitName}"));
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@link {exitName}=home"));
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={exitName}"));
+
+		var location = await Mediator.Send(new GetLocationQuery(player.DbRef));
+
+		await Assert.That(location.WithExitOption().Known().Object().DBRef.ToString()).IsEqualTo(homeDbRef)
+			.Because("the exit is linked to home, and the mover is the player, not the executor");
+	}
 }

--- a/SharpMUSH.Tests/Functions/DbrefFunctionUnitTests.cs
+++ b/SharpMUSH.Tests/Functions/DbrefFunctionUnitTests.cs
@@ -1,4 +1,6 @@
+using Microsoft.Extensions.DependencyInjection;
 using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Services.Interfaces;
 
 namespace SharpMUSH.Tests.Functions;
 
@@ -8,6 +10,10 @@ public class DbrefFunctionUnitTests
 	public required ServerWebAppFactory WebAppFactoryArg { get; init; }
 
 	private IMUSHCodeParser Parser => WebAppFactoryArg.FunctionParser;
+	private IMUSHCodeParser CommandParser => WebAppFactoryArg.CommandParser;
+
+	private IConnectionService ConnectionService =>
+		WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
 
 	[Test]
 	public async Task Loc()
@@ -417,5 +423,46 @@ public class DbrefFunctionUnitTests
 
 		var objIdFromFunc = (await Parser.FunctionParse(MModule.single("objid(%#)")))?.Message!;
 		await Assert.That(objId).IsEqualTo(objIdFromFunc.ToPlainText());
+	}
+
+	/// <summary>
+	/// PennMUSH <c>fun_loc</c> (<c>fundb.c:1459</c>) returns <c>Location(it)</c>, and an exit's location
+	/// is its destination — not the room it sits in, which is what <c>where()</c> reports.
+	/// </summary>
+	[Test]
+	public async Task LocOfAnExitIsItsDestination()
+	{
+		var destName = TestIsolationHelpers.GenerateUniqueName("LocExitDest");
+		var digResult = await CommandParser.CommandParse(1, ConnectionService, MModule.single($"@dig {destName}"));
+		var destDbRef = digResult.Message!.ToPlainText()!.Trim();
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("LocExit");
+		var openResult = await CommandParser.CommandParse(1, ConnectionService,
+			MModule.single($"@open {exitName}={destDbRef}"));
+		var exitDbRef = openResult.Message!.ToPlainText()!.Trim();
+
+		var result = (await Parser.FunctionParse(MModule.single($"loc({exitDbRef})")))?.Message!;
+
+		await Assert.That(result.ToPlainText()).IsEqualTo(destDbRef);
+	}
+
+	/// <summary>
+	/// The complement: <c>where()</c> reports the room an exit sits in (PennMUSH <c>Source()</c>).
+	/// </summary>
+	[Test]
+	public async Task WhereOfAnExitIsTheRoomItSitsIn()
+	{
+		var destName = TestIsolationHelpers.GenerateUniqueName("WhereExitDest");
+		var digResult = await CommandParser.CommandParse(1, ConnectionService, MModule.single($"@dig {destName}"));
+		var destDbRef = digResult.Message!.ToPlainText()!.Trim();
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("WhereExit");
+		var openResult = await CommandParser.CommandParse(1, ConnectionService,
+			MModule.single($"@open {exitName}={destDbRef}"));
+		var exitDbRef = openResult.Message!.ToPlainText()!.Trim();
+
+		var result = (await Parser.FunctionParse(MModule.single($"where({exitDbRef})")))?.Message!;
+
+		await Assert.That(result.ToPlainText()).IsNotEqualTo(destDbRef);
 	}
 }

--- a/SharpMUSH.Tests/Services/PermissionServiceControlTests.cs
+++ b/SharpMUSH.Tests/Services/PermissionServiceControlTests.cs
@@ -1,0 +1,104 @@
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using SharpMUSH.Library.Extensions;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Queries.Database;
+using SharpMUSH.Library.Services.Interfaces;
+
+namespace SharpMUSH.Tests.Services;
+
+/// <summary>
+/// PennMUSH <c>controls()</c> (<c>predicat.c:416</c>) reads the control lock raw and skips it when it is
+/// <c>TRUE_BOOLEXP</c>, so an object with no control lock set is controlled by nobody but its owner.
+/// Evaluating the lock instead would inherit the "unset locks pass" convention and hand control of every
+/// unlocked object to everyone.
+/// </summary>
+public class PermissionServiceControlTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactoryArg { get; init; }
+
+	private IPermissionService PermissionService =>
+		WebAppFactoryArg.Services.GetRequiredService<IPermissionService>();
+
+	private IConnectionService ConnectionService =>
+		WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
+
+	private IMUSHCodeParser Parser => WebAppFactoryArg.CommandParser;
+	private IMediator Mediator => WebAppFactoryArg.Services.GetRequiredService<IMediator>();
+
+	private async Task<SharpMUSH.Library.DiscriminatedUnions.AnySharpObject> ObjectAt(string dbrefText)
+	{
+		SharpMUSH.Library.Models.DBRef.TryParse(dbrefText, out var dbref);
+		return (await Mediator.Send(new GetObjectNodeQuery(dbref!.Value))).WithoutNone();
+	}
+
+	[Test]
+	public async ValueTask AMortalDoesNotControlAnotherPlayersObjectWithNoControlLock()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "CtrlNoLock");
+
+		var thingName = TestIsolationHelpers.GenerateUniqueName("CtrlNoLockThing");
+		var createResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@create {thingName}"));
+
+		var thing = await ObjectAt(createResult.Message!.ToPlainText()!.Trim());
+		var mortal = (await Mediator.Send(new GetObjectNodeQuery(player.DbRef))).WithoutNone();
+
+		await Assert.That(await PermissionService.Controls(mortal, thing)).IsFalse();
+	}
+
+	[Test]
+	public async ValueTask AMortalControlsAnotherPlayersObjectWhenTheControlLockPasses()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "CtrlPassLock");
+
+		var thingName = TestIsolationHelpers.GenerateUniqueName("CtrlPassLockThing");
+		var createResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@create {thingName}"));
+		var thingDbRef = createResult.Message!.ToPlainText()!.Trim();
+
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"@lock/control {thingDbRef}=#{player.DbRef.Number}"));
+
+		var thing = await ObjectAt(thingDbRef);
+		var mortal = (await Mediator.Send(new GetObjectNodeQuery(player.DbRef))).WithoutNone();
+
+		await Assert.That(await PermissionService.Controls(mortal, thing)).IsTrue();
+	}
+
+	[Test]
+	public async ValueTask AMortalDoesNotControlAnotherPlayersObjectWhenTheControlLockFails()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "CtrlFailLock");
+
+		var thingName = TestIsolationHelpers.GenerateUniqueName("CtrlFailLockThing");
+		var createResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@create {thingName}"));
+		var thingDbRef = createResult.Message!.ToPlainText()!.Trim();
+
+		// Locked to God, who is not our mortal.
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@lock/control {thingDbRef}=#1"));
+
+		var thing = await ObjectAt(thingDbRef);
+		var mortal = (await Mediator.Send(new GetObjectNodeQuery(player.DbRef))).WithoutNone();
+
+		await Assert.That(await PermissionService.Controls(mortal, thing)).IsFalse();
+	}
+
+	[Test]
+	public async ValueTask AnOwnerStillControlsTheirOwnObjectWithNoControlLock()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "CtrlOwner");
+
+		var thingName = TestIsolationHelpers.GenerateUniqueName("CtrlOwnerThing");
+		var createResult = await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"@create {thingName}"));
+
+		var thing = await ObjectAt(createResult.Message!.ToPlainText()!.Trim());
+		var owner = (await Mediator.Send(new GetObjectNodeQuery(player.DbRef))).WithoutNone();
+
+		await Assert.That(await PermissionService.Controls(owner, thing)).IsTrue();
+	}
+}

--- a/SharpMUSH.Tests/Services/PermissionServiceControlTests.cs
+++ b/SharpMUSH.Tests/Services/PermissionServiceControlTests.cs
@@ -101,4 +101,28 @@ public class PermissionServiceControlTests
 
 		await Assert.That(await PermissionService.Controls(owner, thing)).IsTrue();
 	}
+
+	/// <summary>
+	/// An explicitly-set <c>#TRUE</c> control lock is not the same as no lock, and is not meant to be:
+	/// PennMUSH parses <c>#TRUE</c> to a real <c>BOOLEXP_BOOL</c> node (<c>boolexp.c:132</c>), which is
+	/// distinct from the <c>TRUE_BOOLEXP</c> sentinel that means "no lock stored". <c>controls()</c> skips
+	/// only the sentinel, so <c>@lock/control &lt;obj&gt;=#TRUE</c> is how you say "anyone controls this".
+	/// </summary>
+	[Test]
+	public async ValueTask AnExplicitlyTrueControlLockGrantsControlToAnyone()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "CtrlExplicitTrue");
+
+		var thingName = TestIsolationHelpers.GenerateUniqueName("CtrlExplicitTrueThing");
+		var createResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@create {thingName}"));
+		var thingDbRef = createResult.Message!.ToPlainText()!.Trim();
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@lock/control {thingDbRef}=#TRUE"));
+
+		var thing = await ObjectAt(thingDbRef);
+		var mortal = (await Mediator.Send(new GetObjectNodeQuery(player.DbRef))).WithoutNone();
+
+		await Assert.That(await PermissionService.Controls(mortal, thing)).IsTrue();
+	}
 }

--- a/SharpMUSH.Tests/Services/TestObjectFactory.cs
+++ b/SharpMUSH.Tests/Services/TestObjectFactory.cs
@@ -172,7 +172,6 @@ public class TestObjectFactory
 		if (_objects.TryGetValue(key, out var existingObject))
 			return existingObject;
 
-		var destination = destRoom ?? sourceRoom;
 
 		var sharpObject = new SharpObject
 		{
@@ -197,8 +196,15 @@ public class TestObjectFactory
 		{
 			Object = sharpObject,
 			Aliases = aliases,
-			Location = new(async ct => { await ValueTask.CompletedTask; return (AnySharpContainer)destination; }),
-			Home = new(async ct => { await ValueTask.CompletedTask; return (AnySharpContainer)sourceRoom; })
+			// Location is the room the exit sits in; Home is where it leads (absent when unlinked).
+			Location = new(async ct => { await ValueTask.CompletedTask; return (AnySharpContainer)sourceRoom; }),
+			Home = new(async ct =>
+			{
+				await ValueTask.CompletedTask;
+				return destRoom is null
+					? new AnyOptionalSharpContainer(new None())
+					: (AnyOptionalSharpContainer)destRoom;
+			})
 		};
 
 		var anySharpObject = new AnySharpObject(exit);


### PR DESCRIPTION
Audits SharpMUSH commands for branches that return without telling the player anything, and gives each one PennMUSH's message. Three clusters, plus one permission fix that fell out of the last of them.

## Exits

The starting symptom: walking an exit that leads nowhere does nothing and says nothing. It turned out to be three stacked bugs.

`SharpMUSH.Library/Models/SharpExit.cs` documented `Location` as DESTINATION and `Home` as SOURCE ROOM. The database says the opposite — `AtLocation` is the room the exit sits in (which is what puts it in that room's contents), and `HasHome` is what `@link` writes and `@unlink` removes. `GoTo` trusted the comment:

- `@open Foo` seeded `HasHome` to the source room, so `Home` was never `#-1` and the "unlinked" check never fired. Walking the exit "moved" you into the room you were already standing in. Silently.
- After `@unlink`, `GetHomeAsync` did `.First()` on an empty result and threw.
- `@unlink` never worked on ArangoDB anyway: `UnlinkExitAsync` traversed the `HasHome` edge **INBOUND** from the exit, so it matched nothing and deleted nothing.

An exit's destination is now `AnyOptionalSharpContainer` across all three providers, `@open` leaves new exits unlinked as PennMUSH does, `LinkExit` replaces rather than accumulates the edge, and `@unlink` traverses the right way. A destinationless exit routes through PennMUSH's `fail_lock` (`lock.c:832`) — `@fail` / `@ofail` / `@afail`, defaulting to "You can't go that way." `goto <non-exit>` gives the same message rather than a generic locate failure. Exits link to any container, not just rooms, and `@open` reports a destination it cannot link to.

The inverted convention had spread further than `GoTo`: `OneOfExtensions.Home`/`Location` (dead code — shadowed by `AnySharpContent`'s instance methods, and swapped relative to them), `WarningService`'s unlinked and one-way checks, the `home()` function, and eleven hand-rolled copies of `Where()` in `MoreCommands` that reached for `exit.Home` when they wanted the source room.

## Emit family

`@pemit`, `@remit`, `@lemit` and `@zemit` (plus `/ns` variants) all declared `SILENT`/`NOISY` switches that nothing read, so the sender was never told what they sent. Added PennMUSH's echoes:

| | |
|---|---|
| `@pemit` | `You pemit "…" to <name>.` / `… to N objects.` / `… to N connections.` |
| `@remit` | `You remit, "…" in <room>` |
| `@lemit` | `You lemit: "…"` |
| `@zemit` | `You zemit, "…" in zone <zone>` |

Each suppressed by `/silent`, and each suppressed when the sender would have seen the message anyway (pemitting to yourself, remitting to the room you are standing in). Plus the missing error branches: `There can't be anything in that!` for `@remit` to an exit, `Too many containers.` for `@lemit` outside a room, and a control check on `@zemit`'s zone.

## Misc guards

`look/outside` read one containment level too shallow — it showed your own location rather than your location's location — and said nothing at all from a room or an opaque container, where PennMUSH says "You can't see through that." `think` with no argument returned silently where PennMUSH prints a blank line. `@open exit=<bad dest>` silently skipped the link.

## Control-lock default

`PermissionService.Controls` ended by evaluating the target's control lock, and `LockService.Evaluate` returns true for an unset lock — the right default for a gate like `@lock/enter`, the wrong one for a permission check. Any mortal "controlled" any object without an explicit control lock, and `CanExamine` delegates to `Controls`, so the same held for examining.

PennMUSH hits the identical default-open convention and special-cases it: `controls()` (`predicat.c:416`) reads the raw boolexp with `getlock_noparent` and skips it when `TRUE_BOOLEXP`, falling through to no control. `LockService.GetIfSet` now exposes the set/unset distinction that `Get` erases by defaulting to `#TRUE`; lock storage already supported it, since `@unlock` removes the key rather than writing `#TRUE`.

Six exit tests added earlier in this branch were leaning on the permissive default — they dug a room as God and then `@open`ed an exit in it as a mortal. They now dig as the player who opens the exit, which is what they meant.

## Testing

20 new tests, each written failing first and watched fail for the right reason. Two previously-skipped tests (`GotoCommand`, `UnlinkExit`) are now implemented rather than skipped.

Unit **4949**, BUnit **267**, integration **248** — all passing. Formatter converged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exits can now link to rooms, players, or things (not just rooms).
  * `@OPEN`/`@LINK` now validate broader destinations and give clearer failures.
  * Communication commands add sender-echo behavior, recipient-count summaries, and port-based recipients (with improved `/SILENT` handling).

* **Bug Fixes**
  * Relinking exits now replaces existing destinations instead of accumulating.
  * Unlinked-exit movement/teleport and exit formatting now report correctly (including *UNLINKED* indicators).
  * `LOOK/LOOK/OUTSIDE`, `EXAMINE`, `THINK`, remit/emit permission semantics improved.

* **Tests**
  * Expanded command and unit test coverage for these behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->