### PR TITLE
Implement PennMUSH variable exits (DESTINATION / EXITTO)

### DIFF
--- a/SharpMUSH.Implementation/Commands/GeneralCommands.cs
+++ b/SharpMUSH.Implementation/Commands/GeneralCommands.cs
@@ -1317,6 +1317,90 @@ public partial class Commands
 		return CallState.Empty;
 	}
 
+	/// <summary>
+	/// How the exit was linked. PennMUSH stores HOME and AMBIGUOUS directly in Destination(); SharpMUSH
+	/// records them in a <c>_LINKTYPE</c> attribute instead, which is the convention <c>loc()</c> already
+	/// reads to answer <c>#-3</c> and <c>#-2</c>.
+	/// </summary>
+	private static async ValueTask<string?> LinkTypeOf(AnySharpObject executor, AnySharpObject exitObject)
+	{
+		var linkTypeAttr = await AttributeService!.GetAttributeAsync(
+			executor, exitObject, AttrLinkType, IAttributeService.AttributeMode.Read, false);
+
+		if (!linkTypeAttr.IsAttribute || linkTypeAttr.AsAttribute.Length == 0)
+		{
+			return null;
+		}
+
+		var linkType = linkTypeAttr.AsAttribute[0].Value.ToPlainText().Trim();
+
+		return string.IsNullOrEmpty(linkType) ? null : linkType.ToLowerInvariant();
+	}
+
+	/// <summary>
+	/// PennMUSH <c>find_var_dest</c> (<c>move.c:360</c>): a variable exit works out where it leads at move
+	/// time by evaluating its <c>DESTINATION</c> attribute — with <c>%0</c> set to the exit name or alias
+	/// the mover typed — falling back to <c>EXITTO</c>. The result is parsed as an objid, so it must name
+	/// an object rather than merely matching something nearby.
+	/// <para>Returns <c>null</c> after notifying the mover when no usable destination comes back.</para>
+	/// </summary>
+	private static async ValueTask<AnySharpContainer?> FindVariableDestination(
+		IMUSHCodeParser parser, AnySharpObject executor, AnySharpObject exitObject, string typedName)
+	{
+		var attributeArgs = new Dictionary<string, CallState> { { "0", new CallState(typedName) } };
+
+		var resolved = await AttributeHelpers.EvaluateFormatAttribute(
+			AttributeService!, parser, executor, exitObject, "DESTINATION", attributeArgs, MModule.empty());
+
+		if (MModule.getLength(resolved) == 0)
+		{
+			resolved = await AttributeHelpers.EvaluateFormatAttribute(
+				AttributeService!, parser, executor, exitObject, "EXITTO", attributeArgs, MModule.empty());
+		}
+
+		var destinationText = resolved.ToPlainText().Trim();
+		var located = DBRef.TryParse(destinationText, out var destinationRef)
+			? await Mediator!.Send(new GetObjectNodeQuery(destinationRef!.Value))
+			: new AnyOptionalSharpObject(new None());
+
+		// PennMUSH only permits a variable destination the exit itself could have been linked to
+		// (move.c:457), and an exit is not somewhere you can end up.
+		if (located.IsNone() || !located.Known().IsContainer
+				|| !await ExitCanLinkTo(exitObject, located.Known()))
+		{
+			await NotifyService!.NotifyLocalized(executor,
+				nameof(ErrorMessages.Notifications.VariableExitDestinationInvalidFormat), executor,
+				located.IsNone() ? "#-1" : located.Known().Object().DBRef.Number.ToString());
+
+			return null;
+		}
+
+		return located.Known().AsContainer;
+	}
+
+	/// <summary>
+	/// PennMUSH <c>can_link_to</c> (<c>mushdb.h:87</c>), asked of the exit rather than of the player: the
+	/// exit controls the destination, is allowed to link anywhere, or the destination is LINK_OK and the
+	/// exit passes its link lock.
+	/// </summary>
+	private static async ValueTask<bool> ExitCanLinkTo(AnySharpObject exitObject, AnySharpObject destination)
+	{
+		if (await PermissionService!.Controls(exitObject, destination))
+		{
+			return true;
+		}
+
+		if (await exitObject.HasPower("Link_Anywhere"))
+		{
+			return true;
+		}
+
+		var destinationFlags = await destination.Object().Flags.Value.ToArrayAsync();
+
+		return destinationFlags.Any(f => f.Name.Equals("LINK_OK", StringComparison.OrdinalIgnoreCase))
+					 && LockService!.Evaluate(LockType.Link, destination, exitObject);
+	}
+
 	[SharpCommand(Name = "GOTO", Behavior = CB.Default, MinArgs = 1, MaxArgs = 1, ParameterNames = ["destination"])]
 	public static async ValueTask<Option<CallState>> GoTo(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
@@ -1348,56 +1432,57 @@ public partial class Commands
 		}
 
 		var exitObj = exit.AsExit;
