### PR TITLE
chore(deps): collate Dependabot NuGet bumps (#732, #734–#737)

### DIFF
--- a/SharpMUSH.Benchmarks/SharpMUSH.Benchmarks.csproj
+++ b/SharpMUSH.Benchmarks/SharpMUSH.Benchmarks.csproj
@@ -12,7 +12,7 @@
 	<ItemGroup>
 		<PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />

--- a/SharpMUSH.Client/SharpMUSH.Client.csproj
+++ b/SharpMUSH.Client/SharpMUSH.Client.csproj
@@ -50,7 +50,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.10" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
-		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.10" />
 		<PackageReference Include="MudBlazor" Version="9.4.0" />
 		<PackageReference Include="OneOf" Version="3.0.271" />
 		<PackageReference Include="PSC.Blazor.Components.MarkdownEditor" Version="10.0.7" />

--- a/SharpMUSH.Library/SharpMUSH.Library.csproj
+++ b/SharpMUSH.Library/SharpMUSH.Library.csproj
@@ -63,9 +63,9 @@
 	</Target>
 
   <ItemGroup>
-    <PackageReference Include="DotNext" Version="6.4.1" />
+    <PackageReference Include="DotNext" Version="6.5.0" />
     <PackageReference Include="Markdig" Version="1.3.2" />
-    <PackageReference Include="DotNext.Threading" Version="6.4.1" />
+    <PackageReference Include="DotNext.Threading" Version="6.5.0" />
     <PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />

--- a/SharpMUSH.Server/SharpMUSH.Server.csproj
+++ b/SharpMUSH.Server/SharpMUSH.Server.csproj
@@ -90,7 +90,7 @@
 
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Mvc" Version="10.0.0" />
-    <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
+    <PackageReference Include="LibGit2Sharp" Version="0.32.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
     <None Include="..\SharpMUSH.Documentation\Helpfiles\SharpMUSH\*.md">
       <Link>TextFiles\help\%(Filename)%(Extension)</Link>

--- a/SharpMUSH.Tests.BUnit/SharpMUSH.Tests.BUnit.csproj
+++ b/SharpMUSH.Tests.BUnit/SharpMUSH.Tests.BUnit.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="bunit" Version="2.7.2" />
-    <PackageReference Include="AngleSharp" Version="1.5.0" />
+    <PackageReference Include="bunit" Version="2.8.6" />
+    <PackageReference Include="AngleSharp" Version="1.5.2" />
     <PackageReference Include="TUnit" Version="1.19.16" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="MudBlazor" Version="9.4.0" />

--- a/SharpMUSH.Tests.Infrastructure/SharpMUSH.Tests.Infrastructure.csproj
+++ b/SharpMUSH.Tests.Infrastructure/SharpMUSH.Tests.Infrastructure.csproj
@@ -14,7 +14,7 @@
 		<!-- TUnit types for IAsyncInitializer, ClassDataSource, TestWebApplicationFactory, etc. -->
 		<PackageReference Include="TUnit.AspNetCore" Version="1.19.16" />
 		<!-- ASP.NET Core test host -->
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
 		<!-- Mocking and assertions -->
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<!-- Test containers -->

--- a/SharpMUSH.Tests/SharpMUSH.Tests.csproj
+++ b/SharpMUSH.Tests/SharpMUSH.Tests.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="bunit" Version="2.7.2" />
-    <PackageReference Include="AngleSharp" Version="1.5.0" />
+    <PackageReference Include="bunit" Version="2.8.6" />
+    <PackageReference Include="AngleSharp" Version="1.5.2" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Collates the five open Dependabot NuGet PRs into one change so CI runs once instead of five times, and so packages pinned in more than one project move together.

## Bumps from the Dependabot PRs
| Package | From | To | Project(s) | PR |
|---|---|---|---|---|
| bunit | 2.7.2 | 2.8.6 | Tests, Tests.BUnit | #732 |
| AngleSharp | 1.5.0 | 1.5.2 | Tests, Tests.BUnit | #732 |
| DotNext | 6.4.1 | 6.5.0 | Library | #734 |
| DotNext.Threading | 6.4.1 | 6.5.0 | Library | #734 |
| LibGit2Sharp | 0.31.0 | 0.32.0 | Server | #735 |
| Microsoft.AspNetCore.Mvc.Testing | 10.0.7 | 10.0.10 | Benchmarks, Tests.Infrastructure | #736 |
| Microsoft.AspNetCore.SignalR.Client | 10.0.7 | 10.0.10 | Client | #737 |

The two ASP.NET Core bumps are the last references still sitting on 10.0.7 — the rest of that family moved to 10.0.10 in #707, hence the branch name.

## Lockstep bumps Dependabot can&#39;t see
**None were needed this round**, which is unusual enough to be worth stating explicitly. Every `.csproj` was grepped for the old version strings to confirm it:

- **#732 and #736 each already edited both projects** that pin their package — `bunit`/`AngleSharp` are pinned in both `SharpMUSH.Tests` and `SharpMUSH.Tests.BUnit`, and `Microsoft.AspNetCore.Mvc.Testing` in both `SharpMUSH.Benchmarks` and `SharpMUSH.Tests.Infrastructure`. Dependabot grouped them, so there was no straggler to chase.
- **`DotNext`, `DotNext.Threading`, `LibGit2Sharp` and `Microsoft.AspNetCore.SignalR.Client` are each referenced by exactly one project**, so their bumps drag nothing with them.
- **`FSharp.Core` needed no action.** Both deliberate pins (`SharpMUSH.Server` and `SharpMUSH.Tests.Integration`) are already at 10.1.302 from #707 and no PR in this batch moves it, so the usual "Dependabot only bumped one of the two" correction does not apply. Both references are left in place — they materialize `FSharp.Core` beside the host binary for the McMaster plugin loader, as the csproj comments explain.
- **The `Microsoft.AspNetCore.Components.WebAssembly*` packages** in `SharpMUSH.Client`, and `Microsoft.AspNetCore.Components.WebAssembly.Server` in `SharpMUSH.Server`, are already at 10.0.10 from #707. The two 10.0.10 bumps here land in the same family without moving them.

## Deleted or omitted
Nothing. No reference was redundant, and — unlike #669, #699 and #703 — no PR in this batch tried to *add* a `Microsoft.AspNetCore.Components.WebAssembly` reference to `SharpMUSH.Server`, so there was nothing to omit. All five diffs were plain version bumps.

## Verification
`dotnet restore` is **clean — zero `NU1605`**, which is the check that matters for a dependency collation. (Two pre-existing `NU1603` warnings about `Microsoft.CodeAnalysis.Analyzers` in the source-generator projects are unrelated and also present on `main`.)

**CI is fully green — 20/20 checks passed**, including `build`, `format`, `test` and `test-integration` across arangodb/memgraph/surrealdb, `test-bunit`, all CodeQL analyses, `claude-review` and `submit-nuget`. No check needed a retry.

A full `dotnet build` could not be verified locally beforehand: the environment this was prepared in had no Microsoft .NET SDK available and only Ubuntu&#39;s distro rebuild (10.0.110) could be installed, whose Razor compiler and `dotnet format` behave differently from the official 10.x SDK CI uses. Under that SDK, unmodified `main` failed identically to this branch — the same 2 `CS7036`, 2 `FORMAT001`, 8 `RZ1011`, 8 `RZ2005` and 653 `WHITESPACE` errors — indicating the bumps introduced no new errors. CI on the official SDK has since confirmed that directly: `build` and `format` both pass.

Closes #732, closes #734, closes #735, closes #736, closes #737.