### PR TITLE
Portal audit 3/4: presence counts people, and a failed fetch stops reading as zero

### DIFF
--- a/SharpMUSH.Client/Components/Widgets/CharacterDirectoryWidget.razor
+++ b/SharpMUSH.Client/Components/Widgets/CharacterDirectoryWidget.razor
@@ -46,6 +46,12 @@
             }
         </div>
     }
+    else if (_failed)
+    {
+        @* The roster could not be read at all. "No characters found" would be a claim about the
+           game rather than about this request. *@
+        <EmptyState>@Loc["WidUnavailable"]</EmptyState>
+    }
     else if (Filtered.Count == 0)
     {
         <EmptyState>@Loc["NoCharactersFound"]</EmptyState>
@@ -93,6 +99,7 @@
 
     private IReadOnlyList<CharacterDirectoryService.CharacterSummary> _all = [];
     private bool _loading = true;
+    private bool _failed;
     private string _search = string.Empty;
     private string? _selectedCategory;
     private List<string> _categories = [];
@@ -117,7 +124,9 @@
 
     protected override async Task OnInitializedAsync()
     {
-        _all = await Directory.ListAsync();
+        var result = await Directory.ListAsync();
+        _failed = result.IsT1;
+        _all = result.Match(rows => rows, _ => (IReadOnlyList<CharacterDirectoryService.CharacterSummary>)[]);
         _categories = _all
             .Select(c => c.Category?.Trim() ?? string.Empty)
             .Distinct()

--- a/SharpMUSH.Client/Components/Widgets/OnlineCharactersWidget.razor
+++ b/SharpMUSH.Client/Components/Widgets/OnlineCharactersWidget.razor
@@ -9,6 +9,12 @@
     {
         @for (var i = 0; i < 4; i++) { <MudSkeleton Height="32px" Class="mb-1" /> }
     }
+    @* Three states, not two: the list failed to load is not the same claim as "nobody is here",
+       and saying the latter for the former is the more damaging of the two mistakes. *@
+    else if (_characters is null)
+    {
+        <MudText Style="color:var(--text-faint);font-size:0.8125rem;">@Loc["WidUnavailable"]</MudText>
+    }
     else if (_characters is { Count: > 0 })
     {
         @foreach (var c in _characters.Take(8))
@@ -43,12 +49,14 @@
     [Parameter] public JsonElement? Config { get; set; }
     [Parameter] public string Zone { get; set; } = string.Empty;
 
+    /// <summary>The connected characters, or null when the fetch failed. Empty means nobody is on.</summary>
     private IReadOnlyList<CharacterDirectoryService.CharacterSummary>? _characters;
     private bool _loading = true;
 
     protected override async Task OnInitializedAsync()
     {
-        _characters = await CharacterDirectory.ListOnlineAsync();
+        _characters = (await CharacterDirectory.ListOnlineAsync())
+            .Match(rows => rows, _ => (IReadOnlyList<CharacterDirectoryService.CharacterSummary>?)null);
         _loading = false;
     }
 }

--- a/SharpMUSH.Client/Components/Widgets/SchemaWidget.razor
+++ b/SharpMUSH.Client/Components/Widgets/SchemaWidget.razor
@@ -110,7 +110,11 @@ else
             return null;
         }
 
-        return await Directory.ResolveObjidAsync(PageContext.CharacterName);
+        // No such character and an unreadable directory are different facts, but this widget's
+        // answer to an unfillable {objid} hole is the same either way: don't fetch. The failed read
+        // is already logged by the directory service, so nothing is lost by not distinguishing here.
+        var resolved = await Directory.ResolveObjidAsync(PageContext.CharacterName);
+        return resolved.TryPickT0(out var objid, out _) ? objid : null;
     }
 
     /// <summary>Replaces {objid}/{character} tokens. Returns null if an {objid} token can't be filled.</summary>

--- a/SharpMUSH.Client/Components/Widgets/StatsWidget.razor
+++ b/SharpMUSH.Client/Components/Widgets/StatsWidget.razor
@@ -12,7 +12,10 @@
         <MudItem xs="6" sm="3">
             <MudPaper Elevation="0" Style="padding:1.25rem;border-radius:var(--radius);border:1px solid var(--border);background:var(--surface);">
                 <MudText Style="font-size:0.6875rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--text-faint);font-family:var(--font-mono);">@Loc[tile.LabelKey]</MudText>
-                <MudText Style="font-size:1.75rem;font-weight:700;color:var(--accent);line-height:1.2;margin-top:0.25rem;">@tile.Value</MudText>
+                @* The placeholder is the same dash whether the value is still loading or could not
+                   be fetched; the title says which, without a banner or a spinner that never ends. *@
+                <MudText title="@(tile.Failed ? Loc["WidUnavailable"].Value : null)"
+                         Style="font-size:1.75rem;font-weight:700;color:var(--accent);line-height:1.2;margin-top:0.25rem;">@tile.Value</MudText>
             </MudPaper>
         </MudItem>
     }
@@ -22,17 +25,22 @@
     [Parameter] public JsonElement? Config { get; set; }
     [Parameter] public string Zone { get; set; } = string.Empty;
 
+    /// <summary>A count once it is known; null both while loading and when the fetch failed.</summary>
     private int? _recent;
     private int? _characters;
     private int? _online;
     private int? _activeScenes;
 
-    private (string LabelKey, string Value)[] Tiles =>
+    /// <summary>Which counts failed to load, so their dash can be explained rather than left ambiguous.</summary>
+    private bool _charactersFailed;
+    private bool _onlineFailed;
+
+    private (string LabelKey, string Value, bool Failed)[] Tiles =>
     [
-        ("WidPlayersOnline", _online?.ToString() ?? "—"),
-        ("WidActiveScenes",  _activeScenes?.ToString() ?? "—"),
-        ("RecentChanges",    _recent?.ToString() ?? "—"),
-        ("Characters",       _characters?.ToString() ?? "—"),
+        ("WidPlayersOnline", _online?.ToString() ?? "—", _onlineFailed),
+        ("WidActiveScenes",  _activeScenes?.ToString() ?? "—", false),
+        ("RecentChanges",    _recent?.ToString() ?? "—", false),
+        ("Characters",       _characters?.ToString() ?? "—", _charactersFailed),
     ];
 
     protected override async Task OnInitializedAsync()
@@ -47,8 +55,14 @@
         await Task.WhenAll(recentTask, charsTask, onlineTask, scenesTask);
 
         _recent = (await recentTask).Count;
-        _characters = (await charsTask).Count;
-        _online = (await onlineTask).Count;
         _activeScenes = (await scenesTask).Count;
+
+        // A tile that could not be fetched keeps the loading placeholder instead of printing 0:
+        // "the game has no characters" and "the request never arrived" look identical as a count,
+        // and only one of them is something the portal actually knows.
+        _characters = (await charsTask).Match(rows => rows.Count, _ => (int?)null);
+        _charactersFailed = _characters is null;
+        _online = (await onlineTask).Match(rows => rows.Count, _ => (int?)null);
+        _onlineFailed = _online is null;
     }
 }

--- a/SharpMUSH.Client/Pages/Characters.razor
+++ b/SharpMUSH.Client/Pages/Characters.razor
@@ -42,6 +42,12 @@
             }
         </div>
     }