+		var exitObject = new AnySharpObject(exitObj);
 
-		var maybeDestination = await exitObj.Home.WithCancellation(CancellationToken.None);
+		// The exit name or alias actually typed: args["1"] when the visitor routed a bare exit command
+		// here, otherwise the argument to an explicit `goto`.
+		var typedName = args.TryGetValue("1", out var typedArg)
+			? typedArg.Message!.ToPlainText()
+			: args["0"].Message!.ToPlainText();
 
-		// PennMUSH could_doit() (predicat.c:75) refuses an exit with no destination before the basic
-		// lock is even evaluated, so do_move falls through to fail_lock.
-		if (maybeDestination.IsNone)
-		{
-			return await FailToGoThatWay(parser, executor, exitObj);
-		}
-
-		var homeLocation = maybeDestination.WithoutNone();
+		var linkType = await LinkTypeOf(executor, exitObject);
 		AnySharpContainer destination;
 
-		if (homeLocation.Object().DBRef.Number == -1)
+		if (linkType == LinkTypeVariable)
 		{
-			var destAttr = await AttributeService!.GetAttributeAsync(
-				executor, exitObj, "DESTINATION", IAttributeService.AttributeMode.Read, false);
+			var variableDestination = await FindVariableDestination(parser, executor, exitObject, typedName);
 
-			if (destAttr.IsNone || destAttr.IsError)
+			if (variableDestination is null)
 			{
-				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.ExitDestinationInvalid), executor);
 				return CallState.Empty;
 			}
 
-			var destValue = destAttr.AsAttribute.Last().Value.ToPlainText();
-			var located = await LocateService!.LocateAndNotifyIfInvalid(
-				parser,
-				executor,
-				executor,
-				destValue!,
-				LocateFlags.All);
-
-			if (!located.IsValid())
+			destination = variableDestination;
+		}
+		else if (linkType == LinkTypeHome)
+		{
+			// PennMUSH do_move (move.c:451): an exit linked to HOME sends the mover to their own home.
+			if (!executor.IsContent)
 			{
-				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.ExitDestinationInvalid), executor);
-				return CallState.Empty;
+				return await FailToGoThatWay(parser, executor, exitObj);
 			}
 
-			var locatedObj = located.WithoutError().WithoutNone();
-			if (!locatedObj.IsContainer)
+			var moverHome = await executor.AsContent.Home();
+
+			if (moverHome.IsNone)
 			{
-				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.ExitNoValidLocationDetail), executor);
-				return CallState.Empty;
+				return await FailToGoThatWay(parser, executor, exitObj);
 			}
 
-			destination = locatedObj.AsContainer;
+			destination = moverHome.WithoutNone();
 		}
 		else
 		{
-			destination = homeLocation;
+			var maybeDestination = await exitObj.Home.WithCancellation(CancellationToken.None);
+
+			// PennMUSH could_doit() (predicat.c:75) refuses an exit with no destination before the basic
+			// lock is even evaluated, so do_move falls through to fail_lock.
+			if (maybeDestination.IsNone)
+			{
+				return await FailToGoThatWay(parser, executor, exitObj);
+			}
+
+			destination = maybeDestination.WithoutNone();
 		}
 
 		if (!await PermissionService!.CanGoto(executor, exitObj, destination))

