### PR TITLE
Portal audit 1/4: a wrong role gate, a crashing dead route, an ungated account page

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -10,7 +10,12 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    # Stacked pull requests target their predecessor rather than main, so a
+    # main-only filter leaves every PR above the bottom of a stack with no build
+    # or test run until its parent merges and GitHub retargets it. Matching the
+    # stack's branch prefix too means each link is verified while it is still
+    # reviewable, instead of after it has already been approved on trust.
+    branches: [ "main", "fix/portal-audit-**" ]
 
 jobs:
   build-and-test:

--- a/SharpMUSH.Client/App.razor
+++ b/SharpMUSH.Client/App.razor
@@ -19,9 +19,9 @@
                                             <MudIcon Icon="@Icons.Material.Filled.Lock" Style="font-size:1.875rem;" />
                                         </div>
                                         <h1>@Loc["NotAuthorized"]</h1>
-                                        <p>You don't have permission to view this page.</p>
+                                        <p>@Loc["NotAuthorizedBody"]</p>
                                         <a class="not-authorized-home" href="/">
-                                            <MudIcon Icon="@Icons.Material.Filled.Home" Style="font-size:0.9375rem;" /> Back to home
+                                            <MudIcon Icon="@Icons.Material.Filled.Home" Style="font-size:0.9375rem;" /> @Loc["NotAuthorizedBackHome"]
                                         </a>
                                     </div>
                                 </div>

--- a/SharpMUSH.Client/Layout/RedirectToLogin.razor
+++ b/SharpMUSH.Client/Layout/RedirectToLogin.razor
@@ -4,10 +4,13 @@
 
     protected override void OnInitialized()
     {
-        // OIDC wiring was removed; NavigateToLogin("authentication/login") pointed at a route
-        // that no longer exists, dead-ending anonymous users who hit an [Authorize] page (see
-        // App.razor's NotAuthorized branch). Send them to our real login page instead, carrying
-        // a returnUrl so a successful sign-in lands back where they were headed.
+        // OIDC wiring was removed, but NavigateToLogin("authentication/login") kept pointing at
+        // the RemoteAuthenticatorView page, which needs the AddRemoteAuthentication registration
+        // that went with it — so that route crashed the SPA rather than merely dead-ending the
+        // anonymous users who hit an [Authorize] page (see App.razor's NotAuthorized branch,
+        // which renders this component). The page has since been deleted. Send them to our real
+        // login page instead, carrying a returnUrl so a successful sign-in lands back where they
+        // were headed.
         var returnUrl = new Uri(Navigation.Uri).PathAndQuery;
         Navigation.NavigateTo($"/login?returnUrl={Uri.EscapeDataString(returnUrl)}");
     }

--- a/SharpMUSH.Client/Pages/Account.razor
+++ b/SharpMUSH.Client/Pages/Account.razor
@@ -1,4 +1,5 @@
 @page "/account"
+@attribute [Authorize]
 @using SharpMUSH.Client.Services
 @using Microsoft.AspNetCore.Components.Authorization
 @inject AccountAuthService AccountAuth
@@ -10,23 +11,23 @@
 
 <div class="acct-page" style="padding:var(--cpad);">
 
