### PR TITLE
Move the default ssl_port to 4203, off the HTTP API port

### DIFF
--- a/SharpMUSH.Configuration/Options/NetOptions.cs
+++ b/SharpMUSH.Configuration/Options/NetOptions.cs
@@ -17,7 +17,7 @@ public record NetOptions(
 	uint Port = 4201,
 
 	[property: SharpConfig(Name = "ssl_port", Category = "Net", Description = "Port for SSL/TLS encrypted connections", ValidationPattern = @"^\d+$", Group = "Connection Settings", Order = 2, Min = 0, Max = 65535, Tooltip = "Set to 0 to disable SSL")]
-	uint SslPort = 4202,
+	uint SslPort = 4203,
 
 	[property: SharpConfig(Name = "portal_port", Category = "Net", Description = "Port for portal connections", ValidationPattern = @"^\d+$", Group = "Connection Settings", Order = 6, Min = 0, Max = 65535)]
 	uint PortalPort = 0,
@@ -81,7 +81,7 @@ public record NetOptions(
 		IpAddr: null,
 		SslIpAddr: null,
 		Port: 4201,
-		SslPort: 4202,
+		SslPort: 4203,
 		PortalPort: 0,
 		SslPortalPort: 0,
 		SocketFile: "/var/run/sharpmush.sock",

--- a/SharpMUSH.Configuration/ReadPennMUSHConfig.cs
+++ b/SharpMUSH.Configuration/ReadPennMUSHConfig.cs
@@ -230,7 +230,7 @@ public static partial class ReadPennMushConfig
 				String(Get(nameof(NetOptions.IpAddr)), null),
 				String(Get(nameof(NetOptions.SslIpAddr)), null),
 				UnsignedInteger(Get(nameof(NetOptions.Port)), 4203),
-				UnsignedInteger(Get(nameof(NetOptions.SslPort)), 4202),
+				UnsignedInteger(Get(nameof(NetOptions.SslPort)), 4203),
 				UnsignedInteger(Get(nameof(NetOptions.PortalPort)), 5117),
 				UnsignedInteger(Get(nameof(NetOptions.SslPortalPort)), 7296),
 				RequiredString(Get(nameof(NetOptions.SocketFile)), "netmush.sock"),

--- a/SharpMUSH.Configuration/ReadPennMUSHConfig.cs
+++ b/SharpMUSH.Configuration/ReadPennMUSHConfig.cs
@@ -229,7 +229,7 @@ public static partial class ReadPennMushConfig
 				String(Get(nameof(NetOptions.MudUrl)), null),
 				String(Get(nameof(NetOptions.IpAddr)), null),
 				String(Get(nameof(NetOptions.SslIpAddr)), null),
-				UnsignedInteger(Get(nameof(NetOptions.Port)), 4203),
+				UnsignedInteger(Get(nameof(NetOptions.Port)), 4201),
 				UnsignedInteger(Get(nameof(NetOptions.SslPort)), 4203),
 				UnsignedInteger(Get(nameof(NetOptions.PortalPort)), 5117),
 				UnsignedInteger(Get(nameof(NetOptions.SslPortalPort)), 7296),

--- a/SharpMUSH.ConnectionServer/SharpMUSH.ConnectionServer.csproj
+++ b/SharpMUSH.ConnectionServer/SharpMUSH.ConnectionServer.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="TelnetNegotiationCore" Version="2.5.0" />
+    <PackageReference Include="TelnetNegotiationCore" Version="2.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SharpMUSH.Library/Services/OptionsService.cs
+++ b/SharpMUSH.Library/Services/OptionsService.cs
@@ -222,7 +222,7 @@ public class OptionsService(ISharpDatabase database) : IOptionsFactory<SharpMUSH
 				MudName: "SharpMUSH",
 				MudUrl: null,
 				PlayerCreation: true,
-				Port: 4203,
+				Port: 4201,
 				PortalPort: 5117,
 				Pueblo: true,
 				SslPortalPort: 7296,

--- a/SharpMUSH.Library/Services/OptionsService.cs
+++ b/SharpMUSH.Library/Services/OptionsService.cs
@@ -233,7 +233,7 @@ public class OptionsService(ISharpDatabase database) : IOptionsFactory<SharpMUSH
 				SqlDatabase: null,
 				SqlUsername: null,
 				SslIpAddr: null,
-				SslPort: 4202,
+				SslPort: 4203,
 				SslRequireClientCert: false,
 				UseDns: true,
 				UseWebsockets: true,

--- a/SharpMUSH.Library/SharpMUSH.Library.csproj
+++ b/SharpMUSH.Library/SharpMUSH.Library.csproj
@@ -88,7 +88,7 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 
     <PackageReference Include="System.Data.SqlClient" Version="4.9.1" />
-    <PackageReference Include="TelnetNegotiationCore" Version="2.5.0" />
+    <PackageReference Include="TelnetNegotiationCore" Version="2.8.1" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="ZiggyCreatures.FusionCache" Version="2.5.0" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/SharpMUSH.Server/SharpMUSH.Server.csproj
+++ b/SharpMUSH.Server/SharpMUSH.Server.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-		<PackageReference Include="TelnetNegotiationCore" Version="2.5.0" />
+		<PackageReference Include="TelnetNegotiationCore" Version="2.8.1" />
 		<!-- FSharp.Core is a runtime transitive (via TelnetNegotiationCore) the engine never JITs, so it is
 		     normally trimmed from output. The McMaster plugin loader eagerly walks the shared SharpMUSH.Library
 		     reference closure and resolves each referenced assembly against the host's default load context,

--- a/SharpMUSH.Tests.BUnit/Controllers/ApplicationsGateTests.cs
+++ b/SharpMUSH.Tests.BUnit/Controllers/ApplicationsGateTests.cs
@@ -191,7 +191,7 @@ public class ApplicationsGateTests
 			Pueblo: true, SslPortalPort: 7296, SocketFile: "netmush.sock",
 			SqlHost: null, SqlPlatform: null, SqlPassword: null,
 			SqlDatabase: null, SqlUsername: null, SslIpAddr: null,
-			SslPort: 4202, SslRequireClientCert: false, UseDns: true,
+			SslPort: 4203, SslRequireClientCert: false, UseDns: true,
 			UseWebsockets: true, WebsocketUrl: "/wsclient"),
 		Alias = new AliasOptions(
 			FunctionAliases: new Dictionary<string, string[]>(),

--- a/SharpMUSH.Tests.BUnit/Controllers/ApplicationsGateTests.cs
+++ b/SharpMUSH.Tests.BUnit/Controllers/ApplicationsGateTests.cs
@@ -187,7 +187,7 @@ public class ApplicationsGateTests
 		Net = new NetOptions(
 			Guests: true, IpAddr: null, JsonUnsafeUnescape: false,
 			Logins: true, MudName: "SharpMUSH", MudUrl: null,
-			PlayerCreation: true, Port: 4203, PortalPort: 5117,
+			PlayerCreation: true, Port: 4201, PortalPort: 5117,
 			Pueblo: true, SslPortalPort: 7296, SocketFile: "netmush.sock",
 			SqlHost: null, SqlPlatform: null, SqlPassword: null,
 			SqlDatabase: null, SqlUsername: null, SslIpAddr: null,

--- a/SharpMUSH.Tests.BUnit/Controllers/ConfigurationControllerTests.cs
+++ b/SharpMUSH.Tests.BUnit/Controllers/ConfigurationControllerTests.cs
@@ -96,7 +96,7 @@ public class ConfigurationControllerTests
 		Net = new NetOptions(
 			Guests: true, IpAddr: null, JsonUnsafeUnescape: false,
 			Logins: true, MudName: "SharpMUSH", MudUrl: null,
-			PlayerCreation: true, Port: 4203, PortalPort: 5117,
+			PlayerCreation: true, Port: 4201, PortalPort: 5117,
 			Pueblo: true, SslPortalPort: 7296, SocketFile: "netmush.sock",
 			SqlHost: null, SqlPlatform: null, SqlPassword: null,
 			SqlDatabase: null, SqlUsername: null, SslIpAddr: null,

--- a/SharpMUSH.Tests.BUnit/Controllers/ConfigurationControllerTests.cs
+++ b/SharpMUSH.Tests.BUnit/Controllers/ConfigurationControllerTests.cs
@@ -100,7 +100,7 @@ public class ConfigurationControllerTests
 			Pueblo: true, SslPortalPort: 7296, SocketFile: "netmush.sock",
 			SqlHost: null, SqlPlatform: null, SqlPassword: null,
 			SqlDatabase: null, SqlUsername: null, SslIpAddr: null,
-			SslPort: 4202, SslRequireClientCert: false, UseDns: true,
+			SslPort: 4203, SslRequireClientCert: false, UseDns: true,
 			UseWebsockets: true, WebsocketUrl: "/wsclient"),
 		Alias = new AliasOptions(
 			FunctionAliases: new Dictionary<string, string[]>(),

--- a/SharpMUSH.Tests/Server/TestSharpMushOptions.cs
+++ b/SharpMUSH.Tests/Server/TestSharpMushOptions.cs
@@ -95,11 +95,11 @@ internal static class TestSharpMushOptions
 			Net = new NetOptions(
 			Guests: true, IpAddr: null, JsonUnsafeUnescape: false,
 			Logins: true, MudName: "SharpMUSH", MudUrl: null,
-			PlayerCreation: true, Port: 4203, PortalPort: 5117,
+			PlayerCreation: true, Port: 4201, PortalPort: 5117,
 			Pueblo: true, SslPortalPort: 7296, SocketFile: "netmush.sock",
 			SqlHost: null, SqlPlatform: null, SqlPassword: null,
 			SqlDatabase: null, SqlUsername: null, SslIpAddr: null,
-			SslPort: 4202, SslRequireClientCert: false, UseDns: true,
+			SslPort: 4203, SslRequireClientCert: false, UseDns: true,
 			UseWebsockets: true, WebsocketUrl: "/wsclient"),
 			Alias = new AliasOptions(
 			FunctionAliases: new Dictionary<string, string[]>(),

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -76,9 +76,10 @@ local development only — over HTTPS a browser will refuse a plaintext `ws://` 
 > Caddy already renews into `caddy-data`, and the Cloudflare stack (which has no Caddy, and so no
 > local certificate) needs an ACME sidecar doing a DNS-01 challenge.
 >
-> Until then, if you need encrypted player connections, terminate TLS in front of `4201` yourself —
-> and be aware that doing so hides the client's IP from the game unless the proxy speaks PROXY
-> protocol, which breaks site-locks, bans and connection logs.
+> Until then, if you need encrypted player connections, terminate TLS in front of `4201` yourself
+> (stunnel, or a TCP-mode proxy). Be aware of the cost: the game takes a connection's IP from the
+> socket's peer address and has no PROXY-protocol support, so every player will appear to connect
+> from the proxy — site-locks, bans and connection logs all lose the real client address.
 
 If you **don't** use Caddy (e.g. you terminate TLS at a load balancer), remember the browser
 terminal's `/ws` endpoint lives on the connection server (`:4202`), not the main server — you must

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -60,10 +60,25 @@ local development only — over HTTPS a browser will refuse a plaintext `ws://` 
 | Port | Service | Exposed to internet? |
 |------|---------|----------------------|
 | 80 / 443 | Caddy (web portal, SignalR, and `/ws` → connection server) | yes |
-| 4201 | Telnet | yes |
+| 4201 | Telnet — **plaintext** | yes |
+| 4203 | Telnet over TLS — *configured but not yet implemented* | not yet |
 | 8080 | ASP.NET server (HTTP) | no — internal, behind Caddy |
 | 4202 | Connection server HTTP / `/ws` WebSocket | no — internal, reached via Caddy's `/ws` route |
 | 4222 / 8222 | NATS client / monitoring | no — internal only |
+
+> **Telnet is unencrypted today.** Everything a player types on `4201`, including their password
+> on login, crosses the network in the clear. The web portal is HTTPS via Caddy, but MU\* clients
+> connect straight to `4201` and bypass it entirely.
+>
+> `ssl_port` (4203) exists in the configuration and **nothing listens on it** —
+> [#743](https://github.com/SharpMUSH/SharpMUSH/issues/743) is the issue to implement it, and
+> records the intended deployment shape: the Caddy stack can reuse the Let's Encrypt certificate
+> Caddy already renews into `caddy-data`, and the Cloudflare stack (which has no Caddy, and so no
+> local certificate) needs an ACME sidecar doing a DNS-01 challenge.
+>
+> Until then, if you need encrypted player connections, terminate TLS in front of `4201` yourself —
+> and be aware that doing so hides the client's IP from the game unless the proxy speaks PROXY
+> protocol, which breaks site-locks, bans and connection logs.
 
 If you **don't** use Caddy (e.g. you terminate TLS at a load balancer), remember the browser
 terminal's `/ws` endpoint lives on the connection server (`:4202`), not the main server — you must


### PR DESCRIPTION
`NetOptions.SslPort` defaulted to **4202**, and so does `ConnectionServerOptions.HttpPort` — which
`docker-compose.yml` publishes as *"ConnectionServer HTTP API"* and the Blazor client dials for its
WebSocket (`ws://localhost:4202/ws`).

Two different services claimed one port by default. It hasn't bitten yet only because **nothing
listens on `ssl_port`** — see #743, which is the issue for actually implementing TLS. Better to fix
the default before something binds it than after.

4203 keeps the block contiguous:

| Port | |
|---|---|
| 4201 | telnet |
| 4202 | HTTP API / WebSocket |
| **4203** | **TLS** |

## The plaintext default was tracking it

Review caught that `NetOptions.Port` also defaulted to **4203** in two construction paths —
`ReadPennMushConfig` (mush.cnf with no `port` line) and the `OptionsService` config seeded into the
database — so moving `ssl_port` to 4203 made `Port == SslPort`. Those 4203s were already wrong
before this PR: the record default is 4201, `ConnectionServerOptions.TelnetPort` (the only value
that binds a listener) is 4201, and every document says 4201. Fixed to 4201, fixtures included.

One 4202 is left, in `AdminConfigServiceTests` — it's payload inside fixture JSON for a
deserialization-*failure* case, not a default.

## Verification

`ConfigurationControllerTests` 11/11, `ApplicationsGateTests` 4/4 (both assert the full
`NetOptions` record including these values), `SharpMUSH.Tests` Configuration 11/11 and Server
179/179. Full solution builds clean; `dotnet format whitespace --verify-no-changes` clean on all
four touched projects.

## Also

`deploy/README.md` said a TLS-terminating proxy hides the client IP *"unless the proxy speaks PROXY
protocol"* — nothing in the codebase parses PROXY protocol (a connection's address is the socket
peer address), so external termination costs site-locks, bans and connection logs unconditionally.
Reworded. #743's stale `4202` references are updated, and its collision checkbox is ticked.

`TelnetNegotiationCore` 2.5.0 → **2.8.1** (latest). Fixes and additive API only, all of it on the
telnet path: the declared `FSharp.Core` dependency (2.5.1), server-mode-only `WILL CHARSET` so two
peers can't wedge CHARSET and eat the first line (2.5.2), NAWS direction per RFC 1073 — the bug that
intermittently bounced typed logins back to the login screen (2.5.3), bodyless GMCP delivery
(2.6.0), and MoG data-section forwarding, a 1 MiB bounded subnegotiation accumulator replacing
silent 8 KiB truncation, plus MSSP multi-value/boolean/unknown-variable fixes (2.7.0). `FSharp.Core`
stays pinned at 10.1.302 in `SharpMUSH.Server` for the plugin loader; 2.8.1 floors it at 10.1.203.

Verified with the bump in place: `SharpMUSH.Tests` 5135/5135 (196 skipped), `SharpMUSH.Tests.BUnit`
396/396, ConnectionServer 68/68, solution builds clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Changed the default plaintext telnet port from 4203 to 4201.
  * Changed the default SSL telnet port from 4202 to 4203.
  * Applied the updated defaults when port settings are missing or blank.
* **Documentation**
  * Clarified plaintext telnet security considerations and SSL port availability.
  * Documented external TLS proxy options and current source-IP limitations.
* **Tests**
  * Updated configuration tests to reflect the revised network ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

