### PR TITLE
Fix fail-open account status parsing: accept names, never numeric text

### DIFF
--- a/SharpMUSH.Library/Models/AccountStatus.cs
+++ b/SharpMUSH.Library/Models/AccountStatus.cs
@@ -23,9 +23,39 @@ public static class AccountStatusParser
 	/// and a corrupt value must not be able to re-enable a closed account.
 	/// </summary>
 	public static AccountStatus Parse(string? stored)
-		=> string.IsNullOrEmpty(stored)
+		=> string.IsNullOrWhiteSpace(stored)
 			? AccountStatus.Active
-			: Enum.TryParse<AccountStatus>(stored, out var parsed)
+			: TryParseName(stored, out var parsed)
 				? parsed
 				: AccountStatus.Disabled;
+
+	/// <summary>
+	/// Matches a status <em>name</em>, case-insensitively and ignoring surrounding whitespace.
+	/// Returns <see langword="false"/> for anything else, including a value that is absent.
+	/// </summary>
+	/// <remarks>
+	/// Deliberately not <see cref="Enum.TryParse{T}(string, bool, out T)"/>: that accepts numeric
+	/// text, so <c>"42"</c> yields an undefined status and — worse — <c>"0"</c> yields
+	/// <see cref="AccountStatus.Active"/>, failing open on the field that gates authentication.
+	/// <see cref="Enum.IsDefined{T}"/> does not catch the second case, because 0 is defined.
+	/// Only a name is accepted, which is the only form ever written.
+	/// </remarks>
+	public static bool TryParseName(string? value, out AccountStatus status)
+	{
+		if (!string.IsNullOrWhiteSpace(value))
+		{
+			var trimmed = value.Trim();
+			foreach (var candidate in Enum.GetValues<AccountStatus>())
+			{
+				if (string.Equals(candidate.ToString(), trimmed, StringComparison.OrdinalIgnoreCase))
+				{
+					status = candidate;
+					return true;
+				}
+			}
+		}
+
+		status = AccountStatus.Disabled;
+		return false;
+	}
 }

--- a/SharpMUSH.Server/Controllers/AdminAccountsController.cs
+++ b/SharpMUSH.Server/Controllers/AdminAccountsController.cs
@@ -126,7 +126,7 @@ public class AdminAccountsController(
 		var (adminId, failure) = await RequireWizardAsync();
 		if (failure is not null) return failure;
 
-		if (!Enum.TryParse<AccountStatus>(request.Status, ignoreCase: true, out var status))
+		if (!AccountStatusParser.TryParseName(request.Status, out var status))
 			return BadRequest($"Unknown account status '{request.Status}'.");
 
 		// Resolving the account here separates the two error causes: absent is 404, present but

--- a/SharpMUSH.Tests.Integration/Auth/AdminAccountsApiTests.cs
+++ b/SharpMUSH.Tests.Integration/Auth/AdminAccountsApiTests.cs
@@ -211,6 +211,32 @@ public class AdminAccountsApiTests(ServerWebAppFactory factory)
 		await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
 	}
 