--- a/SharpMUSH.Implementation/Commands/GeneralCommands.cs
+++ b/SharpMUSH.Implementation/Commands/GeneralCommands.cs
@@ -1338,6 +1338,61 @@ public partial class Commands
 	}
 
 	/// <summary>
+	/// Why an exit could not say where it leads.
+	/// </summary>
+	private enum ExitDestinationFailure
+	{
+		/// <summary>No destination at all — never linked, or <c>@unlink</c>ed.</summary>
+		Unlinked,
+
+		/// <summary>A variable exit failed to resolve one, and has already told the executor why.</summary>
+		AlreadyReported
+	}
+
+	/// <summary>
+	/// Where an exit leads for a particular mover. <c>goto</c> and <c>@teleport</c> both need this and
+	/// must not drift apart: a variable exit computes its destination from <c>@DESTINATION</c>, a
+	/// home-linked exit sends the mover to <em>their own</em> home — which is why the mover is a separate
+	/// parameter from the executor — and otherwise it is the stored destination edge.
+	/// </summary>
+	private static async ValueTask<OneOf<AnySharpContainer, ExitDestinationFailure>> ResolveExitDestination(
+		IMUSHCodeParser parser, AnySharpObject executor, AnySharpObject mover, SharpExit exitObj, string typedName)
+	{
+		var exitObject = new AnySharpObject(exitObj);
+		var linkType = await LinkTypeOf(executor, exitObject);
+
+		if (linkType == LinkTypeVariable)
+		{
+			var variableDestination = await FindVariableDestination(parser, executor, exitObject, typedName);
+
+			return variableDestination is null
+				? ExitDestinationFailure.AlreadyReported
+				: variableDestination;
+		}
+
+		if (linkType == LinkTypeHome)
+		{
+			// PennMUSH do_move (move.c:451): an exit linked to HOME sends the mover to their own home.
+			if (!mover.IsContent)
+			{
+				return ExitDestinationFailure.Unlinked;
+			}
+
+			var moverHome = await mover.AsContent.Home();
+
+			return moverHome.IsNone
+				? ExitDestinationFailure.Unlinked
+				: moverHome.WithoutNone();
+		}
+
+		var maybeDestination = await exitObj.Home.WithCancellation(CancellationToken.None);
+
+		return maybeDestination.IsNone
+			? ExitDestinationFailure.Unlinked
+			: maybeDestination.WithoutNone();
+	}
+
+	/// <summary>
 	/// PennMUSH <c>find_var_dest</c> (<c>move.c:360</c>): a variable exit works out where it leads at move
 	/// time by evaluating its <c>DESTINATION</c> attribute — with <c>%0</c> set to the exit name or alias
 	/// the mover typed — falling back to <c>EXITTO</c>. The result is parsed as an objid, so it must name
@@ -1440,50 +1495,19 @@ public partial class Commands
 			? typedArg.Message!.ToPlainText()
 			: args["0"].Message!.ToPlainText();
 
-		var linkType = await LinkTypeOf(executor, exitObject);
-		AnySharpContainer destination;
+		var resolved = await ResolveExitDestination(parser, executor, executor, exitObj, typedName);
 
