### PR TITLE
fix(tests): repair the integration tests broken by #724, and the MovementCommandTests parallelism flake

### DIFF
--- a/SharpMUSH.Tests.Integration/Auth/BanEnforcementTests.cs
+++ b/SharpMUSH.Tests.Integration/Auth/BanEnforcementTests.cs
@@ -55,7 +55,7 @@ public class BanEnforcementTests(ServerWebAppFactory factory)
 		var sessions = factory.Services.GetRequiredService<IAccountSessionStore>();
 
 		// The token authenticates before enforcement.
-		await Assert.That(await sessions.ValidateAsync(account.AccountSessionToken)).IsEqualTo(account.AccountId);
+		await Assert.That((await sessions.ValidateAsync(account.AccountSessionToken))?.AccountId).IsEqualTo(account.AccountId);
 
 		await enforcement.EnforceAccountBanAsync(account.AccountId);
 

--- a/SharpMUSH.Tests.Integration/Auth/SessionPersistenceTests.cs
+++ b/SharpMUSH.Tests.Integration/Auth/SessionPersistenceTests.cs
@@ -21,7 +21,7 @@ public class SessionPersistenceTests(ServerWebAppFactory factory)
 		var token = await store.CreateTokenAsync("node_accounts/1", TimeSpan.FromMinutes(15), "203.0.113.50");
 
 		var fresh = new DatabaseAccountSessionStore(db); // simulates a server restart
-		await Assert.That(await fresh.ValidateAsync(token)).IsEqualTo("node_accounts/1");
+		await Assert.That((await fresh.ValidateAsync(token))?.AccountId).IsEqualTo("node_accounts/1");
 
 		await fresh.RevokeAllForIpAsync("203.0.113.50");
 		await Assert.That(await fresh.ValidateAsync(token)).IsNull();

--- a/SharpMUSH.Tests/Commands/MovementCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/MovementCommandTests.cs
@@ -11,6 +11,12 @@ using SharpMUSH.Library.Services.Interfaces;
 
 namespace SharpMUSH.Tests.Commands;
 
+// Movement tests drive full command pipelines (@dig/@open/@link/@tel/walk) against the shared
+// PerTestSession database and assert on the resulting location and the shared NotifyService mock.
+// Run in parallel with the rest of the suite they race on that shared state — which surfaced as
+// flaky, provider-timing-dependent failures (worst on memgraph). Every other stateful command
+// test class here is [NotInParallel] for the same reason; this one was simply missing it.
+[NotInParallel]
 public class MovementCommandTests
 {
 	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]


### PR DESCRIPTION
## What was broken

`main`'s `test-integration` checks were red on every provider. Root cause: **#724** ("bind the acting character to the session token") changed `IAccountSessionStore.ValidateAsync` from `Task<string?>` (the account id) to `Task<SessionIdentity?>` (a record: `AccountId` + `CharacterKey` + `CharacterCreationTime`). It correctly updated the unit tests (`InMemoryAccountSessionStoreTests` all read `(await …ValidateAsync(…))?.AccountId`) and all five production callers — but **two integration tests were missed** and still compared the whole record to a bare string:

- `SessionPersistenceTests.Session_SurvivesNewStoreInstance_AndRevokes` → `.IsEqualTo("node_accounts/1")`
- `BanEnforcementTests.EnforceAccountBan_RevokesSession` → `.IsEqualTo(account.AccountId)`

Both failed deterministically. The store actually returns a valid `SessionIdentity`, so persistence and revocation work correctly — only the assertions were stale.

## The fix

Extract `?.AccountId` from the returned record, exactly matching the pattern the unit tests already use. Two-line, test-only change.

## About the alarming CI duration

The `test-integration` job was taking ~13 min, which looked like a hang. It isn't: CI wraps each test step in `nick-fields/retry@v4` (`max_attempts: 3`), so a **deterministic** failure re-runs the whole suite 3×. A single clean pass of the integration suite is **~3m47s**. With these two tests fixed, the retries stop and the job returns to one pass.

## Verification

Full `SharpMUSH.Tests.Integration` suite locally (arangodb provider): **255 total, 0 failed, 255 succeeded, 3m47s** — down from 253/2 failed. The two tests individually pass 1/1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved integration test assertions for account session validation to safely handle nullable session validation results.
  * Continued verifying that account bans revoke sessions, sessions persist across store instances, and IP-based revocation invalidates tokens.
* **Tests**
  * Marked movement command tests as non-parallel to prevent flaky timing-dependent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->