+    else if (_failed)
+    {
+        @* The directory request failed. "No characters found" would state something about the game
+           that this page has no evidence for. *@
+        <div class="char-empty">@Loc["WidUnavailable"]</div>
+    }
     else if (Filtered.Count == 0)
     {
         <div class="char-empty">@Loc["NoCharactersFound"]</div>
@@ -87,16 +93,21 @@
 @code {
     private IReadOnlyList<CharacterDirectoryService.CharacterSummary> _all = [];
     private bool _loading = true;
+    private bool _failed;
     private string _search = string.Empty;
     private string? _selectedCategory;
     private List<string> _categories = [];
 
     private static readonly int[] AvHues = [168, 28, 264, 210, 340, 130, 50];
 
+    // "0 characters registered" is the same lie as the 0 on the dashboard tile when the directory
+    // request is what failed, so the count is only claimed for a roster that actually arrived.
     private string HeaderKicker =>
         _loading
             ? Loc["Loading"].Value
-            : Loc.Plural("NavCharactersRegistered", "count", _all.Count);
+            : _failed
+                ? Loc["WidUnavailable"].Value
+                : Loc.Plural("NavCharactersRegistered", "count", _all.Count);
 
     private IReadOnlyList<CharacterDirectoryService.CharacterSummary> Filtered
     {
@@ -113,7 +124,9 @@
 
     protected override async Task OnInitializedAsync()
     {
-        _all = await Directory.ListAsync();
+        var result = await Directory.ListAsync();
+        _failed = result.IsT1;
+        _all = result.Match(rows => rows, _ => (IReadOnlyList<CharacterDirectoryService.CharacterSummary>)[]);
         _categories = _all
             .Select(c => c.Category?.Trim() ?? string.Empty)
             .Distinct()

--- a/SharpMUSH.Client/Resources/SharedResource.bg.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.bg.resx
@@ -3840,6 +3840,10 @@
     <value>В момента няма свързани играчи.</value>
     <comment>MT</comment>
   </data>
+  <data name="WidUnavailable" xml:space="preserve">
+    <value>В момента не е налично.</value>
+    <comment>MT</comment>
+  </data>
   <data name="WidNothingToDisplay" xml:space="preserve">
     <value>Няма какво да се покаже.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.da.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.da.resx
@@ -3840,6 +3840,10 @@
     <value>Der er ingen online lige nu.</value>
     <comment>MT</comment>
   </data>
+  <data name="WidUnavailable" xml:space="preserve">
+    <value>Ikke tilgængeligt lige nu.</value>
+    <comment>MT</comment>
+  </data>
   <data name="WidNothingToDisplay" xml:space="preserve">
     <value>Intet at vise.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.de.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.de.resx
@@ -3840,6 +3840,10 @@
     <value>Derzeit ist niemand verbunden.</value>
     <comment>MT</comment>
   </data>
+  <data name="WidUnavailable" xml:space="preserve">
+    <value>Derzeit nicht verfügbar.</value>
+    <comment>MT</comment>
+  </data>
   <data name="WidNothingToDisplay" xml:space="preserve">
     <value>Nichts anzuzeigen.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.es.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.es.resx
@@ -3840,6 +3840,10 @@
     <value>No hay nadie conectado ahora mismo.</value>
     <comment>MT</comment>
   </data>
+  <data name="WidUnavailable" xml:space="preserve">
+    <value>No disponible en este momento.</value>
+    <comment>MT</comment>
+  </data>
   <data name="WidNothingToDisplay" xml:space="preserve">
     <value>No hay nada que mostrar.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.fr.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.fr.resx
@@ -2042,6 +2042,10 @@
   <data name="WidNobodyConnected" xml:space="preserve">
     <value>Personne n'est connecté pour le moment.</value>
   </data>
+  <data name="WidUnavailable" xml:space="preserve">
+    <value>Indisponible pour le moment.</value>
+    <comment>MT</comment>
+  </data>
   <data name="WidConfigureQuickLinks" xml:space="preserve">
     <value>Configurer les liens rapides</value>
   </data>

--- a/SharpMUSH.Client/Resources/SharedResource.hr.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.hr.resx
@@ -3840,6 +3840,10 @@
     <value>Trenutačno nitko nije povezan.</value>
     <comment>MT</comment>
   </data>
+  <data name="WidUnavailable" xml:space="preserve">
+    <value>Trenutačno nedostupno.</value>
+    <comment>MT</comment>
+  </data>
   <data name="WidNothingToDisplay" xml:space="preserve">
     <value>Nema ništa za prikaz.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.hu.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.hu.resx
@@ -3840,6 +3840,10 @@
     <value>Jelenleg senki sincs bejelentkezve.</value>
     <comment>MT</comment>
   </data>
+  <data name="WidUnavailable" xml:space="preserve">
+    <value>Jelenleg nem érhető el.</value>
+    <comment>MT</comment>
+  </data>
   <data name="WidNothingToDisplay" xml:space="preserve">
     <value>Nincs megjeleníthető tartalom.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.nb.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.nb.resx
@@ -3840,6 +3840,10 @@
     <value>Ingen er tilkoblet akkurat nå.</value>
     <comment>MT</comment>
   </data>
+  <data name="WidUnavailable" xml:space="preserve">
+    <value>Ikke tilgjengelig akkurat nå.</value>
+    <comment>MT</comment>
+  </data>
   <data name="WidNothingToDisplay" xml:space="preserve">
     <value>Ingenting å vise.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.nl.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.nl.resx
@@ -3840,6 +3840,10 @@
     <value>Er is op dit moment niemand ingelogd.</value>
     <comment>MT</comment>
   </data>
+  <data name="WidUnavailable" xml:space="preserve">
+    <value>Momenteel niet beschikbaar.</value>
+    <comment>MT</comment>
+  </data>
   <data name="WidNothingToDisplay" xml:space="preserve">
     <value>Niets om weer te geven.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.pl.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.pl.resx
@@ -3840,6 +3840,10 @@
     <value>Obecnie nikt nie jest połączony.</value>
     <comment>MT</comment>
   </data>
+  <data name="WidUnavailable" xml:space="preserve">
+    <value>Obecnie niedostępne.</value>
+    <comment>MT</comment>
+  </data>
   <data name="WidNothingToDisplay" xml:space="preserve">
     <value>Brak elementów do wyświetlenia.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.pt-BR.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.pt-BR.resx
@@ -3840,6 +3840,10 @@
     <value>Ninguém está conectado no momento.</value>
     <comment>MT</comment>
   </data>
+  <data name="WidUnavailable" xml:space="preserve">
+    <value>Indisponível no momento.</value>
+    <comment>MT</comment>
+  </data>
   <data name="WidNothingToDisplay" xml:space="preserve">
     <value>Nada a exibir.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.resx
@@ -2919,6 +2919,9 @@
   <data name="WidNobodyConnected" xml:space="preserve">
     <value>No one is connected right now.</value>
   </data>
+  <data name="WidUnavailable" xml:space="preserve">
+    <value>Unavailable right now.</value>
+  </data>
   <data name="WidConfigureQuickLinks" xml:space="preserve">
     <value>Configure Quick Links</value>
   </data>

--- a/SharpMUSH.Client/Resources/SharedResource.ro.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.ro.resx
@@ -3840,6 +3840,10 @@
     <value>Nimeni nu este conectat în acest moment.</value>
     <comment>MT</comment>
   </data>
+  <data name="WidUnavailable" xml:space="preserve">
+    <value>Indisponibil în acest moment.</value>
+    <comment>MT</comment>
+  </data>
   <data name="WidNothingToDisplay" xml:space="preserve">
     <value>Nu există nimic de afișat.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.ru.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.ru.resx
@@ -3840,6 +3840,10 @@
     <value>Сейчас никого нет в игре.</value>
     <comment>MT</comment>
   </data>
+  <data name="WidUnavailable" xml:space="preserve">
+    <value>Сейчас недоступно.</value>
+    <comment>MT</comment>
+  </data>
   <data name="WidNothingToDisplay" xml:space="preserve">
     <value>Нечего показать.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.sv.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.sv.resx
@@ -3840,6 +3840,10 @@
     <value>Ingen är uppkopplad just nu.</value>
     <comment>MT — 'uppkopplad' is the corpus rendering of connected/online.</comment>
   </data>
+  <data name="WidUnavailable" xml:space="preserve">
+    <value>Inte tillgängligt just nu.</value>
+    <comment>MT</comment>
+  </data>
   <data name="WidNothingToDisplay" xml:space="preserve">
     <value>Inget att visa.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.zh-Hans.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.zh-Hans.resx
@@ -3840,6 +3840,10 @@
     <value>当前没有人在线。</value>
     <comment>MT</comment>
   </data>
+  <data name="WidUnavailable" xml:space="preserve">
+    <value>当前不可用。</value>
+    <comment>MT</comment>
+  </data>
   <data name="WidNothingToDisplay" xml:space="preserve">
     <value>没有可显示的内容。</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Services/CharacterDirectoryService.cs
+++ b/SharpMUSH.Client/Services/CharacterDirectoryService.cs
@@ -128,15 +128,25 @@ public class CharacterDirectoryService(IHttpClientFactory httpClientFactory, ILo
 				.ToList();
 
 	/// <summary>
-	/// Resolves a character's objid by (case-insensitive) name via the directory; null if absent.
-	/// A failed directory read is also null here: the caller (a route template with an
-	/// <c>{objid}</c> hole) can do nothing with either answer but decline to fetch.
+	/// Resolves a character's objid by (case-insensitive) name via the directory.
+	/// <see cref="NotFound"/> means no character answers to that name; <see cref="Error"/> means the
+	/// directory could not be read.
 	/// </summary>
-	public async Task<string?> ResolveObjidAsync(string name, CancellationToken cancellationToken = default)
+	/// <remarks>
+	/// The same two facts <see cref="ListAsync"/> keeps apart, kept apart here as well. This used to
+	/// return one null for both, justified by its only caller — a route template with an
+	/// <c>{objid}</c> hole — declining to fetch either way. That is still true of that caller, but it
+	/// is a fact about the caller, not about the answer: "there is no such character" is a 404 page
+	/// and "we could not ask the game" is not, and a caller that wants to say so should not have to
+	/// widen this signature first.
+	/// </remarks>
+	public async Task<OneOf<string, NotFound, Error>> ResolveObjidAsync(string name, CancellationToken cancellationToken = default)
 	{
 		var rows = await ListAsync(cancellationToken);
-		return rows.Match(
-			found => found.FirstOrDefault(r => string.Equals(r.Name, name, StringComparison.OrdinalIgnoreCase))?.Objid,
-			_ => null);
+		return rows.Match<OneOf<string, NotFound, Error>>(
+			found => found.FirstOrDefault(r => string.Equals(r.Name, name, StringComparison.OrdinalIgnoreCase)) is { } match
+				? match.Objid
+				: new NotFound(),
+			error => error);
 	}
 }

--- a/SharpMUSH.Client/Services/CharacterDirectoryService.cs
+++ b/SharpMUSH.Client/Services/CharacterDirectoryService.cs
@@ -37,22 +37,15 @@ public class CharacterDirectoryService(IHttpClientFactory httpClientFactory, ILo
 	/// answer must not make one — so the failure is in the type, where a consumer has to decide
 	/// what to do with it rather than inherit the old lie by accident.
 	/// </remarks>
-	public async Task<OneOf<IReadOnlyList<CharacterSummary>, Error>> ListAsync()
+	public async Task<OneOf<IReadOnlyList<CharacterSummary>, Error>> ListAsync(CancellationToken cancellationToken = default)
 	{
 		try
 		{
 			var http = httpClientFactory.CreateClient("api");
-			var rows = await http.GetFromJsonAsync<List<CharacterSummary>>("http/characters");
+			var rows = await http.GetFromJsonAsync<List<CharacterSummary>>("http/characters", cancellationToken);
 			return OneOf<IReadOnlyList<CharacterSummary>, Error>.FromT0(Normalize(rows));
 		}
-		// These handlers are redefinable per game, so a malformed response is a configuration
-		// mistake rather than a bug here: degrade to the failed arm instead of taking the page down.
-		// JsonException covers a body that is not JSON; InvalidOperationException covers a
-		// Content-Type whose charset is unrecognised, which fails while reading the body, before
-		// any parsing. NotSupportedException is documented on ReadFromJsonAsync for an unusable
-		// content type — it does not fire on this stack today, but it is part of the API's contract.
-		catch (Exception ex) when (ex is HttpRequestException or JsonException
-			or InvalidOperationException or NotSupportedException)
+		catch (Exception ex) when (IsRequestFailure(ex, cancellationToken))
 		{
 			logger.LogWarning(ex, "Failed to load character directory.");
 			return new Error();
@@ -66,27 +59,49 @@ public class CharacterDirectoryService(IHttpClientFactory httpClientFactory, ILo
 	/// the roster of every character that exists: a character being listed there implies nothing
 	/// about presence.
 	/// </summary>
-	public async Task<OneOf<IReadOnlyList<CharacterSummary>, Error>> ListOnlineAsync()
+	public async Task<OneOf<IReadOnlyList<CharacterSummary>, Error>> ListOnlineAsync(CancellationToken cancellationToken = default)
 	{
 		try
 		{
 			var http = httpClientFactory.CreateClient("api");
-			var rows = await http.GetFromJsonAsync<List<CharacterSummary>>("http/online");
+			var rows = await http.GetFromJsonAsync<List<CharacterSummary>>("http/online", cancellationToken);
 			return OneOf<IReadOnlyList<CharacterSummary>, Error>.FromT0(Normalize(rows));
 		}
-		// These handlers are redefinable per game, so a malformed response is a configuration
-		// mistake rather than a bug here: degrade to the failed arm instead of taking the page down.
-		// JsonException covers a body that is not JSON; InvalidOperationException covers a
-		// Content-Type whose charset is unrecognised, which fails while reading the body, before
-		// any parsing. NotSupportedException is documented on ReadFromJsonAsync for an unusable
-		// content type — it does not fire on this stack today, but it is part of the API's contract.
-		catch (Exception ex) when (ex is HttpRequestException or JsonException
-			or InvalidOperationException or NotSupportedException)
+		catch (Exception ex) when (IsRequestFailure(ex, cancellationToken))
 		{
 			logger.LogWarning(ex, "Failed to load the online character list.");
 			return new Error();
 		}
 	}
+
+	/// <summary>
+	/// True for a failure that belongs in the <see cref="Error"/> arm rather than up the stack.
+	/// </summary>
+	/// <remarks>
+	/// These handlers are redefinable per game, so a malformed response is a configuration mistake
+	/// rather than a bug here: degrade instead of taking the page down. JsonException covers a body
+	/// that is not JSON; InvalidOperationException covers a Content-Type whose charset is
+	/// unrecognised, which fails while reading the body, before any parsing. NotSupportedException
+	/// is documented on ReadFromJsonAsync for an unusable content type — it does not fire on this
+	/// stack today, but it is part of the API's contract.
+	/// <para>
+	/// A request that exceeds <see cref="HttpClient.Timeout"/> surfaces as a
+	/// <see cref="TaskCanceledException"/> (an <see cref="OperationCanceledException"/>, which is
+	/// not an <see cref="InvalidOperationException"/>), so it used to escape as an unhandled
+	/// exception out of a component's OnInitializedAsync — a slow game taking the page down, which
+	/// is the failure mode this service exists to avoid. A cancellation the caller actually asked
+	/// for is a different fact: it means the caller stopped wanting an answer, not that the game
+	/// could not give one, and rendering "unavailable" for a navigation the user themselves
+	/// abandoned would be a lie in the other direction. That one propagates.
+	/// </para>
+	/// </remarks>
+	private static bool IsRequestFailure(Exception ex, CancellationToken cancellationToken) =>
+		ex switch
+		{
+			OperationCanceledException => !cancellationToken.IsCancellationRequested,
+			HttpRequestException or JsonException or InvalidOperationException or NotSupportedException => true,
+			_ => false
+		};
 
 	/// <summary>
 	/// One row per character, name-sorted. A <c>null</c> body (a bare <c>null</c> literal, which is
@@ -117,9 +132,9 @@ public class CharacterDirectoryService(IHttpClientFactory httpClientFactory, ILo
 	/// A failed directory read is also null here: the caller (a route template with an
 	/// <c>{objid}</c> hole) can do nothing with either answer but decline to fetch.
 	/// </summary>
-	public async Task<string?> ResolveObjidAsync(string name)
+	public async Task<string?> ResolveObjidAsync(string name, CancellationToken cancellationToken = default)
 	{
-		var rows = await ListAsync();
+		var rows = await ListAsync(cancellationToken);
 		return rows.Match(
 			found => found.FirstOrDefault(r => string.Equals(r.Name, name, StringComparison.OrdinalIgnoreCase))?.Objid,
 			_ => null);

--- a/SharpMUSH.Client/Services/CharacterDirectoryService.cs
+++ b/SharpMUSH.Client/Services/CharacterDirectoryService.cs
@@ -1,3 +1,5 @@
+using OneOf;
+using OneOf.Types;
 using System.Net.Http.Json;
 using System.Text.Json;
 
@@ -24,17 +26,27 @@ public class CharacterDirectoryService(IHttpClientFactory httpClientFactory, ILo
 		public string Dbref => Objid.Split(':')[0];
 	}
 
-	/// <summary>Returns every character, name-sorted; an empty list on failure.</summary>
-	public async Task<IReadOnlyList<CharacterSummary>> ListAsync()
+	/// <summary>
+	/// Returns every character, name-sorted; <see cref="Error"/> if the request failed.
+	/// </summary>
+	/// <remarks>
+	/// The failed arm is not decoration: "nobody" and "we could not ask" are different facts that
+	/// used to render identically, because a failed fetch degraded to an empty list. The
+	/// dashboard's "Characters" tile then printed a confident <c>0</c> for a game with four
+	/// characters in it. A count is an assertion about the game, and a caller that never got an
+	/// answer must not make one — so the failure is in the type, where a consumer has to decide
+	/// what to do with it rather than inherit the old lie by accident.
+	/// </remarks>
+	public async Task<OneOf<IReadOnlyList<CharacterSummary>, Error>> ListAsync()
 	{
 		try
 		{
 			var http = httpClientFactory.CreateClient("api");
 			var rows = await http.GetFromJsonAsync<List<CharacterSummary>>("http/characters");
-			return rows is null ? [] : rows.OrderBy(r => r.Name, StringComparer.OrdinalIgnoreCase).ToList();
+			return OneOf<IReadOnlyList<CharacterSummary>, Error>.FromT0(Normalize(rows));
 		}
 		// These handlers are redefinable per game, so a malformed response is a configuration
-		// mistake rather than a bug here: degrade to an empty list instead of taking the page down.
+		// mistake rather than a bug here: degrade to the failed arm instead of taking the page down.
 		// JsonException covers a body that is not JSON; InvalidOperationException covers a
 		// Content-Type whose charset is unrecognised, which fails while reading the body, before
 		// any parsing. NotSupportedException is documented on ReadFromJsonAsync for an unusable
@@ -43,26 +55,27 @@ public class CharacterDirectoryService(IHttpClientFactory httpClientFactory, ILo
 			or InvalidOperationException or NotSupportedException)
 		{
 			logger.LogWarning(ex, "Failed to load character directory.");
-			return [];
+			return new Error();
 		}
 	}
 
 	/// <summary>
-	/// Returns the characters currently connected, name-sorted; an empty list on failure.
-	/// Backed by <c>GET /http/online</c> → <c>GET`ONLINE</c> on #8, which reads lwho() — the same
-	/// connection registry WHO reads. Distinct from <see cref="ListAsync"/>, which is the roster of
-	/// every character that exists: a character being listed there implies nothing about presence.
+	/// Returns the characters currently connected, name-sorted and one row per character;
+	/// <see cref="Error"/> if the request failed. Backed by <c>GET /http/online</c> →
+	/// <c>GET`ONLINE</c> on #8, which reads mwho(). Distinct from <see cref="ListAsync"/>, which is
+	/// the roster of every character that exists: a character being listed there implies nothing
+	/// about presence.
 	/// </summary>
-	public async Task<IReadOnlyList<CharacterSummary>> ListOnlineAsync()
+	public async Task<OneOf<IReadOnlyList<CharacterSummary>, Error>> ListOnlineAsync()
 	{
 		try
 		{
 			var http = httpClientFactory.CreateClient("api");
 			var rows = await http.GetFromJsonAsync<List<CharacterSummary>>("http/online");
-			return rows is null ? [] : rows.OrderBy(r => r.Name, StringComparer.OrdinalIgnoreCase).ToList();
+			return OneOf<IReadOnlyList<CharacterSummary>, Error>.FromT0(Normalize(rows));
 		}
 		// These handlers are redefinable per game, so a malformed response is a configuration
-		// mistake rather than a bug here: degrade to an empty list instead of taking the page down.
+		// mistake rather than a bug here: degrade to the failed arm instead of taking the page down.
 		// JsonException covers a body that is not JSON; InvalidOperationException covers a
 		// Content-Type whose charset is unrecognised, which fails while reading the body, before
 		// any parsing. NotSupportedException is documented on ReadFromJsonAsync for an unusable
@@ -71,14 +84,44 @@ public class CharacterDirectoryService(IHttpClientFactory httpClientFactory, ILo
 			or InvalidOperationException or NotSupportedException)
 		{
 			logger.LogWarning(ex, "Failed to load the online character list.");
-			return [];
+			return new Error();
 		}
 	}
 
-	/// <summary>Resolves a character's objid by (case-insensitive) name via the directory; null if absent.</summary>
+	/// <summary>
+	/// One row per character, name-sorted. A <c>null</c> body (a bare <c>null</c> literal, which is
+	/// valid JSON) reads as an empty list, not a failure.
+	/// </summary>
+	/// <remarks>
+	/// Deduplication on objid belongs here rather than in each widget so that "players online"
+	/// means people, not sockets, for every consumer present and future. It matters most for
+	/// GET`ONLINE: mwho() now lists each player once, but the route is redefinable per game and a
+	/// redefinition over ports()/lports() is a connection list, which is exactly how the portal
+	/// came to report "2, 0, 1, 14" players online for a world with four characters and to render
+	/// "Castor, Solitaire, Solitaire, Solitaire". Identity is the objid, never the name: two
+	/// characters may share a display name, and the same character may not share an objid. The
+	/// multiplicity is dropped rather than surfaced — the portal has nothing to say about a
+	/// character being connected twice, and a deduplicated upstream can no longer report it
+	/// truthfully anyway; WHO and ports() remain the per-connection view.
+	/// </remarks>
+	private static IReadOnlyList<CharacterSummary> Normalize(List<CharacterSummary>? rows) =>
+		rows is null
+			? []
+			: rows
+				.DistinctBy(r => r.Objid, StringComparer.Ordinal)
+				.OrderBy(r => r.Name, StringComparer.OrdinalIgnoreCase)
+				.ToList();
+
+	/// <summary>
+	/// Resolves a character's objid by (case-insensitive) name via the directory; null if absent.
+	/// A failed directory read is also null here: the caller (a route template with an
+	/// <c>{objid}</c> hole) can do nothing with either answer but decline to fetch.
+	/// </summary>
 	public async Task<string?> ResolveObjidAsync(string name)
 	{
 		var rows = await ListAsync();
-		return rows.FirstOrDefault(r => string.Equals(r.Name, name, StringComparison.OrdinalIgnoreCase))?.Objid;
+		return rows.Match(
+			found => found.FirstOrDefault(r => string.Equals(r.Name, name, StringComparison.OrdinalIgnoreCase))?.Objid,
+			_ => null);
 	}
 }

--- a/SharpMUSH.Implementation/Functions/ConnectionFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/ConnectionFunctions.cs
@@ -732,46 +732,73 @@ public partial class Functions
 		return new CallState(string.Join(" ", resultId));
 	}
 
-	[SharpFunction(Name = "mwho", MinArgs = 0, MaxArgs = 0, Flags = FunctionFlags.Regular | FunctionFlags.StripAnsi, ParameterNames = [])]
-	public static async ValueTask<CallState> MortalWho(IMUSHCodeParser parser, SharpFunctionAttribute _2)
-	{
-		// The mortal (public) view: never lists DARK players or portal-class connections, independent of caller.
-		var nonHiddenConnections = ConnectionService!
+	/// <summary>
+	/// The mortal (public) WHO list, as <em>players</em>: never DARK, never portal-class, and
+	/// independent of the caller.
+	/// </summary>
+	/// <remarks>
+	/// The distinct step is load-bearing. <see cref="IConnectionService.GetAll"/> yields one row per
+	/// open socket, so a player connected twice was listed twice — but help mwho defines mwho() as
+	/// "exactly the same as lwho() used by a mortal", and lwho() walks the player table, so the
+	/// connection-shaped answer disagreed with both its own documentation and its privileged twin.
+	/// Everything downstream inherited the duplicate: nmwho() over-counted, and the portal's
+	/// "Players online" tile — which reads this through the profile-handler's GET`ONLINE route —
+	/// counted sockets while claiming to count people. Deduplicating before the object lookup also
+	/// costs one query per player rather than one per connection. The per-connection view is what
+	/// ports()/lports() and WHO are for.
+	/// <para>
+	/// On <see cref="DBRef.Number"/> and not on the whole <see cref="DBRef"/>: the bound reference
+	/// is a bare <c>#N</c> on some login paths and a full <c>#N:creation</c> objid on others, and
+	/// those two compare unequal, so a player holding one connection of each kind would still have
+	/// been listed twice. Two live connections sharing a dbref number are the same player — the
+	/// number cannot be reused while an object still holds it.
+	/// </para>
+	/// </remarks>
+	private static IAsyncEnumerable<AnySharpObject> MortalWhoPlayers() =>
+		ConnectionService!
 			.GetAll()
 			.Where(x => x.Ref is not null && x.State == IConnectionService.ConnectionState.LoggedIn
 				&& x.PresenceClass != PresenceClasses.Portal)
-			.Select(async (x, ct) => (await Mediator!.Send(new GetObjectNodeQuery(x.Ref!.Value), ct)).Known)
-			.Where(async (x, _) => !await x.HasFlag("DARK"))
-			.Select(player => $"#{player.Object().DBRef.Number}");
+			.Select(x => x.Ref!.Value)
+			.DistinctBy(x => x.Number)
+			.Select(async (dbref, ct) => (await Mediator!.Send(new GetObjectNodeQuery(dbref), ct)).Known)
+			.Where(async (x, _) => !await x.HasFlag("DARK"));
 
-		return new CallState(string.Join(" ", await nonHiddenConnections.ToArrayAsync()));
+	/// <summary>
+	/// The caller-visible WHO list, as <em>players</em>: everyone logged in whom
+	/// <paramref name="looker"/> can see. The counterpart to <see cref="MortalWhoPlayers"/> for the
+	/// nwho()/xwho() family, and distinct for the same reason — help nwho documents it as
+	/// <c>words(lwho(&lt;viewer&gt;))</c>, and lwho() lists each player once.
+	/// </summary>
+	private static IAsyncEnumerable<AnySharpObject> VisibleWhoPlayers(AnySharpObject looker) =>
+		ConnectionService!
+			.GetAll()
+			.Where(x => x.Ref is not null && x.State == IConnectionService.ConnectionState.LoggedIn)
+			.Select(x => x.Ref!.Value)
+			.DistinctBy(x => x.Number)
+			.Select(async (dbref, ct) => (await Mediator!.Send(new GetObjectNodeQuery(dbref), ct)).Known)
+			.Where(async (x, _) => await PermissionService!.CanSee(looker, x));
+
+	[SharpFunction(Name = "mwho", MinArgs = 0, MaxArgs = 0, Flags = FunctionFlags.Regular | FunctionFlags.StripAnsi, ParameterNames = [])]
+	public static async ValueTask<CallState> MortalWho(IMUSHCodeParser parser, SharpFunctionAttribute _2)
+	{
+		var nonHiddenPlayers = MortalWhoPlayers().Select(player => $"#{player.Object().DBRef.Number}");
+
+		return new CallState(string.Join(" ", await nonHiddenPlayers.ToArrayAsync()));
 	}
 
 	[SharpFunction(Name = "mwhoid", MinArgs = 0, MaxArgs = 0, Flags = FunctionFlags.Regular | FunctionFlags.StripAnsi, ParameterNames = [])]
 	public static async ValueTask<CallState> MortalWhoObjectIds(IMUSHCodeParser parser, SharpFunctionAttribute _2)
 	{
-		// The mortal (public) view: never lists DARK players or portal-class connections, independent of caller.
-		var nonHiddenConnectionsObjIds = ConnectionService!
-			.GetAll()
-			.Where(x => x.Ref is not null && x.State == IConnectionService.ConnectionState.LoggedIn
-				&& x.PresenceClass != PresenceClasses.Portal)
-			.Select(async (x, ct) => (await Mediator!.Send(new GetObjectNodeQuery(x.Ref!.Value), ct)).Known)
-			.Where(async (x, _) => !await x.HasFlag("DARK"))
-			.Select(x => x.Object().DBRef);
+		var nonHiddenPlayerObjIds = MortalWhoPlayers().Select(x => x.Object().DBRef);
 
-		return new CallState(string.Join(" ", await nonHiddenConnectionsObjIds.ToArrayAsync()));
+		return new CallState(string.Join(" ", await nonHiddenPlayerObjIds.ToArrayAsync()));
 	}
 
 	[SharpFunction(Name = "nmwho", MinArgs = 0, MaxArgs = 0, Flags = FunctionFlags.Regular, ParameterNames = [])]
 	public static async ValueTask<CallState> NumberMortalWho(IMUSHCodeParser parser, SharpFunctionAttribute _2)
 	{
-		var count = await ConnectionService!
-			.GetAll()
-			.Where(x => x.Ref is not null && x.State == IConnectionService.ConnectionState.LoggedIn
-				&& x.PresenceClass != PresenceClasses.Portal)
-			.Select(async (x, ct) => (await Mediator!.Send(new GetObjectNodeQuery(x.Ref!.Value), ct)).Known)
-			.Where(async (x, _) => !await x.HasFlag("DARK"))
-			.CountAsync();
+		var count = await MortalWhoPlayers().CountAsync();
 
 		return new CallState(count.ToString(CultureInfo.InvariantCulture));
 	}
@@ -800,12 +827,7 @@ public partial class Functions
 			}
 		}
 
-		var count = await ConnectionService!
-			.GetAll()
-			.Where(x => x.Ref is not null && x.State == IConnectionService.ConnectionState.LoggedIn)
-			.Select(async (x, ct) => (await Mediator!.Send(new GetObjectNodeQuery(x.Ref!.Value), ct)).Known)
-			.Where(async (x, _) => await PermissionService!.CanSee(looker, x))
-			.CountAsync();
+		var count = await VisibleWhoPlayers(looker).CountAsync();
 
 		return new CallState(count.ToString(CultureInfo.InvariantCulture));
 	}
@@ -1038,13 +1060,7 @@ public partial class Functions
 			return new CallState(ErrorMessages.Returns.ArgRange);
 		}
 
-		var allDbrefs = ConnectionService!
-			.GetAll()
-			.Where(x => x.Ref is not null && x.State == IConnectionService.ConnectionState.LoggedIn
-				&& x.PresenceClass != PresenceClasses.Portal)
-			.Select(async (x, ct) => (await Mediator!.Send(new GetObjectNodeQuery(x.Ref!.Value), ct)).Known)
-			.Where(async (x, _) => !await x.HasFlag("DARK"))
-			.Select(x => $"#{x.Object().DBRef.Number}");
+		var allDbrefs = MortalWhoPlayers().Select(x => $"#{x.Object().DBRef.Number}");
 
 		var result = allDbrefs.Skip(start - 1).Take(count);
 		return new CallState(string.Join(" ", await result.ToArrayAsync()));
@@ -1067,13 +1083,7 @@ public partial class Functions
 			return new CallState(ErrorMessages.Returns.ArgRange);
 		}
 
-		var allObjIds = ConnectionService!
-			.GetAll()
-			.Where(x => x.Ref is not null && x.State == IConnectionService.ConnectionState.LoggedIn
-				&& x.PresenceClass != PresenceClasses.Portal)
-			.Select(async (x, ct) => (await Mediator!.Send(new GetObjectNodeQuery(x.Ref!.Value), ct)).Known)
-			.Where(async (x, _) => !await x.HasFlag("DARK"))
-			.Select(x => x.Object().DBRef);
+		var allObjIds = MortalWhoPlayers().Select(x => x.Object().DBRef);
 
 		var result = allObjIds.Skip(start - 1).Take(count);
 		return new CallState(string.Join(" ", await result.ToArrayAsync()));
@@ -1123,12 +1133,7 @@ public partial class Functions
 			return new CallState(ErrorMessages.Returns.ArgRange);
 		}
 
-		var allDbrefs = ConnectionService!
-			.GetAll()
-			.Where(x => x.Ref is not null && x.State == IConnectionService.ConnectionState.LoggedIn)
-			.Select(async (x, ct) => (await Mediator!.Send(new GetObjectNodeQuery(x.Ref!.Value), ct)).Known)
-			.Where(async (x, _) => await PermissionService!.CanSee(looker, x))
-			.Select(x => $"#{x.Object().DBRef.Number}");
+		var allDbrefs = VisibleWhoPlayers(looker).Select(x => $"#{x.Object().DBRef.Number}");
 
 		var result = allDbrefs.Skip(start - 1).Take(count);
 		return new CallState(string.Join(" ", await result.ToArrayAsync()));
@@ -1178,12 +1183,7 @@ public partial class Functions
 			return new CallState(ErrorMessages.Returns.ArgRange);
 		}
 
-		var allObjIds = ConnectionService!
-			.GetAll()
-			.Where(x => x.Ref is not null && x.State == IConnectionService.ConnectionState.LoggedIn)
-			.Select(async (x, ct) => (await Mediator!.Send(new GetObjectNodeQuery(x.Ref!.Value), ct)).Known)
-			.Where(async (x, _) => await PermissionService!.CanSee(looker, x))
-			.Select(x => x.Object().DBRef);
+		var allObjIds = VisibleWhoPlayers(looker).Select(x => x.Object().DBRef);
 
 		var result = allObjIds.Skip(start - 1).Take(count);
 		return new CallState(string.Join(" ", await result.ToArrayAsync()));

--- a/SharpMUSH.Tests.BUnit/Components/CharacterDirectoryWidgetTests.cs
+++ b/SharpMUSH.Tests.BUnit/Components/CharacterDirectoryWidgetTests.cs
@@ -32,6 +32,13 @@ file sealed class RosterHandler : HttpMessageHandler
 					: new HttpResponseMessage(HttpStatusCode.NotFound));
 }
 