-		if (linkType == LinkTypeVariable)
+		if (!resolved.IsT0)
 		{
-			var variableDestination = await FindVariableDestination(parser, executor, exitObject, typedName);
-
-			if (variableDestination is null)
-			{
-				return CallState.Empty;
-			}
-
-			destination = variableDestination;
-		}
-		else if (linkType == LinkTypeHome)
-		{
-			// PennMUSH do_move (move.c:451): an exit linked to HOME sends the mover to their own home.
-			if (!executor.IsContent)
-			{
-				return await FailToGoThatWay(parser, executor, exitObj);
-			}
-
-			var moverHome = await executor.AsContent.Home();
-
-			if (moverHome.IsNone)
-			{
-				return await FailToGoThatWay(parser, executor, exitObj);
-			}
-
-			destination = moverHome.WithoutNone();
-		}
-		else
-		{
-			var maybeDestination = await exitObj.Home.WithCancellation(CancellationToken.None);
-
 			// PennMUSH could_doit() (predicat.c:75) refuses an exit with no destination before the basic
-			// lock is even evaluated, so do_move falls through to fail_lock.
-			if (maybeDestination.IsNone)
-			{
-				return await FailToGoThatWay(parser, executor, exitObj);
-			}
-
-			destination = maybeDestination.WithoutNone();
+			// lock is even evaluated, so do_move falls through to fail_lock. A variable exit that could
+			// not work out where it leads has already reported that itself.
+			return resolved.AsT1 == ExitDestinationFailure.Unlinked
+				? await FailToGoThatWay(parser, executor, exitObj)
+				: CallState.Empty;
 		}
+
+		var destination = resolved.AsT0;
 
 		if (!await PermissionService!.CanGoto(executor, exitObj, destination))
 		{
@@ -1543,25 +1567,10 @@ public partial class Commands
 
 		var validDestination = destination.WithoutError().WithoutNone();
 
-		AnySharpContainer destinationContainer;
-		if (validDestination.IsExit)
-		{
-			// Teleporting to an exit means going where it leads. GetExitDestinationAsync yields either a
-			// real object or None, so there is no sentinel dbref to test for here.
-			var maybeHomeLocation = await validDestination.AsExit.Home.WithCancellation(CancellationToken.None);
-
-			if (maybeHomeLocation.IsNone)
-			{
-				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.ExitGoesNowhere), executor);
-				return CallState.Empty;
-			}
-
-			destinationContainer = maybeHomeLocation.WithoutNone();
-		}
-		else
-		{
-			destinationContainer = validDestination.AsContainer;
-		}
+		// Teleporting to an exit means going where it leads. That is resolved per target inside the loop,
+		// because a home-linked exit leads somewhere different for each mover.
+		var destinationExit = validDestination.IsExit ? validDestination.AsExit : null;
+		var fixedDestination = destinationExit is null ? validDestination.AsContainer : null;
 
 		foreach (var obj in toTeleportStringList)
 		{
@@ -1587,6 +1596,30 @@ public partial class Commands
 			{
 				await NotifyService!.Notify(executor, ErrorMessages.Returns.CannotTeleport, executor);
 				continue;
+			}
+
+			AnySharpContainer destinationContainer;
+
+			if (destinationExit is null)
+			{
+				destinationContainer = fixedDestination!;
+			}
+			else
+			{
+				var resolvedExit = await ResolveExitDestination(
+					parser, executor, target, destinationExit, destinationString);
+
+				if (!resolvedExit.IsT0)
+				{
+					if (resolvedExit.AsT1 == ExitDestinationFailure.Unlinked)
+					{
+						await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.ExitGoesNowhere), executor);
+					}
+
+					continue;
+				}
+
+				destinationContainer = resolvedExit.AsT0;
 			}
 
 			// Zone teleport restriction: check if the source room blocks teleporting out.

--- a/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
+++ b/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
@@ -954,7 +954,7 @@ public class SharpMUSHParserVisitor(
 				if (locate.IsExit)
 				{
 					var exit = locate.AsExit;
-					return await HandleGoCommandPattern(parser, exit);
+					return await HandleGoCommandPattern(parser, exit, command);
 				}
 			}
 
@@ -1192,14 +1192,20 @@ public class SharpMUSHParserVisitor(
 		return CallState.Empty;
 	}
 