+	/// <summary>
+	/// Enum.TryParse succeeds on numeric text, so without an IsDefined check "42" would be
+	/// persisted as an undefined status that no UI label or query understands.
+	/// </summary>
+	[Test, NotInParallel("SetupFlow", Order = 11)]
+	public async Task SetStatus_NumericStatus_ReturnsBadRequest()
+	{
+		var (http, sessionToken) = await LoginAsGodAccountAsync();
+		var (_, target) = await RegisterAccountAsync();
+
+		using var listRequest = new HttpRequestMessage(HttpMethod.Get, "api/admin/accounts");
+		listRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", sessionToken);
+		using var listResponse = await http.SendAsync(listRequest);
+		var rows = await listResponse.Content.ReadFromJsonAsync<List<AdminAccountRow>>();
+		var targetRow = rows!.Single(r => r.Username == target.Username);
+
+		using var request = new HttpRequestMessage(HttpMethod.Post, $"api/admin/accounts/{targetRow.Id}/status")
+		{
+			Content = JsonContent.Create(new { status = "42" })
+		};
+		request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", sessionToken);
+		using var response = await http.SendAsync(request);
+
+		await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.BadRequest);
+	}
+
 	[Test, NotInParallel("SetupFlow", Order = 8)]
 	public async Task SetStatus_UnknownStatus_ReturnsBadRequest()
 	{

--- a/SharpMUSH.Tests/Services/AccountStatusTests.cs
+++ b/SharpMUSH.Tests/Services/AccountStatusTests.cs
@@ -45,6 +45,13 @@ public class AccountStatusTests
 	[Arguments("Deleted", AccountStatus.Deleted)]
 	[Arguments("Banished", AccountStatus.Disabled)]
 	[Arguments("garbage", AccountStatus.Disabled)]
+	[Arguments("   ", AccountStatus.Active)]
+	[Arguments("  Closed  ", AccountStatus.Closed)]
+	[Arguments("active", AccountStatus.Active)]
+	[Arguments("CLOSED", AccountStatus.Closed)]
+	[Arguments("42", AccountStatus.Disabled)]
+	[Arguments("-1", AccountStatus.Disabled)]
+	[Arguments("0", AccountStatus.Disabled)]
 	public async ValueTask ParseStatus_MissingIsActive_UnparseableFailsClosed(string? stored, AccountStatus expected)
 	{
 		await Assert.That(AccountStatusParser.Parse(stored)).IsEqualTo(expected);


### PR DESCRIPTION
Follow-up to #726, which merged before this fix was pushed. **`main` currently has a fail-open on the field that gates authentication.**

## The bug

`AccountStatusParser.Parse` uses `Enum.TryParse`, which accepts numeric text and returns `true` for it:

| Stored value | `main` reads it as | Should be |
|---|---|---|
| `"0"` | **`Active`** | `Disabled` |
| `"42"` | `(AccountStatus)42` — undefined | `Disabled` |
| `"active"` | `Disabled` (case-sensitive) | `Active` |

The first row is the problem. A corrupt or hand-edited `"0"` silently reads as **Active**, re-activating a closed or deleted account — precisely the failure the missing-vs-unparseable asymmetry was introduced to prevent. #726's own doc comment asserts "Any other unrecognised value fails closed", which is false as merged.

`POST /api/admin/accounts/{key}/status` had the same hole: it accepted `"42"` and `"0"` and would persist an undefined status that no UI label or query understands.

## Why `Enum.IsDefined` is not the fix

That was my first attempt, and it's worse than it looks: `TryParse("0")` yields `Active`, and `IsDefined(Active)` is `true`, so `"0"` still sails through. `IsDefined` structurally cannot catch it, because 0 *is* a defined member. The `"0"` test case added alongside is what caught this — the fix looked right and passed everything except that one row.

## The fix

`TryParseName` matches a status **name** only — case-insensitively, whitespace-trimmed. Numeric text matches no name and so fails closed. Names are the only form ever written (`Status.ToString()`), so nothing legitimate is rejected.

The HTTP surface now shares that parser instead of doing its own `TryParse`, so "what counts as a status" is answered in one place. It still distinguishes *unknown* (400) from valid, which the storage path deliberately cannot — storage must fail closed to `Disabled` rather than reject.

## Severity

Lower than it reads: nothing in the codebase *writes* a numeric status, and SharpMUSH is pre-production. This is a latent hole in a documented guarantee rather than an active exploit. Worth fixing promptly because the guarantee is the whole reason the asymmetry exists.

## Verification

`AccountStatusTests` 29/29, including the new rows: `"0"`, `"-1"`, `"42"` → `Disabled`; `"active"`, `"CLOSED"`, `"  Closed  "` → the right member; `"   "` → `Active`. Plus an integration test that the endpoint rejects `"42"` with 400. Build clean, formatter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)