+/// <summary>Fails the roster route outright, for the could-not-read state.</summary>
+file sealed class RosterUnreachableHandler : HttpMessageHandler
+{
+	protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+}
+
 /// <summary>
 /// Verifies the directory widget's category grouping comes entirely from the data: named
 /// categories alphabetical, blanks pooled untitled at the bottom, no invented labels.
@@ -39,13 +46,13 @@ file sealed class RosterHandler : HttpMessageHandler
 /// </summary>
 public class CharacterDirectoryWidgetTests : BunitContext
 {
-	public CharacterDirectoryWidgetTests()
+	private static void Wire(BunitContext ctx, HttpMessageHandler handler)
 	{
-		var apiClient = new HttpClient(new RosterHandler()) { BaseAddress = new Uri("https://localhost:8081/") };
+		var apiClient = new HttpClient(handler) { BaseAddress = new Uri("https://localhost:8081/") };
 		var factory = Substitute.For<IHttpClientFactory>();
 		factory.CreateClient("api").Returns(apiClient);
 
-		Services
+		ctx.Services
 				.AddSingleton(apiClient)
 				.AddMudServices()
 				.AddSingleton(factory)
@@ -54,12 +61,14 @@ public class CharacterDirectoryWidgetTests : BunitContext
 						NullLogger<CharacterDirectoryService>.Instance))
 				.AddSingleton<IStringLocalizer<SharedResource>, EchoLocalizer<SharedResource>>();
 