-	private static async ValueTask<Option<CallState>> HandleGoCommandPattern(IMUSHCodeParser prs, SharpExit exit)
+	/// <param name="typedName">
+	/// The exit name or alias the player actually typed. PennMUSH passes this to a variable exit's
+	/// DESTINATION attribute as %0 (move.c:369), so one exit can route differently per alias.
+	/// </param>
+	private static async ValueTask<Option<CallState>> HandleGoCommandPattern(
+		IMUSHCodeParser prs, SharpExit exit, string typedName)
 	{
 		var newParser = prs.Push(prs.CurrentState with
 		{
 			Command = "GOTO",
 			Arguments = new Dictionary<string, CallState>
 			{
-				{ "0", new CallState(exit.Object.DBRef.ToString(), 0) }
+				{ "0", new CallState(exit.Object.DBRef.ToString(), 0) },
+				{ "1", new CallState(typedName, 0) }
 			},
 			Function = null
 		});

--- a/SharpMUSH.Library/Definitions/ErrorMessages.cs
+++ b/SharpMUSH.Library/Definitions/ErrorMessages.cs
@@ -621,6 +621,9 @@ public static class ErrorMessages
 		public const string CantGoThatWay = "You can't go that way.";
 		public const string CantSeeThroughThat = "You can't see through that.";
 		public const string ExitNoValidLocation = "That exit doesn't go to a valid location.";
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string VariableExitDestinationInvalidFormat =
+			"Variable exit destination #{0} is invalid or not permitted.";
 		public const string CantGoThatWayContainmentLoop = "You can't go that way - it would create a containment loop.";
 		public const string YouHaveBeenTeleported = "You have been teleported.";
 

--- a/SharpMUSH.Library/Resources/Notifications.resx
+++ b/SharpMUSH.Library/Resources/Notifications.resx
@@ -710,6 +710,9 @@
   <data name="CantSeeThroughThat" xml:space="preserve">
     <value>You can't see through that.</value>
   </data>
+  <data name="VariableExitDestinationInvalidFormat" xml:space="preserve">
+    <value>Variable exit destination #{0} is invalid or not permitted.</value>
+  </data>
   <data name="ExitNoValidLocation" xml:space="preserve">
     <value>That exit doesn't go to a valid location.</value>
   </data>

--- a/SharpMUSH.Tests/Commands/MovementCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/MovementCommandTests.cs
@@ -503,4 +503,63 @@ public class MovementCommandTests
 			NotifyService, nameof(ErrorMessages.Notifications.VariableExitDestinationInvalidFormat),
 			player.DbRef, player.DbRef)).IsTrue();
 	}
+
+	/// <summary>
+	/// SharpMUSH lets <c>@teleport</c> target an exit, meaning "go where it leads". That has to agree with
+	/// what walking the exit does, so a variable exit must resolve its DESTINATION here too.
+	/// </summary>
+	[Test]
+	public async ValueTask TeleportToAVariableExitUsesTheDestinationAttribute()
+	{
+		var player = await CreateTestPlayerAsync("TelVarDest");
+
+		var sourceName = TestIsolationHelpers.GenerateUniqueName("TelVarSource");
+		var sourceResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {sourceName}"));
+		var sourceDbRef = sourceResult.Message!.ToPlainText()!.Trim();
+
+		var destName = TestIsolationHelpers.GenerateUniqueName("TelVarTarget");
+		var destResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {destName}"));
+		var destDbRef = destResult.Message!.ToPlainText()!.Trim();
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={sourceDbRef}"));
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("TelVarExit");
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@open {exitName}"));
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@link {exitName}=variable"));
+		await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"&DESTINATION {exitName}={destDbRef}"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@tel {exitName}"));
+
+		var location = await Mediator.Send(new GetLocationQuery(player.DbRef));
+
+		await Assert.That(location.WithExitOption().Known().Object().DBRef.ToString()).IsEqualTo(destDbRef);
+	}
+
+	/// <summary>
+	/// A home-linked exit resolves against whoever is moving, not against whoever typed the command — so
+	/// teleporting someone else through one must send them to <em>their</em> home.
+	/// </summary>
+	[Test]
+	public async ValueTask TeleportToAHomeLinkedExitSendsTheTargetToTheirOwnHome()
+	{
+		var player = await CreateTestPlayerAsync("TelHomeTarget");
+
+		var homeName = TestIsolationHelpers.GenerateUniqueName("TelHomeTargetHome");
+		var homeResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {homeName}"));
+		var homeDbRef = homeResult.Message!.ToPlainText()!.Trim();
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@link me={homeDbRef}"));
+
+		// Opened where God stands, so God can see it to teleport the player through it.
+		var exitName = TestIsolationHelpers.GenerateUniqueName("TelHomeExit");
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@open {exitName}"));
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@link {exitName}=home"));
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={exitName}"));
+
+		var location = await Mediator.Send(new GetLocationQuery(player.DbRef));
+
+		await Assert.That(location.WithExitOption().Known().Object().DBRef.ToString()).IsEqualTo(homeDbRef)
+			.Because("the exit is linked to home, and the mover is the player, not the executor");
+	}
 }