+    @* [Authorize] hands anonymous visitors to RedirectToLogin, so reaching this page without an
+       account session now means exactly one thing: a DebugAuth principal whose debug-OTT never
+       produced one (development only). The old "not logged in — use the terminal login panel"
+       card that stood here was the anonymous dead end, and is unreachable now. _isDebugAuth
+       still gates the card so the logged-out re-render during LogoutAsync shows nothing at all
+       rather than a stale Debug Mode alert. *@
     @if (!AccountAuth.IsLoggedIn)
     {
-        <div class="acct-card" style="max-width:560px;">
-            @if (_isDebugAuth)
-            {
+        @if (_isDebugAuth)
+        {
+            <div class="acct-card" style="max-width:560px;">
                 <MudAlert Severity="Severity.Info" Class="mb-3">
                     <strong>@Loc["AuthDebugMode"]</strong> — @Loc["AuthDebugModeBody", "DebugAdmin"]
                 </MudAlert>
-            }
-            else
-            {
-                <MudAlert Severity="Severity.Info" Class="mb-3">
-                    @Loc["AuthNotLoggedInAccount"]
-                </MudAlert>
-            }
-            <button class="acct-btn acct-btn-primary" @onclick='() => Nav.NavigateTo("/")'>@Loc["AuthGoToHome"]</button>
-        </div>
+                <button class="acct-btn acct-btn-primary" @onclick='() => Nav.NavigateTo("/")'>@Loc["AuthGoToHome"]</button>
+            </div>
+        }
     }
     else
     {
@@ -242,7 +243,8 @@
         await AccountAuth.LogoutAsync();
         // _isDebugAuth is computed once in OnInitializedAsync and otherwise stays true after
         // logout, which would keep this page's "Debug Mode" alert showing the stale DebugAdmin
-        // identity instead of the plain "not logged in" message — reset it directly here.
+        // identity during the re-render that AuthStateChanged triggers before we navigate away
+        // — reset it directly here.
         // (NavMenu's HandleLogoutAsync has no flag of its own to mirror: it just navigates away.
         // Ending the game terminals is handled inside AccountAuth.LogoutAsync for every caller.)
         // Land on "/" (the anonymous home) rather than /login:

--- a/SharpMUSH.Client/Pages/Admin/Packages/AdminPackageReview.razor
+++ b/SharpMUSH.Client/Pages/Admin/Packages/AdminPackageReview.razor
@@ -1,5 +1,5 @@
 @page "/admin/packages/review"
-@attribute [Authorize(Roles = "Wizard")]
+@attribute [Authorize(Policy = "packages.admin")]
 @using SharpMUSH.Client.Services
 @using SharpMUSH.Library.API
 @using SharpMUSH.Library.Models.Packages
@@ -291,7 +291,7 @@ else
         _renders.GetValueOrDefault((change.TargetRef, change.Attribute));
 
     private static string DecisionKey(PackageAttributeChange change) =>
-        $"{change.TargetRef} {change.Attribute}";
+        $"{change.TargetRef}\0{change.Attribute}";
 
     private async Task ApplyAsync()
     {

--- a/SharpMUSH.Client/Pages/Authentication.razor
+++ b/SharpMUSH.Client/Pages/Authentication.razor
@@ -1,7 +1,0 @@
-﻿@page "/authentication/{action}"
-@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
-<RemoteAuthenticatorView Action="@Action"/>
-
-@code{
-    [Parameter] public string? Action { get; set; }
-}

--- a/SharpMUSH.Client/Resources/SharedResource.bg.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.bg.resx
@@ -2188,6 +2188,14 @@
     <value>Нямате права за достъп до този ресурс.</value>
     <comment>MT — polite Вие-form</comment>
   </data>
+  <data name="NotAuthorizedBackHome" xml:space="preserve">
+    <value>Назад към началото</value>
+    <comment>MT</comment>
+  </data>
+  <data name="NotAuthorizedBody" xml:space="preserve">
+    <value>Нямате разрешение да преглеждате тази страница.</value>
+    <comment>MT</comment>
+  </data>
   <data name="NotFound" xml:space="preserve">
     <value>Не е намерено</value>
     <comment>MT — assumed an HTTP 404 page title, hence neuter impersonal</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.bg.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.bg.resx
@@ -532,10 +532,6 @@
     <value>Няма герои, свързани с този акаунт.</value>
     <comment>MT</comment>
   </data>
-  <data name="AuthNotLoggedInAccount" xml:space="preserve">
-    <value>Не сте влезли в акаунт. Използвайте панела за вход в терминала, за да влезете.</value>
-    <comment>MT</comment>
-  </data>
   <data name="AuthOpenInNewTab" xml:space="preserve">
     <value>Отвори {0} в нов раздел</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.da.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.da.resx
@@ -532,10 +532,6 @@
     <value>Ingen karakterer er knyttet til denne konto.</value>
     <comment>MT</comment>
   </data>
-  <data name="AuthNotLoggedInAccount" xml:space="preserve">
-    <value>Du er ikke logget ind på en konto. Brug terminalens loginpanel til at logge ind.</value>
-    <comment>MT</comment>
-  </data>
   <data name="AuthOpenInNewTab" xml:space="preserve">
     <value>Åbn {0} i en ny fane</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.da.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.da.resx
@@ -2188,6 +2188,14 @@
     <value>Du har ikke tilladelse til at tilgå denne ressource.</value>
     <comment>MT</comment>
   </data>
+  <data name="NotAuthorizedBackHome" xml:space="preserve">
+    <value>Tilbage til forsiden</value>
+    <comment>MT</comment>
+  </data>
+  <data name="NotAuthorizedBody" xml:space="preserve">
+    <value>Du har ikke tilladelse til at se denne side.</value>
+    <comment>MT</comment>
+  </data>
   <data name="NotFound" xml:space="preserve">
     <value>Ikke fundet</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.de.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.de.resx
@@ -2188,6 +2188,14 @@
     <value>Sie sind nicht berechtigt, auf diese Ressource zuzugreifen.</value>
     <comment>MT</comment>
   </data>
+  <data name="NotAuthorizedBackHome" xml:space="preserve">
+    <value>Zurück zur Startseite</value>
+    <comment>MT</comment>
+  </data>
+  <data name="NotAuthorizedBody" xml:space="preserve">
+    <value>Sie haben keine Berechtigung, diese Seite anzuzeigen.</value>
+    <comment>MT</comment>
+  </data>
   <data name="NotFound" xml:space="preserve">
     <value>Nicht gefunden</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.de.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.de.resx
@@ -532,10 +532,6 @@
     <value>Keine Charaktere mit diesem Konto verknüpft.</value>
     <comment>MT</comment>
   </data>
-  <data name="AuthNotLoggedInAccount" xml:space="preserve">
-    <value>Sie sind nicht bei einem Konto angemeldet. Verwenden Sie das Anmeldefeld im Terminal, um sich anzumelden.</value>
-    <comment>MT</comment>
-  </data>
   <data name="AuthOpenInNewTab" xml:space="preserve">
     <value>{0} in neuem Tab öffnen</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.es.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.es.resx
@@ -2188,6 +2188,14 @@
     <value>No tiene autorización para acceder a este recurso.</value>
     <comment>MT</comment>
   </data>
+  <data name="NotAuthorizedBackHome" xml:space="preserve">
+    <value>Volver al inicio</value>
+    <comment>MT</comment>
+  </data>
+  <data name="NotAuthorizedBody" xml:space="preserve">
+    <value>No tiene permiso para ver esta página.</value>
+    <comment>MT</comment>
+  </data>
   <data name="NotFound" xml:space="preserve">
     <value>No encontrado</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.es.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.es.resx
@@ -532,10 +532,6 @@
     <value>No hay personajes vinculados a esta cuenta.</value>
     <comment>MT</comment>
   </data>
-  <data name="AuthNotLoggedInAccount" xml:space="preserve">
-    <value>No ha iniciado sesión en ninguna cuenta. Use el panel de inicio de sesión del terminal para acceder.</value>
-    <comment>MT</comment>
-  </data>
   <data name="AuthOpenInNewTab" xml:space="preserve">
     <value>Abrir {0} en una pestaña nueva</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.fr.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.fr.resx
@@ -421,9 +421,6 @@
   <data name="AuthDebugModeBody" xml:space="preserve">
     <value>Vous êtes authentifié en tant que {0} (environnement de développement). Aucune session de compte n'est associée ; la gestion du compte nécessite une connexion à un compte réel.</value>
   </data>
-  <data name="AuthNotLoggedInAccount" xml:space="preserve">
-    <value>Vous n'êtes pas connecté à un compte. Utilisez le panneau de connexion du terminal pour vous connecter.</value>
-  </data>
   <data name="AuthGoToHome" xml:space="preserve">
     <value>Aller à l'accueil</value>
   </data>

--- a/SharpMUSH.Client/Resources/SharedResource.fr.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.fr.resx
@@ -46,6 +46,14 @@
   <data name="NotAuthorized" xml:space="preserve">
     <value>Vous n'êtes pas autorisé à accéder à cette ressource.</value>
   </data>
+  <data name="NotAuthorizedBackHome" xml:space="preserve">
+    <value>Retour à l'accueil</value>
+    <comment>MT</comment>
+  </data>
+  <data name="NotAuthorizedBody" xml:space="preserve">
+    <value>Vous n'avez pas la permission de consulter cette page.</value>
+    <comment>MT</comment>
+  </data>
 
   <!-- MainLayout / NavMenu -->
   <data name="Configuration" xml:space="preserve">

--- a/SharpMUSH.Client/Resources/SharedResource.hr.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.hr.resx
@@ -532,10 +532,6 @@
     <value>Nijedan lik nije povezan s ovim računom.</value>
     <comment>MT</comment>
   </data>
-  <data name="AuthNotLoggedInAccount" xml:space="preserve">
-    <value>Niste prijavljeni na račun. Za prijavu upotrijebite ploču za prijavu u terminalu.</value>
-    <comment>MT</comment>
-  </data>
   <data name="AuthOpenInNewTab" xml:space="preserve">
     <value>Otvori u novoj kartici: {0}</value>
     <comment>MT — restructured so the target name sits after a colon; the accusative it would otherwise need cannot be controlled</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.hr.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.hr.resx
@@ -2188,6 +2188,14 @@
     <value>Nemate ovlaštenje za pristup ovom resursu.</value>
     <comment>MT</comment>
   </data>
+  <data name="NotAuthorizedBackHome" xml:space="preserve">
+    <value>Natrag na početnu</value>
+    <comment>MT</comment>
+  </data>
+  <data name="NotAuthorizedBody" xml:space="preserve">
+    <value>Nemate dopuštenje za pregled ove stranice.</value>
+    <comment>MT</comment>
+  </data>
   <data name="NotFound" xml:space="preserve">
     <value>Nije pronađeno</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.hu.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.hu.resx
@@ -2188,6 +2188,14 @@
     <value>Nincs jogosultsága ennek az erőforrásnak az eléréséhez.</value>
     <comment>MT</comment>
   </data>
+  <data name="NotAuthorizedBackHome" xml:space="preserve">
+    <value>Vissza a kezdőlapra</value>
+    <comment>MT</comment>
+  </data>
+  <data name="NotAuthorizedBody" xml:space="preserve">
+    <value>Nincs jogosultsága az oldal megtekintéséhez.</value>
+    <comment>MT</comment>
+  </data>
   <data name="NotFound" xml:space="preserve">
     <value>Nem található</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.hu.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.hu.resx
@@ -532,10 +532,6 @@
     <value>Ehhez a fiókhoz nincs karakter kapcsolva.</value>
     <comment>MT</comment>
   </data>
-  <data name="AuthNotLoggedInAccount" xml:space="preserve">
-    <value>Nincs bejelentkezve fiókkal. A bejelentkezéshez használja a terminál bejelentkezési paneljét.</value>
-    <comment>MT</comment>
-  </data>
   <data name="AuthOpenInNewTab" xml:space="preserve">
     <value>{0} megnyitása új lapon</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.nb.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.nb.resx
@@ -2188,6 +2188,14 @@
     <value>Du har ikke tilgang til denne ressursen.</value>
     <comment>MT</comment>
   </data>
+  <data name="NotAuthorizedBackHome" xml:space="preserve">
+    <value>Tilbake til forsiden</value>
+    <comment>MT</comment>
+  </data>
+  <data name="NotAuthorizedBody" xml:space="preserve">
+    <value>Du har ikke tillatelse til å se denne siden.</value>
+    <comment>MT</comment>
+  </data>
   <data name="NotFound" xml:space="preserve">
     <value>Ikke funnet</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.nb.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.nb.resx
@@ -532,10 +532,6 @@
     <value>Ingen karakterer er knyttet til denne kontoen.</value>
     <comment>MT</comment>
   </data>
-  <data name="AuthNotLoggedInAccount" xml:space="preserve">
-    <value>Du er ikke logget inn på en konto. Bruk innloggingspanelet i terminalen for å logge inn.</value>
-    <comment>MT</comment>
-  </data>
   <data name="AuthOpenInNewTab" xml:space="preserve">
     <value>Åpne {0} i en ny fane</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.nl.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.nl.resx
@@ -532,10 +532,6 @@
     <value>Er zijn geen personages aan dit account gekoppeld.</value>
     <comment>MT</comment>
   </data>
-  <data name="AuthNotLoggedInAccount" xml:space="preserve">
-    <value>Je bent niet ingelogd op een account. Gebruik het inlogpaneel van de terminal om in te loggen.</value>
-    <comment>MT</comment>
-  </data>
   <data name="AuthOpenInNewTab" xml:space="preserve">
     <value>{0} openen in een nieuw tabblad</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.nl.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.nl.resx
@@ -2188,6 +2188,14 @@
     <value>Je hebt geen toegang tot deze bron.</value>
     <comment>MT</comment>
   </data>
+  <data name="NotAuthorizedBackHome" xml:space="preserve">
+    <value>Terug naar de startpagina</value>
+    <comment>MT</comment>
+  </data>
+  <data name="NotAuthorizedBody" xml:space="preserve">
+    <value>Je hebt geen toestemming om deze pagina te bekijken.</value>
+    <comment>MT</comment>
+  </data>
   <data name="NotFound" xml:space="preserve">
     <value>Niet gevonden</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.pl.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.pl.resx
@@ -532,10 +532,6 @@
     <value>Brak postaci powiązanych z tym kontem.</value>
     <comment>MT</comment>
   </data>
-  <data name="AuthNotLoggedInAccount" xml:space="preserve">
-    <value>Brak zalogowania na konto. Aby się zalogować, należy użyć panelu logowania w terminalu.</value>
-    <comment>MT</comment>
-  </data>
   <data name="AuthOpenInNewTab" xml:space="preserve">
     <value>Otwórz w nowej karcie: {0}</value>
     <comment>MT — restructured so {0} sits after a colon in the nominative instead of taking the accusative</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.pl.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.pl.resx
@@ -2188,6 +2188,14 @@
     <value>Brak uprawnień do tego zasobu.</value>
     <comment>MT — impersonal per register</comment>
   </data>
+  <data name="NotAuthorizedBackHome" xml:space="preserve">
+    <value>Powrót do strony głównej</value>
+    <comment>MT</comment>
+  </data>
+  <data name="NotAuthorizedBody" xml:space="preserve">
+    <value>Nie masz uprawnień do wyświetlenia tej strony.</value>
+    <comment>MT</comment>
+  </data>
   <data name="NotFound" xml:space="preserve">
     <value>Nie znaleziono</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.pt-BR.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.pt-BR.resx
@@ -532,10 +532,6 @@
     <value>Nenhum personagem vinculado a esta conta.</value>
     <comment>MT</comment>
   </data>
-  <data name="AuthNotLoggedInAccount" xml:space="preserve">
-    <value>Você não está conectado a uma conta. Use o painel de login do terminal para entrar.</value>
-    <comment>MT</comment>
-  </data>
   <data name="AuthOpenInNewTab" xml:space="preserve">
     <value>Abrir {0} em uma nova aba</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.pt-BR.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.pt-BR.resx
@@ -2188,6 +2188,14 @@
     <value>Você não tem autorização para acessar este recurso.</value>
     <comment>MT</comment>
   </data>
+  <data name="NotAuthorizedBackHome" xml:space="preserve">
+    <value>Voltar para o início</value>
+    <comment>MT</comment>
+  </data>
+  <data name="NotAuthorizedBody" xml:space="preserve">
+    <value>Você não tem permissão para ver esta página.</value>
+    <comment>MT</comment>
+  </data>
   <data name="NotFound" xml:space="preserve">
     <value>Não encontrado</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.resx
@@ -46,6 +46,12 @@
   <data name="NotAuthorized" xml:space="preserve">
     <value>You are not authorized to access this resource.</value>
   </data>
+  <data name="NotAuthorizedBackHome" xml:space="preserve">
+    <value>Back to home</value>
+  </data>
+  <data name="NotAuthorizedBody" xml:space="preserve">
+    <value>You don't have permission to view this page.</value>
+  </data>
 
   <!-- ======================== -->
   <!-- MainLayout.razor         -->

--- a/SharpMUSH.Client/Resources/SharedResource.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.resx
@@ -1291,9 +1291,6 @@
   <data name="AuthDebugModeBody" xml:space="preserve">
     <value>You are authenticated as {0} (development environment). No account session is associated; account management features require a real account login.</value>
   </data>
-  <data name="AuthNotLoggedInAccount" xml:space="preserve">
-    <value>You are not logged in to an account. Use the terminal login panel to log in.</value>
-  </data>
   <data name="AuthGoToHome" xml:space="preserve">
     <value>Go to Home</value>
   </data>

--- a/SharpMUSH.Client/Resources/SharedResource.ro.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.ro.resx
@@ -532,10 +532,6 @@
     <value>Niciun personaj asociat acestui cont.</value>
     <comment>MT</comment>
   </data>
-  <data name="AuthNotLoggedInAccount" xml:space="preserve">
-    <value>Nu sunteți autentificat într-un cont. Folosiți panoul de autentificare din terminal pentru a vă conecta.</value>
-    <comment>MT</comment>
-  </data>
   <data name="AuthOpenInNewTab" xml:space="preserve">
     <value>Deschideți {0} într-o filă nouă</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.ro.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.ro.resx
@@ -2188,6 +2188,14 @@
     <value>Nu aveți autorizația de a accesa această resursă.</value>
     <comment>MT</comment>
   </data>
+  <data name="NotAuthorizedBackHome" xml:space="preserve">
+    <value>Înapoi la pagina principală</value>
+    <comment>MT</comment>
+  </data>
+  <data name="NotAuthorizedBody" xml:space="preserve">
+    <value>Nu aveți permisiunea de a vizualiza această pagină.</value>
+    <comment>MT</comment>
+  </data>
   <data name="NotFound" xml:space="preserve">
     <value>Nu a fost găsit</value>
     <comment>MT — 404 page heading</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.ru.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.ru.resx
@@ -532,10 +532,6 @@
     <value>К этому аккаунту не привязано ни одного персонажа.</value>
     <comment>MT</comment>
   </data>
-  <data name="AuthNotLoggedInAccount" xml:space="preserve">
-    <value>Вы не вошли в аккаунт. Используйте панель входа в терминале.</value>
-    <comment>MT</comment>
-  </data>
   <data name="AuthOpenInNewTab" xml:space="preserve">
     <value>Открыть в новой вкладке: {0}</value>
     <comment>MT — restructured: the direct object would need the accusative, so {0} was moved after a colon where it stays in its supplied form.</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.ru.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.ru.resx
@@ -2188,6 +2188,14 @@
     <value>У вас нет прав доступа к этому ресурсу.</value>
     <comment>MT — «права доступа» per the corpus.</comment>
   </data>
+  <data name="NotAuthorizedBackHome" xml:space="preserve">
+    <value>Вернуться на главную</value>
+    <comment>MT</comment>
+  </data>
+  <data name="NotAuthorizedBody" xml:space="preserve">
+    <value>У вас нет разрешения на просмотр этой страницы.</value>
+    <comment>MT</comment>
+  </data>
   <data name="NotFound" xml:space="preserve">
     <value>Не найдено</value>
     <comment>MT — impersonal error-page heading.</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.sv.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.sv.resx
@@ -532,10 +532,6 @@
     <value>Inga karaktärer är kopplade till det här kontot.</value>
     <comment>MT</comment>
   </data>
-  <data name="AuthNotLoggedInAccount" xml:space="preserve">
-    <value>Du är inte inloggad på ett konto. Använd terminalens inloggningspanel för att logga in.</value>
-    <comment>MT</comment>
-  </data>
   <data name="AuthOpenInNewTab" xml:space="preserve">
     <value>Öppna {0} i en ny flik</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.sv.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.sv.resx
@@ -2188,6 +2188,14 @@
     <value>Du har inte behörighet att komma åt den här resursen.</value>
     <comment>MT</comment>
   </data>
+  <data name="NotAuthorizedBackHome" xml:space="preserve">
+    <value>Tillbaka till startsidan</value>
+    <comment>MT</comment>
+  </data>
+  <data name="NotAuthorizedBody" xml:space="preserve">
+    <value>Du har inte behörighet att visa den här sidan.</value>
+    <comment>MT</comment>
+  </data>
   <data name="NotFound" xml:space="preserve">
     <value>Hittades inte</value>
     <comment>MT — corpus phrasing for not found.</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.zh-Hans.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.zh-Hans.resx
@@ -532,10 +532,6 @@
     <value>此账号未关联任何角色。</value>
     <comment>MT</comment>
   </data>
-  <data name="AuthNotLoggedInAccount" xml:space="preserve">
-    <value>您尚未登录账号。请使用终端登录面板登录。</value>
-    <comment>MT</comment>
-  </data>
   <data name="AuthOpenInNewTab" xml:space="preserve">
     <value>在新标签页中打开 {0}</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.zh-Hans.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.zh-Hans.resx
@@ -2188,6 +2188,14 @@
     <value>您无权访问此资源。</value>
     <comment>MT</comment>
   </data>
+  <data name="NotAuthorizedBackHome" xml:space="preserve">
+    <value>返回首页</value>
+    <comment>MT</comment>
+  </data>
+  <data name="NotAuthorizedBody" xml:space="preserve">
+    <value>您无权查看此页面。</value>
+    <comment>MT</comment>
+  </data>
   <data name="NotFound" xml:space="preserve">
     <value>未找到</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/SharpMUSH.Client.csproj
+++ b/SharpMUSH.Client/SharpMUSH.Client.csproj
@@ -46,9 +46,13 @@
 	<ItemGroup>
 		<PackageReference Include="BlazorMonaco" Version="3.5.0" />
 		<PackageReference Include="MessageFormat" Version="8.0.0" />
+		<!-- AuthenticationStateProvider / CascadingAuthenticationState / [Authorize] on routable
+		     components. Referenced directly: it used to arrive transitively through
+		     Microsoft.AspNetCore.Components.WebAssembly.Authentication, which was only ever needed by
+		     the OIDC RemoteAuthenticatorView page and went away with it. -->
+		<PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.10" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.10" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.10" />
 		<PackageReference Include="MudBlazor" Version="9.4.0" />

--- a/SharpMUSH.Client/wwwroot/index.html
+++ b/SharpMUSH.Client/wwwroot/index.html
@@ -41,7 +41,6 @@
          after the Blazor boot script are evaluated, causing ReferenceErrors. -->
     <script src="/_content/PSC.Blazor.Components.MarkdownEditor/js/easymde.min.js"></script>
     <script src="/_content/PSC.Blazor.Components.MarkdownEditor/js/markdownEditor.js"></script>
-    <script src="_content/Microsoft.AspNetCore.Components.WebAssembly.Authentication/AuthenticationService.js"></script>
     <!-- Monaco Editor (BlazorMonaco) — must come before blazor.webassembly.js -->
     <script src="_content/BlazorMonaco/jsInterop.js"></script>
     <script src="_content/BlazorMonaco/lib/monaco-editor/min/vs/loader.js"></script>

--- a/SharpMUSH.Tests.BUnit/Pages/AccountPageTests.cs
+++ b/SharpMUSH.Tests.BUnit/Pages/AccountPageTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using Bunit;
 using Bunit.TestDoubles;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -131,19 +132,63 @@ public class AccountPageTests : BunitContext, IAsyncDisposable
 		await Assert.That(cut.Markup).DoesNotContain("Characters");
 	}
 
+	/// <summary>
+	/// /account used to be the only account page with no auth gate, so an anonymous visitor got a
+	/// dead-end card telling them to "use the terminal login panel". The gate is what sends them to
+	/// /login instead (via App.razor's NotAuthorized branch → RedirectToLogin), and bUnit renders a
+	/// page component directly, below AuthorizeRouteView — so the attribute itself is the thing to
+	/// assert, not a redirect the direct render can never perform.
+	/// </summary>
 	[TUnit.Core.Test]
-	public async Task Render_LoggedOut_DoesNotThrow()
+	public async Task AccountPage_IsGatedByAuthorize()
 	{
+		var authorize = typeof(SharpMUSH.Client.Pages.Account)
+			.GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true)
+			.Cast<AuthorizeAttribute>()
+			.SingleOrDefault();
+
+		await Assert.That(authorize).IsNotNull()
+			.Because("/account exposes the username, character list and password form of whoever is signed in");
+		// Plain [Authorize]: any signed-in account may manage its own account.
+		await Assert.That(authorize!.Roles).IsNull();
+		await Assert.That(authorize.Policy).IsNull();
+	}
+
+	/// <summary>
+	/// The one state that still reaches the page's no-account-session branch now that [Authorize]
+	/// intercepts anonymous visitors: a development DebugAuth principal whose debug-OTT never
+	/// produced an account session (here, because the fake API 404s <c>api/auth/debug-ott</c>).
+	/// </summary>
+	[TUnit.Core.Test]
+	public async Task Render_DebugAuthWithoutAccountSession_ShowsDebugCard()
+	{
+		Auth.SetAuthorized("DebugAdmin");
 		SeedAuthState(loggedIn: false);
 
 		var cut = Render<SharpMUSH.Client.Pages.Account>();
 
 		cut.WaitForAssertion(() =>
 		{
-			if (!cut.Markup.Contains("AuthNotLoggedInAccount"))
-				throw new InvalidOperationException("logged-out card not rendered yet");
+			if (!cut.Markup.Contains("AuthDebugMode"))
+				throw new InvalidOperationException("debug-mode card not rendered yet");
 		});
-		await Assert.That(cut.Markup).Contains("AuthNotLoggedInAccount");
+		await Assert.That(cut.Markup).Contains("AuthDebugMode");
+	}
+
+	/// <summary>
+	/// Post-logout, before the redirect lands: no account session and no debug identity either.
+	/// The page must render its empty shell — not the removed "use the terminal login panel"
+	/// dead end, and not a stale Debug Mode alert.
+	/// </summary>
+	[TUnit.Core.Test]
+	public async Task Render_LoggedOut_RendersNoCard()
+	{
+		SeedAuthState(loggedIn: false);
+
+		var cut = Render<SharpMUSH.Client.Pages.Account>();
+
+		await Assert.That(cut.Markup).DoesNotContain("acct-card");
+		await Assert.That(cut.Markup).DoesNotContain("AuthDebugMode");
 	}
 
 	/// <summary>