-		JSInterop.Mode = JSRuntimeMode.Loose;
+		ctx.JSInterop.Mode = JSRuntimeMode.Loose;
 	}
 
 	[TUnit.Core.Test]
 	public async Task GroupsAlphabetically_WithBlankCategoryUntitledLast()
 	{
+		Wire(this, new RosterHandler());
+
 		var cut = Render<CharacterDirectoryWidget>();
 		cut.WaitForAssertion(() =>
 		{
@@ -77,5 +86,22 @@ public class CharacterDirectoryWidgetTests : BunitContext
 				.IsLessThan(markup.IndexOf(">Pleb<", StringComparison.Ordinal));
 		// The widget invents no label for the blank category.
 		await Assert.That(markup).DoesNotContain("Player");
+	}
+
+	[TUnit.Core.Test]
+	public async Task AnUnreadableRoster_SaysUnavailable_NotNoCharactersFound()
+	{
+		Wire(this, new RosterUnreachableHandler());
+
+		var cut = Render<CharacterDirectoryWidget>();
+		cut.WaitForAssertion(() =>
+		{
+			if (cut.Markup.Contains("mud-skeleton")) throw new InvalidOperationException("still loading");
+		}, TimeSpan.FromSeconds(5));
+
+		// "No characters found" describes the game; this request never got far enough to describe
+		// anything, and the empty list it degrades to must not be read as an answer.
+		await Assert.That(cut.Markup).Contains("WidUnavailable");
+		await Assert.That(cut.Markup).DoesNotContain("NoCharactersFound");
 	}
 }

--- a/SharpMUSH.Tests.BUnit/Components/OnlineCharactersWidgetTests.cs
+++ b/SharpMUSH.Tests.BUnit/Components/OnlineCharactersWidgetTests.cs
@@ -58,6 +58,29 @@ file sealed class PresenceHandler : HttpMessageHandler
 	}
 }
 
