### PR TITLE
Require a full objid wherever a reference is a routing key

### DIFF
--- a/SharpMUSH.Library/Models/DBref.cs
+++ b/SharpMUSH.Library/Models/DBref.cs
@@ -13,6 +13,18 @@ public readonly struct DBRef : IEquatable<DBRef>
 	public int Number { get; init; }
 	public long? CreationMilliseconds { get; init; }
 
+	/// <summary>
+	/// Whether this is a full objid (<c>#N:creation</c>) rather than a bare dbref (<c>#N</c>).
+	/// </summary>
+	/// <remarks>
+	/// Required wherever a reference is used as an identity <em>key</em> — a SignalR group name, a
+	/// cache key — because <c>#N</c> and <c>#N:creation</c> are necessarily different keys, so a
+	/// producer and consumer that disagree on completeness miss each other silently. Being a
+	/// <see cref="DBRef"/> stops the two from being spelled differently; it does not stop one side
+	/// from lacking the timestamp, which this exists to catch.
+	/// </remarks>
+	public bool IsObjid => CreationMilliseconds.HasValue;
+
 	public override bool Equals(object? obj) => obj is DBRef @ref && Equals(@ref);
 
 	public bool Equals(DBRef other)

--- a/SharpMUSH.Server/Authentication/DebugAuthenticationHandler.cs
+++ b/SharpMUSH.Server/Authentication/DebugAuthenticationHandler.cs
@@ -85,8 +85,10 @@ public class DebugAuthenticationHandler(
 					Logger.LogWarning(
 						"[DebugAuth] Account {AccountId} has no linked character with key 1; omitting character claims",
 						account.Id);
+					// No character_dbref claim: without the object we have no creation time, and a
+					// bare "#1" would route to char:#1 while publishers use char:#1:creation — the
+					// connection would silently receive nothing. Better to be plainly characterless.
 					claims.Add(new("character_key", "1"));
-					claims.Add(new(GameHub.CharacterDbrefClaim, "#1"));
 				}
 			}
 			else
@@ -125,6 +127,7 @@ public class DebugAuthenticationHandler(
 		claims.Add(new(ClaimTypes.Name, "DebugAdmin"));
 		claims.Add(new(ClaimTypes.NameIdentifier, "debug-bootstrap-pending"));
 		claims.Add(new("character_key", "1"));
-		claims.Add(new(GameHub.CharacterDbrefClaim, "#1"));
+		// Deliberately no character_dbref: bootstrap has not run, so there is no object to read a
+		// creation time from, and a bare "#1" would name a group no publisher ever targets.
 	}
 }

--- a/SharpMUSH.Server/Authentication/DebugAuthenticationHandler.cs
+++ b/SharpMUSH.Server/Authentication/DebugAuthenticationHandler.cs
@@ -83,7 +83,8 @@ public class DebugAuthenticationHandler(
 					// Account exists but character list lookup returned nothing (shouldn't happen
 					// after a successful bootstrap, but guard defensively).
 					Logger.LogWarning(
-						"[DebugAuth] Account {AccountId} has no linked character with key 1; omitting character claims",
+						"[DebugAuth] Account {AccountId} has no linked character with key 1; omitting the " +
+						"character_dbref routing claim (character_key is still emitted)",
 						account.Id);
 					// No character_dbref claim: without the object we have no creation time, and a
 					// bare "#1" would route to char:#1 while publishers use char:#1:creation — the

--- a/SharpMUSH.Server/Hubs/GameHub.cs
+++ b/SharpMUSH.Server/Hubs/GameHub.cs
@@ -176,9 +176,10 @@ public class GameHub(IMessageBus messageBus, ILogger<GameHub> logger, HubConnect
 			return room.Value;
 		}
 
+		var shown = roomDbref is null ? "(null)" : $"'{roomDbref}'";
 		logger.LogWarning("[GameHub] Connection {ConnectionId} sent an unroutable room reference {Room}",
-			Context.ConnectionId, roomDbref);
-		throw new HubException($"'{roomDbref}' is not a valid objid; a bare dbref cannot be routed.");
+			Context.ConnectionId, shown);
+		throw new HubException($"{shown} is not a valid objid; a bare dbref cannot be routed.");
 	}
 
 	// These are called by internal services (e.g. NatsBridgeService, REST controllers)

--- a/SharpMUSH.Server/Hubs/GameHub.cs
+++ b/SharpMUSH.Server/Hubs/GameHub.cs
@@ -75,7 +75,7 @@ public class GameHub(IMessageBus messageBus, ILogger<GameHub> logger, HubConnect
 			return;
 		}
 