--- a/SharpMUSH.Tests/Commands/MovementCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/MovementCommandTests.cs
@@ -315,4 +315,192 @@ public class MovementCommandTests
 
 		await Assert.That(result).IsNotNull();
 	}
+
+	/// <summary>
+	/// PennMUSH variable exits: <c>@link &lt;exit&gt;=variable</c> leaves the destination unresolved, and
+	/// <c>find_var_dest</c> (<c>move.c:360</c>) reads it from the exit's <c>DESTINATION</c> attribute at
+	/// move time.
+	/// </summary>
+	[Test]
+	public async ValueTask VariableExitMovesToTheDestinationAttribute()
+	{
+		var player = await CreateTestPlayerAsync("VarDestPlain");
+
+		var sourceName = TestIsolationHelpers.GenerateUniqueName("VarDestSource");
+		var sourceResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {sourceName}"));
+		var sourceDbRef = sourceResult.Message!.ToPlainText()!.Trim();
+
+		var destName = TestIsolationHelpers.GenerateUniqueName("VarDestTarget");
+		var destResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {destName}"));
+		var destDbRef = destResult.Message!.ToPlainText()!.Trim();
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={sourceDbRef}"));
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("VarDestExit");
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@open {exitName}"));
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@link {exitName}=variable"));
+		await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"&DESTINATION {exitName}={destDbRef}"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single(exitName));
+
+		var location = await Mediator.Send(new GetLocationQuery(player.DbRef));
+
+		await Assert.That(location.WithExitOption().Known().Object().DBRef.ToString()).IsEqualTo(destDbRef);
+	}
+
+	/// <summary>
+	/// PennMUSH <c>find_var_dest</c> uses <c>call_attrib</c>, so <c>DESTINATION</c> is softcode that is
+	/// evaluated — that is the whole point of a variable exit.
+	/// </summary>
+	[Test]
+	public async ValueTask VariableExitEvaluatesTheDestinationAttribute()
+	{
+		var player = await CreateTestPlayerAsync("VarDestEval");
+
+		var sourceName = TestIsolationHelpers.GenerateUniqueName("VarEvalSource");
+		var sourceResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {sourceName}"));
+		var sourceDbRef = sourceResult.Message!.ToPlainText()!.Trim();
+
+		var destName = TestIsolationHelpers.GenerateUniqueName("VarEvalTarget");
+		var destResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {destName}"));
+		var destDbRef = destResult.Message!.ToPlainText()!.Trim();
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={sourceDbRef}"));
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("VarEvalExit");
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@open {exitName}"));
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@link {exitName}=variable"));
+		await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"&DESTINATION {exitName}=[first({destDbRef} {sourceDbRef})]"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single(exitName));
+
+		var location = await Mediator.Send(new GetLocationQuery(player.DbRef));
+
+		await Assert.That(location.WithExitOption().Known().Object().DBRef.ToString()).IsEqualTo(destDbRef);
+	}
+
+	/// <summary>
+	/// PennMUSH <c>move.c:377</c> falls back to <c>EXITTO</c> when <c>DESTINATION</c> is absent, "for
+	/// portability".
+	/// </summary>
+	[Test]
+	public async ValueTask VariableExitFallsBackToTheExitToAttribute()
+	{
+		var player = await CreateTestPlayerAsync("VarDestExitTo");
+
+		var sourceName = TestIsolationHelpers.GenerateUniqueName("VarExitToSource");
+		var sourceResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {sourceName}"));
+		var sourceDbRef = sourceResult.Message!.ToPlainText()!.Trim();
+
+		var destName = TestIsolationHelpers.GenerateUniqueName("VarExitToTarget");
+		var destResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {destName}"));
+		var destDbRef = destResult.Message!.ToPlainText()!.Trim();
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={sourceDbRef}"));
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("VarExitToExit");
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@open {exitName}"));
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@link {exitName}=variable"));
+		await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"&EXITTO {exitName}={destDbRef}"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single(exitName));
+
+		var location = await Mediator.Send(new GetLocationQuery(player.DbRef));
+
+		await Assert.That(location.WithExitOption().Known().Object().DBRef.ToString()).IsEqualTo(destDbRef);
+	}
+
+	/// <summary>
+	/// PennMUSH <c>move.c:369</c> passes the exit name or alias the player actually typed as <c>%0</c>,
+	/// so one exit can route differently per alias.
+	/// </summary>
+	[Test]
+	public async ValueTask VariableExitPassesTheUsedExitNameAsPercentZero()
+	{
+		var player = await CreateTestPlayerAsync("VarDestArg");
+
+		var sourceName = TestIsolationHelpers.GenerateUniqueName("VarArgSource");
+		var sourceResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {sourceName}"));
+		var sourceDbRef = sourceResult.Message!.ToPlainText()!.Trim();
+
+		var northName = TestIsolationHelpers.GenerateUniqueName("VarArgNorth");
+		var northResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {northName}"));
+		var northDbRef = northResult.Message!.ToPlainText()!.Trim();
+
+		var southName = TestIsolationHelpers.GenerateUniqueName("VarArgSouth");
+		var southResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {southName}"));
+		var southDbRef = southResult.Message!.ToPlainText()!.Trim();
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={sourceDbRef}"));
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("VarArgExit");
+		await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"@open {exitName};{exitName}North;{exitName}South"));
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@link {exitName}=variable"));
+		await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"&DESTINATION {exitName}=[switch(%0,*South,{southDbRef},{northDbRef})]"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"{exitName}South"));
+
+		var location = await Mediator.Send(new GetLocationQuery(player.DbRef));
+
+		await Assert.That(location.WithExitOption().Known().Object().DBRef.ToString()).IsEqualTo(southDbRef);
+	}
+
+	/// <summary>
+	/// PennMUSH <c>do_move</c> (<c>move.c:451</c>): an exit linked to HOME sends the mover to their own
+	/// home, not to a fixed room.
+	/// </summary>
+	[Test]
+	public async ValueTask HomeLinkedExitSendsTheMoverToTheirOwnHome()
+	{
+		var player = await CreateTestPlayerAsync("HomeLinkWalker");
+
+		var homeName = TestIsolationHelpers.GenerateUniqueName("HomeLinkHome");
+		var homeResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {homeName}"));
+		var homeDbRef = homeResult.Message!.ToPlainText()!.Trim();
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@link me={homeDbRef}"));
+
+		var sourceName = TestIsolationHelpers.GenerateUniqueName("HomeLinkSource");
+		var sourceResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {sourceName}"));
+		var sourceDbRef = sourceResult.Message!.ToPlainText()!.Trim();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={sourceDbRef}"));
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("HomeLinkExit");
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@open {exitName}"));
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@link {exitName}=home"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single(exitName));
+
+		var location = await Mediator.Send(new GetLocationQuery(player.DbRef));
+
+		await Assert.That(location.WithExitOption().Known().Object().DBRef.ToString()).IsEqualTo(homeDbRef);
+	}
+
+	/// <summary>
+	/// PennMUSH <c>move.c:459</c> names the offending dbref rather than giving the generic exit failure.
+	/// </summary>
+	[Test]
+	public async ValueTask VariableExitWithNoDestinationAttributeReportsAnInvalidDestination()
+	{
+		var player = await CreateTestPlayerAsync("VarDestMissing");
+
+		var sourceName = TestIsolationHelpers.GenerateUniqueName("VarMissingSource");
+		var sourceResult = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@dig {sourceName}"));
+		var sourceDbRef = sourceResult.Message!.ToPlainText()!.Trim();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@tel {player.DbRef}={sourceDbRef}"));
+
+		var exitName = TestIsolationHelpers.GenerateUniqueName("VarMissingExit");
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@open {exitName}"));
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@link {exitName}=variable"));
+
+		await Parser.CommandParse(player.Handle, ConnectionService, MModule.single(exitName));
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.VariableExitDestinationInvalidFormat),
+			player.DbRef, player.DbRef)).IsTrue();
+	}
 }