+/// <summary>
+/// Serves the same character on several rows, which is what a connection-shaped online route
+/// produces for anyone logged in twice — the shape measured live against GET`ONLINE, where one
+/// character came back eight times under one objid. The widget must render people, not sockets.
+/// </summary>
+file sealed class DoubledConnectionHandler : HttpMessageHandler
+{
+	private record Row(string Name, string Objid, long Created, string Category);
+
+	private static readonly Row[] Online =
+	[
+		new("Solitaire", "#11:1100", 1100, ""),
+		new("Solitaire", "#11:1100", 1100, ""),
+		new("Solitaire", "#11:1100", 1100, ""),
+		new("Castor", "#12:1200", 1200, ""),
+	];
+
+	protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+		Task.FromResult(request.RequestUri!.AbsolutePath == "/http/online"
+			? new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(Online) }
+			: new HttpResponseMessage(HttpStatusCode.NotFound));
+}
+
 /// <summary>Serves an empty connection list, for the nobody-connected state.</summary>
 file sealed class NobodyOnlineHandler : HttpMessageHandler
 {
@@ -70,8 +93,9 @@ file sealed class NobodyOnlineHandler : HttpMessageHandler
 /// <summary>
 /// Serves 200 with a completely empty body — what the route emits if the softcode ever loses its
 /// firstof() guard, because fold() drops its base case on an empty list. The widget must degrade
-/// to the empty state rather than throwing out of OnInitializedAsync (the service only catches
-/// HttpRequestException, and a blank body raises JsonException).
+/// to the unavailable state rather than throwing out of OnInitializedAsync (a blank body raises
+/// JsonException) — and specifically not to the nobody-connected state, which is a claim about the
+/// game that a failed read cannot support.
 /// </summary>
 file sealed class EmptyBodyHandler : HttpMessageHandler
 {
@@ -155,11 +179,28 @@ public class OnlineCharactersWidgetTests : BunitContext
 		await Assert.That(cut.Markup).Contains("WidNobodyConnected");
 	}
 
+	[TUnit.Core.Test]
+	public async Task ACharacterConnectedTwice_IsListedOnce()
+	{
+		Wire(this, new DoubledConnectionHandler());
+
+		var cut = Render<OnlineCharactersWidget>();
+		cut.WaitForAssertion(() =>
+		{
+			if (!cut.Markup.Contains("Castor")) throw new InvalidOperationException("online list not loaded yet");
+		}, TimeSpan.FromSeconds(5));
+
+		var rows = cut.FindAll("a[href^='/characters/']").Select(a => a.TextContent.Trim()).ToList();
+
+		// Name ordering survives the deduplication: Castor before Solitaire, each exactly once.
+		await Assert.That(rows).IsEquivalentTo(new[] { "Castor", "Solitaire" });
+	}
+
 	// An unrecognised charset makes reading the body throw InvalidOperationException before the
 	// JSON parser is ever reached, so the JsonException filter does not cover it. Reachable from a
 	// typo in a redefined handler's `@respond/type`.
 	[TUnit.Core.Test]
-	public async Task BadCharsetHeader_DegradesToEmptyState_RatherThanThrowing()
+	public async Task BadCharsetHeader_SaysUnavailable_NotNobodyConnected()
 	{
 		Wire(this, new BadCharsetHandler());
 
@@ -169,11 +210,14 @@ public class OnlineCharactersWidgetTests : BunitContext
 			if (cut.Markup.Contains("mud-skeleton")) throw new InvalidOperationException("still loading");
 		}, TimeSpan.FromSeconds(5));
 