-		if (Context.User?.GetActingCharacter() is { } character)
+		if (Context.User?.GetActingCharacter() is { IsObjid: true } character)
 		{
 			await Groups.AddToGroupAsync(Context.ConnectionId, CharacterGroupName(character));
 			logger.LogInformation("[GameHub] Connection {ConnectionId} joined character group {Group}",
@@ -83,7 +83,11 @@ public class GameHub(IMessageBus messageBus, ILogger<GameHub> logger, HubConnect
 		}
 		else
 		{
-			logger.LogWarning("[GameHub] Connection {ConnectionId} has no usable {Claim} claim; not added to character group",
+			// A bare dbref is refused rather than routed: it would name char:#N while publishers
+			// name char:#N:creation, and the connection would receive nothing with no error anywhere.
+			logger.LogWarning(
+				"[GameHub] Connection {ConnectionId} has no usable {Claim} claim (absent, unparseable, " +
+				"or a bare dbref rather than an objid); not added to character group",
 				Context.ConnectionId, CharacterDbrefClaim);
 		}
 
@@ -110,11 +114,13 @@ public class GameHub(IMessageBus messageBus, ILogger<GameHub> logger, HubConnect
 	/// <param name="command">The raw command string typed by the player.</param>
 	public async Task SendCommand(string command)
 	{
-		if (Context.User?.GetActingCharacter() is not { } character)
+		if (Context.User?.GetActingCharacter() is not { IsObjid: true } character)
 		{
-			// No character identity → the command is unroutable; fail at the auth boundary
-			// rather than publishing an empty-dbref message onto the bus.
-			logger.LogWarning("[GameHub] Connection {ConnectionId} sent a command without a usable {Claim} claim; rejecting",
+			// No routable character identity → the command is unroutable; fail at the auth boundary
+			// rather than publishing a reference the engine cannot reply to onto the bus.
+			logger.LogWarning(
+				"[GameHub] Connection {ConnectionId} sent a command without a usable {Claim} claim " +
+				"(absent, unparseable, or a bare dbref rather than an objid); rejecting",
 				Context.ConnectionId, CharacterDbrefClaim);
 			throw new HubException("No character identity on this connection.");
 		}
@@ -165,14 +171,14 @@ public class GameHub(IMessageBus messageBus, ILogger<GameHub> logger, HubConnect
 	/// </summary>
 	private DBRef ParseRoomOrThrow(string? roomDbref)
 	{
-		if (DBRef.TryParse(roomDbref, out var room) && room is not null)
+		if (DBRef.TryParse(roomDbref, out var room) && room is { IsObjid: true })
 		{
 			return room.Value;
 		}
 
-		logger.LogWarning("[GameHub] Connection {ConnectionId} sent an unparseable room reference {Room}",
+		logger.LogWarning("[GameHub] Connection {ConnectionId} sent an unroutable room reference {Room}",
 			Context.ConnectionId, roomDbref);
-		throw new HubException($"'{roomDbref}' is not a valid dbref or objid.");
+		throw new HubException($"'{roomDbref}' is not a valid objid; a bare dbref cannot be routed.");
 	}
 
 	// These are called by internal services (e.g. NatsBridgeService, REST controllers)

--- a/SharpMUSH.Server/Services/NatsBridgeService.cs
+++ b/SharpMUSH.Server/Services/NatsBridgeService.cs
@@ -154,11 +154,12 @@ public sealed class NatsBridgeService : BackgroundService, INatsBridgeService
 			if (msg.Data is null) continue;
 
 			var dbref = msg.Data.CharacterDbref;
-			if (!DBRef.TryParse(dbref, out var character) || character is null)
+			if (!DBRef.TryParse(dbref, out var character) || character is not { IsObjid: true })
 			{
 				_logger.LogWarning(
-					"[NatsBridge] Dropping GameOutputMessage with unparseable CharacterDbref {Dbref}; " +
-					"the contract is an objid such as #42:1700000000", dbref);
+					"[NatsBridge] Dropping GameOutputMessage whose CharacterDbref {Dbref} is not a " +
+					"routable objid such as #42:1700000000; a bare dbref names a different group than subscribers join",
+					dbref);
 				continue;
 			}
 
@@ -189,11 +190,12 @@ public sealed class NatsBridgeService : BackgroundService, INatsBridgeService
 			if (msg.Data is null) continue;
 
 			var dbref = msg.Data.RoomDbref;
-			if (!DBRef.TryParse(dbref, out var room) || room is null)
+			if (!DBRef.TryParse(dbref, out var room) || room is not { IsObjid: true })
 			{
 				_logger.LogWarning(
-					"[NatsBridge] Dropping RoomEventMessage with unparseable RoomDbref {Dbref}; " +
-					"the contract is an objid such as #7:1700000000", dbref);
+					"[NatsBridge] Dropping RoomEventMessage whose RoomDbref {Dbref} is not a " +
+					"routable objid such as #7:1700000000; a bare dbref names a different group than subscribers join",
+					dbref);
 				continue;
 			}
 

--- a/SharpMUSH.Tests/Hubs/GameHubTests.cs
+++ b/SharpMUSH.Tests/Hubs/GameHubTests.cs
@@ -188,8 +188,11 @@ public class GameHubTests
 	}
 
 	/// <summary>
-	/// A malformed room reference is rejected at the boundary. Previously it was interpolated
-	/// straight into a group name, so the caller silently joined a group nothing ever publishes to.
+	/// A room reference that cannot be routed is rejected at the boundary — unparseable
+	/// (<c>"not-a-dbref"</c>, <c>"5"</c>, empty, null) or parseable but incomplete (<c>"#5"</c>,
+	/// which names <c>room:#5</c> while publishers name <c>room:#5:creation</c>). Previously any of
+	/// them was interpolated straight into a group name, so the caller silently joined a group
+	/// nothing ever publishes to.
 	/// </summary>
 	[Test]
 	[Arguments("5")]

--- a/SharpMUSH.Tests/Hubs/GameHubTests.cs
+++ b/SharpMUSH.Tests/Hubs/GameHubTests.cs
@@ -196,7 +196,8 @@ public class GameHubTests
 	[Arguments("not-a-dbref")]
 	[Arguments("")]
 	[Arguments(null)]
-	public async Task JoinRoom_WithUnparseableReference_Throws(string? roomDbref)
+	[Arguments("#5")]
+	public async Task JoinRoom_WithUnroutableReference_Throws(string? roomDbref)
 	{
 		var (hub, groups) = BuildHub();
 
@@ -210,6 +211,34 @@ public class GameHubTests
 	/// A claim carrying a bare number rather than a dbref or objid does not resolve, so the
 	/// connection joins no character group. Every handler emits the objid form.
 	/// </summary>
+	/// <summary>
+	/// A bare dbref is refused rather than routed. It parses, so it would have joined
+	/// <c>char:#42</c> while publishers name <c>char:#42:creation</c> — the same silent-drop the
+	/// objid contract exists to prevent, reintroduced by an incomplete reference rather than a
+	/// misspelled one.
+	/// </summary>
+	[Test]
+	public async Task OnConnectedAsync_WithBareDbrefClaim_DoesNotAddToGroup()
+	{
+		var (hub, groups) = BuildHub("#42");
+
+		await hub.OnConnectedAsync();
+
+		await groups.DidNotReceive().AddToGroupAsync(
+			Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task SendCommand_WithBareDbrefClaim_Throws()
+	{
+		var (hub, _, bus) = BuildHubWithBus("#42");
+
+		await Assert.That(async () => await hub.SendCommand("look")).Throws<HubException>();
+
+		await bus.DidNotReceive().Publish(
+			Arg.Any<GameCommandMessage>(), Arg.Any<CancellationToken>());
+	}
+
 	[Test]
 	public async Task OnConnectedAsync_WithUnparseableCharacterClaim_DoesNotAddToGroup()
 	{

--- a/SharpMUSH.Tests/Hubs/GameHubTests.cs
+++ b/SharpMUSH.Tests/Hubs/GameHubTests.cs
@@ -211,10 +211,6 @@ public class GameHubTests
 	}
 
 	/// <summary>
-	/// A claim carrying a bare number rather than a dbref or objid does not resolve, so the
-	/// connection joins no character group. Every handler emits the objid form.
-	/// </summary>
-	/// <summary>
 	/// A bare dbref is refused rather than routed. It parses, so it would have joined
 	/// <c>char:#42</c> while publishers name <c>char:#42:creation</c> — the same silent-drop the
 	/// objid contract exists to prevent, reintroduced by an incomplete reference rather than a
@@ -242,6 +238,10 @@ public class GameHubTests
 			Arg.Any<GameCommandMessage>(), Arg.Any<CancellationToken>());
 	}
 
+	/// <summary>
+	/// A claim carrying a bare number rather than a dbref or objid does not resolve at all, so the
+	/// connection joins no character group. Every handler emits the objid form.
+	/// </summary>
 	[Test]
 	public async Task OnConnectedAsync_WithUnparseableCharacterClaim_DoesNotAddToGroup()
 	{

--- a/SharpMUSH.Tests/Models/DBRefParseTests.cs
+++ b/SharpMUSH.Tests/Models/DBRefParseTests.cs
@@ -29,16 +29,20 @@ public class DBRefParseTests
 	public async ValueTask TryParse_BareDbref_HasNoCreationTime()
 	{
 		await Assert.That(DBRef.TryParse("#42", out var dbref)).IsTrue();
-		await Assert.That(dbref!.Value.Number).IsEqualTo(42);
-		await Assert.That(dbref.Value.CreationMilliseconds).IsNull();
+		var parsed = dbref!.Value;
+		await Assert.That(parsed.Number).IsEqualTo(42);
+		await Assert.That(parsed.CreationMilliseconds).IsNull();
+		await Assert.That(parsed.IsObjid).IsFalse();
 	}
 
 	[Test]
 	public async ValueTask TryParse_Objid_KeepsTheCreationTime()
 	{
 		await Assert.That(DBRef.TryParse("#42:1700000000", out var dbref)).IsTrue();
-		await Assert.That(dbref!.Value.Number).IsEqualTo(42);
-		await Assert.That(dbref.Value.CreationMilliseconds).IsEqualTo(1700000000L);
+		var parsed = dbref!.Value;
+		await Assert.That(parsed.Number).IsEqualTo(42);
+		await Assert.That(parsed.CreationMilliseconds).IsEqualTo(1700000000L);
+		await Assert.That(parsed.IsObjid).IsTrue();
 	}
 
 	/// <summary>


### PR DESCRIPTION
Completes what #722 claimed. Small, and worth landing because that PR's description overstates what it delivered.

## What #722 got wrong

It typed the group-name API to `DBRef` so the two sides couldn't spell a reference differently, and I described that as making a wrong reference *unrepresentable in C#*. Overstated: **`DBRef` permits a null creation time**, so it prevents spelling variance but not **incompleteness** — and `char:#42` versus `char:#42:1700000000` are necessarily different groups. An incomplete reference reproduces exactly the silent drop the change was meant to close.

It's reachable on `main` today. `DebugAuthenticationHandler` emits a hardcoded `"#1"` on two fallback paths — bootstrap not yet run, and the account-exists-but-no-character-1 guard. #722 deliberately left those alone, reasoning they had no object to read a timestamp from, without noticing that made them emit a routing claim that routes nowhere. A connection authenticated that way joins `char:#1` while publishers target `char:#1:<creation>`, and receives nothing, with no error at either end.

Narrow in practice (debug auth, degenerate startup states) but it's the exact failure mode #722 exists to prevent.

## The fix, at both ends

Deliberately not a normalizer — collapsing the two forms would preserve the divergence and also throw away the recycle-safety that motivated objids in the first place.

**Producers stop emitting a routing claim they can't complete.** Both debug fallbacks omit `character_dbref` entirely. `GameHub` already handles a characterless connection by logging and not joining, which is the honest outcome: a bootstrap-pending debug session genuinely has no character to route to.

**The routing boundary refuses an incomplete reference regardless of producer**, so a future producer can't quietly reintroduce it:

| Site | Before | After |
|---|---|---|
| `OnConnectedAsync` | joins `char:#N` | doesn't join; logs why |
| `SendCommand` | publishes a bare ref | `HubException` |
| `JoinRoom` / `LeaveRoom` | joins `room:#N` | `HubException` |
| `NatsBridgeService` | forwards to an empty group | drops; logs why |

`DBRef.IsObjid` names the requirement. Its doc comment draws the line that matters: it's required wherever a reference is an identity **key** — a group name, a cache key — as opposed to a *lookup argument*, where a bare dbref is legitimate and `DBRef.Matches` already handles the objid check. That's why this doesn't tighten the controllers.

## Tests

A bare `#42` claim doesn't route and `SendCommand` throws; a bare `#5` room argument is refused; and the existing assertion that objid and bare dbref are *distinct* groups stays, so a later "simplification" can't collapse them and silently undo recycle-safety.

## Verification

| Suite | Result |
|---|---|
| `SharpMUSH.Tests` | 4956 total, **0 failed**, 198 skipped |
| `SharpMUSH.Tests.BUnit` | 274 total, **0 failed** |
| `dotnet build` | 0 errors, 0 C# warnings |
| `dotnet format whitespace` | no changes on either pass |

Integration not run locally — the machine currently has concurrent `SharpMUSH.Tests.Integration` runs from other work, which starved an earlier attempt. CI's three-backend matrix covers it.

## One review item from #722 I'm still declining

Copilot flagged `BootstrapService` using `GetAllAccountsAsync` + `Any` to answer an existence question. Technically right, but it's a **once-at-startup** check, and the alternative costs a new `ISharpDatabase` method plus three provider implementations. Wrong trade for a boot-time existence test; worth revisiting only if account counts get large enough to matter. Recording it here since #722 is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a way to distinguish full object identifiers from basic database references.

* **Bug Fixes**
  * Improved routing validation to reject incomplete or non-routable references.
  * Prevented connections, commands, rooms, and messages from using bare references incorrectly.
  * Improved authentication fallback behavior when no character is available.
  * Added clearer warnings for invalid or incomplete references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->