### PR TITLE
Make objid the one contract for identifying an object across a boundary

### DIFF
--- a/SharpMUSH.Contracts/Models/Portal/GameCommandMessage.cs
+++ b/SharpMUSH.Contracts/Models/Portal/GameCommandMessage.cs
@@ -4,6 +4,9 @@ namespace SharpMUSH.Library.Models.Portal;
 /// Carries a command typed by a character in the web portal.
 /// Published to NATS so the game engine can route it to the command pipeline.
 /// </summary>
+/// <param name="CharacterDbref">
+/// The issuing character's objid — <c>"#42:1700000000"</c>, the round-trip form of <c>DBRef</c>.
+/// </param>
 public record GameCommandMessage(
 	string CharacterDbref,
 	string Command,

--- a/SharpMUSH.Contracts/Models/Portal/GameOutputMessage.cs
+++ b/SharpMUSH.Contracts/Models/Portal/GameOutputMessage.cs
@@ -3,10 +3,16 @@ namespace SharpMUSH.Library.Models.Portal;
 /// <summary>
 /// Carries output from the game engine to a specific connected character.
 /// Serialised as JSON and forwarded by <c>NatsBridgeService</c> to the
-/// character's SignalR group (<c>char:{dbref}</c>).
+/// character's SignalR group (<c>char:{objid}</c>).
 /// </summary>
+/// <param name="CharacterDbref">
+/// The recipient character's objid — <c>"#42:1700000000"</c>, the round-trip form of
+/// <c>DBRef</c>. A bare <c>"#42"</c> parses but is recycle-unsafe. <see langword="null"/> marks a
+/// server-wide broadcast with no single recipient; the bridge drops such a message rather than
+/// forwarding it to a group nobody is in, as do values that do not parse.
+/// </param>
 public record GameOutputMessage(
-	string CharacterDbref,
+	string? CharacterDbref,
 	string Content,
 	DateTimeOffset Timestamp,
 	MessageType MessageType);

--- a/SharpMUSH.Contracts/Models/Portal/RoomEventMessage.cs
+++ b/SharpMUSH.Contracts/Models/Portal/RoomEventMessage.cs
@@ -3,8 +3,12 @@ namespace SharpMUSH.Library.Models.Portal;
 /// <summary>
 /// Carries a room-scoped event to every character observing that room.
 /// Serialised as JSON and forwarded by <c>NatsBridgeService</c> to the
-/// room's SignalR group (<c>room:{dbref}</c>).
+/// room's SignalR group (<c>room:{objid}</c>).
 /// </summary>
+/// <param name="RoomDbref">
+/// The room's objid — <c>"#7:1700000000"</c>, the round-trip form of <c>DBRef</c>. A value that
+/// does not parse is dropped by the bridge.
+/// </param>
 public record RoomEventMessage(
 	string RoomDbref,
 	RoomEventType EventType,

--- a/SharpMUSH.Library/Definitions/SystemAccount.cs
+++ b/SharpMUSH.Library/Definitions/SystemAccount.cs
@@ -1,0 +1,13 @@
+namespace SharpMUSH.Library.Definitions;
+
+/// <summary>
+/// The reserved account that owns server-authored content. It exists unconditionally, so anything
+/// asking "has a human registered yet?" must exclude reserved accounts rather than counting rows.
+/// </summary>
+public static class SystemAccount
+{
+	public const string Username = "system";
+
+	public static bool IsReserved(string username)
+		=> string.Equals(username, Username, StringComparison.OrdinalIgnoreCase);
+}

--- a/SharpMUSH.Library/Models/DBref.cs
+++ b/SharpMUSH.Library/Models/DBref.cs
@@ -39,11 +39,24 @@ public readonly struct DBRef : IEquatable<DBRef>
 
 	public static bool operator !=(DBRef left, DBRef right) => !(left == right);
 
-	public static bool TryParse(string value, out DBRef? dbref)
+	public static bool TryParse(string? value, out DBRef? dbref)
 	{
+		// Null and blank return false rather than throwing, matching every framework TryParse.
+		// This is the inbound boundary for untrusted text — JSON payloads and SignalR arguments
+		// deserialize to null despite non-nullable declarations, since nullable reference types
+		// are not enforced at runtime — so callers must be able to rely on a bool, not a catch.
+		if (string.IsNullOrWhiteSpace(value))
+		{
+			dbref = default;
+			return false;
+		}
+
 		var parsed = HelperFunctions.ParseDbRef(value);
 
-		dbref = parsed.IsSome() ? parsed.AsValue() : default;
+		// Cast the null arm explicitly: with `: default` the ternary's natural type is DBRef, so a
+		// failed parse yielded default(DBRef) — #0 — which then widened to DBRef?. The signature
+		// promised null and never produced it, making `out var` look safe when it was #0.
+		dbref = parsed.IsSome() ? parsed.AsValue() : (DBRef?)null;
 		return parsed.IsSome();
 	}
 

--- a/SharpMUSH.Server/Authentication/AccountSessionAuthenticationHandler.cs
+++ b/SharpMUSH.Server/Authentication/AccountSessionAuthenticationHandler.cs
@@ -55,7 +55,7 @@ public class AccountSessionAuthenticationHandler(
 		var acting = ResolveActingCharacter(characters);
 		if (acting is not null)
 		{
-			claims.Add(new Claim(GameHub.CharacterDbrefClaim, $"#{acting.Object.Key}"));
+			claims.Add(new Claim(GameHub.CharacterDbrefClaim, acting.Object.DBRef.ToString()));
 			claims.Add(new Claim("character_key", acting.Object.Key.ToString()));
 			claims.Add(new Claim("character_creation_time", acting.Object.CreationTime.ToString()));
 			claims.Add(new Claim("character_name", acting.Object.Name));

--- a/SharpMUSH.Server/Authentication/CharacterClaimsExtensions.cs
+++ b/SharpMUSH.Server/Authentication/CharacterClaimsExtensions.cs
@@ -1,15 +1,25 @@
-using System.Security.Claims;
+using SharpMUSH.Library.Models;
 using SharpMUSH.Server.Hubs;
+using System.Security.Claims;
 
 namespace SharpMUSH.Server.Authentication;
 
 public static class CharacterClaimsExtensions
 {
 	/// <summary>
-	/// The dbref (<c>"#N"</c>) of the character this request acts as, from the <c>character_dbref</c>
-	/// claim, or <see langword="null"/> when the principal carries no character. Not
+	/// The character this request acts as, from the <c>character_dbref</c> claim, or
+	/// <see langword="null"/> when the principal carries no character or an unparseable one. Not
 	/// <see cref="ClaimTypes.NameIdentifier"/>, which carries the account id.
 	/// </summary>
-	public static string? GetActingCharacterDbref(this ClaimsPrincipal user)
-		=> user.FindFirst(GameHub.CharacterDbrefClaim)?.Value;
+	/// <remarks>
+	/// Returns a <see cref="DBRef"/> rather than the raw claim string so callers cannot compare or
+	/// format two different spellings of the same character. Handlers emit the claim as an objid,
+	/// so the creation time is normally present and <see cref="DBRef.Matches"/> will reject a
+	/// recycled dbref; a bare <c>"#N"</c> claim still parses, with a null creation time.
+	/// </remarks>
+	public static DBRef? GetActingCharacter(this ClaimsPrincipal user)
+		=> user.FindFirst(GameHub.CharacterDbrefClaim)?.Value is { } claim
+			&& DBRef.TryParse(claim, out var dbref)
+				? dbref
+				: null;
 }

--- a/SharpMUSH.Server/Authentication/DebugAuthenticationHandler.cs
+++ b/SharpMUSH.Server/Authentication/DebugAuthenticationHandler.cs
@@ -76,7 +76,7 @@ public class DebugAuthenticationHandler(
 					claims.Add(new("character_creation_time", player.Object.CreationTime.ToString()));
 					claims.Add(new("character_name", player.Object.Name));
 					// GameHub uses this claim for SignalR character-group routing.
-					claims.Add(new(GameHub.CharacterDbrefClaim, $"#{player.Object.Key}"));
+					claims.Add(new(GameHub.CharacterDbrefClaim, player.Object.DBRef.ToString()));
 				}
 				else
 				{

--- a/SharpMUSH.Server/Authentication/MushBasicAuthenticationHandler.cs
+++ b/SharpMUSH.Server/Authentication/MushBasicAuthenticationHandler.cs
@@ -118,7 +118,7 @@ public class MushBasicAuthenticationHandler(
 			new("character_key", player.Object.Key.ToString()),
 			new("character_creation_time", player.Object.CreationTime.ToString()),
 			new("character_name", player.Object.Name),
-			new(GameHub.CharacterDbrefClaim, $"#{player.Object.Key}")
+			new(GameHub.CharacterDbrefClaim, player.Object.DBRef.ToString())
 		};
 
 		var identity = new ClaimsIdentity(claims, SchemeName);

--- a/SharpMUSH.Server/Controllers/GalleryController.cs
+++ b/SharpMUSH.Server/Controllers/GalleryController.cs
@@ -83,7 +83,7 @@ public class GalleryController(
 
 		// Never default a missing identity to God (#1): reject so uploads cannot be
 		// misattributed or bypass identity-based controls downstream.
-		var uploaderDbref = User.GetActingCharacterDbref();
+		var uploaderDbref = User.GetActingCharacter()?.ToString();
 		if (string.IsNullOrEmpty(uploaderDbref))
 			return Unauthorized("Missing character identity.");
 		await using var content = file.OpenReadStream();
@@ -188,13 +188,9 @@ public class GalleryController(
 
 	private async Task<AnySharpObject?> ResolveViewerAsync(CancellationToken ct)
 	{
-		var raw = User.GetActingCharacterDbref();
-		if (string.IsNullOrWhiteSpace(raw)) return null;
+		if (User.GetActingCharacter() is not { } character) return null;
 
-		var numberPart = raw.TrimStart('#').Split(':', 2)[0];
-		if (!int.TryParse(numberPart, out var number)) return null;
-
-		var result = await mediator.Send(new GetObjectNodeQuery(new DBRef(number, null)), ct);
+		var result = await mediator.Send(new GetObjectNodeQuery(character), ct);
 		return result.IsNone ? null : result.Known;
 	}
 

--- a/SharpMUSH.Server/Controllers/MailController.cs
+++ b/SharpMUSH.Server/Controllers/MailController.cs
@@ -159,13 +159,9 @@ public class MailController(IMediator mediator, ILogger<MailController> logger) 
 	/// <summary>Resolves the character this request acts as (the primary character's dbref) to a player, or null.</summary>
 	private async Task<SharpPlayer?> ResolvePlayerAsync(CancellationToken ct)
 	{
-		var raw = User.GetActingCharacterDbref();
-		if (string.IsNullOrWhiteSpace(raw)) return null;
+		if (User.GetActingCharacter() is not { } character) return null;
 
-		var numberPart = raw.TrimStart('#').Split(':', 2)[0];
-		if (!int.TryParse(numberPart, out var dbref)) return null;
-
-		var result = await mediator.Send(new GetObjectNodeQuery(new DBRef(dbref, null)), ct);
+		var result = await mediator.Send(new GetObjectNodeQuery(character), ct);
 		return result.IsPlayer ? result.AsPlayer : null;
 	}
 

--- a/SharpMUSH.Server/Controllers/WikiAssetController.cs
+++ b/SharpMUSH.Server/Controllers/WikiAssetController.cs
@@ -86,7 +86,7 @@ public partial class WikiAssetController(
 			}
 		}
 
-		var uploaderDbref = User.GetActingCharacterDbref();
+		var uploaderDbref = User.GetActingCharacter()?.ToString();
 		if (string.IsNullOrEmpty(uploaderDbref))
 			return Unauthorized(new { error = "No character on this session." });
 

--- a/SharpMUSH.Server/Controllers/WikiController.cs
+++ b/SharpMUSH.Server/Controllers/WikiController.cs
@@ -113,7 +113,7 @@ public class WikiController(
 	/// claim). Never defaults to a privileged dbref: a missing claim means we cannot attribute the
 	/// action, so callers must reject the request rather than silently acting as God (#1).
 	/// </summary>
-	private string? CallerDbref => User.GetActingCharacterDbref();
+	private string? CallerDbref => User.GetActingCharacter()?.ToString();
 
 	/// <summary>True when the caller is the original author of <paramref name="page"/>. Authors
 	/// always see their own drafts even without the <see cref="PortalPermission.WikiRead"/> scope.</summary>

--- a/SharpMUSH.Server/Hubs/GameHub.cs
+++ b/SharpMUSH.Server/Hubs/GameHub.cs
@@ -134,8 +134,8 @@ public class GameHub(IMessageBus messageBus, ILogger<GameHub> logger, HubConnect
 	/// The client calls this after moving to a new room.
 	/// </summary>
 	/// <param name="roomDbref">The room's objid, e.g. <c>"#7:1700000000"</c>.</param>
-	/// <exception cref="HubException">The argument is not a parseable dbref or objid.</exception>
-	public async Task JoinRoom(string roomDbref)
+	/// <exception cref="HubException">The argument is absent or not a parseable dbref or objid.</exception>
+	public async Task JoinRoom(string? roomDbref)
 	{
 		var room = ParseRoomOrThrow(roomDbref);
 		await Groups.AddToGroupAsync(Context.ConnectionId, RoomGroupName(room));
@@ -148,8 +148,8 @@ public class GameHub(IMessageBus messageBus, ILogger<GameHub> logger, HubConnect
 	/// The client calls this before moving away from a room.
 	/// </summary>
 	/// <param name="roomDbref">The room's objid, e.g. <c>"#7:1700000000"</c>.</param>
-	/// <exception cref="HubException">The argument is not a parseable dbref or objid.</exception>
-	public async Task LeaveRoom(string roomDbref)
+	/// <exception cref="HubException">The argument is absent or not a parseable dbref or objid.</exception>
+	public async Task LeaveRoom(string? roomDbref)
 	{
 		var room = ParseRoomOrThrow(roomDbref);
 		await Groups.RemoveFromGroupAsync(Context.ConnectionId, RoomGroupName(room));
@@ -160,9 +160,10 @@ public class GameHub(IMessageBus messageBus, ILogger<GameHub> logger, HubConnect
 	/// <summary>
 	/// Parses a client-supplied room reference. Client input is the one place a malformed
 	/// spelling can enter, so it is rejected here rather than silently naming a group nothing
-	/// publishes to.
+	/// publishes to. The parameter is nullable because a client can send JSON <c>null</c>
+	/// regardless of the declared type — nullable reference types are not enforced at runtime.
 	/// </summary>
-	private DBRef ParseRoomOrThrow(string roomDbref)
+	private DBRef ParseRoomOrThrow(string? roomDbref)
 	{
 		if (DBRef.TryParse(roomDbref, out var room) && room is not null)
 		{

--- a/SharpMUSH.Server/Hubs/GameHub.cs
+++ b/SharpMUSH.Server/Hubs/GameHub.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
+using SharpMUSH.Library.Models;
 using SharpMUSH.Library.Models.Portal;
 using SharpMUSH.Messaging.Abstractions;
 using SharpMUSH.Server.Authentication;
@@ -50,14 +51,17 @@ public class GameHub(IMessageBus messageBus, ILogger<GameHub> logger, HubConnect
 	public const string CharacterDbrefClaim = "character_dbref";
 
 	/// <summary>
-	/// Formats a SignalR group name for a character.
+	/// The SignalR group for a character. Takes a <see cref="DBRef"/> rather than a string so
+	/// subscriber and publisher cannot disagree on a spelling: <see cref="DBRef.ToString"/> is the
+	/// one serialization, and <see cref="DBRef.TryParse"/> the one way in from the wire.
 	/// </summary>
-	public static string CharacterGroupName(string dbref) => $"char:{dbref}";
+	public static string CharacterGroupName(DBRef character) => $"char:{character}";
 
 	/// <summary>
-	/// Formats a SignalR group name for a room.
+	/// The SignalR group for a room. Takes a <see cref="DBRef"/> for the same reason as
+	/// <see cref="CharacterGroupName"/>.
 	/// </summary>
-	public static string RoomGroupName(string dbref) => $"room:{dbref}";
+	public static string RoomGroupName(DBRef room) => $"room:{room}";
 
 	/// <inheritdoc/>
 	public override async Task OnConnectedAsync()
@@ -71,16 +75,15 @@ public class GameHub(IMessageBus messageBus, ILogger<GameHub> logger, HubConnect
 			return;
 		}
 
-		var dbref = Context.User?.FindFirst(CharacterDbrefClaim)?.Value;
-		if (!string.IsNullOrWhiteSpace(dbref))
+		if (Context.User?.GetActingCharacter() is { } character)
 		{
-			await Groups.AddToGroupAsync(Context.ConnectionId, CharacterGroupName(dbref));
+			await Groups.AddToGroupAsync(Context.ConnectionId, CharacterGroupName(character));
 			logger.LogInformation("[GameHub] Connection {ConnectionId} joined character group {Group}",
-				Context.ConnectionId, CharacterGroupName(dbref));
+				Context.ConnectionId, CharacterGroupName(character));
 		}
 		else
 		{
-			logger.LogWarning("[GameHub] Connection {ConnectionId} has no {Claim} claim; not added to character group",
+			logger.LogWarning("[GameHub] Connection {ConnectionId} has no usable {Claim} claim; not added to character group",
 				Context.ConnectionId, CharacterDbrefClaim);
 		}
 
@@ -107,16 +110,16 @@ public class GameHub(IMessageBus messageBus, ILogger<GameHub> logger, HubConnect
 	/// <param name="command">The raw command string typed by the player.</param>
 	public async Task SendCommand(string command)
 	{
-		var dbref = Context.User?.FindFirst(CharacterDbrefClaim)?.Value;
-		if (string.IsNullOrEmpty(dbref))
+		if (Context.User?.GetActingCharacter() is not { } character)
 		{
 			// No character identity → the command is unroutable; fail at the auth boundary
 			// rather than publishing an empty-dbref message onto the bus.
-			logger.LogWarning("[GameHub] Connection {ConnectionId} sent a command without a {Claim} claim; rejecting",
+			logger.LogWarning("[GameHub] Connection {ConnectionId} sent a command without a usable {Claim} claim; rejecting",
 				Context.ConnectionId, CharacterDbrefClaim);
 			throw new HubException("No character identity on this connection.");
 		}
 
+		var dbref = character.ToString();
 		logger.LogDebug("[GameHub] Connection {ConnectionId} (char:{Dbref}) sent command: {Command}",
 			Context.ConnectionId, dbref, command);
 
@@ -130,24 +133,45 @@ public class GameHub(IMessageBus messageBus, ILogger<GameHub> logger, HubConnect
 	/// Adds the calling connection to the SignalR group for the specified room.
 	/// The client calls this after moving to a new room.
 	/// </summary>
-	/// <param name="roomDbref">The dbref of the room to subscribe to.</param>
+	/// <param name="roomDbref">The room's objid, e.g. <c>"#7:1700000000"</c>.</param>
+	/// <exception cref="HubException">The argument is not a parseable dbref or objid.</exception>
 	public async Task JoinRoom(string roomDbref)
 	{
-		await Groups.AddToGroupAsync(Context.ConnectionId, RoomGroupName(roomDbref));
+		var room = ParseRoomOrThrow(roomDbref);
+		await Groups.AddToGroupAsync(Context.ConnectionId, RoomGroupName(room));
 		logger.LogDebug("[GameHub] Connection {ConnectionId} joined room group {Group}",
-			Context.ConnectionId, RoomGroupName(roomDbref));
+			Context.ConnectionId, RoomGroupName(room));
 	}
 
 	/// <summary>
 	/// Removes the calling connection from the SignalR group for the specified room.
 	/// The client calls this before moving away from a room.
 	/// </summary>
-	/// <param name="roomDbref">The dbref of the room to unsubscribe from.</param>
+	/// <param name="roomDbref">The room's objid, e.g. <c>"#7:1700000000"</c>.</param>
+	/// <exception cref="HubException">The argument is not a parseable dbref or objid.</exception>
 	public async Task LeaveRoom(string roomDbref)
 	{
-		await Groups.RemoveFromGroupAsync(Context.ConnectionId, RoomGroupName(roomDbref));
+		var room = ParseRoomOrThrow(roomDbref);
+		await Groups.RemoveFromGroupAsync(Context.ConnectionId, RoomGroupName(room));
 		logger.LogDebug("[GameHub] Connection {ConnectionId} left room group {Group}",
-			Context.ConnectionId, RoomGroupName(roomDbref));
+			Context.ConnectionId, RoomGroupName(room));
+	}
+
+	/// <summary>
+	/// Parses a client-supplied room reference. Client input is the one place a malformed
+	/// spelling can enter, so it is rejected here rather than silently naming a group nothing
+	/// publishes to.
+	/// </summary>
+	private DBRef ParseRoomOrThrow(string roomDbref)
+	{
+		if (DBRef.TryParse(roomDbref, out var room) && room is not null)
+		{
+			return room.Value;
+		}
+
+		logger.LogWarning("[GameHub] Connection {ConnectionId} sent an unparseable room reference {Room}",
+			Context.ConnectionId, roomDbref);
+		throw new HubException($"'{roomDbref}' is not a valid dbref or objid.");
 	}
 
 	// These are called by internal services (e.g. NatsBridgeService, REST controllers)
@@ -158,25 +182,25 @@ public class GameHub(IMessageBus messageBus, ILogger<GameHub> logger, HubConnect
 	/// Sends a <see cref="GameOutputMessage"/> to all connections belonging to a specific character.
 	/// </summary>
 	/// <param name="hubContext">The hub context injected by the calling service.</param>
-	/// <param name="characterDbref">The character's dbref string (e.g. "#42").</param>
+	/// <param name="character">The character's objid.</param>
 	/// <param name="message">The output message to deliver.</param>
 	public static Task SendToCharacterAsync(
 		IHubContext<GameHub, IGameHubClient> hubContext,
-		string characterDbref,
+		DBRef character,
 		GameOutputMessage message) =>
-		hubContext.Clients.Group(CharacterGroupName(characterDbref)).ReceiveOutput(message);
+		hubContext.Clients.Group(CharacterGroupName(character)).ReceiveOutput(message);
 
 	/// <summary>
 	/// Broadcasts a <see cref="RoomEventMessage"/> to all connections observing a room.
 	/// </summary>
 	/// <param name="hubContext">The hub context injected by the calling service.</param>
-	/// <param name="roomDbref">The room's dbref string (e.g. "#1").</param>
+	/// <param name="room">The room's objid.</param>
 	/// <param name="message">The room event message to broadcast.</param>
 	public static Task SendToRoomAsync(
 		IHubContext<GameHub, IGameHubClient> hubContext,
-		string roomDbref,
+		DBRef room,
 		RoomEventMessage message) =>
-		hubContext.Clients.Group(RoomGroupName(roomDbref)).ReceiveRoomEvent(message);
+		hubContext.Clients.Group(RoomGroupName(room)).ReceiveRoomEvent(message);
 
 	/// <summary>
 	/// Broadcasts a system <see cref="GameOutputMessage"/> to all currently connected clients.
@@ -188,7 +212,7 @@ public class GameHub(IMessageBus messageBus, ILogger<GameHub> logger, HubConnect
 		IHubContext<GameHub, IGameHubClient> hubContext,
 		string content) =>
 		hubContext.Clients.All.ReceiveOutput(new GameOutputMessage(
-			CharacterDbref: "*",
+			CharacterDbref: null,
 			Content: content,
 			Timestamp: DateTimeOffset.UtcNow,
 			MessageType: MessageType.System));

--- a/SharpMUSH.Server/Services/BootstrapService.cs
+++ b/SharpMUSH.Server/Services/BootstrapService.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using SharpMUSH.Library.Definitions;
 using SharpMUSH.Library.Models;
 using SharpMUSH.Library.Services.Interfaces;
 
@@ -17,7 +18,11 @@ public class BootstrapService(
 {
 	public async Task StartAsync(CancellationToken cancellationToken)
 	{
-		if (await accountService.HasAnyAccountAsync(cancellationToken))
+		// Reserved accounts don't count as "someone has registered" — they are created by the
+		// server, so counting them would make this guard permanently true and the admin account
+		// would never be pre-generated.
+		var accounts = await accountService.GetAllAccountsAsync(cancellationToken);
+		if (accounts.Any(a => !SystemAccount.IsReserved(a.Username)))
 		{
 			logger.LogDebug("Bootstrap: accounts already exist, skipping.");
 			return;

--- a/SharpMUSH.Server/Services/NatsBridgeService.cs
+++ b/SharpMUSH.Server/Services/NatsBridgeService.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using NATS.Client.Core;
 using NATS.Client.Serializers.Json;
 using SharpMUSH.Implementation.Services;
+using SharpMUSH.Library.Models;
 using SharpMUSH.Library.Models.Portal;
 using SharpMUSH.Messaging.NATS;
 using SharpMUSH.Server.Hubs;
@@ -21,8 +22,9 @@ public interface INatsBridgeService : IHostedService;
 /// forwards incoming messages to the appropriate SignalR groups.
 ///
 /// Subjects consumed:
-///   "game.output.{characterDbref}" → SignalR group "char:{characterDbref}"
-///   "game.room.{roomDbref}"        → SignalR group "room:{roomDbref}"
+///   "game.output.{characterObjid}" → SignalR group "char:{characterObjid}"
+///   "game.room.{roomObjid}"        → SignalR group "room:{roomObjid}"
+/// Both carry an objid ("#42:1700000000"); a message whose reference does not parse is dropped.
 /// The "game.scene.{sceneId}" → "scene:{sceneId}" leg moved into the Scene plugin (Phase 5) as an
 /// IBridgeSubscriptionSource, run here alongside the built-ins via the catalog's BridgeSources.
 ///
@@ -152,7 +154,15 @@ public sealed class NatsBridgeService : BackgroundService, INatsBridgeService
 			if (msg.Data is null) continue;
 
 			var dbref = msg.Data.CharacterDbref;
-			var group = GameHub.CharacterGroupName(dbref);
+			if (dbref is null || !DBRef.TryParse(dbref, out var character) || character is null)
+			{
+				_logger.LogWarning(
+					"[NatsBridge] Dropping GameOutputMessage with unparseable CharacterDbref {Dbref}; " +
+					"the contract is an objid such as #42:1700000000", dbref);
+				continue;
+			}
+
+			var group = GameHub.CharacterGroupName(character.Value);
 
 			_logger.LogDebug("[NatsBridge] Forwarding GameOutputMessage for char:{Dbref} to group {Group}",
 				dbref, group);
@@ -179,7 +189,15 @@ public sealed class NatsBridgeService : BackgroundService, INatsBridgeService
 			if (msg.Data is null) continue;
 
 			var dbref = msg.Data.RoomDbref;
-			var group = GameHub.RoomGroupName(dbref);
+			if (!DBRef.TryParse(dbref, out var room) || room is null)
+			{
+				_logger.LogWarning(
+					"[NatsBridge] Dropping RoomEventMessage with unparseable RoomDbref {Dbref}; " +
+					"the contract is an objid such as #7:1700000000", dbref);
+				continue;
+			}
+
+			var group = GameHub.RoomGroupName(room.Value);
 
 			_logger.LogDebug("[NatsBridge] Forwarding RoomEventMessage for room:{Dbref} to group {Group}",
 				dbref, group);

--- a/SharpMUSH.Server/Services/NatsBridgeService.cs
+++ b/SharpMUSH.Server/Services/NatsBridgeService.cs
@@ -154,7 +154,7 @@ public sealed class NatsBridgeService : BackgroundService, INatsBridgeService
 			if (msg.Data is null) continue;
 
 			var dbref = msg.Data.CharacterDbref;
-			if (dbref is null || !DBRef.TryParse(dbref, out var character) || character is null)
+			if (!DBRef.TryParse(dbref, out var character) || character is null)
 			{
 				_logger.LogWarning(
 					"[NatsBridge] Dropping GameOutputMessage with unparseable CharacterDbref {Dbref}; " +

--- a/SharpMUSH.Tests/Authentication/AccountSessionAuthHandlerTests.cs
+++ b/SharpMUSH.Tests/Authentication/AccountSessionAuthHandlerTests.cs
@@ -163,7 +163,7 @@ public class AccountSessionAuthHandlerTests
 		var result = await handler.AuthenticateAsync();
 
 		await Assert.That(result.Succeeded).IsTrue();
-		await Assert.That(result.Principal!.FindFirst(GameHub.CharacterDbrefClaim)!.Value).IsEqualTo("#1");
+		await Assert.That(result.Principal!.FindFirst(GameHub.CharacterDbrefClaim)!.Value).IsEqualTo("#1:0");
 		await Assert.That(result.Principal!.IsInRole("Wizard")).IsTrue();
 		await Assert.That(result.Principal!.FindAll(PortalPermission.ClaimType).Select(c => c.Value))
 			.Contains("players.view");
@@ -204,7 +204,7 @@ public class AccountSessionAuthHandlerTests
 		await Assert.That(result.Principal!.FindFirst("character_key")!.Value).IsEqualTo("42");
 		await Assert.That(result.Principal!.FindFirst("character_creation_time")!.Value).IsEqualTo("987654321");
 		await Assert.That(result.Principal!.FindFirst("character_name")!.Value).IsEqualTo("Alice");
-		await Assert.That(result.Principal!.FindFirst(GameHub.CharacterDbrefClaim)!.Value).IsEqualTo("#42");
+		await Assert.That(result.Principal!.FindFirst(GameHub.CharacterDbrefClaim)!.Value).IsEqualTo("#42:987654321");
 	}
 
 	private static (IAccountSessionStore, IAccountService, AccountClaimsService) TwoCharacterAccount()
@@ -233,7 +233,7 @@ public class AccountSessionAuthHandlerTests
 		var result = await handler.AuthenticateAsync();
 
 		await Assert.That(result.Succeeded).IsTrue();
-		await Assert.That(result.Principal!.FindFirst(GameHub.CharacterDbrefClaim)!.Value).IsEqualTo("#7");
+		await Assert.That(result.Principal!.FindFirst(GameHub.CharacterDbrefClaim)!.Value).IsEqualTo("#7:777");
 		await Assert.That(result.Principal!.FindFirst("character_key")!.Value).IsEqualTo("7");
 		await Assert.That(result.Principal!.FindFirst("character_name")!.Value).IsEqualTo("Bob");
 	}
@@ -248,7 +248,7 @@ public class AccountSessionAuthHandlerTests
 
 		var result = await handler.AuthenticateAsync();
 
-		await Assert.That(result.Principal!.FindFirst(GameHub.CharacterDbrefClaim)!.Value).IsEqualTo("#7");
+		await Assert.That(result.Principal!.FindFirst(GameHub.CharacterDbrefClaim)!.Value).IsEqualTo("#7:777");
 	}
 
 	[Test]
@@ -262,7 +262,7 @@ public class AccountSessionAuthHandlerTests
 		var result = await handler.AuthenticateAsync();
 
 		await Assert.That(result.Succeeded).IsTrue();
-		await Assert.That(result.Principal!.FindFirst(GameHub.CharacterDbrefClaim)!.Value).IsEqualTo("#1");
+		await Assert.That(result.Principal!.FindFirst(GameHub.CharacterDbrefClaim)!.Value).IsEqualTo("#1:111");
 	}
 
 	[Test]

--- a/SharpMUSH.Tests/Hubs/GameHubTests.cs
+++ b/SharpMUSH.Tests/Hubs/GameHubTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using SharpMUSH.Configuration.Options;
+using SharpMUSH.Library.Models;
 using SharpMUSH.Library.Models.Portal;
 using SharpMUSH.Library.Services.Interfaces;
 using SharpMUSH.Messaging.Abstractions;
@@ -28,14 +29,14 @@ public class GameHubTests
 		return guard;
 	}
 
-	private static (GameHub hub, IGroupManager groups) BuildHub(string? characterDbref = "42")
+	private static (GameHub hub, IGroupManager groups) BuildHub(string? characterDbref = "#42:1700000000")
 	{
 		var (hub, groups, _) = BuildHubWithBus(characterDbref);
 		return (hub, groups);
 	}
 
 	private static (GameHub hub, IGroupManager groups, IMessageBus bus) BuildHubWithBus(
-		string? characterDbref = "42", SitelockGuard? sitelockGuard = null)
+		string? characterDbref = "#42:1700000000", SitelockGuard? sitelockGuard = null)
 	{
 		var groups = Substitute.For<IGroupManager>();
 		groups.AddToGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -79,13 +80,13 @@ public class GameHubTests
 	[Test]
 	public async Task OnConnectedAsync_WithCharacterDbrefClaim_AddsToCharacterGroup()
 	{
-		var (hub, groups) = BuildHub("99");
+		var (hub, groups) = BuildHub("#99:1700000000");
 
 		await hub.OnConnectedAsync();
 
 		await groups.Received(1).AddToGroupAsync(
 			"conn-001",
-			"char:99",
+			"char:#99:1700000000",
 			Arg.Any<CancellationToken>());
 	}
 
@@ -105,7 +106,7 @@ public class GameHubTests
 	[Test]
 	public async Task OnConnectedAsync_WhenSitelockBlocked_AbortsAndNeverJoinsGroup()
 	{
-		var (hub, groups, _) = BuildHubWithBus("42", sitelockGuard: BuildSitelockGuard(blocked: true));
+		var (hub, groups, _) = BuildHubWithBus("#42:1700000000", sitelockGuard: BuildSitelockGuard(blocked: true));
 
 		await hub.OnConnectedAsync();
 
@@ -119,12 +120,12 @@ public class GameHubTests
 	[Test]
 	public async Task OnConnectedAsync_WhenSitelockNotBlocked_JoinsGroupNormally()
 	{
-		var (hub, groups, _) = BuildHubWithBus("42", sitelockGuard: BuildSitelockGuard(blocked: false));
+		var (hub, groups, _) = BuildHubWithBus("#42:1700000000", sitelockGuard: BuildSitelockGuard(blocked: false));
 
 		await hub.OnConnectedAsync();
 
 		hub.Context.DidNotReceive().Abort();
-		await groups.Received(1).AddToGroupAsync("conn-001", "char:42", Arg.Any<CancellationToken>());
+		await groups.Received(1).AddToGroupAsync("conn-001", "char:#42:1700000000", Arg.Any<CancellationToken>());
 	}
 
 	[Test]
@@ -139,24 +140,24 @@ public class GameHubTests
 	[Test]
 	public async Task SendCommand_WithCommand_PublishesMessageForCorrectCharacter()
 	{
-		var (hub, _, bus) = BuildHubWithBus("77");
+		var (hub, _, bus) = BuildHubWithBus("#77:1700000000");
 
 		await hub.SendCommand("look");
 
 		await bus.Received(1).Publish(
-			Arg.Is<GameCommandMessage>(m => m.CharacterDbref == "77" && m.Command == "look"),
+			Arg.Is<GameCommandMessage>(m => m.CharacterDbref == "#77:1700000000" && m.Command == "look"),
 			Arg.Any<CancellationToken>());
 	}
 
 	[Test]
 	public async Task SendCommand_WithEmptyCommand_StillPublishes()
 	{
-		var (hub, _, bus) = BuildHubWithBus("1");
+		var (hub, _, bus) = BuildHubWithBus("#1:1700000000");
 
 		await hub.SendCommand(string.Empty);
 
 		await bus.Received(1).Publish(
-			Arg.Is<GameCommandMessage>(m => m.CharacterDbref == "1" && m.Command == string.Empty),
+			Arg.Is<GameCommandMessage>(m => m.CharacterDbref == "#1:1700000000" && m.Command == string.Empty),
 			Arg.Any<CancellationToken>());
 	}
 
@@ -165,11 +166,11 @@ public class GameHubTests
 	{
 		var (hub, groups) = BuildHub();
 
-		await hub.JoinRoom("5");
+		await hub.JoinRoom("#5:1700000000");
 
 		await groups.Received(1).AddToGroupAsync(
 			"conn-001",
-			"room:5",
+			"room:#5:1700000000",
 			Arg.Any<CancellationToken>());
 	}
 
@@ -178,23 +179,104 @@ public class GameHubTests
 	{
 		var (hub, groups) = BuildHub();
 
-		await hub.LeaveRoom("5");
+		await hub.LeaveRoom("#5:1700000000");
 
 		await groups.Received(1).RemoveFromGroupAsync(
 			"conn-001",
-			"room:5",
+			"room:#5:1700000000",
 			Arg.Any<CancellationToken>());
 	}
 
+	/// <summary>
+	/// A malformed room reference is rejected at the boundary. Previously it was interpolated
+	/// straight into a group name, so the caller silently joined a group nothing ever publishes to.
+	/// </summary>
 	[Test]
-	public async Task CharacterGroupName_ReturnsExpectedFormat()
+	[Arguments("5")]
+	[Arguments("not-a-dbref")]
+	[Arguments("")]
+	public async Task JoinRoom_WithUnparseableReference_Throws(string roomDbref)
 	{
-		await Assert.That(GameHub.CharacterGroupName("42")).IsEqualTo("char:42");
+		var (hub, groups) = BuildHub();
+
+		await Assert.That(async () => await hub.JoinRoom(roomDbref)).Throws<HubException>();
+
+		await groups.DidNotReceive().AddToGroupAsync(
+			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	/// <summary>
+	/// A claim carrying a bare number rather than a dbref or objid does not resolve, so the
+	/// connection joins no character group. Every handler emits the objid form.
+	/// </summary>
+	[Test]
+	public async Task OnConnectedAsync_WithUnparseableCharacterClaim_DoesNotAddToGroup()
+	{
+		var (hub, groups) = BuildHub("42");
+
+		await hub.OnConnectedAsync();
+
+		await groups.DidNotReceive().AddToGroupAsync(
+			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]
-	public async Task RoomGroupName_ReturnsExpectedFormat()
+	public async Task SendCommand_WithUnparseableCharacterClaim_Throws()
 	{
-		await Assert.That(GameHub.RoomGroupName("7")).IsEqualTo("room:7");
+		var (hub, _, bus) = BuildHubWithBus("42");
+
+		await Assert.That(async () => await hub.SendCommand("look")).Throws<HubException>();
+
+		await bus.DidNotReceive().Publish(
+			Arg.Any<GameCommandMessage>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task CharacterGroupName_UsesTheObjid()
+	{
+		await Assert.That(GameHub.CharacterGroupName(new DBRef(42, 1700000000)))
+			.IsEqualTo("char:#42:1700000000");
+	}
+
+	[Test]
+	public async Task RoomGroupName_UsesTheObjid()
+	{
+		await Assert.That(GameHub.RoomGroupName(new DBRef(7, 1700000000)))
+			.IsEqualTo("room:#7:1700000000");
+	}
+
+	/// <summary>
+	/// The contract that makes subscriber and publisher agree: whatever a producer writes with
+	/// <see cref="DBRef.ToString"/>, a consumer parses with <see cref="DBRef.TryParse"/> back to the
+	/// same group name. Publisher and subscriber reach the group by different routes — a claim, a
+	/// client argument, a NATS payload — and this is what stops them diverging.
+	/// </summary>
+	[Test]
+	[Arguments(42, 1700000000L)]
+	[Arguments(42, null)]
+	[Arguments(1, 0L)]
+	public async Task GroupName_RoundTripsThroughTheWireForm(int number, long? creationMilliseconds)
+	{
+		var produced = new DBRef(number, creationMilliseconds);
+
+		var onTheWire = produced.ToString();
+		await Assert.That(DBRef.TryParse(onTheWire, out var consumed)).IsTrue();
+
+		await Assert.That(GameHub.CharacterGroupName(consumed!.Value))
+			.IsEqualTo(GameHub.CharacterGroupName(produced));
+		await Assert.That(GameHub.RoomGroupName(consumed.Value))
+			.IsEqualTo(GameHub.RoomGroupName(produced));
+	}
+
+	/// <summary>
+	/// A bare dbref and the same object's objid are deliberately *different* groups: the objid is
+	/// what makes delivery recycle-safe, so collapsing them would resurrect the bug this contract
+	/// exists to prevent.
+	/// </summary>
+	[Test]
+	public async Task GroupName_ObjidAndBareDbrefAreDistinctGroups()
+	{
+		await Assert.That(GameHub.CharacterGroupName(new DBRef(42, 1700000000)))
+			.IsNotEqualTo(GameHub.CharacterGroupName(new DBRef(42)));
 	}
 }

--- a/SharpMUSH.Tests/Hubs/GameHubTests.cs
+++ b/SharpMUSH.Tests/Hubs/GameHubTests.cs
@@ -195,7 +195,8 @@ public class GameHubTests
 	[Arguments("5")]
 	[Arguments("not-a-dbref")]
 	[Arguments("")]
-	public async Task JoinRoom_WithUnparseableReference_Throws(string roomDbref)
+	[Arguments(null)]
+	public async Task JoinRoom_WithUnparseableReference_Throws(string? roomDbref)
 	{
 		var (hub, groups) = BuildHub();
 
@@ -261,10 +262,11 @@ public class GameHubTests
 
 		var onTheWire = produced.ToString();
 		await Assert.That(DBRef.TryParse(onTheWire, out var consumed)).IsTrue();
+		var roundTripped = consumed!.Value;
 
-		await Assert.That(GameHub.CharacterGroupName(consumed!.Value))
+		await Assert.That(GameHub.CharacterGroupName(roundTripped))
 			.IsEqualTo(GameHub.CharacterGroupName(produced));
-		await Assert.That(GameHub.RoomGroupName(consumed.Value))
+		await Assert.That(GameHub.RoomGroupName(roundTripped))
 			.IsEqualTo(GameHub.RoomGroupName(produced));
 	}
 

--- a/SharpMUSH.Tests/Hubs/GameHubWriteOpsTests.cs
+++ b/SharpMUSH.Tests/Hubs/GameHubWriteOpsTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.SignalR;
 using NSubstitute;
+using SharpMUSH.Library.Models;
 using SharpMUSH.Library.Models.Portal;
 using SharpMUSH.Server.Hubs;
 
@@ -41,7 +42,7 @@ public class GameHubWriteOpsTests
 		var (ctx, _, clients) = BuildHubContext();
 		var msg = new GameOutputMessage("#42", "Hello", DateTimeOffset.UtcNow, MessageType.Normal);
 
-		await GameHub.SendToCharacterAsync(ctx, "#42", msg);
+		await GameHub.SendToCharacterAsync(ctx, new DBRef(42), msg);
 
 		clients.Received(1).Group("char:#42");
 	}
@@ -52,7 +53,7 @@ public class GameHubWriteOpsTests
 		var (ctx, groupClient, _) = BuildHubContext();
 		var msg = new GameOutputMessage("#7", "Hello", DateTimeOffset.UtcNow, MessageType.Normal);
 
-		await GameHub.SendToCharacterAsync(ctx, "#7", msg);
+		await GameHub.SendToCharacterAsync(ctx, new DBRef(7), msg);
 
 		await groupClient.Received(1).ReceiveOutput(msg);
 	}
@@ -63,8 +64,8 @@ public class GameHubWriteOpsTests
 		var (ctx, _, clients) = BuildHubContext();
 		var msg = new GameOutputMessage("#1", "hi", DateTimeOffset.UtcNow, MessageType.Normal);
 
-		await GameHub.SendToCharacterAsync(ctx, "#1", msg);
-		await GameHub.SendToCharacterAsync(ctx, "#2", msg);
+		await GameHub.SendToCharacterAsync(ctx, new DBRef(1), msg);
+		await GameHub.SendToCharacterAsync(ctx, new DBRef(2), msg);
 
 		clients.Received(1).Group("char:#1");
 		clients.Received(1).Group("char:#2");
@@ -76,7 +77,7 @@ public class GameHubWriteOpsTests
 		var (ctx, _, clients) = BuildHubContext();
 		var msg = new RoomEventMessage("#1", RoomEventType.Arrive, "Gandalf", "Gandalf arrives.");
 
-		await GameHub.SendToRoomAsync(ctx, "#1", msg);
+		await GameHub.SendToRoomAsync(ctx, new DBRef(1), msg);
 
 		clients.Received(1).Group("room:#1");
 	}
@@ -87,7 +88,7 @@ public class GameHubWriteOpsTests
 		var (ctx, groupClient, _) = BuildHubContext();
 		var msg = new RoomEventMessage("#5", RoomEventType.Say, "Aragorn", "Well met.");
 
-		await GameHub.SendToRoomAsync(ctx, "#5", msg);
+		await GameHub.SendToRoomAsync(ctx, new DBRef(5), msg);
 
 		await groupClient.Received(1).ReceiveRoomEvent(msg);
 	}
@@ -108,13 +109,13 @@ public class GameHubWriteOpsTests
 
 		await allClient.Received(1).ReceiveOutput(
 				Arg.Is<GameOutputMessage>(m =>
-						m.CharacterDbref == "*" &&
+						m.CharacterDbref == null &&
 						m.Content == "Server restart in 5 minutes." &&
 						m.MessageType == MessageType.System));
 	}
 
 	[Test]
-	public async Task BroadcastSystemMessageAsync_UsesWildcardDbref()
+	public async Task BroadcastSystemMessageAsync_HasNoRecipientCharacter()
 	{
 		var allClient = Substitute.For<IGameHubClient>();
 		allClient.ReceiveOutput(Arg.Any<GameOutputMessage>()).Returns(Task.CompletedTask);
@@ -128,6 +129,6 @@ public class GameHubWriteOpsTests
 		await GameHub.BroadcastSystemMessageAsync(ctx, "Hello all.");
 
 		await allClient.Received(1).ReceiveOutput(
-				Arg.Is<GameOutputMessage>(m => m.CharacterDbref == "*" && m.MessageType == MessageType.System));
+				Arg.Is<GameOutputMessage>(m => m.CharacterDbref == null && m.MessageType == MessageType.System));
 	}
 }

--- a/SharpMUSH.Tests/Hubs/NatsBridgeServiceTests.cs
+++ b/SharpMUSH.Tests/Hubs/NatsBridgeServiceTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using SharpMUSH.Library.Models;
 using SharpMUSH.Library.Models.Portal;
 using SharpMUSH.Messaging.NATS;
 using SharpMUSH.Server.Hubs;
@@ -50,8 +51,9 @@ public class NatsBridgeServiceTests
 	{
 		var (_, hubContext) = BuildService();
 		var clients = hubContext.Clients;
-		var dbref = "123";
-		var expectedGroup = GameHub.CharacterGroupName(dbref);
+		var character = new DBRef(123, 1700000000);
+		var dbref = character.ToString();
+		var expectedGroup = GameHub.CharacterGroupName(character);
 		var message = new GameOutputMessage(dbref, "Hello!", DateTimeOffset.UtcNow, MessageType.Normal);
 
 		// simulate what NatsBridgeService does when it receives the message
@@ -67,8 +69,9 @@ public class NatsBridgeServiceTests
 	{
 		var (_, hubContext) = BuildService();
 		var clients = hubContext.Clients;
-		var roomDbref = "42";
-		var expectedGroup = GameHub.RoomGroupName(roomDbref);
+		var room = new DBRef(42, 1700000000);
+		var roomDbref = room.ToString();
+		var expectedGroup = GameHub.RoomGroupName(room);
 		var message = new RoomEventMessage(roomDbref, RoomEventType.Say, "Wizard", "Hello all!");
 
 		var proxy = hubContext.Clients.Group(expectedGroup);

--- a/SharpMUSH.Tests/Models/DBRefParseTests.cs
+++ b/SharpMUSH.Tests/Models/DBRefParseTests.cs
@@ -1,0 +1,59 @@
+using SharpMUSH.Library.Models;
+
+namespace SharpMUSH.Tests.Models;
+
+/// <summary>
+/// <see cref="DBRef.TryParse"/> is the inbound boundary for object references arriving as
+/// untrusted text — SignalR method arguments, NATS payloads, auth claims. Those deserialize to
+/// <see langword="null"/> despite non-nullable declarations, because nullable reference types are
+/// not enforced at runtime, so this must answer with a bool rather than an exception.
+/// </summary>
+public class DBRefParseTests
+{
+	[Test]
+	[Arguments(null)]
+	[Arguments("")]
+	[Arguments("   ")]
+	[Arguments("42")]
+	[Arguments("not-a-dbref")]
+	[Arguments("#")]
+	[Arguments("#4 2")]
+	[Arguments("#42:")]
+	public async ValueTask TryParse_Unparseable_ReturnsFalseWithoutThrowing(string? value)
+	{
+		await Assert.That(DBRef.TryParse(value, out var dbref)).IsFalse();
+		await Assert.That(dbref).IsNull();
+	}
+
+	[Test]
+	public async ValueTask TryParse_BareDbref_HasNoCreationTime()
+	{
+		await Assert.That(DBRef.TryParse("#42", out var dbref)).IsTrue();
+		await Assert.That(dbref!.Value.Number).IsEqualTo(42);
+		await Assert.That(dbref.Value.CreationMilliseconds).IsNull();
+	}
+
+	[Test]
+	public async ValueTask TryParse_Objid_KeepsTheCreationTime()
+	{
+		await Assert.That(DBRef.TryParse("#42:1700000000", out var dbref)).IsTrue();
+		await Assert.That(dbref!.Value.Number).IsEqualTo(42);
+		await Assert.That(dbref.Value.CreationMilliseconds).IsEqualTo(1700000000L);
+	}
+
+	/// <summary>
+	/// The round-trip that every cross-boundary reference relies on: whatever a producer writes
+	/// with <see cref="DBRef.ToString"/>, a consumer parses back to an equal value.
+	/// </summary>
+	[Test]
+	[Arguments(42, 1700000000L)]
+	[Arguments(42, null)]
+	[Arguments(1, 0L)]
+	public async ValueTask ToString_RoundTripsThroughTryParse(int number, long? creationMilliseconds)
+	{
+		var original = new DBRef(number, creationMilliseconds);
+
+		await Assert.That(DBRef.TryParse(original.ToString(), out var parsed)).IsTrue();
+		await Assert.That(parsed!.Value).IsEqualTo(original);
+	}
+}

--- a/SharpMUSH.Tests/Services/BootstrapServiceTests.cs
+++ b/SharpMUSH.Tests/Services/BootstrapServiceTests.cs
@@ -1,0 +1,65 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using SharpMUSH.Library.Definitions;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.Services.Interfaces;
+using SharpMUSH.Server.Services;
+
+namespace SharpMUSH.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="BootstrapService"/>'s first-run guard. The guard has to ignore
+/// reserved accounts: once a reserved account exists unconditionally, "any account exists" is
+/// permanently true and the admin account would never be pre-generated.
+/// </summary>
+public class BootstrapServiceTests
+{
+	private static SharpAccount Account(string username) => new()
+	{
+		Id = $"node_accounts/{username}",
+		Username = username,
+		PasswordHash = string.Empty
+	};
+
+	private static (BootstrapService Service, IAccountService Accounts) Build(params SharpAccount[] existing)
+	{
+		var accounts = Substitute.For<IAccountService>();
+		accounts.GetAllAccountsAsync(Arg.Any<CancellationToken>()).Returns(existing.ToList());
+		accounts.CreateUnclaimedAccountAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo => Account(callInfo.Arg<string>()));
+		return (new BootstrapService(accounts, NullLogger<BootstrapService>.Instance), accounts);
+	}
+
+	[Test]
+	public async ValueTask FreshDatabase_PreGeneratesAdminLinkedToGod()
+	{
+		var (service, accounts) = Build();
+
+		await service.StartAsync(CancellationToken.None);
+
+		await accounts.Received(1).CreateUnclaimedAccountAsync("admin", Arg.Any<CancellationToken>());
+		await accounts.Received(1).LinkCharacterAsync(
+			"node_accounts/admin", new DBRef(1), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async ValueTask ExistingPlayerAccount_SkipsPreGeneration()
+	{
+		var (service, accounts) = Build(Account("someplayer"));
+
+		await service.StartAsync(CancellationToken.None);
+
+		await accounts.DidNotReceive().CreateUnclaimedAccountAsync(
+			Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async ValueTask OnlyReservedAccountsExist_StillPreGeneratesAdmin()
+	{
+		var (service, accounts) = Build(Account(SystemAccount.Username));
+
+		await service.StartAsync(CancellationToken.None);
+
+		await accounts.Received(1).CreateUnclaimedAccountAsync("admin", Arg.Any<CancellationToken>());
+	}
+}


### PR DESCRIPTION
Two latent traps fixed ahead of the account-attribution work in #720. **Neither is breaking anything today** — both are groundwork, with tests. Calling that out plainly because the failure modes below read like live bugs and aren't.

## 1. The objid contract

A character or room reference crossed four boundaries as a bare string — an auth claim, a client hub argument, a NATS payload, and a SignalR group name — with nothing forcing the spellings to agree. `"42"`, `"#42"`, and `"#42:1700000000"` named three different groups.

The failure mode is silent: SignalR joins any group name you hand it, and publishing to a group with no members is not an error. A producer and consumer that disagreed on spelling would deliver nothing, with no exception and no log. `JoinRoom` took whatever the client sent and interpolated it straight into a group name.

They agree today only by coincidence — the claim and `IGameEngineBridge`'s shape both happen to use `#N`, and nothing calls `JoinRoom` yet. Moving the claim to objid form (which #720 needs, for recycle-safety) would have broken output delivery.

**The fix is the contract, not a normalizer.** Collapsing every spelling at the group-name chokepoint would have preserved the divergence and hidden it:

- `CharacterGroupName`, `RoomGroupName`, `SendToCharacterAsync`, and `SendToRoomAsync` take `DBRef`, not `string` — a wrong spelling is unrepresentable in C#.
- `DBRef.ToString()` is the only serialization; `DBRef.TryParse` the only way in from the wire.
- All three auth handlers emit `character_dbref` as the objid. `CharacterClaimsExtensions.GetActingCharacter` returns a parsed `DBRef` rather than a raw claim string.
- The NATS bridge drops payloads whose reference doesn't parse, with a log line naming the expected form.
- `JoinRoom`/`LeaveRoom` reject unparseable client input with a `HubException` instead of joining a dead group.
- The wire records document the contract, so the engine side — still unimplemented behind `IGameEngineBridge` — has something to conform to.

Objid rather than bare dbref is the point: it makes delivery recycle-safe, so a stale reference to a destroyed object can't leak to whatever now occupies that slot. A test asserts the objid and the bare dbref are *distinct* groups, to keep a future "simplification" from collapsing them.

Two incidental catches: `MailController` and `GalleryController` were each hand-stripping the objid suffix and rebuilding `new DBRef(n, null)` — exactly the recycle-unsafe pattern — and now use the parsed accessor.

`GameOutputMessage.CharacterDbref` becomes nullable. The `"*"` sentinel for a server-wide broadcast meant the field was sometimes not a dbref at all; `null` says "no single recipient" in the type instead.

## 2. The bootstrap guard

`BootstrapService` asked "does any account exist?" to decide whether to pre-generate the unclaimed admin. #720 adds a reserved `system` account that exists unconditionally, which makes that answer permanently yes — so the admin would never be pre-generated on a fresh database, silently, since nothing asserted it happens.

It now asks "does any *non-reserved* account exist?", which is the question actually being asked. Behaviour is unchanged today because no reserved account exists yet.

`SystemAccount` (`Username`, `IsReserved`) lands here rather than with the attribution work because the guard needs to name the reserved username, and one spelling shared between guard and creator is the whole point.

## Verification

| Suite | Result |
|---|---|
| `SharpMUSH.Tests` | 4939 total, **0 failed**, 198 skipped |
| `SharpMUSH.Tests.BUnit` | 274 total, **0 failed** |
| `SharpMUSH.Tests.Integration` | 248 total, **0 failed** |
| `dotnet build` | 0 errors, 0 warnings |
| `dotnet format whitespace` | no changes on either pass |

Tests updated rather than worked around, in three groups — each one is the old loose contract being pinned to the new one:

- `GameHubTests` used claims like `"42"` with no `#`, which `DBRef.TryParse` correctly rejects. Now uses objids, plus new tests that unparseable input is *rejected* rather than silently joining a junk group.
- `AccountSessionAuthHandlerTests` asserted the claim was a bare `#N`; it's now the objid.
- `GameHubWriteOpsTests` asserted the `"*"` sentinel; now asserts `null`.

The "every spelling converges" tests from my first attempt were deleted rather than kept — the type makes them unrepresentable, and a test for an impossible state is noise. What replaced them asserts the round-trip property: whatever a producer writes with `ToString()`, a consumer parses back to the same group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)