-		await Assert.That(cut.Markup).Contains("WidNobodyConnected");
+		// Still degrades instead of throwing out of OnInitializedAsync — but a request that failed
+		// is not evidence that the game is empty, and it used to be reported as exactly that.
+		await Assert.That(cut.Markup).Contains("WidUnavailable");
+		await Assert.That(cut.Markup).DoesNotContain("WidNobodyConnected");
 	}
 
 	[TUnit.Core.Test]
-	public async Task EmptyResponseBody_DegradesToEmptyState_RatherThanThrowing()
+	public async Task EmptyResponseBody_SaysUnavailable_NotNobodyConnected()
 	{
 		Wire(this, new EmptyBodyHandler());
 
@@ -183,6 +227,7 @@ public class OnlineCharactersWidgetTests : BunitContext
 			if (cut.Markup.Contains("mud-skeleton")) throw new InvalidOperationException("still loading");
 		}, TimeSpan.FromSeconds(5));
 
-		await Assert.That(cut.Markup).Contains("WidNobodyConnected");
+		await Assert.That(cut.Markup).Contains("WidUnavailable");
+		await Assert.That(cut.Markup).DoesNotContain("WidNobodyConnected");
 	}
 }

--- a/SharpMUSH.Tests.BUnit/Components/StatsWidgetTests.cs
+++ b/SharpMUSH.Tests.BUnit/Components/StatsWidgetTests.cs
@@ -50,17 +50,81 @@ file sealed class StatsHandler : HttpMessageHandler
 }
 
 /// <summary>
-/// The "Players Online" tile must report connections, not the size of the character roster.
+/// Serves the same character on several connection rows plus one other character, so a tile that
+/// counts rows reads 4 where a tile that counts people reads 2.
+/// </summary>
+file sealed class DoubledConnectionStatsHandler : HttpMessageHandler
+{
+	private record Row(string Name, string Objid, long Created, string Category);
+
+	private static readonly Row[] Roster =
+	[
+		new("Solitaire", "#11:1100", 1100, ""),
+		new("Castor", "#12:1200", 1200, ""),
+	];
+
+	private static readonly Row[] Online =
+	[
+		new("Solitaire", "#11:1100", 1100, ""),
+		new("Solitaire", "#11:1100", 1100, ""),
+		new("Solitaire", "#11:1100", 1100, ""),
+		new("Castor", "#12:1200", 1200, ""),
+	];
+
+	protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+	{
+		var path = request.RequestUri!.AbsolutePath;
+		object? payload = path switch
+		{
+			"/http/characters" => Roster,
+			"/http/online" => Online,
+			"/api/wiki/recent" => Array.Empty<object>(),
+			_ when path.StartsWith("/api/scenes", StringComparison.Ordinal) => Array.Empty<object>(),
+			_ => null
+		};
+
+		return Task.FromResult(payload is null
+			? new HttpResponseMessage(HttpStatusCode.NotFound)
+			: new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(payload) });
+	}
+}
+
+/// <summary>
+/// Answers the online route but fails the roster route, so the widget finishes loading with one
+/// count known and the other unknowable — the state that used to render as a confident zero.
+/// </summary>
+file sealed class RosterFailsHandler : HttpMessageHandler
+{
+	private record Row(string Name, string Objid, long Created, string Category);
+
+	private static readonly Row[] Online = [new("Bree", "#11:1100", 1100, "")];
+
+	protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+	{
+		var path = request.RequestUri!.AbsolutePath;
+		return Task.FromResult(path switch
+		{
+			"/http/characters" => new HttpResponseMessage(HttpStatusCode.InternalServerError),
+			"/http/online" => new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(Online) },
+			_ => new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(Array.Empty<object>()) }
+		});
+	}
+}
+
+/// <summary>
+/// The "Players Online" tile must report who is connected — as people, one per character — rather
+/// than the size of the character roster or the number of open connections. And no tile may state
+/// a count it never received: a request that failed shows the unknown placeholder, not zero.
 /// </summary>
 public class StatsWidgetTests : BunitContext
 {
-	public StatsWidgetTests()
+	private static void Wire(BunitContext ctx, HttpMessageHandler handler)
 	{
-		var apiClient = new HttpClient(new StatsHandler()) { BaseAddress = new Uri("https://localhost:8081/") };
+		var apiClient = new HttpClient(handler) { BaseAddress = new Uri("https://localhost:8081/") };
 		var factory = Substitute.For<IHttpClientFactory>();
 		factory.CreateClient("api").Returns(apiClient);
 
-		Services
+		ctx.Services
 			.AddSingleton(apiClient)
 			.AddMudServices()
 			.AddSingleton(factory)
@@ -75,7 +139,7 @@ public class StatsWidgetTests : BunitContext
 				NullLogger<SceneService>.Instance))
 			.AddSingleton<IStringLocalizer<SharedResource>, EchoLocalizer<SharedResource>>();
 
-		JSInterop.Mode = JSRuntimeMode.Loose;
+		ctx.JSInterop.Mode = JSRuntimeMode.Loose;
 	}
 
 	/// <summary>Reads the number rendered in the tile whose label is <paramref name="label"/>.</summary>
@@ -94,6 +158,8 @@ public class StatsWidgetTests : BunitContext
 	[TUnit.Core.Test]
 	public async Task PlayersOnline_CountsConnections_NotTheRoster()
 	{
+		Wire(this, new StatsHandler());
+
 		var cut = Render<StatsWidget>();
 		cut.WaitForAssertion(() =>
 		{
@@ -104,5 +170,41 @@ public class StatsWidgetTests : BunitContext
 		// 3 characters exist; exactly 1 holds a connection. Before the fix both tiles read 3.
 		await Assert.That(TileValue(markup, "Characters")).IsEqualTo("3");
 		await Assert.That(TileValue(markup, "WidPlayersOnline")).IsEqualTo("1");
+	}
+
+	[TUnit.Core.Test]
+	public async Task PlayersOnline_CountsPeople_NotConnections()
+	{
+		Wire(this, new DoubledConnectionStatsHandler());
+
+		var cut = Render<StatsWidget>();
+		cut.WaitForAssertion(() =>
+		{
+			if (cut.Markup.Contains("—")) throw new InvalidOperationException("stats not loaded yet");
+		}, TimeSpan.FromSeconds(5));
+
+		// Four rows, two people: one of them is logged in three times. The tile says "Players
+		// Online", so it must say 2 — the live portal read 14 for a world with four characters.
+		await Assert.That(TileValue(cut.Markup, "WidPlayersOnline")).IsEqualTo("2");
+	}
+
+	[TUnit.Core.Test]
+	public async Task AFailedRosterFetch_LeavesTheTileUnknown_RatherThanZero()
+	{
+		Wire(this, new RosterFailsHandler());
+
+		var cut = Render<StatsWidget>();
+		// The online route still answers, so waiting on its tile proves the widget finished loading;
+		// the Characters tile keeping its dash is then a decision, not an unfinished fetch.
+		cut.WaitForAssertion(() =>
+		{
+			if (TileValue(cut.Markup, "WidPlayersOnline") == "—") throw new InvalidOperationException("stats not loaded yet");
+		}, TimeSpan.FromSeconds(5));
+
+		var markup = cut.Markup;
+		await Assert.That(TileValue(markup, "WidPlayersOnline")).IsEqualTo("1");
+		await Assert.That(TileValue(markup, "Characters")).IsEqualTo("—");
+		// And the dash is explained rather than left looking like a value still in flight.
+		await Assert.That(markup).Contains("WidUnavailable");
 	}
 }

--- a/SharpMUSH.Tests.BUnit/Services/CharacterDirectoryServiceTests.cs
+++ b/SharpMUSH.Tests.BUnit/Services/CharacterDirectoryServiceTests.cs
@@ -1,0 +1,103 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using SharpMUSH.Client.Services;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http.Json;
+
+namespace SharpMUSH.Tests.BUnit.Services;
+
+/// <summary>Never answers, so the request only ends when something cancels it.</summary>
+file sealed class HangingHandler : HttpMessageHandler
+{
+	protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+	{
+		await Task.Delay(Timeout.Infinite, cancellationToken);
+		throw new UnreachableException();
+	}
+}
+
+/// <summary>Answers immediately with an empty list, for the caller-cancellation cases.</summary>
+file sealed class EmptyListHandler : HttpMessageHandler
+{
+	protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+		Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(Array.Empty<object>()) });
+}
+
+/// <summary>
+/// The two ways a directory read can end in an <see cref="OperationCanceledException"/>, which are
+/// opposite facts and must not share an answer.
+///
+/// A read that outlives <see cref="HttpClient.Timeout"/> is a failed request — the game is slow or
+/// gone — and belongs in the failed arm with every other failed request. It reaches the catch as a
+/// TaskCanceledException, which is not an InvalidOperationException and was not covered by the
+/// exception filter, so it escaped out of a component's OnInitializedAsync and took the page down:
+/// exactly the "unavailable renders as broken" failure this service exists to prevent.
+///
+/// A cancellation the caller asked for is not a statement about the game at all — the caller
+/// stopped wanting an answer (a navigation away, a superseded render) — and reporting "unavailable"
+/// for it would be the same class of lie in the other direction. It propagates.
+/// </summary>
+public class CharacterDirectoryServiceTests
+{
+	private static CharacterDirectoryService Build(HttpMessageHandler handler, TimeSpan? timeout = null)
+	{
+		var client = new HttpClient(handler) { BaseAddress = new Uri("https://localhost:8081/") };
+		if (timeout is { } value)
+		{
+			client.Timeout = value;
+		}
+
+		var factory = Substitute.For<IHttpClientFactory>();
+		factory.CreateClient("api").Returns(client);
+		return new CharacterDirectoryService(factory, NullLogger<CharacterDirectoryService>.Instance);
+	}
+
+	[TUnit.Core.Test]
+	public async Task ListAsync_RequestTimeout_ReturnsTheFailedArm()
+	{
+		var service = Build(new HangingHandler(), TimeSpan.FromMilliseconds(50));
+
+		var result = await service.ListAsync();
+
+		await Assert.That(result.IsT1).IsTrue();
+	}
+
+	[TUnit.Core.Test]
+	public async Task ListOnlineAsync_RequestTimeout_ReturnsTheFailedArm()
+	{
+		var service = Build(new HangingHandler(), TimeSpan.FromMilliseconds(50));
+
+		var result = await service.ListOnlineAsync();
+
+		await Assert.That(result.IsT1).IsTrue();
+	}
+
+	[TUnit.Core.Test]
+	public async Task ResolveObjidAsync_RequestTimeout_ResolvesToNothing()
+	{
+		var service = Build(new HangingHandler(), TimeSpan.FromMilliseconds(50));
+
+		await Assert.That(await service.ResolveObjidAsync("Solitaire")).IsNull();
+	}
+
+	[TUnit.Core.Test]
+	public async Task ListAsync_CallerCancellation_Propagates()
+	{
+		var service = Build(new EmptyListHandler());
+		using var cts = new CancellationTokenSource();
+		await cts.CancelAsync();
+
+		await Assert.That(async () => await service.ListAsync(cts.Token)).Throws<OperationCanceledException>();
+	}
+
+	[TUnit.Core.Test]
+	public async Task ListOnlineAsync_CallerCancellation_Propagates()
+	{
+		var service = Build(new EmptyListHandler());
+		using var cts = new CancellationTokenSource();
+		await cts.CancelAsync();
+
+		await Assert.That(async () => await service.ListOnlineAsync(cts.Token)).Throws<OperationCanceledException>();
+	}
+}