--- a/SharpMUSH.Tests.BUnit/Pages/PackagesAdminGateTests.cs
+++ b/SharpMUSH.Tests.BUnit/Pages/PackagesAdminGateTests.cs
@@ -1,0 +1,51 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Components;
+using SharpMUSH.Library.Authorization;
+
+namespace SharpMUSH.Tests.BUnit.Pages;
+
+/// <summary>
+/// The package admin section must gate on the <c>packages.admin</c> permission, never on a role name.
+/// <para>
+/// AdminPackageReview gated on <c>[Authorize(Roles = "Wizard")]</c> while its four siblings gated on
+/// the policy. Role claims carry no hierarchy — AccountAuthStateProvider emits exactly one
+/// <see cref="System.Security.Claims.ClaimTypes.Role"/> claim from the account's role — so a God
+/// account holding every permission scope, <c>packages.admin</c> included, failed an exact-match
+/// check for "Wizard" and got the not-authorized card on one page out of five.
+/// </para>
+/// <para>
+/// Discovered from the routes rather than a hand-written page list: a sixth package page added with
+/// a role gate has to fail here, which a list of five type names would not do.
+/// </para>
+/// </summary>
+public class PackagesAdminGateTests
+{
+	public static IEnumerable<Type> PackageAdminPages() =>
+		typeof(SharpMUSH.Client.Pages.Admin.Packages.AdminPackages).Assembly
+			.GetTypes()
+			.Where(t => t.Namespace == typeof(SharpMUSH.Client.Pages.Admin.Packages.AdminPackages).Namespace)
+			.Where(t => t.GetCustomAttributes<RouteAttribute>().Any())
+			.OrderBy(t => t.FullName, StringComparer.Ordinal);
+
+	[TUnit.Core.Test]
+	public async Task Every_package_admin_page_is_discovered()
+	{
+		// Guards the discovery above: a namespace rename would leave every case below unrun and
+		// nothing else would notice.
+		await Assert.That(PackageAdminPages().Count()).IsGreaterThanOrEqualTo(5);
+	}
+
+	[TUnit.Core.Test]
+	[MethodDataSource(nameof(PackageAdminPages))]
+	public async Task Package_admin_page_gates_on_the_packages_admin_policy(Type page)
+	{
+		var authorize = page.GetCustomAttributes<AuthorizeAttribute>(inherit: true).SingleOrDefault();
+
+		await Assert.That(authorize).IsNotNull()
+			.Because($"{page.Name} administers installable softcode packages");
+		await Assert.That(authorize!.Policy).IsEqualTo(PortalPermission.PackagesAdmin);
+		await Assert.That(authorize.Roles).IsNull()
+			.Because("role claims have no hierarchy here, so a role gate silently excludes higher roles");
+	}
+}