### PR DESCRIPTION
Stacked on #721 — review that first; this branch adds two commits on top of it.

## The bug

`@link <exit>=variable` marks the exit by setting a **`_LINKTYPE=variable` attribute** (`BuildingCommands.cs:648`). `GoTo` recognised a variable exit by checking **`Home.DBRef.Number == -1`** (`GeneralCommands.cs:1361`) — a value SharpMUSH never stores anywhere. The two markers never agreed, so the whole `DESTINATION` block was unreachable and a variable exit went nowhere.

`loc()` already reads `_LINKTYPE` to answer `#-2` and `#-3` (`DbrefFunctions.cs:52`), so the read side knew the convention the write side used. `GoTo` was the odd one out.

Four tests written against PennMUSH behaviour all failed, including the simplest case — a literal `#dbref` in `DESTINATION`.

## What it does now

`GoTo` dispatches on `_LINKTYPE` and implements `find_var_dest` (`move.c:360`) properly:

| PennMUSH | before | now |
|---|---|---|
| `call_attrib` **evaluates** DESTINATION as softcode | raw `ToPlainText()` | evaluated |
| `%0` = the exit name/alias typed | not passed | passed |
| falls back to `EXITTO` | DESTINATION only | falls back |
| `parse_objid` — must name an object | name-locate from the mover's position | parsed as an objid |
| `can_link_to(exit, dest)` (`mushdb.h:87`) | no check | checked against the **exit**, not the mover |
| `Variable exit destination #%d is invalid or not permitted.` | `Exit destination is invalid.` | Penn's message, naming the dbref |

Evaluation is the substantive one — a variable exit that can't compute its destination is just a worse fixed exit.

`@link <exit>=home` works too: the exit sends the mover to their own home (`move.c:451`).

The typed name reaches `GOTO` as `args["1"]`, pushed by the visitor's exit-as-command path; an explicit `goto` still uses `args["0"]`.

## Testing

Six new tests, each watched failing first — the four above, plus the home-link and invalid-destination branches. For those last two I disabled the new branches and re-ran to confirm all six went red for the right reason before restoring.

Unit **4957**, 0 failed. Formatter converged.

## Note

`ExitCanLinkTo` checks `Controls || Link_Anywhere power || (LINK_OK flag && link lock)`, mirroring both PennMUSH's macro and SharpMUSH's existing `@link`. It does not implement Penn's `NO_LINK_TO_OBJECT` config gate, since SharpMUSH has no such option — exits may lead to any container either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)