--- a/SharpMUSH.Tests.BUnit/Services/CharacterDirectoryServiceTests.cs
+++ b/SharpMUSH.Tests.BUnit/Services/CharacterDirectoryServiceTests.cs
@@ -17,6 +17,23 @@ file sealed class HangingHandler : HttpMessageHandler
 	}
 }
 
+/// <summary>Serves a two-character roster on http/characters, for the name-resolution cases.</summary>
+file sealed class RosterHandler : HttpMessageHandler
+{
+	private record Row(string Name, string Objid, long Created, string Category);
+
+	private static readonly Row[] Roster =
+	[
+		new("Castor", "#12:1200", 1200, ""),
+		new("Solitaire", "#11:1100", 1100, ""),
+	];
+
+	protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+		Task.FromResult(request.RequestUri!.AbsolutePath == "/http/characters"
+			? new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(Roster) }
+			: new HttpResponseMessage(HttpStatusCode.NotFound));
+}
+
 /// <summary>Answers immediately with an empty list, for the caller-cancellation cases.</summary>
 file sealed class EmptyListHandler : HttpMessageHandler
 {
@@ -25,8 +42,10 @@ file sealed class EmptyListHandler : HttpMessageHandler
 }
 
 /// <summary>
-/// The two ways a directory read can end in an <see cref="OperationCanceledException"/>, which are
-/// opposite facts and must not share an answer.
+/// Directory outcomes that are different facts and must not share an answer — the service's whole
+/// reason for returning a discriminated union.
+///
+/// The two ways a read can end in an <see cref="OperationCanceledException"/> are the sharpest case.
 ///
 /// A read that outlives <see cref="HttpClient.Timeout"/> is a failed request — the game is slow or
 /// gone — and belongs in the failed arm with every other failed request. It reaches the catch as a
@@ -74,11 +93,35 @@ public class CharacterDirectoryServiceTests
 	}
 
 	[TUnit.Core.Test]
-	public async Task ResolveObjidAsync_RequestTimeout_ResolvesToNothing()
+	public async Task ResolveObjidAsync_RequestTimeout_ReportsTheFailedRead()
 	{
 		var service = Build(new HangingHandler(), TimeSpan.FromMilliseconds(50));
 
-		await Assert.That(await service.ResolveObjidAsync("Solitaire")).IsNull();
+		var result = await service.ResolveObjidAsync("Solitaire");
+
+		// The failed arm, not "no such character" — the two used to be the same null.
+		await Assert.That(result.IsT2).IsTrue();
+	}
+
+	[TUnit.Core.Test]
+	public async Task ResolveObjidAsync_KnownName_ReturnsTheObjid()
+	{
+		var service = Build(new RosterHandler());
+
+		var result = await service.ResolveObjidAsync("sOlItAiRe");
+
+		await Assert.That(result.IsT0).IsTrue();
+		await Assert.That(result.AsT0).IsEqualTo("#11:1100");
+	}
+
+	[TUnit.Core.Test]
+	public async Task ResolveObjidAsync_UnknownName_ReportsNotFound()
+	{
+		var service = Build(new RosterHandler());
+
+		var result = await service.ResolveObjidAsync("Nobody");
+
+		await Assert.That(result.IsT1).IsTrue();
 	}
 
 	[TUnit.Core.Test]

--- a/SharpMUSH.Tests.Integration/Profile/ProfileApiTests.cs
+++ b/SharpMUSH.Tests.Integration/Profile/ProfileApiTests.cs
@@ -1,12 +1,16 @@
 using Mediator;
 using Microsoft.Extensions.DependencyInjection;
 using SharpMUSH.Library.Commands.Database;
+using SharpMUSH.Library.Definitions;
 using SharpMUSH.Library.DiscriminatedUnions;
 using SharpMUSH.Library.Extensions;
 using SharpMUSH.Library.Models;
 using SharpMUSH.Library.Queries.Database;
+using SharpMUSH.Library.Services.Interfaces;
 using SharpMUSH.Tests.Infrastructure;
+using System.Collections.Concurrent;
 using System.Net;
+using System.Text;
 using System.Text.Json;
 
 namespace SharpMUSH.Tests.Integration.Profile;
@@ -145,10 +149,10 @@ public class ProfileApiTests(ServerWebAppFactory factory)
 	}
 
 	/// <summary>
-	/// GET /http/online is the connection list, not the roster: it is built on lwho(), the same
-	/// registry WHO reads, so it tracks actual connections in both directions. The portal used to
-	/// derive "players online" from the full character roster, which made every seeded player —
-	/// including the Package Manager principal — look connected.
+	/// GET /http/online reports presence, not the roster: it is built on mwho(), which reads the
+	/// same connection registry WHO does, so it tracks who is actually here in both directions. The
+	/// portal used to derive "players online" from the full character roster, which made every
+	/// seeded player — including the Package Manager principal — look connected.
 	/// The shared factory logs God in, so God is the connected fixture here; a freshly created
 	/// player that never binds a connection is the unconnected one.
 	/// </summary>
@@ -179,6 +183,54 @@ public class ProfileApiTests(ServerWebAppFactory factory)
 		// Exist but never bound a connection → absent. This is what the roster-backed widget got wrong.
 		await Assert.That(names).DoesNotContain("OnlineNobody");
 		await Assert.That(names).DoesNotContain("Package Manager");
+	}
+
+	/// <summary>
+	/// One row per player, however many sockets they hold. mwho() lists players, so a second login
+	/// for the same character adds no row — measured against a live server, this route returned the
+	/// same objid eight times for one character, and the portal reported eight people online.
+	/// </summary>
+	[Test]
+	public async Task Online_ListsADoublyConnectedPlayerOnce()
+	{
+		var (godName, _) = await GodIdentity();
+		var connectionService = factory.Services.GetRequiredService<IConnectionService>();
+
+		// A second connection bound to the same character as the factory's own login.
+		const long handle = 810_001;
+		await connectionService.Register(handle, "127.0.0.1", "localhost", "websocket",
+			_ => ValueTask.CompletedTask, _ => ValueTask.CompletedTask, () => Encoding.UTF8,
+			new ConcurrentDictionary<string, string>(new Dictionary<string, string>
+			{
+				["ConnectionStartTime"] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(),
+				["LastConnectionSignal"] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(),
+				["InternetProtocolAddress"] = "127.0.0.1",
+				["HostName"] = "localhost",
+				["ConnectionType"] = "websocket",
+				["PresenceClass"] = PresenceClasses.Play
+			}));
+		await connectionService.Bind(handle, new DBRef(1, null));
+
+		try
+		{
+			var http = factory.CreateHttpClient();
+			var response = await http.GetAsync("http/online");
+			var body = await response.Content.ReadAsStringAsync();
+
+			await Assert.That((int)response.StatusCode).IsEqualTo(200);
+			using var doc = JsonDocument.Parse(body);
+			var rows = doc.RootElement.EnumerateArray()
+				.Select(row => (Name: row.GetProperty("name").GetString(), Objid: row.GetProperty("objid").GetString()))
+				.ToList();
+
+			await Assert.That(rows.Count(r => r.Name == godName)).IsEqualTo(1);
+			// The objid is the identity the portal deduplicates on, so it must be unique too.
+			await Assert.That(rows.Select(r => r.Objid).Distinct().Count()).IsEqualTo(rows.Count);
+		}
+		finally
+		{
+			await connectionService.Disconnect(handle);
+		}
 	}
 
 	[Test]