### PR DESCRIPTION
Part 1 of 4 in a stack fixing findings from a full portal audit: every reachable route (63) walked as five personas (anonymous, account with no character, account with one character, account with two, admin) against a **Release build in Production mode** — so `DebugAuthStateProvider`, which grants a claim for every `PortalRole`, could not mask a permission gate.

**Stack:** ← you are here → #2 server-side → #3 portal data → #4 portal UX

## What this fixes

### The God account was locked out of `/admin/packages/review`
`AdminPackageReview.razor` gated on `[Authorize(Roles = "Wizard")]` while its four sibling package pages all gate on `[Authorize(Policy = "packages.admin")]`. `AccountAuthStateProvider` emits exactly one role claim with no hierarchy, so an account whose role is `God` — owner of `#1`, holding all 16 scopes including `packages.admin` — did not satisfy `Roles="Wizard"` and got "You are not authorized to access this resource."

The page has no nav entry anywhere, so it is reachable only by typing the URL. That is part of why this went unnoticed.

`AdminAccounts.razor` uses `Roles = "Wizard,God"` and is correct; it was left alone. No other page in the client has a role gate that excludes a strictly higher role.

### `/authentication/{action}` hard-crashed the SPA
The page rendered `RemoteAuthenticatorView`, but the OIDC wiring it needs was removed when `AccountAuthStateProvider` replaced it. Loading the route left the app stuck on the startup splash with the unhandled-error bar, while the server was healthy.

