### PR TITLE
Fix the build: close the <data> tag the #729 squash merge dropped

### DIFF
--- a/SharpMUSH.Client/Resources/SharedResource.fr.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.fr.resx
@@ -2609,6 +2609,7 @@
   </data>
   <data name="ResWikiStatTranslations" xml:space="preserve">
     <value>Traductions</value>
+  </data>
   <data name="ConfigSavedCount" xml:space="preserve">
     <value>{count, plural, one {# paramètre enregistré} other {# paramètres enregistrés}}</value>
   </data>


### PR DESCRIPTION
**`main` does not currently build.** One inserted line fixes it.

## The break

`SharedResource.fr.resx` has an unclosed `<data>` at `ResWikiStatTranslations` — 867 `<data>` opens against 866 closes — so MSBuild fails the whole `SharpMUSH.Client` project:

```
error MSB3103: Invalid Resx file. System.Xml.XmlException: The 'data' start tag on
line 2610 position 4 does not match the end tag of 'root'. Line 2660, position 3.
```

## Cause

#728 (ICU plurals) and #729 (wiki localization) both appended keys to the same region of that file. The squash merge resolved the overlap by splicing #728's `ConfigSavedCount` block into the middle of #729's `ResWikiStatTranslations` block, dropping the closing tag between them.

The English file was unaffected — only French had both sides landing at the same offset. Worth stating plainly: **the defect exists in neither PR.** Both files were individually valid; the break was created by the merge resolution itself.

## Verification on `main` with this applied

| | |
|---|---|
| `dotnet build SharpMUSH.sln` | **0 errors** |
| `dotnet format whitespace --verify-no-changes` | exit 0 |
| `tools/i18n/validate_resx.py` | all gates passed — 1123 en / 867 fr, no duplicate keys |
| `SharpMUSH.Tests` | **5287 / 5091 passed / 196 skipped / 0 failed** |
| `SharpMUSH.Tests.BUnit` | **319 / 319** |
| `SharpMUSH.Tests.Integration` | **281 / 281** on each of `arangodb`, `memgraph`, `surrealdb` |

Nothing else was wrong — the merged localization work is sound, and this is purely a merge artefact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)