--- a/SharpMUSH.Tests.Integration/Profile/ProfileApiTests.cs
+++ b/SharpMUSH.Tests.Integration/Profile/ProfileApiTests.cs
@@ -156,7 +156,7 @@ public class ProfileApiTests(ServerWebAppFactory factory)
 	/// The shared factory logs God in, so God is the connected fixture here; a freshly created
 	/// player that never binds a connection is the unconnected one.
 	/// </summary>
-	[Test]
+	[Test, NotInParallel("PortalPresence")]
 	public async Task Online_ListsConnectedPlayersOnly()
 	{
 		var (godName, _) = await GodIdentity();
@@ -190,7 +190,15 @@ public class ProfileApiTests(ServerWebAppFactory factory)
 	/// for the same character adds no row — measured against a live server, this route returned the
 	/// same objid eight times for one character, and the portal reported eight people online.
 	/// </summary>
-	[Test]
+	/// <remarks>
+	/// This binds a real connection in a server shared for the whole test session, so it shares the
+	/// "PortalPresence" constraint group with <see cref="Online_ListsConnectedPlayersOnly"/>: the two
+	/// read a presence snapshot the other mutates, and only a group they both name serializes them.
+	/// A bare <c>[NotInParallel]</c> would not — measured on TUnit 1.19.16, an unkeyed not-in-parallel
+	/// test still ran alongside four unconstrained ones, so it constrains a test only against others
+	/// that are also unkeyed.
+	/// </remarks>
+	[Test, NotInParallel("PortalPresence")]
 	public async Task Online_ListsADoublyConnectedPlayerOnce()
 	{
 		var (godName, _) = await GodIdentity();

--- a/SharpMUSH.Tests/Functions/PortalPresenceTests.cs
+++ b/SharpMUSH.Tests/Functions/PortalPresenceTests.cs
@@ -101,6 +101,42 @@ public class PortalPresenceTests
 		}
 	}
 
+	/// <summary>
+	/// mwho() is a list of players, not of sockets — help mwho defines it as "exactly the same as
+	/// lwho() used by a mortal", and lwho() walks the player table. Someone logged in twice used to
+	/// be listed twice, which the portal then rendered as two players online (and, at eight
+	/// connections, as fourteen players in a four-character game).
+	/// </summary>
+	[Test, NotInParallel(nameof(PortalPresenceTests))]
+	public async Task TwoConnectionsFromOnePlayer_AreOneEntryInTheMortalWho()
+	{
+		var services = WebAppFactoryArg.Services;
+		var mediator = services.GetRequiredService<IMediator>();
+		var connectionService = services.GetRequiredService<IConnectionService>();
+
+		var doubledRef = await TestIsolationHelpers.CreateTestPlayerAsync(services, mediator, "DoubleDipper");
+		var first = await ConnectAsAsync(doubledRef, PresenceClasses.Play);
+		var second = await ConnectAsAsync(doubledRef, PresenceClasses.Play);
+
+		try
+		{
+			// Occurrences of this player, not the length of the list: the connection registry is
+			// shared across the test session, so other players come and go in it.
+			var mortalWho = await WhoAsync("mwho()");
+			await Assert.That(mortalWho.Count(x => x == $"#{doubledRef.Number}")).IsEqualTo(1);
+
+			// mwhoid() yields objids ("#12:1700000000000"), so match on the dbref part alone — a
+			// StartsWith would also count #120 when looking for #12.
+			var mortalWhoIds = await WhoAsync("mwhoid()");
+			await Assert.That(mortalWhoIds.Count(x => x.Split(':')[0] == $"#{doubledRef.Number}")).IsEqualTo(1);
+		}
+		finally
+		{
+			await connectionService.Disconnect(first);
+			await connectionService.Disconnect(second);
+		}
+	}
+
 	[Test, NotInParallel(nameof(PortalPresenceTests))]
 	public async Task PortalConnection_ReportedByConnAndIdle_ButOfflineForConnectedFlag()
 	{

--- a/examples/packages/profile-handler/package.yaml
+++ b/examples/packages/profile-handler/package.yaml
@@ -55,9 +55,11 @@ objects:
       GET`CHARACTERS: |-
         @respond/type application/json; think json_array(iter(filter(me/FN`CHARVIS,lsearch(all,type,player)),u(me/FN`CHARROW,%i0),,%r),%r)
       # GET /http/online — connected, visible players, same row shape as GET`CHARACTERS. mwho() is
-      # the mortal connection list: caller-independent (this handler is wizard-flagged), so it hides
-      # DARK players and portal-class background connections. Objects that never bind a connection
-      # can't appear.
+      # the mortal who-list: caller-independent (this handler is wizard-flagged), so it hides DARK
+      # players and portal-class background connections. Objects that never bind a connection can't
+      # appear. It lists PLAYERS, one entry each — someone logged in twice is one row, so this route
+      # answers "who is here", not "how many sockets are open". A redefinition built on lwho()/
+      # ports() would reintroduce per-connection rows and make the portal's presence counts wrong.
       GET`ONLINE: |-
         @respond/type application/json; think json_array(iter(filter(me/FN`ONLINEVIS,mwho()),u(me/FN`CHARROW,%i0),,%r),%r)
       # GET /http/profile?objid=#1:123 — one character's public profile.


### PR DESCRIPTION
Part 3 of 4 in a stack fixing findings from a full portal audit. **Targets `fix/portal-audit-02-server-side`, not `main`.**

**Stack:** #1 quick wins → #2 server-side → ← you are here → #4 portal UX

## Presence counted connections, not people

`GET /http/online` returned one row per socket. Measured live, the same character came back eight times with an identical `objid`. The portal's "Players online" tile read 2, 0, 1 and 14 across five personas against a world containing four characters, and "Online now" listed the same character repeatedly.

**Fixed in the engine first.** `mwho()` walked the connection registry and emitted one entry per socket — which contradicts its own helpfile ("returns a list of the dbref numbers for all current-connected, non-hidden **players**… exactly the same as `lwho()` used by a mortal") and contradicts `lwho()`, which walks the player table. The portal was faithfully reporting a number the engine had already got wrong.

Two shared helpers now deduplicate before the object lookup: `MortalWhoPlayers()` (`mwho`/`mwhoid`/`nmwho`/`xmwho`/`xmwhoid`) and `VisibleWhoPlayers(looker)` (`nwho`/`xwho`/`xwhoid`, documented as `words(lwho(<viewer>))`). This also drops the cost to one object query per player instead of one per connection. `WHO`, `ports()` and `lports()` keep the per-connection view — that is what they are for.

**Deduplicating on `DBRef.Number`, not the whole `DBRef`.** Connections bind a bare `#N` on some login paths and a full `#N:creation` objid on others, and those compare unequal — an end-to-end integration test failed on exactly that before the switch. Two live connections sharing a dbref number are the same player, since the number cannot be reused while an object still holds it. (This is the same root-cause family as the scene bug in #2, which reaches a different conclusion for a different reason — a stored owner edge can outlive its object, whereas a live connection cannot.)

The client deduplicates too, in `CharacterDirectoryService`, so widgets cannot opt out: these routes are redefinable per game and a redefinition over `ports()`/`lports()` would put connection rows back on the wire.

**Correcting the audit:** the `/http/online` route reads `mwho()`, not `lwho()`. The claim came from a stale comment in `CharacterDirectoryService`, now fixed.

## A failed request rendered as a confident zero

`ListAsync`/`ListOnlineAsync` swallowed request failures into an empty list, and the stats tile rendered `.Count` — so a broken fetch was indistinguishable from an empty game. Reproduced: the "Characters" tile showed 0 on one load while `/http/characters` returned 4 on five of five direct probes at the same time.

Both now return `OneOf<IReadOnlyList<CharacterSummary>, Error>`, so failure is in the type. The existing deliberate decision — a malformed response from a redefinable per-game handler must not take the page down — is unchanged; it just no longer lies about what it caught. Stats tiles keep `—` and explain it via a `title`; the online, directory and `/characters` surfaces render "Unavailable right now" instead of "nobody connected" / "no characters found"; the characters page no longer claims a count it never received.

## Verification
- `dotnet build` — 0 errors, warnings-as-errors untouched.
- `SharpMUSH.Tests.BUnit` — 400 passed / 0 failed on this branch alone (+4 new).
- `PortalPresenceTests` 5/5, including a doubly-connected case verified to **fail** with the dedup removed. `ConnectionFunctionUnitTests` 30/30. `ProfileApiTests` 10/10, including an end-to-end case binding a second connection to `#1` and asserting one row per objid.

## Flagged, not fixed
`WikiService.GetRecentChangesAsync` and `SceneService.GetActiveScenesAsync` have the identical swallow-to-empty pattern, so "Recent changes" and "Active scenes" can still show a confident 0. Changing those return types touches every wiki and scene surface; the pattern to copy is now in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Widgets and character pages now distinguish unavailable data from valid empty results.
  * Failed requests display an “Unavailable right now” message instead of misleading zero or empty-state values.
  * Online-character counts and WHO results now list each connected player only once, even with multiple connections.
  * Directory results are consistently deduplicated and sorted.

* **Localization**
  * Added unavailable-state translations for supported languages.

* **Documentation**
  * Clarified online-player reporting behavior and visibility rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->