Deleting it required a package split rather than a straight removal: `Microsoft.AspNetCore.Components.WebAssembly.Authentication` was transitively supplying `Microsoft.AspNetCore.Components.Authorization`, which backs `_Imports.razor`'s `@using`, `AuthenticationStateProvider`, `CascadingAuthenticationState` and every `[Authorize]` in the portal — removing it outright produced 156 errors. The authorization package is now referenced directly; only the remote/OIDC half was dead. `docs/superpowers/plans/2026-07-13-account-login-setup.md:2452` anticipated exactly this and deferred the cleanup for that reason.

### `/account` was the only account page with no auth gate
`/settings`, `/settings/characters` and `/settings/theme` all redirect anonymous visitors to `/login?returnUrl=…`. `/account` had no `[Authorize]` and instead rendered a dead-end card whose only action was "Go to Home", telling the visitor to "Use the terminal login panel to log in" — which is not the login route.

The page's `!IsLoggedIn` branch still covers a second, live case: a DebugAuth session with no account session. That branch and its guard stay; only the anonymous branch and its now-unused resource key are removed. Without the guard, the re-render that `AuthStateChanged` triggers during logout would flash a stale "Debug Mode" alert on the way out.

### Hardcoded English in a localized client
`App.razor` had two hardcoded strings inside the not-authorized card whose heading *was* localized. Every non-admin persona meets this card. Both are now resource keys across the neutral file and all 15 locales.

### A source file that tooling read as binary
`AdminPackageReview.razor` contained a raw `NUL` at byte 14462 — `$"{change.TargetRef}\0{change.Attribute}"` written literally rather than escaped. `file` reported it as `data` and recursive `grep` skipped it silently, which is how the authorization bug in the same file nearly escaped the audit. The composed key value is unchanged; `file` now reports UTF-8 text and `grep -rn '@page'` finds it.

## Verification
- `dotnet build` — 0 errors. Warnings-as-errors untouched; no suppressions added.
- `dotnet run --project SharpMUSH.Tests.BUnit` — 404 passed / 0 failed.
- `python3 tools/i18n/validate_resx.py` — all gates passed, 16/16 files at 100% coverage.

New tests discover the package admin pages from their `RouteAttribute`s rather than a fixed list, so a future page added without the policy gate fails the suite.

Note: rendering a page component directly in bUnit sits *below* `AuthorizeRouteView`, so `[Authorize]` has no runtime effect there — a "render anonymously and expect a redirect" test would silently prove nothing. The gate tests assert the attribute by reflection, with the reason recorded in the doc comments.

## Not addressed here
`dotnet build -c Release` fails on `main` with 4 `MSB3030` fixture-copy errors. Pre-existing and verified as such; CI builds Debug, so it does not gate this stack. It needs its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unauthorized-page messaging now includes localized explanations and a link back home.
  * Account access is restricted to authorized users.
  * Package administration pages now use dedicated access controls.

* **Bug Fixes**
  * Removed obsolete authentication-page and sign-in behavior.
  * Improved handling of logged-out and debug-authenticated account states.

* **Tests**
  * Added coverage for account authorization and package administration access rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->