### PR TITLE
Portal audit 5: require a character who may see the scene before joining its live group

### DIFF
--- a/SharpMUSH.Client/Pages/SceneLive.razor
+++ b/SharpMUSH.Client/Pages/SceneLive.razor
@@ -269,6 +269,11 @@ else
     /// during disposal, where a thrown <see cref="HubException"/> has nowhere to surface; a refused leave
     /// costs at most one subscription that the connection's own teardown drops anyway.
     /// </summary>
+    /// <remarks>
+    /// Only the refusal is caught here. A connection that closes mid-call is the hub control's problem and
+    /// is a no-op there (<see cref="ISceneHubControl.LeaveSceneAsync"/>) — which matters most on this path,
+    /// since disposal is exactly when the connection is being torn down.
+    /// </remarks>
     private async Task LeaveJoinedSceneAsync()
     {
         if (_joinedSceneId is not { } sceneId) return;

--- a/SharpMUSH.Client/Pages/SceneLive.razor
+++ b/SharpMUSH.Client/Pages/SceneLive.razor
@@ -1,6 +1,7 @@
 @page "/scenes/{Id}/live"
 @attribute [Authorize]
 @implements IAsyncDisposable
+@using Microsoft.AspNetCore.SignalR
 @using SharpMUSH.Client.Models
 @using SharpMUSH.Library.Models.Portal
 @using SharpMUSH.Library.Services.Interfaces
@@ -122,13 +123,24 @@ else
         // Join the SignalR scene group so we receive realtime ReceiveSceneMessage events.
         if (!string.Equals(_joinedSceneId, Id, StringComparison.Ordinal))
         {
-            if (_joinedSceneId is not null)
-            {
-                await SceneHub.LeaveSceneAsync(_joinedSceneId);
-            }
+            await LeaveJoinedSceneAsync();
 
-            await SceneHub.JoinSceneAsync(Id);
-            _joinedSceneId = Id;
+            try
+            {
+                await SceneHub.JoinSceneAsync(Id);
+                _joinedSceneId = Id;
+            }
+            catch (HubException)
+            {
+                // The hub gates a join on the same visibility the REST fetch above passed, plus a character
+                // on the connection. A refusal here therefore means either this session acts as no character
+                // or the scene stopped being visible in between — in both cases the honest answer is the one
+                // the archive would give, not a live view that silently never updates.
+                _notFound = true;
+                _scene = null;
+                _loading = false;
+                return;
+            }
         }
 
         _loading = false;
@@ -249,10 +261,26 @@ else
             _subscribed = false;
         }
 
-        if (_joinedSceneId is not null)
+        await LeaveJoinedSceneAsync();
+    }
+
+    /// <summary>
+    /// Leaves the joined scene group, if any, tolerating a hub refusal. This runs on navigation away and
+    /// during disposal, where a thrown <see cref="HubException"/> has nowhere to surface; a refused leave
+    /// costs at most one subscription that the connection's own teardown drops anyway.
+    /// </summary>
+    private async Task LeaveJoinedSceneAsync()
+    {
+        if (_joinedSceneId is not { } sceneId) return;
+
+        _joinedSceneId = null;
+        try
         {
-            await SceneHub.LeaveSceneAsync(_joinedSceneId);
-            _joinedSceneId = null;
+            await SceneHub.LeaveSceneAsync(sceneId);
+        }
+        catch (HubException)
+        {
+            // Nothing to do and nowhere to report it: the group membership dies with the connection.
         }
     }
 

--- a/SharpMUSH.Client/Pages/SceneLive.razor
+++ b/SharpMUSH.Client/Pages/SceneLive.razor
@@ -46,7 +46,13 @@ else
             </MudButton>
         </div>
 
-        @if (!Hub.IsConnected)
+        @if (_liveUnavailable)
+        {
+            <MudAlert Severity="Severity.Warning" Dense="true" Style="border-radius:0;flex-shrink:0;">
+                @Loc["RolSceneLiveUnavailable"]
+            </MudAlert>
+        }
+        else if (!Hub.IsConnected)
         {
             <MudAlert Severity="Severity.Warning" Dense="true" Style="border-radius:0;flex-shrink:0;">
                 @Loc["RolNotConnected"]
@@ -79,7 +85,7 @@ else
             <MudIconButton Icon="@Icons.Material.Filled.Send" Color="Color.Primary"
                            Size="Size.Medium" Variant="Variant.Filled"
                            OnClick="SendPoseAsync"
-                           Disabled="@(string.IsNullOrWhiteSpace(_composeText) || !Hub.IsConnected)" />
+                           Disabled="@(string.IsNullOrWhiteSpace(_composeText) || !Hub.IsConnected || _liveUnavailable)" />
         </div>
     </div>
 }
@@ -91,6 +97,7 @@ else
     private readonly List<ScenePoseView> _poses = [];
     private bool _loading = true;
     private bool _notFound;
+    private bool _liveUnavailable;
     private string _composeText = string.Empty;
     private string _mode = "pose";
     private bool _subscribed;
@@ -106,9 +113,15 @@ else
     {
         _loading = true;
         _notFound = false;
+        _liveUnavailable = false;
         _poses.Clear();
         _scene = null;
 
+        // A scene that does not exist and one that exists but is not visible to this caller BOTH land here,
+        // and both must render the one _notFound card. The REST route answers 404 to both for that reason,
+        // and the hub throws one message for both — a refusal a caller can tell apart is a way to enumerate
+        // private scene ids. Any future edit that wants to explain a not-found must keep those two cases
+        // sharing an answer.
         var scene = await SceneService.GetSceneAsync(Id);
         if (scene is null)
         {
@@ -132,14 +145,16 @@ else
             }
             catch (HubException)
             {
-                // The hub gates a join on the same visibility the REST fetch above passed, plus a character
-                // on the connection. A refusal here therefore means either this session acts as no character
-                // or the scene stopped being visible in between — in both cases the honest answer is the one
-                // the archive would give, not a live view that silently never updates.
-                _notFound = true;
-                _scene = null;
-                _loading = false;
-                return;
+                // NOT the not-found card. The fetch above already returned this scene, so the caller
+                // demonstrably may read it and its archive is about to render; calling it missing would be
+                // a plain lie, and it is the lie that costs a real user the page they are entitled to.
+                //
+                // What was refused is only the live subscription. The hub gates that on a character AND on
+                // the same visibility the fetch just passed, so this is either a session acting as no
+                // character (guests cannot join scenes) or a scene that stopped being visible in the moment
+                // between the two calls. Naming that leaks nothing: the caller learned this scene exists
+                // from the 200 they already hold, which is the enumeration boundary — not this message.
+                _liveUnavailable = true;
             }
         }
 
@@ -228,7 +243,9 @@ else
     private async Task SendPoseAsync()
     {
         var text = _composeText.Trim();
-        if (text.Length == 0 || !Hub.IsConnected) return;
+        // _liveUnavailable means this connection is not in the scene's group. Nothing renders a pose but the
+        // round-trip event, so posting from here would look like the command vanished.
+        if (text.Length == 0 || !Hub.IsConnected || _liveUnavailable) return;
 
         var command = _mode switch
         {

--- a/SharpMUSH.Client/Resources/SharedResource.bg.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.bg.resx
@@ -3164,6 +3164,10 @@
     <value>Сцена в {0}</value>
     <comment>MT — {0} is a room name; no inflection required after the preposition</comment>
   </data>
+  <data name="RolSceneLiveUnavailable" xml:space="preserve">
+    <value>Актуализациите на живо не са достъпни — за присъединяване към сцена е необходим герой, който може да я вижда. Позите по-долу няма да се обновяват.</value>
+    <comment>MT</comment>
+  </data>
   <data name="RolSceneNotFound" xml:space="preserve">
     <value>Сцената не е намерена.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.da.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.da.resx
@@ -3164,6 +3164,10 @@
     <value>Scene i {0}</value>
     <comment>MT</comment>
   </data>
+  <data name="RolSceneLiveUnavailable" xml:space="preserve">
+    <value>Live-opdateringer er ikke tilgængelige — at deltage i en scene kræver en rollefigur, der kan se den. Poserne nedenfor opdateres ikke.</value>
+    <comment>MT</comment>
+  </data>
   <data name="RolSceneNotFound" xml:space="preserve">
     <value>Scenen blev ikke fundet.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.de.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.de.resx
@@ -3164,6 +3164,10 @@
     <value>Szene in {0}</value>
     <comment>MT</comment>
   </data>
+  <data name="RolSceneLiveUnavailable" xml:space="preserve">
+    <value>Live-Aktualisierungen sind nicht verfügbar — einer Szene beizutreten erfordert einen Charakter, der sie sehen kann. Die Posen unten werden nicht aktualisiert.</value>
+    <comment>MT</comment>
+  </data>
   <data name="RolSceneNotFound" xml:space="preserve">
     <value>Szene nicht gefunden.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.es.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.es.resx
@@ -3164,6 +3164,10 @@
     <value>Escena en {0}</value>
     <comment>MT</comment>
   </data>
+  <data name="RolSceneLiveUnavailable" xml:space="preserve">
+    <value>Las actualizaciones en vivo no están disponibles — unirse a una escena requiere un personaje que pueda verla. Las poses de abajo no se actualizarán.</value>
+    <comment>MT</comment>
+  </data>
   <data name="RolSceneNotFound" xml:space="preserve">
     <value>No se encontró la escena.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.fr.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.fr.resx
@@ -1980,6 +1980,10 @@
   <data name="RolLiveScene" xml:space="preserve">
     <value>Scène en direct</value>
   </data>
+  <data name="RolSceneLiveUnavailable" xml:space="preserve">
+    <value>Les mises à jour en direct sont indisponibles — rejoindre une scène nécessite un personnage qui peut la voir. Les poses ci-dessous ne seront pas actualisées.</value>
+    <comment>MT</comment>
+  </data>
   <data name="RolSceneNotFound" xml:space="preserve">
     <value>Scène introuvable.</value>
   </data>

--- a/SharpMUSH.Client/Resources/SharedResource.hr.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.hr.resx
@@ -3164,6 +3164,10 @@
     <value>Scena · {0}</value>
     <comment>MT — same restructure as WidSceneIn: 'scena u …' would need the locative of a room name we cannot inflect</comment>
   </data>
+  <data name="RolSceneLiveUnavailable" xml:space="preserve">
+    <value>Ažuriranja uživo nisu dostupna — za pridruživanje sceni potreban je lik koji je može vidjeti. Poze u nastavku neće se ažurirati.</value>
+    <comment>MT</comment>
+  </data>
   <data name="RolSceneNotFound" xml:space="preserve">
     <value>Scena nije pronađena.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.hu.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.hu.resx
@@ -3164,6 +3164,10 @@
     <value>Jelenet itt: {0}</value>
     <comment>MT</comment>
   </data>
+  <data name="RolSceneLiveUnavailable" xml:space="preserve">
+    <value>Az élő frissítések nem érhetők el — egy jelenethez való csatlakozáshoz olyan karakter kell, amely látja azt. Az alábbi pózok nem frissülnek.</value>
+    <comment>MT</comment>
+  </data>
   <data name="RolSceneNotFound" xml:space="preserve">
     <value>A jelenet nem található.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.nb.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.nb.resx
@@ -3164,6 +3164,10 @@
     <value>Scene i {0}</value>
     <comment>MT</comment>
   </data>
+  <data name="RolSceneLiveUnavailable" xml:space="preserve">
+    <value>Sanntidsoppdateringer er utilgjengelige — å bli med i en scene krever en rollefigur som kan se den. Posene nedenfor oppdateres ikke.</value>
+    <comment>MT</comment>
+  </data>
   <data name="RolSceneNotFound" xml:space="preserve">
     <value>Fant ikke scenen.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.nl.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.nl.resx
@@ -3164,6 +3164,10 @@
     <value>Scène in {0}</value>
     <comment>MT</comment>
   </data>
+  <data name="RolSceneLiveUnavailable" xml:space="preserve">
+    <value>Live-updates zijn niet beschikbaar — deelnemen aan een scène vereist een personage dat de scène kan zien. De poses hieronder worden niet bijgewerkt.</value>
+    <comment>MT</comment>
+  </data>
   <data name="RolSceneNotFound" xml:space="preserve">
     <value>Scène niet gevonden.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.pl.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.pl.resx
@@ -3164,6 +3164,10 @@
     <value>Scena w pokoju: {0}</value>
     <comment>MT — head noun 'pokój' carries the locative so the room name {0} stays in the nominative; matches WidSceneIn</comment>
   </data>
+  <data name="RolSceneLiveUnavailable" xml:space="preserve">
+    <value>Aktualizacje na żywo są niedostępne — dołączenie do sceny wymaga postaci, która może ją zobaczyć. Pozy poniżej nie będą aktualizowane.</value>
+    <comment>MT</comment>
+  </data>
   <data name="RolSceneNotFound" xml:space="preserve">
     <value>Nie znaleziono sceny.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.pt-BR.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.pt-BR.resx
@@ -3164,6 +3164,10 @@
     <value>Cena em {0}</value>
     <comment>MT — assumed {0} is a room name</comment>
   </data>
+  <data name="RolSceneLiveUnavailable" xml:space="preserve">
+    <value>As atualizações ao vivo não estão disponíveis — entrar em uma cena exige um personagem que possa vê-la. As poses abaixo não serão atualizadas.</value>
+    <comment>MT</comment>
+  </data>
   <data name="RolSceneNotFound" xml:space="preserve">
     <value>Cena não encontrada.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.resx
@@ -2826,6 +2826,9 @@
   <data name="RolLiveScene" xml:space="preserve">
     <value>Live Scene</value>
   </data>
+  <data name="RolSceneLiveUnavailable" xml:space="preserve">
+    <value>Live updates are unavailable — joining a scene requires a character who can see it. The poses below will not update.</value>
+  </data>
   <data name="RolSceneNotFound" xml:space="preserve">
     <value>Scene not found.</value>
   </data>

--- a/SharpMUSH.Client/Resources/SharedResource.ro.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.ro.resx
@@ -3164,6 +3164,10 @@
     <value>Scenă în {0}</value>
     <comment>MT</comment>
   </data>
+  <data name="RolSceneLiveUnavailable" xml:space="preserve">
+    <value>Actualizările în timp real nu sunt disponibile — alăturarea la o scenă necesită un personaj care o poate vedea. Pozele de mai jos nu se vor actualiza.</value>
+    <comment>MT</comment>
+  </data>
   <data name="RolSceneNotFound" xml:space="preserve">
     <value>Scena nu a fost găsită.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.ru.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.ru.resx
@@ -3164,6 +3164,10 @@
     <value>Сцена в комнате «{0}»</value>
     <comment>MT — restructured: the head noun «комнате» carries the prepositional case and the room name stays nominative inside guillemets, so the interpolated {0} never has to inflect.</comment>
   </data>
+  <data name="RolSceneLiveUnavailable" xml:space="preserve">
+    <value>Обновления в реальном времени недоступны — чтобы присоединиться к сцене, нужен персонаж, который её видит. Позы ниже обновляться не будут.</value>
+    <comment>MT</comment>
+  </data>
   <data name="RolSceneNotFound" xml:space="preserve">
     <value>Сцена не найдена.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.sv.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.sv.resx
@@ -3164,6 +3164,10 @@
     <value>Scen i {0}</value>
     <comment>MT — {0} is a room name.</comment>
   </data>
+  <data name="RolSceneLiveUnavailable" xml:space="preserve">
+    <value>Liveuppdateringar är inte tillgängliga — att gå med i en scen kräver en rollfigur som kan se den. Poserna nedan uppdateras inte.</value>
+    <comment>MT</comment>
+  </data>
   <data name="RolSceneNotFound" xml:space="preserve">
     <value>Scenen hittades inte.</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.zh-Hans.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.zh-Hans.resx
@@ -3164,6 +3164,10 @@
     <value>场景地点：{0}</value>
     <comment>MT</comment>
   </data>
+  <data name="RolSceneLiveUnavailable" xml:space="preserve">
+    <value>实时更新不可用 —— 加入场景需要一个能看到该场景的角色。下方的姿态不会更新。</value>
+    <comment>MT</comment>
+  </data>
   <data name="RolSceneNotFound" xml:space="preserve">
     <value>未找到场景。</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Services/ConnectionStateService.cs
+++ b/SharpMUSH.Client/Services/ConnectionStateService.cs
@@ -217,17 +217,38 @@ public sealed class ConnectionStateService : IConnectionStateService, ISceneHubC
 	}
 
 	/// <inheritdoc/>
-	public Task JoinSceneAsync(string sceneId)
-	{
-		if (_sceneHub is null || _sceneHub.State != SignalRState.Connected) return Task.CompletedTask;
-		return _sceneHub.InvokeAsync("JoinScene", sceneId);
-	}
+	public Task JoinSceneAsync(string sceneId) => InvokeSceneHubAsync("JoinScene", sceneId);
 
 	/// <inheritdoc/>
-	public Task LeaveSceneAsync(string sceneId)
+	public Task LeaveSceneAsync(string sceneId) => InvokeSceneHubAsync("LeaveScene", sceneId);
+
+	/// <summary>
+	/// Invokes a scene-hub group method, treating an absent connection as the documented no-op.
+	/// <para>The state check alone cannot deliver that: the scene connection can close between the check and
+	/// the invoke, and SignalR then answers with a transport fault rather than a no-op —
+	/// <see cref="InvalidOperationException"/> ("the connection is not active"),
+	/// <see cref="ObjectDisposedException"/> for a connection torn down underneath the call, or a cancelled
+	/// invocation when the close races an in-flight one. All three mean the same thing as the check that
+	/// missed them by a hair, and the caller has nothing to do about any of them: the group membership dies
+	/// with the connection. The window is not theoretical — <c>SceneLive</c> leaves its group from
+	/// <c>DisposeAsync</c>, which is exactly when the connection is being taken down.</para>
+	/// <para>A <see cref="HubException"/> is deliberately NOT caught here. That is not a transport fault but
+	/// the hub's authorization answer (no character, or a scene the caller may not see), which the calling
+	/// page renders.</para>
+	/// </summary>
+	private async Task InvokeSceneHubAsync(string method, string sceneId)
 	{
-		if (_sceneHub is null || _sceneHub.State != SignalRState.Connected) return Task.CompletedTask;
-		return _sceneHub.InvokeAsync("LeaveScene", sceneId);
+		if (_sceneHub is not { } sceneHub || sceneHub.State != SignalRState.Connected) return;
+
+		try
+		{
+			await sceneHub.InvokeAsync(method, sceneId);
+		}
+		catch (Exception ex) when (ex is InvalidOperationException or OperationCanceledException)
+		{
+			_logger.LogDebug(ex, "[ConnectionStateService] Scene hub {Method}({SceneId}) lost the connection mid-call",
+				method, sceneId);
+		}
 	}
 
 	private void SetState(SignalRState state)

--- a/SharpMUSH.Client/Services/ISceneHubControl.cs
+++ b/SharpMUSH.Client/Services/ISceneHubControl.cs
@@ -16,12 +16,19 @@ public interface ISceneHubControl
 
 	/// <summary>
 	/// Joins the SignalR <c>scene:{sceneId}</c> group so this client receives the
-	/// scene's realtime <c>ReceiveSceneMessage</c> events. No-ops when not connected.
+	/// scene's realtime <c>ReceiveSceneMessage</c> events. No-ops when not connected, and when the
+	/// connection drops mid-call — see <see cref="LeaveSceneAsync"/>.
 	/// </summary>
+	/// <exception cref="Microsoft.AspNetCore.SignalR.HubException">The hub refused the join: this
+	/// connection acts as no character, or the scene does not exist / is not visible to it.</exception>
 	Task JoinSceneAsync(string sceneId);
 
 	/// <summary>
-	/// Leaves the SignalR <c>scene:{sceneId}</c> group. No-ops when not connected.
+	/// Leaves the SignalR <c>scene:{sceneId}</c> group. No-ops when not connected — including when the
+	/// connection closes between the state check and the invoke, which callers cannot pre-empt and have
+	/// nothing to do about: the group membership dies with the connection either way.
 	/// </summary>
+	/// <exception cref="Microsoft.AspNetCore.SignalR.HubException">The hub refused the leave: this
+	/// connection acts as no character.</exception>
 	Task LeaveSceneAsync(string sceneId);
 }

--- a/SharpMUSH.Plugins.Scene/Web/SceneController.cs
+++ b/SharpMUSH.Plugins.Scene/Web/SceneController.cs
@@ -37,13 +37,6 @@ namespace SharpMUSH.Plugins.Scene.Web;
 [AllowAnonymous]
 public class SceneController(ISceneService sceneService) : ControllerBase
 {
-	/// <summary>
-	/// Claim name that carries the authenticated character's dbref — mirrors the host's
-	/// <c>GameHub.CharacterDbrefClaim</c>. Inlined here so the plugin controller takes no dependency
-	/// on the Server's hub types.
-	/// </summary>
-	private const string CharacterDbrefClaim = "character_dbref";
-
 	/// <summary>Scene data returned by the API. Timestamps are UTC Unix-millis (long).</summary>
 	public record SceneDto(
 		string Id,
@@ -106,19 +99,11 @@ public class SceneController(ISceneService sceneService) : ControllerBase
 		m.SceneId, m.MemberDbref, m.MemberName, m.Role, m.ShowAs, m.IsCurrent, m.GrantedAt);
 
 	/// <summary>
-	/// The caller's acting character, parsed from the <c>character_dbref</c> claim. Null when the caller
-	/// is anonymous, carries no character, or carries an unparseable one — such callers may only see
+	/// The caller's acting character, from the <c>character_dbref</c> claim. Null when the caller is
+	/// anonymous, carries no character, or carries an unparseable one — such callers may only see
 	/// public scenes.
 	/// </summary>
-	/// <remarks>
-	/// Parsed rather than kept as the raw claim string because the two references being compared are
-	/// spelled differently: the claim is a full objid (<c>#1:1785989066109</c>, minted from the session's
-	/// character) while a scene's owner/member dbref is resolved from a live object edge and comes back
-	/// bare (<c>#1</c>). String comparison between those two forms can never succeed, which is what used
-	/// to make every non-public scene invisible to its own owner.
-	/// </remarks>
-	private DBRef? CallerRef =>
-		DBRef.TryParse(User.FindFirst(CharacterDbrefClaim)?.Value, out var parsed) ? parsed : null;
+	private DBRef? CallerRef => SceneVisibility.ActingCharacter(User);
 
 	/// <summary>The caller's character in its canonical spelling, for the service calls that take a string.</summary>
 	private string? CallerDbref => CallerRef?.ToString();
@@ -126,26 +111,11 @@ public class SceneController(ISceneService sceneService) : ControllerBase
 	/// <summary>
 	/// True when <paramref name="scene"/> is visible to the caller: it is public, the caller owns
 	/// it, or the caller is a member of it. Non-public scenes require an authenticated character.
+	/// The rule itself lives in <see cref="SceneVisibility"/> because the scene hub asks the same
+	/// question of the same scenes, and two copies of it would drift.
 	/// </summary>
-	private async Task<bool> CanSeeAsync(Contracts.Scene scene)
-	{
-		if (scene.IsPublic) return true;
-
-		if (CallerRef is not { } me) return false;
-
-		// Owner always sees their own scene. Both sides here are resolved live in this request — the owner
-		// by dereferencing the scene's owner edge to its object vertex, the caller from the session's
-		// current character — so two live objects cannot share the number and DBRef.SameObjectAs is exact;
-		// it still compares the creation stamp on the side that has one.
-		if (scene.OwnerDbref is { } owner && DBRef.TryParse(owner, out var ownerRef) && ownerRef is { } o
-				&& o.SameObjectAs(me))
-			return true;
-
-		// Otherwise the caller must hold a membership edge on the scene. The storage resolves the reference
-		// against the live object itself (rejecting a stale objid), so hand it the same canonical spelling.
-		var member = await sceneService.GetMemberAsync(scene.Id, me.ToString());
-		return member.IsT0;
-	}
+	private Task<bool> CanSeeAsync(Contracts.Scene scene) =>
+		SceneVisibility.CanSeeAsync(sceneService, scene, CallerRef);
 
 	/// <summary>
 	/// GET /api/scenes?filter=active|recent|scheduled&amp;count=50

--- a/SharpMUSH.Plugins.Scene/Web/SceneHub.cs
+++ b/SharpMUSH.Plugins.Scene/Web/SceneHub.cs
@@ -1,4 +1,8 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Plugins.Scene.Storage;
 
 namespace SharpMUSH.Plugins.Scene.Web;
 
@@ -21,20 +25,119 @@ namespace SharpMUSH.Plugins.Scene.Web;
 /// group membership. Server-to-client pushes come from the plugin's <c>IBridgeSubscriptionSource</c> leg,
 /// which forwards <c>game.scene.*</c> NATS messages to the matching group via the non-generic
 /// <c>IHubContext&lt;SceneHub&gt;</c>.</para>
+///
+/// <para><b>AUTHORIZATION.</b> Group membership on this hub IS the subscription to a scene's live contents,
+/// so joining a group is a read of the scene and is gated exactly like one. Three layers, outermost first:
+/// <list type="number">
+///   <item><see cref="AuthorizeAttribute"/> on the hub — same primitive and same (default) scheme as the
+///   host's <c>GameHub</c>, i.e. <c>AccountSession</c> in production and <c>DebugAuth</c> in development.
+///   An anonymous connection is refused at the endpoint and never reaches a hub method.</item>
+///   <item>A usable <c>character_dbref</c> claim, checked per method: <i>joining a Scene requires a
+///   Character; Guests cannot join scenes.</i> An authenticated account acting as no character is refused
+///   even for a public scene.</item>
+///   <item>Scene visibility — public, owned by the caller, or the caller is a member — through the shared
+///   <see cref="SceneVisibility"/> predicate the REST controller uses, so the live feed can never expose a
+///   scene the archive would 404 on.</item>
+/// </list>
+/// Layer 3 is deliberately separate from layer 2: were the character requirement ever judged sufficient on
+/// its own, deleting the <see cref="SceneVisibility.CanSeeAsync"/> call from <see cref="JoinScene"/> relaxes
+/// it without touching anything else.</para>
 /// </summary>
-public sealed class SceneHub : Hub
+[Authorize]
+public sealed class SceneHub(ISceneService sceneService, ILogger<SceneHub> logger) : Hub
 {
 	/// <summary>The SignalR client method the portal subscribes to for live scene events.</summary>
 	public const string ReceiveSceneMessageMethod = "ReceiveSceneMessage";
 
+	/// <summary>
+	/// The refusal a caller sees for a scene that does not exist AND for one they may not see. One message
+	/// for both on purpose: the REST side answers 404 to the same two cases, and a distinguishable refusal
+	/// would let a caller enumerate private scene ids.
+	/// </summary>
+	private const string SceneUnavailable = "That scene is not available.";
+
+	/// <summary>The refusal a caller with no acting character sees. Naming the reason is safe — it leaks nothing about the scene.</summary>
+	private const string CharacterRequired = "Joining a scene requires a character; guests cannot join scenes.";
+
 	/// <summary>The SignalR scene group key — mirrors the bridge leg's <c>scene:{id}</c>.</summary>
 	public static string SceneGroupName(string sceneId) => $"scene:{sceneId}";
 
-	/// <summary>Adds the calling connection to the <c>scene:{sceneId}</c> group (live scene view opened).</summary>
-	public Task JoinScene(string sceneId) =>
-		Groups.AddToGroupAsync(Context.ConnectionId, SceneGroupName(sceneId));
+	/// <summary>
+	/// Adds the calling connection to the <c>scene:{sceneId}</c> group (live scene view opened), after
+	/// proving the caller is a character who may see that scene.
+	/// </summary>
+	/// <param name="sceneId">The scene's id. Nullable because a client can send JSON <c>null</c> regardless
+	/// of the declared type — nullable reference types are not enforced at runtime.</param>
+	/// <exception cref="HubException">The id is absent, the connection carries no character, or the scene
+	/// does not exist / is not visible to that character.</exception>
+	public async Task JoinScene(string? sceneId)
+	{
+		var id = RequireSceneId(sceneId);
+		var character = RequireCharacter();
 
-	/// <summary>Removes the calling connection from the <c>scene:{sceneId}</c> group (live scene view closed).</summary>
-	public Task LeaveScene(string sceneId) =>
-		Groups.RemoveFromGroupAsync(Context.ConnectionId, SceneGroupName(sceneId));
+		var result = await sceneService.GetSceneAsync(id);
+		if (result.IsT1 || !await SceneVisibility.CanSeeAsync(sceneService, result.AsT0, character))
+		{
+			logger.LogWarning(
+				"[SceneHub] Connection {ConnectionId} (char:{Character}) was refused scene group {Group}: " +
+				"the scene is missing or not visible to that character",
+				Context.ConnectionId, character, SceneGroupName(id));
+			throw new HubException(SceneUnavailable);
+		}
+
+		await Groups.AddToGroupAsync(Context.ConnectionId, SceneGroupName(id));
+		logger.LogDebug("[SceneHub] Connection {ConnectionId} joined scene group {Group}",
+			Context.ConnectionId, SceneGroupName(id));
+	}
+
+	/// <summary>
+	/// Removes the calling connection from the <c>scene:{sceneId}</c> group (live scene view closed).
+	/// </summary>
+	/// <remarks>
+	/// Gated on the character requirement (a connection that could never join has nothing to leave) but
+	/// deliberately NOT on scene visibility: dropping your own subscription only ever removes access, and
+	/// requiring visibility would strand a player whose membership was revoked while they were watching —
+	/// they would keep receiving the scene's poses with no way to unsubscribe short of disconnecting.
+	/// </remarks>
+	/// <param name="sceneId">The scene's id; nullable for the same reason as in <see cref="JoinScene"/>.</param>
+	/// <exception cref="HubException">The id is absent or the connection carries no character.</exception>
+	public async Task LeaveScene(string? sceneId)
+	{
+		var id = RequireSceneId(sceneId);
+		RequireCharacter();
+
+		await Groups.RemoveFromGroupAsync(Context.ConnectionId, SceneGroupName(id));
+		logger.LogDebug("[SceneHub] Connection {ConnectionId} left scene group {Group}",
+			Context.ConnectionId, SceneGroupName(id));
+	}
+
+	/// <summary>
+	/// The caller's acting character, or a refusal. The claim is read exactly as the REST side reads it
+	/// (<see cref="SceneVisibility.ActingCharacter"/>) so the two surfaces cannot disagree about who is
+	/// calling. A bare dbref is accepted here — unlike <c>GameHub</c>, which needs an objid to name a
+	/// routing group — because the group key is the scene id and the reference is only ever compared
+	/// against a scene's owner/member edge.
+	/// </summary>
+	private DBRef RequireCharacter()
+	{
+		if (SceneVisibility.ActingCharacter(Context.User) is { } character) return character;
+
+		// Refusals throw rather than no-op: a silently ignored join leaves the client believing it is
+		// subscribed while nothing is ever delivered, which is invisible in the browser and indistinguishable
+		// from a quiet scene. The portal handles the exception (SceneLive.razor) instead.
+		logger.LogWarning(
+			"[SceneHub] Connection {ConnectionId} has no usable {Claim} claim (absent, unparseable, or an " +
+			"account acting as no character); refusing the scene group operation",
+			Context.ConnectionId, SceneVisibility.CharacterDbrefClaim);
+		throw new HubException(CharacterRequired);
+	}
+
+	/// <summary>Rejects an absent scene id — client input is the one place a missing id can enter.</summary>
+	private string RequireSceneId(string? sceneId)
+	{
+		if (!string.IsNullOrWhiteSpace(sceneId)) return sceneId;
+
+		logger.LogWarning("[SceneHub] Connection {ConnectionId} sent an empty scene id", Context.ConnectionId);
+		throw new HubException(SceneUnavailable);
+	}
 }

--- a/SharpMUSH.Plugins.Scene/Web/SceneVisibility.cs
+++ b/SharpMUSH.Plugins.Scene/Web/SceneVisibility.cs
@@ -1,0 +1,65 @@
+using System.Security.Claims;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Plugins.Scene.Storage;
+
+namespace SharpMUSH.Plugins.Scene.Web;
+
+/// <summary>
+/// The one implementation of "may this caller see this scene", shared by the plugin's two web surfaces:
+/// <see cref="SceneController"/> (REST) and <see cref="SceneHub"/> (SignalR). Both answer the same question
+/// about the same scenes, and a second copy of an authorization rule is how the two drift — the REST side
+/// once denied owners their own private scenes while the hub let anyone into any scene's broadcast group,
+/// which is precisely the shape of bug a single predicate prevents.
+///
+/// <para>The hub layers an ADDITIONAL requirement on top of this (a scene subscription requires a character
+/// at all, so guests never join even a public scene); that rule lives at the hub because it is a hub rule.
+/// This type is only the visibility half.</para>
+/// </summary>
+internal static class SceneVisibility
+{
+	/// <summary>
+	/// Claim name that carries the authenticated character's dbref — mirrors the host's
+	/// <c>GameHub.CharacterDbrefClaim</c>. Inlined here so the plugin takes no dependency on the
+	/// Server's hub types.
+	/// </summary>
+	internal const string CharacterDbrefClaim = "character_dbref";
+
+	/// <summary>
+	/// The caller's acting character, parsed from the <c>character_dbref</c> claim. Null when the caller
+	/// is anonymous, carries no character, or carries an unparseable one.
+	/// </summary>
+	/// <remarks>
+	/// Parsed rather than kept as the raw claim string because the two references being compared are
+	/// spelled differently: the claim is a full objid (<c>#1:1785989066109</c>, minted from the session's
+	/// character) while a scene's owner/member dbref is resolved from a live object edge and comes back
+	/// bare (<c>#1</c>). String comparison between those two forms can never succeed, which is what used
+	/// to make every non-public scene invisible to its own owner.
+	/// </remarks>
+	internal static DBRef? ActingCharacter(ClaimsPrincipal? user) =>
+		DBRef.TryParse(user?.FindFirst(CharacterDbrefClaim)?.Value, out var parsed) ? parsed : null;
+
+	/// <summary>
+	/// True when <paramref name="scene"/> is visible to <paramref name="caller"/>: it is public, the caller
+	/// owns it, or the caller is a member of it. Non-public scenes require a character
+	/// (<paramref name="caller"/> is null for anonymous/characterless callers).
+	/// </summary>
+	internal static async Task<bool> CanSeeAsync(ISceneService sceneService, Contracts.Scene scene, DBRef? caller)
+	{
+		if (scene.IsPublic) return true;
+
+		if (caller is not { } me) return false;
+
+		// Owner always sees their own scene. Both sides here are resolved live in this request — the owner
+		// by dereferencing the scene's owner edge to its object vertex, the caller from the session's
+		// current character — so two live objects cannot share the number and DBRef.SameObjectAs is exact;
+		// it still compares the creation stamp on the side that has one.
+		if (scene.OwnerDbref is { } owner && DBRef.TryParse(owner, out var ownerRef) && ownerRef is { } o
+				&& o.SameObjectAs(me))
+			return true;
+
+		// Otherwise the caller must hold a membership edge on the scene. The storage resolves the reference
+		// against the live object itself (rejecting a stale objid), so hand it the same canonical spelling.
+		var member = await sceneService.GetMemberAsync(scene.Id, me.ToString());
+		return member.IsT0;
+	}
+}

--- a/SharpMUSH.Tests.BUnit/Components/SceneSurfaceTests.cs
+++ b/SharpMUSH.Tests.BUnit/Components/SceneSurfaceTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -102,6 +103,9 @@ internal sealed class FakeSceneHub : IConnectionStateService, ISceneHubControl
 	public List<string> Joined { get; } = [];
 	public List<string> Left { get; } = [];
 
+	/// <summary>Set to make <see cref="JoinSceneAsync"/> refuse, as the hub does for a caller with no character.</summary>
+	public HubException? JoinRefusal { get; set; }
+
 	public bool IsConnected => true;
 	public HubConnectionState ConnectionState => HubConnectionState.Connected;
 
@@ -123,6 +127,8 @@ internal sealed class FakeSceneHub : IConnectionStateService, ISceneHubControl
 
 	public Task JoinSceneAsync(string sceneId)
 	{
+		if (JoinRefusal is { } refusal) return Task.FromException(refusal);
+
 		Joined.Add(sceneId);
 		return Task.CompletedTask;
 	}
@@ -265,6 +271,62 @@ public class SceneSurfaceTests : BunitContext
 
 		// No optimistic insert: the author's pose only appears after the round-trip event.
 		await Assert.That(cut.Markup).DoesNotContain("waves hello");
+	}
+
+	/// <summary>
+	/// A refused join is not a missing scene. The REST fetch already returned this scene, so the caller may
+	/// read it and its archive renders; only the live subscription was refused (no character, or visibility
+	/// revoked in the moment between the two calls). Reporting that as "scene not found" told a user with a
+	/// perfectly readable scene that it does not exist.
+	/// </summary>
+	[TUnit.Core.Test]
+	public async Task SceneLive_WhenTheHubRefusesTheJoin_KeepsTheSceneAndSaysLiveIsUnavailable()
+	{
+		_hub.JoinRefusal = new HubException("Joining a scene requires a character; guests cannot join scenes.");
+
+		var cut = Render<SceneLiveHarness>(p => p.Add(c => c.Id, "S1"));
+
+		cut.WaitForAssertion(() =>
+		{
+			if (!cut.Markup.Contains("RolSceneLiveUnavailable"))
+				throw new InvalidOperationException("join refusal not handled yet");
+		}, TimeSpan.FromSeconds(5));
+
+		var markup = cut.Markup;
+		await Assert.That(markup).Contains("RolSceneLiveUnavailable");
+		await Assert.That(markup).DoesNotContain("RolSceneNotFound")
+			.Because("the scene was fetched successfully; calling it missing is false");
+		// The archive the caller is entitled to is still on screen.
+		await Assert.That(markup).Contains("Barroom Brawl");
+		await Assert.That(markup).Contains("draws a blade");
+		// Nothing renders a pose but the round-trip event, and this connection is in no scene group.
+		await Assert.That(cut.Find("button.mud-icon-button").HasAttribute("disabled")).IsTrue();
+		await Assert.That(_hub.Joined).IsEmpty();
+	}
+
+	/// <summary>
+	/// The other half of the same split, and the one with the security property: a scene that does not exist
+	/// and a scene that exists but is not visible to this caller are BOTH a 404 from the REST route, so both
+	/// reach this one card with this one message. A refusal a caller can tell apart is a way to enumerate
+	/// private scene ids, which is why the server refuses to distinguish them and why the page must not
+	/// invent a distinction the server withheld.
+	/// </summary>
+	[TUnit.Core.Test]
+	public async Task SceneLive_WhenTheSceneIsNotFetchable_SaysNotFound_WithoutNamingWhy()
+	{
+		// The fake API answers 404 for any id it does not serve — exactly as the real route answers 404 for
+		// a missing scene and for a private one the caller may not see, indistinguishably.
+		var cut = Render<SceneLiveHarness>(p => p.Add(c => c.Id, "S404"));
+
+		cut.WaitForAssertion(() =>
+		{
+			if (!cut.Markup.Contains("RolSceneNotFound"))
+				throw new InvalidOperationException("not-found state not reached yet");
+		}, TimeSpan.FromSeconds(5));
+
+		await Assert.That(cut.Markup).Contains("RolSceneNotFound");
+		await Assert.That(cut.Markup).DoesNotContain("RolSceneLiveUnavailable")
+			.Because("naming the live-subscription reason here would tell a stranger the scene exists");
 	}
 
 	[TUnit.Core.Test]

--- a/SharpMUSH.Tests.BUnit/Services/SceneHubGroupTeardownTests.cs
+++ b/SharpMUSH.Tests.BUnit/Services/SceneHubGroupTeardownTests.cs
@@ -1,0 +1,126 @@
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Logging.Abstractions;
+using SharpMUSH.Client.Models;
+using SharpMUSH.Client.Services;
+using SharpMUSH.Library.Models.Portal;
+
+namespace SharpMUSH.Tests.BUnit.Services;
+
+/// <summary>A scene connection that reports itself Connected and throws whatever a test hands it.</summary>
+file sealed class ThrowingSceneConnection(Exception? onInvoke) : IGameHubConnection
+{
+	public List<string> Invoked { get; } = [];
+	public HubConnectionState State { get; private set; } = HubConnectionState.Disconnected;
+
+	public Task StartAsync(CancellationToken cancellationToken = default)
+	{
+		State = HubConnectionState.Connected;
+		return Task.CompletedTask;
+	}
+
+	public Task StopAsync(CancellationToken cancellationToken = default)
+	{
+		State = HubConnectionState.Disconnected;
+		return Task.CompletedTask;
+	}
+
+	public Task InvokeAsync(string methodName, string arg, CancellationToken cancellationToken = default)
+	{
+		Invoked.Add($"{methodName}:{arg}");
+		return onInvoke is null ? Task.CompletedTask : Task.FromException(onInvoke);
+	}
+
+	public IDisposable On(string methodName, Action<GameOutputMessage> handler) => new Noop();
+	public IDisposable On(string methodName, Action<RoomEventMessage> handler) => new Noop();
+	public IDisposable On(string methodName, Action<SceneEventMessage> handler) => new Noop();
+	public IDisposable On(string methodName, Action handler) => new Noop();
+	public event Func<Exception?, Task>? Closed;
+	public event Func<Exception?, Task>? Reconnecting;
+	public event Func<string?, Task>? Reconnected;
+	public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+	private sealed class Noop : IDisposable { public void Dispose() { } }
+}
+
+file sealed class SceneHubFactory(Exception? onInvoke) : IGameHubConnectionFactory
+{
+	public ThrowingSceneConnection Game { get; } = new(null);
+	public ThrowingSceneConnection Scene { get; } = new(onInvoke);
+
+	public IGameHubConnection Create() => Game;
+	public IGameHubConnection? CreateScene() => Scene;
+}
+
+/// <summary>
+/// Joining and leaving a scene group must survive the connection going away underneath the call.
+/// <para>Both methods check <c>State == Connected</c> and then invoke, and the connection can close in
+/// between — SignalR answers a closed or disposed connection with a transport fault, not the no-op the
+/// check was reaching for. <c>SceneLive</c> leaves its group from <c>DisposeAsync</c>, where a throw has
+/// nowhere to surface, and that is precisely when the connection is being torn down.</para>
+/// <para>A <c>HubException</c> is the opposite case and must still reach the caller: it is the hub's
+/// authorization answer, and the page renders it.</para>
+/// </summary>
+public class SceneHubGroupTeardownTests
+{
+	/// <summary>What SignalR answers a connection that closed, disposed, or cancelled underneath the call.</summary>
+	public static IEnumerable<Exception> TransportFaults() =>
+	[
+		new InvalidOperationException("The 'InvokeCoreAsync' method cannot be called if the connection is not active."),
+		new ObjectDisposedException(nameof(HubConnection)),
+		new TaskCanceledException("The underlying connection was closed."),
+		new OperationCanceledException("Connection closed."),
+	];
+
+	private static async Task<ISceneHubControl> ConnectedServiceAsync(IGameHubConnectionFactory factory)
+	{
+		var service = new ConnectionStateService(factory, NullLogger<ConnectionStateService>.Instance);
+		await service.ConnectAsync();
+		return service;
+	}
+
+	[Test]
+	[MethodDataSource(nameof(TransportFaults))]
+	public async Task LeaveSceneAsync_WhenTheConnectionDiesMidCall_DoesNotThrow(Exception fault)
+	{
+		var factory = new SceneHubFactory(fault);
+		var service = await ConnectedServiceAsync(factory);
+
+		await service.LeaveSceneAsync("scene-1");
+
+		await Assert.That(factory.Scene.Invoked).Contains("LeaveScene:scene-1");
+	}
+
+	[Test]
+	[MethodDataSource(nameof(TransportFaults))]
+	public async Task JoinSceneAsync_WhenTheConnectionDiesMidCall_DoesNotThrow(Exception fault)
+	{
+		var factory = new SceneHubFactory(fault);
+		var service = await ConnectedServiceAsync(factory);
+
+		await service.JoinSceneAsync("scene-1");
+
+		await Assert.That(factory.Scene.Invoked).Contains("JoinScene:scene-1");
+	}
+
+	[Test]
+	public async Task JoinSceneAsync_StillSurfacesTheHubsRefusal()
+	{
+		var factory = new SceneHubFactory(new HubException("That scene is not available."));
+		var service = await ConnectedServiceAsync(factory);
+
+		await Assert.That(async () => await service.JoinSceneAsync("scene-1"))
+			.Throws<HubException>()
+			.Because("a refusal is the hub's answer about the caller, not a transport fault — SceneLive renders it");
+	}
+
+	[Test]
+	public async Task LeaveSceneAsync_StillSurfacesTheHubsRefusal()
+	{
+		var factory = new SceneHubFactory(new HubException("Joining a scene requires a character."));
+		var service = await ConnectedServiceAsync(factory);
+
+		await Assert.That(async () => await service.LeaveSceneAsync("scene-1"))
+			.Throws<HubException>();
+	}
+}

--- a/SharpMUSH.Tests.Integration/Scenes/SceneHubRealtimeTests.cs
+++ b/SharpMUSH.Tests.Integration/Scenes/SceneHubRealtimeTests.cs
@@ -49,6 +49,26 @@ public class SceneHubRealtimeTests(ServerWebAppFactory factory)
 			.Because("the Scene plugin's IEndpointContributor must have mapped SceneHub at /hubs/scene");
 	}
 
+	/// <summary>
+	/// The hub authorizes each join against <c>ISceneService</c>, so SignalR must be able to CONSTRUCT it:
+	/// its dependencies (the plugin's own <c>ISceneService</c> and an <c>ILogger&lt;SceneHub&gt;</c> over a
+	/// collectible-ALC type) have to resolve from the host container. SignalR's default hub activator does
+	/// exactly this — <c>ActivatorUtilities.CreateInstance</c> on a request scope for a hub type that is not
+	/// itself registered — and it only runs when a client connects, so nothing else in this suite would
+	/// catch a hub that cannot be built.
+	/// </summary>
+	[Test]
+	public async Task SceneHub_CanBeActivatedFromHostDi_LikeSignalRDoes()
+	{
+		using var scope = factory.Services.CreateScope();
+
+		var hub = ActivatorUtilities.CreateInstance(scope.ServiceProvider, SceneHubType);
+
+		await Assert.That(hub).IsNotNull()
+			.Because("SignalR activates the hub per invocation; its ISceneService/ILogger dependencies must " +
+				"resolve from the host container across the plugin ALC");
+	}
+
 	[Test]
 	public async Task SceneHubContext_ResolvesAcrossPluginAlc_AndBridgeTargetIsPublished()
 	{

--- a/SharpMUSH.Tests.ScenePlugin/SceneControllerVisibilityTests.cs
+++ b/SharpMUSH.Tests.ScenePlugin/SceneControllerVisibilityTests.cs
@@ -1,9 +1,5 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using OneOf;
-using OneOf.Types;
-using SharpMUSH.Library.Models;
-using SharpMUSH.Plugins.Scene.Models;
 using SharpMUSH.Plugins.Scene.Web;
 using System.Security.Claims;
 using Scene = SharpMUSH.Plugins.Scene.Models.Scene;
@@ -47,7 +43,7 @@ public class SceneControllerVisibilityTests
 		Meta: new Dictionary<string, string>());
 
 	/// <summary>Builds the controller with <paramref name="claimValue"/> as the acting character (null = anonymous).</summary>
-	private static SceneController ControllerFor(StubSceneService service, string? claimValue)
+	private static SceneController ControllerFor(FixedSceneService service, string? claimValue)
 	{
 		var identity = claimValue is null
 			? new ClaimsIdentity()
@@ -65,7 +61,7 @@ public class SceneControllerVisibilityTests
 	[Test]
 	public async Task GetScene_PrivateSceneOwnedByCaller_IsVisible()
 	{
-		var service = new StubSceneService(SceneOwnedBy("#1", isPublic: false));
+		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: false));
 		var controller = ControllerFor(service, GodObjid);
 
 		var result = await controller.GetScene("scene-1");
@@ -78,7 +74,7 @@ public class SceneControllerVisibilityTests
 	[Test]
 	public async Task GetScene_PrivateSceneCallerIsMember_IsVisible()
 	{
-		var service = new StubSceneService(SceneOwnedBy("#7", isPublic: false)) { MemberDbref = "#1" };
+		var service = new FixedSceneService(SceneOwnedBy("#7", isPublic: false)) { MemberDbref = "#1" };
 		var controller = ControllerFor(service, GodObjid);
 
 		var result = await controller.GetScene("scene-1");
@@ -92,7 +88,7 @@ public class SceneControllerVisibilityTests
 	[Test]
 	public async Task GetScene_PrivateSceneCallerIsNeitherOwnerNorMember_Is404()
 	{
-		var service = new StubSceneService(SceneOwnedBy("#7", isPublic: false));
+		var service = new FixedSceneService(SceneOwnedBy("#7", isPublic: false));
 		var controller = ControllerFor(service, GodObjid);
 
 		var result = await controller.GetScene("scene-1");
@@ -104,7 +100,7 @@ public class SceneControllerVisibilityTests
 	[Test]
 	public async Task GetScene_PrivateSceneOwnedByARecycledObjid_Is404()
 	{
-		var service = new StubSceneService(SceneOwnedBy("#1:1700000000000", isPublic: false));
+		var service = new FixedSceneService(SceneOwnedBy("#1:1700000000000", isPublic: false));
 		var controller = ControllerFor(service, GodObjid);
 
 		var result = await controller.GetScene("scene-1");
@@ -115,7 +111,7 @@ public class SceneControllerVisibilityTests
 	[Test]
 	public async Task GetScene_PrivateScene_IsHiddenFromAnonymousCallers()
 	{
-		var service = new StubSceneService(SceneOwnedBy("#1", isPublic: false));
+		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: false));
 		var controller = ControllerFor(service, claimValue: null);
 
 		var result = await controller.GetScene("scene-1");
@@ -128,7 +124,7 @@ public class SceneControllerVisibilityTests
 	[Test]
 	public async Task GetScene_PublicScene_IsVisibleToAnonymousCallers()
 	{
-		var service = new StubSceneService(SceneOwnedBy("#1", isPublic: true));
+		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: true));
 		var controller = ControllerFor(service, claimValue: null);
 
 		var result = await controller.GetScene("scene-1");
@@ -139,7 +135,7 @@ public class SceneControllerVisibilityTests
 	[Test]
 	public async Task ListScenes_ReturnsOnlyTheScenesTheCallerMaySee()
 	{
-		var service = new StubSceneService(
+		var service = new FixedSceneService(
 			SceneOwnedBy("#1", isPublic: false) with { Id = "mine" },
 			SceneOwnedBy("#7", isPublic: false) with { Id = "theirs" },
 			SceneOwnedBy("#7", isPublic: true) with { Id = "public" });
@@ -149,43 +145,5 @@ public class SceneControllerVisibilityTests
 
 		var listed = ((IEnumerable<SceneController.SceneDto>)((OkObjectResult)result).Value!).Select(s => s.Id);
 		await Assert.That(listed).IsEquivalentTo(new[] { "mine", "public" });
-	}
-
-	/// <summary>
-	/// Scene service returning a fixed set of scenes, recording the dbrefs it was asked to look memberships
-	/// up by (the second half of the same spelling bug — a mangled reference resolves to no object at all).
-	/// </summary>
-	private sealed class StubSceneService(params Scene[] scenes) : SceneServiceStub
-	{
-		/// <summary>The member dbref that holds a membership edge on every scene, or null for none.</summary>
-		public string? MemberDbref { get; init; }
-
-		public List<string> MemberLookups { get; } = [];
-
-		public override Task<OneOf<Scene, NotFound>> GetSceneAsync(string sceneId) =>
-			Task.FromResult(scenes.FirstOrDefault(s => s.Id == sceneId) is { } scene
-				? OneOf<Scene, NotFound>.FromT0(scene)
-				: new NotFound());
-
-		public override Task<IReadOnlyList<Scene>> ListScenesAsync(string filter, string? viewerDbref = null,
-			long? fromUtcMillis = null, long? toUtcMillis = null, int count = 50) =>
-			Task.FromResult<IReadOnlyList<Scene>>(scenes);
-
-		public override Task<OneOf<SceneMember, NotFound>> GetMemberAsync(string sceneId, string playerDbref)
-		{
-			MemberLookups.Add(playerDbref);
-
-			// Match the storages, which resolve the reference through the live object rather than comparing
-			// strings: a bare dbref and its objid name the same player.
-			var matches = MemberDbref is { } member
-				&& DBRef.TryParse(member, out var expected)
-				&& DBRef.TryParse(playerDbref, out var actual)
-				&& expected!.Value.SameObjectAs(actual!.Value);
-
-			return Task.FromResult(matches
-				? OneOf<SceneMember, NotFound>.FromT0(
-					new SceneMember(sceneId, MemberDbref, "God", "participant", string.Empty, true, 3))
-				: new NotFound());
-		}
 	}
 }

--- a/SharpMUSH.Tests.ScenePlugin/SceneControllerVisibilityTests.cs
+++ b/SharpMUSH.Tests.ScenePlugin/SceneControllerVisibilityTests.cs
@@ -1,8 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using SharpMUSH.Plugins.Scene.Web;
-using System.Security.Claims;
-using Scene = SharpMUSH.Plugins.Scene.Models.Scene;
 
 namespace SharpMUSH.Tests.ScenePlugin;
 
@@ -20,49 +18,21 @@ namespace SharpMUSH.Tests.ScenePlugin;
 /// </summary>
 public class SceneControllerVisibilityTests
 {
-	private const string CharacterDbrefClaim = "character_dbref";
-
-	/// <summary>God's claim as the auth handlers actually mint it — objid, not bare dbref.</summary>
-	private const string GodObjid = "#1:1785989066109";
-
-	private static Scene SceneOwnedBy(string? ownerDbref, bool isPublic) => new(
-		Id: "scene-1",
-		Status: "active",
-		IsPublic: isPublic,
-		IsTempRoom: false,
-		ScheduledFor: null,
-		StartedAt: 1,
-		LastActivityAt: 2,
-		PoseCount: 0,
-		OwnerDbref: ownerDbref,
-		OwnerName: "God",
-		StarterDbref: ownerDbref,
-		StarterName: "God",
-		RoomDbref: null,
-		RoomName: string.Empty,
-		Meta: new Dictionary<string, string>());
-
 	/// <summary>Builds the controller with <paramref name="claimValue"/> as the acting character (null = anonymous).</summary>
-	private static SceneController ControllerFor(FixedSceneService service, string? claimValue)
-	{
-		var identity = claimValue is null
-			? new ClaimsIdentity()
-			: new ClaimsIdentity([new Claim(CharacterDbrefClaim, claimValue)], "TestScheme");
-
-		return new SceneController(service)
+	private static SceneController ControllerFor(FixedSceneService service, string? claimValue) =>
+		new(service)
 		{
 			ControllerContext = new ControllerContext
 			{
-				HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+				HttpContext = new DefaultHttpContext { User = SceneFixture.PrincipalFor(claimValue) }
 			}
 		};
-	}
 
 	[Test]
 	public async Task GetScene_PrivateSceneOwnedByCaller_IsVisible()
 	{
-		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: false));
-		var controller = ControllerFor(service, GodObjid);
+		var service = new FixedSceneService(SceneFixture.SceneOwnedBy("#1", isPublic: false));
+		var controller = ControllerFor(service, SceneFixture.GodObjid);
 
 		var result = await controller.GetScene("scene-1");
 
@@ -74,22 +44,22 @@ public class SceneControllerVisibilityTests
 	[Test]
 	public async Task GetScene_PrivateSceneCallerIsMember_IsVisible()
 	{
-		var service = new FixedSceneService(SceneOwnedBy("#7", isPublic: false)) { MemberDbref = "#1" };
-		var controller = ControllerFor(service, GodObjid);
+		var service = new FixedSceneService(SceneFixture.SceneOwnedBy("#7", isPublic: false)) { MemberDbref = "#1" };
+		var controller = ControllerFor(service, SceneFixture.GodObjid);
 
 		var result = await controller.GetScene("scene-1");
 
 		await Assert.That(result).IsTypeOf<OkObjectResult>();
 		// The storage resolves the reference against the live object, so it must be handed a parseable
 		// dbref — the canonical objid spelling, not a hash-stripped fragment.
-		await Assert.That(service.MemberLookups).Contains(GodObjid);
+		await Assert.That(service.MemberLookups).Contains(SceneFixture.GodObjid);
 	}
 
 	[Test]
 	public async Task GetScene_PrivateSceneCallerIsNeitherOwnerNorMember_Is404()
 	{
-		var service = new FixedSceneService(SceneOwnedBy("#7", isPublic: false));
-		var controller = ControllerFor(service, GodObjid);
+		var service = new FixedSceneService(SceneFixture.SceneOwnedBy("#7", isPublic: false));
+		var controller = ControllerFor(service, SceneFixture.GodObjid);
 
 		var result = await controller.GetScene("scene-1");
 
@@ -100,8 +70,8 @@ public class SceneControllerVisibilityTests
 	[Test]
 	public async Task GetScene_PrivateSceneOwnedByARecycledObjid_Is404()
 	{
-		var service = new FixedSceneService(SceneOwnedBy("#1:1700000000000", isPublic: false));
-		var controller = ControllerFor(service, GodObjid);
+		var service = new FixedSceneService(SceneFixture.SceneOwnedBy("#1:1700000000000", isPublic: false));
+		var controller = ControllerFor(service, SceneFixture.GodObjid);
 
 		var result = await controller.GetScene("scene-1");
 
@@ -111,7 +81,7 @@ public class SceneControllerVisibilityTests
 	[Test]
 	public async Task GetScene_PrivateScene_IsHiddenFromAnonymousCallers()
 	{
-		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: false));
+		var service = new FixedSceneService(SceneFixture.SceneOwnedBy("#1", isPublic: false));
 		var controller = ControllerFor(service, claimValue: null);
 
 		var result = await controller.GetScene("scene-1");
@@ -124,7 +94,7 @@ public class SceneControllerVisibilityTests
 	[Test]
 	public async Task GetScene_PublicScene_IsVisibleToAnonymousCallers()
 	{
-		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: true));
+		var service = new FixedSceneService(SceneFixture.SceneOwnedBy("#1", isPublic: true));
 		var controller = ControllerFor(service, claimValue: null);
 
 		var result = await controller.GetScene("scene-1");
@@ -136,10 +106,10 @@ public class SceneControllerVisibilityTests
 	public async Task ListScenes_ReturnsOnlyTheScenesTheCallerMaySee()
 	{
 		var service = new FixedSceneService(
-			SceneOwnedBy("#1", isPublic: false) with { Id = "mine" },
-			SceneOwnedBy("#7", isPublic: false) with { Id = "theirs" },
-			SceneOwnedBy("#7", isPublic: true) with { Id = "public" });
-		var controller = ControllerFor(service, GodObjid);
+			SceneFixture.SceneOwnedBy("#1", isPublic: false) with { Id = "mine" },
+			SceneFixture.SceneOwnedBy("#7", isPublic: false) with { Id = "theirs" },
+			SceneFixture.SceneOwnedBy("#7", isPublic: true) with { Id = "public" });
+		var controller = ControllerFor(service, SceneFixture.GodObjid);
 
 		var result = await controller.ListScenes();
 

--- a/SharpMUSH.Tests.ScenePlugin/SceneHubAuthorizationTests.cs
+++ b/SharpMUSH.Tests.ScenePlugin/SceneHubAuthorizationTests.cs
@@ -1,0 +1,246 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using SharpMUSH.Plugins.Scene.Web;
+using System.Reflection;
+using System.Security.Claims;
+using Scene = SharpMUSH.Plugins.Scene.Models.Scene;
+
+namespace SharpMUSH.Tests.ScenePlugin;
+
+/// <summary>
+/// The scene realtime hub's permission boundary, exercised directly against <see cref="SceneHub"/> with the
+/// shared <see cref="FixedSceneService"/> — no SignalR pipeline, so every caller shape is reachable.
+///
+/// <para>REGRESSION: <c>JoinScene</c> was a one-liner that added <em>any</em> caller — including an
+/// anonymous one — to the <c>scene:{id}</c> broadcast group for any id it named, after which every pose
+/// broadcast to that scene reached them. A private scene leaked its live contents to anyone who asked,
+/// while the REST route for the same scene answered 404. The gate is three layers: the hub's
+/// <see cref="AuthorizeAttribute"/>, then a character on the connection, then the shared visibility
+/// predicate the REST controller uses.</para>
+/// </summary>
+public class SceneHubAuthorizationTests
+{
+	private const string CharacterDbrefClaim = "character_dbref";
+
+	/// <summary>God's claim as the auth handlers actually mint it — objid, not bare dbref.</summary>
+	private const string GodObjid = "#1:1785989066109";
+
+	/// <summary>A different, unrelated character's claim.</summary>
+	private const string StrangerObjid = "#7:1700000000000";
+
+	private static Scene SceneOwnedBy(string? ownerDbref, bool isPublic) => new(
+		Id: "scene-1",
+		Status: "active",
+		IsPublic: isPublic,
+		IsTempRoom: false,
+		ScheduledFor: null,
+		StartedAt: 1,
+		LastActivityAt: 2,
+		PoseCount: 0,
+		OwnerDbref: ownerDbref,
+		OwnerName: "God",
+		StarterDbref: ownerDbref,
+		StarterName: "God",
+		RoomDbref: null,
+		RoomName: string.Empty,
+		Meta: new Dictionary<string, string>());
+
+	/// <summary>
+	/// Builds the hub for a caller: <paramref name="claimValue"/> is the acting character, or null for a
+	/// caller with no character. <paramref name="authenticated"/> distinguishes the two null cases —
+	/// an anonymous connection (no authentication type) from a signed-in account acting as no character
+	/// (a guest, or an account whose only characters were unlinked). Both must be refused.
+	/// </summary>
+	private static (SceneHub hub, RecordingGroupManager groups) HubFor(
+		FixedSceneService service, string? claimValue, bool authenticated = true)
+	{
+		var identity = claimValue is null
+			? authenticated ? new ClaimsIdentity(authenticationType: "TestScheme") : new ClaimsIdentity()
+			: new ClaimsIdentity([new Claim(CharacterDbrefClaim, claimValue)], "TestScheme");
+
+		var groups = new RecordingGroupManager();
+		var hub = new SceneHub(service, NullLogger<SceneHub>.Instance)
+		{
+			Groups = groups,
+			Context = new FakeHubCallerContext(new ClaimsPrincipal(identity)),
+		};
+
+		return (hub, groups);
+	}
+
+	/// <summary>
+	/// The outermost layer: an anonymous connection must never reach a hub method at all. <c>[Authorize]</c>
+	/// with no scheme resolves against the host's DEFAULT scheme — <c>AccountSession</c> in production,
+	/// <c>DebugAuth</c> in development — exactly as the host's <c>GameHub</c> is secured.
+	/// </summary>
+	[Test]
+	public async Task SceneHub_CarriesTheAuthorizeAttribute_WithNoSchemeOverride()
+	{
+		var authorize = typeof(SceneHub).GetCustomAttributes<AuthorizeAttribute>(inherit: true).ToList();
+
+		await Assert.That(authorize).IsNotEmpty()
+			.Because("an unauthenticated connection must be refused at the endpoint, before any hub method runs");
+		await Assert.That(authorize[0].AuthenticationSchemes).IsNull()
+			.Because("the hub must authorize on the host's default scheme, like GameHub does");
+	}
+
+	[Test]
+	public async Task JoinScene_AnonymousCaller_IsRefusedAndNeverJoinsTheGroup()
+	{
+		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: true));
+		var (hub, groups) = HubFor(service, claimValue: null, authenticated: false);
+
+		await Assert.That(async () => await hub.JoinScene("scene-1")).Throws<HubException>();
+		await Assert.That(groups.Added).IsEmpty();
+	}
+
+	/// <summary>
+	/// "Joining a Scene requires a Character. Guests cannot join scenes." — an authenticated account acting
+	/// as no character is refused even for a PUBLIC scene, which the REST route would happily serve it.
+	/// </summary>
+	[Test]
+	public async Task JoinScene_AuthenticatedAccountWithNoCharacter_IsRefusedEvenForAPublicScene()
+	{
+		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: true));
+		var (hub, groups) = HubFor(service, claimValue: null);
+
+		await Assert.That(async () => await hub.JoinScene("scene-1")).Throws<HubException>();
+		await Assert.That(groups.Added).IsEmpty();
+		// The character check short-circuits: no scene is even looked up for a caller who cannot join any.
+		await Assert.That(service.SceneLookups).IsEmpty();
+	}
+
+	[Test]
+	public async Task JoinScene_PublicScene_AdmitsAnyCharacter()
+	{
+		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: true));
+		var (hub, groups) = HubFor(service, StrangerObjid);
+
+		await hub.JoinScene("scene-1");
+
+		await Assert.That(groups.Added).IsEquivalentTo(new[] { ("conn-001", "scene:scene-1") });
+	}
+
+	[Test]
+	public async Task JoinScene_PrivateSceneOwnedByCaller_IsAdmitted()
+	{
+		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: false));
+		var (hub, groups) = HubFor(service, GodObjid);
+
+		await hub.JoinScene("scene-1");
+
+		await Assert.That(groups.Added).IsEquivalentTo(new[] { ("conn-001", "scene:scene-1") });
+		// The owner check must answer on its own — a membership lookup would mask a broken owner comparison.
+		await Assert.That(service.MemberLookups).IsEmpty();
+	}
+
+	[Test]
+	public async Task JoinScene_PrivateSceneCallerIsMember_IsAdmitted()
+	{
+		var service = new FixedSceneService(SceneOwnedBy("#7", isPublic: false)) { MemberDbref = "#1" };
+		var (hub, groups) = HubFor(service, GodObjid);
+
+		await hub.JoinScene("scene-1");
+
+		await Assert.That(groups.Added).IsEquivalentTo(new[] { ("conn-001", "scene:scene-1") });
+		// The storage resolves the reference against the live object, so it must be handed a parseable
+		// dbref — the canonical objid spelling, not a hash-stripped fragment.
+		await Assert.That(service.MemberLookups).Contains(GodObjid);
+	}
+
+	[Test]
+	public async Task JoinScene_PrivateSceneCallerIsNeitherOwnerNorMember_IsRefused()
+	{
+		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: false));
+		var (hub, groups) = HubFor(service, StrangerObjid);
+
+		await Assert.That(async () => await hub.JoinScene("scene-1")).Throws<HubException>();
+		await Assert.That(groups.Added).IsEmpty();
+	}
+
+	/// <summary>
+	/// A missing scene and an invisible one must be indistinguishable, or the refusal itself enumerates
+	/// private scene ids. The REST side answers 404 to both for the same reason.
+	/// </summary>
+	[Test]
+	public async Task JoinScene_UnknownScene_IsRefusedIndistinguishablyFromAnInvisibleOne()
+	{
+		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: false));
+		var (hub, _) = HubFor(service, StrangerObjid);
+
+		var missing = await Assert.That(async () => await hub.JoinScene("no-such-scene")).Throws<HubException>();
+		var invisible = await Assert.That(async () => await hub.JoinScene("scene-1")).Throws<HubException>();
+
+		await Assert.That(missing!.Message).IsEqualTo(invisible!.Message);
+	}
+
+	[Test]
+	public async Task JoinScene_WithoutASceneId_IsRefused()
+	{
+		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: true));
+		var (hub, groups) = HubFor(service, GodObjid);
+
+		await Assert.That(async () => await hub.JoinScene(null)).Throws<HubException>();
+		await Assert.That(groups.Added).IsEmpty();
+	}
+
+	[Test]
+	public async Task LeaveScene_WithoutACharacter_IsRefused()
+	{
+		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: true));
+		var (hub, groups) = HubFor(service, claimValue: null);
+
+		await Assert.That(async () => await hub.LeaveScene("scene-1")).Throws<HubException>();
+		await Assert.That(groups.Removed).IsEmpty();
+	}
+
+	/// <summary>
+	/// Leaving is gated on the character requirement only — deliberately NOT on visibility. A player whose
+	/// membership is revoked mid-scene must still be able to drop the subscription; requiring visibility
+	/// would leave them receiving poses with no way to unsubscribe short of disconnecting.
+	/// </summary>
+	[Test]
+	public async Task LeaveScene_WithACharacter_LeavesTheGroupWithoutConsultingVisibility()
+	{
+		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: false));
+		var (hub, groups) = HubFor(service, StrangerObjid);
+
+		await hub.LeaveScene("scene-1");
+
+		await Assert.That(groups.Removed).IsEquivalentTo(new[] { ("conn-001", "scene:scene-1") });
+		await Assert.That(service.SceneLookups).IsEmpty();
+	}
+
+	/// <summary>Records group membership calls instead of performing them.</summary>
+	private sealed class RecordingGroupManager : IGroupManager
+	{
+		public List<(string ConnectionId, string Group)> Added { get; } = [];
+		public List<(string ConnectionId, string Group)> Removed { get; } = [];
+
+		public Task AddToGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default)
+		{
+			Added.Add((connectionId, groupName));
+			return Task.CompletedTask;
+		}
+
+		public Task RemoveFromGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default)
+		{
+			Removed.Add((connectionId, groupName));
+			return Task.CompletedTask;
+		}
+	}
+
+	/// <summary>The caller context a hub method reads: a connection id and the connection's principal.</summary>
+	private sealed class FakeHubCallerContext(ClaimsPrincipal user) : HubCallerContext
+	{
+		public override string ConnectionId => "conn-001";
+		public override string? UserIdentifier => null;
+		public override ClaimsPrincipal? User => user;
+		public override IDictionary<object, object?> Items { get; } = new Dictionary<object, object?>();
+		public override IFeatureCollection Features { get; } = new FeatureCollection();
+		public override CancellationToken ConnectionAborted => CancellationToken.None;
+		public override void Abort() { }
+	}
+}

--- a/SharpMUSH.Tests.ScenePlugin/SceneHubAuthorizationTests.cs
+++ b/SharpMUSH.Tests.ScenePlugin/SceneHubAuthorizationTests.cs
@@ -55,8 +55,20 @@ public class SceneHubAuthorizationTests
 			.Because("the hub must authorize on the host's default scheme, like GameHub does");
 	}
 
+	/// <summary>
+	/// The principal an anonymous connection would carry — no authentication type, no claims — is refused by
+	/// the method body too. That is defence in depth, not the anonymous gate: these tests call the hub
+	/// directly, so no SignalR pipeline and therefore no <c>[Authorize]</c> ever runs, and
+	/// <c>SceneVisibility.ActingCharacter</c> reads only the <c>character_dbref</c> claim — it never consults
+	/// <c>Identity.IsAuthenticated</c>. The refusal below is the missing-character one, and the name says so.
+	///
+	/// <para>Rejecting an anonymous <em>connection</em> is unreachable from here and is asserted where it
+	/// lives: <see cref="SceneHub_CarriesTheAuthorizeAttribute_WithNoSchemeOverride"/> for the attribute and
+	/// its scheme, and the integration suite's <c>SceneHub_IsMappedAt_HubsScene</c> for the endpoint the
+	/// attribute is applied to.</para>
+	/// </summary>
 	[Test]
-	public async Task JoinScene_AnonymousCaller_IsRefusedAndNeverJoinsTheGroup()
+	public async Task JoinScene_UnauthenticatedIdentityWithNoCharacter_IsRefusedAndNeverJoinsTheGroup()
 	{
 		var service = new FixedSceneService(SceneFixture.SceneOwnedBy("#1", isPublic: true));
 		var (hub, groups) = HubFor(service, claimValue: null, authenticated: false);

--- a/SharpMUSH.Tests.ScenePlugin/SceneHubAuthorizationTests.cs
+++ b/SharpMUSH.Tests.ScenePlugin/SceneHubAuthorizationTests.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using SharpMUSH.Plugins.Scene.Web;
 using System.Reflection;
 using System.Security.Claims;
-using Scene = SharpMUSH.Plugins.Scene.Models.Scene;
 
 namespace SharpMUSH.Tests.ScenePlugin;
 
@@ -22,49 +21,19 @@ namespace SharpMUSH.Tests.ScenePlugin;
 /// </summary>
 public class SceneHubAuthorizationTests
 {
-	private const string CharacterDbrefClaim = "character_dbref";
-
-	/// <summary>God's claim as the auth handlers actually mint it — objid, not bare dbref.</summary>
-	private const string GodObjid = "#1:1785989066109";
-
-	/// <summary>A different, unrelated character's claim.</summary>
-	private const string StrangerObjid = "#7:1700000000000";
-
-	private static Scene SceneOwnedBy(string? ownerDbref, bool isPublic) => new(
-		Id: "scene-1",
-		Status: "active",
-		IsPublic: isPublic,
-		IsTempRoom: false,
-		ScheduledFor: null,
-		StartedAt: 1,
-		LastActivityAt: 2,
-		PoseCount: 0,
-		OwnerDbref: ownerDbref,
-		OwnerName: "God",
-		StarterDbref: ownerDbref,
-		StarterName: "God",
-		RoomDbref: null,
-		RoomName: string.Empty,
-		Meta: new Dictionary<string, string>());
-
 	/// <summary>
 	/// Builds the hub for a caller: <paramref name="claimValue"/> is the acting character, or null for a
-	/// caller with no character. <paramref name="authenticated"/> distinguishes the two null cases —
-	/// an anonymous connection (no authentication type) from a signed-in account acting as no character
-	/// (a guest, or an account whose only characters were unlinked). Both must be refused.
+	/// caller with no character. <paramref name="authenticated"/> picks which of the two null shapes
+	/// <see cref="SceneFixture.PrincipalFor"/> builds. Both must be refused.
 	/// </summary>
 	private static (SceneHub hub, RecordingGroupManager groups) HubFor(
 		FixedSceneService service, string? claimValue, bool authenticated = true)
 	{
-		var identity = claimValue is null
-			? authenticated ? new ClaimsIdentity(authenticationType: "TestScheme") : new ClaimsIdentity()
-			: new ClaimsIdentity([new Claim(CharacterDbrefClaim, claimValue)], "TestScheme");
-
 		var groups = new RecordingGroupManager();
 		var hub = new SceneHub(service, NullLogger<SceneHub>.Instance)
 		{
 			Groups = groups,
-			Context = new FakeHubCallerContext(new ClaimsPrincipal(identity)),
+			Context = new FakeHubCallerContext(SceneFixture.PrincipalFor(claimValue, authenticated)),
 		};
 
 		return (hub, groups);
@@ -89,7 +58,7 @@ public class SceneHubAuthorizationTests
 	[Test]
 	public async Task JoinScene_AnonymousCaller_IsRefusedAndNeverJoinsTheGroup()
 	{
-		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: true));
+		var service = new FixedSceneService(SceneFixture.SceneOwnedBy("#1", isPublic: true));
 		var (hub, groups) = HubFor(service, claimValue: null, authenticated: false);
 
 		await Assert.That(async () => await hub.JoinScene("scene-1")).Throws<HubException>();
@@ -103,7 +72,7 @@ public class SceneHubAuthorizationTests
 	[Test]
 	public async Task JoinScene_AuthenticatedAccountWithNoCharacter_IsRefusedEvenForAPublicScene()
 	{
-		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: true));
+		var service = new FixedSceneService(SceneFixture.SceneOwnedBy("#1", isPublic: true));
 		var (hub, groups) = HubFor(service, claimValue: null);
 
 		await Assert.That(async () => await hub.JoinScene("scene-1")).Throws<HubException>();
@@ -115,8 +84,8 @@ public class SceneHubAuthorizationTests
 	[Test]
 	public async Task JoinScene_PublicScene_AdmitsAnyCharacter()
 	{
-		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: true));
-		var (hub, groups) = HubFor(service, StrangerObjid);
+		var service = new FixedSceneService(SceneFixture.SceneOwnedBy("#1", isPublic: true));
+		var (hub, groups) = HubFor(service, SceneFixture.StrangerObjid);
 
 		await hub.JoinScene("scene-1");
 
@@ -126,8 +95,8 @@ public class SceneHubAuthorizationTests
 	[Test]
 	public async Task JoinScene_PrivateSceneOwnedByCaller_IsAdmitted()
 	{
-		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: false));
-		var (hub, groups) = HubFor(service, GodObjid);
+		var service = new FixedSceneService(SceneFixture.SceneOwnedBy("#1", isPublic: false));
+		var (hub, groups) = HubFor(service, SceneFixture.GodObjid);
 
 		await hub.JoinScene("scene-1");
 
@@ -139,22 +108,22 @@ public class SceneHubAuthorizationTests
 	[Test]
 	public async Task JoinScene_PrivateSceneCallerIsMember_IsAdmitted()
 	{
-		var service = new FixedSceneService(SceneOwnedBy("#7", isPublic: false)) { MemberDbref = "#1" };
-		var (hub, groups) = HubFor(service, GodObjid);
+		var service = new FixedSceneService(SceneFixture.SceneOwnedBy("#7", isPublic: false)) { MemberDbref = "#1" };
+		var (hub, groups) = HubFor(service, SceneFixture.GodObjid);
 
 		await hub.JoinScene("scene-1");
 
 		await Assert.That(groups.Added).IsEquivalentTo(new[] { ("conn-001", "scene:scene-1") });
 		// The storage resolves the reference against the live object, so it must be handed a parseable
 		// dbref — the canonical objid spelling, not a hash-stripped fragment.
-		await Assert.That(service.MemberLookups).Contains(GodObjid);
+		await Assert.That(service.MemberLookups).Contains(SceneFixture.GodObjid);
 	}
 
 	[Test]
 	public async Task JoinScene_PrivateSceneCallerIsNeitherOwnerNorMember_IsRefused()
 	{
-		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: false));
-		var (hub, groups) = HubFor(service, StrangerObjid);
+		var service = new FixedSceneService(SceneFixture.SceneOwnedBy("#1", isPublic: false));
+		var (hub, groups) = HubFor(service, SceneFixture.StrangerObjid);
 
 		await Assert.That(async () => await hub.JoinScene("scene-1")).Throws<HubException>();
 		await Assert.That(groups.Added).IsEmpty();
@@ -167,8 +136,8 @@ public class SceneHubAuthorizationTests
 	[Test]
 	public async Task JoinScene_UnknownScene_IsRefusedIndistinguishablyFromAnInvisibleOne()
 	{
-		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: false));
-		var (hub, _) = HubFor(service, StrangerObjid);
+		var service = new FixedSceneService(SceneFixture.SceneOwnedBy("#1", isPublic: false));
+		var (hub, _) = HubFor(service, SceneFixture.StrangerObjid);
 
 		var missing = await Assert.That(async () => await hub.JoinScene("no-such-scene")).Throws<HubException>();
 		var invisible = await Assert.That(async () => await hub.JoinScene("scene-1")).Throws<HubException>();
@@ -179,8 +148,8 @@ public class SceneHubAuthorizationTests
 	[Test]
 	public async Task JoinScene_WithoutASceneId_IsRefused()
 	{
-		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: true));
-		var (hub, groups) = HubFor(service, GodObjid);
+		var service = new FixedSceneService(SceneFixture.SceneOwnedBy("#1", isPublic: true));
+		var (hub, groups) = HubFor(service, SceneFixture.GodObjid);
 
 		await Assert.That(async () => await hub.JoinScene(null)).Throws<HubException>();
 		await Assert.That(groups.Added).IsEmpty();
@@ -189,7 +158,7 @@ public class SceneHubAuthorizationTests
 	[Test]
 	public async Task LeaveScene_WithoutACharacter_IsRefused()
 	{
-		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: true));
+		var service = new FixedSceneService(SceneFixture.SceneOwnedBy("#1", isPublic: true));
 		var (hub, groups) = HubFor(service, claimValue: null);
 
 		await Assert.That(async () => await hub.LeaveScene("scene-1")).Throws<HubException>();
@@ -204,8 +173,8 @@ public class SceneHubAuthorizationTests
 	[Test]
 	public async Task LeaveScene_WithACharacter_LeavesTheGroupWithoutConsultingVisibility()
 	{
-		var service = new FixedSceneService(SceneOwnedBy("#1", isPublic: false));
-		var (hub, groups) = HubFor(service, StrangerObjid);
+		var service = new FixedSceneService(SceneFixture.SceneOwnedBy("#1", isPublic: false));
+		var (hub, groups) = HubFor(service, SceneFixture.StrangerObjid);
 
 		await hub.LeaveScene("scene-1");
 

--- a/SharpMUSH.Tests.ScenePlugin/SceneServiceStub.cs
+++ b/SharpMUSH.Tests.ScenePlugin/SceneServiceStub.cs
@@ -3,6 +3,7 @@ using OneOf.Types;
 using SharpMUSH.Library.Models;
 using SharpMUSH.Plugins.Scene.Models;
 using SharpMUSH.Plugins.Scene.Storage;
+using System.Security.Claims;
 using Scene = SharpMUSH.Plugins.Scene.Models.Scene;
 
 namespace SharpMUSH.Tests.ScenePlugin;
@@ -90,4 +91,56 @@ internal sealed class FixedSceneService(params Scene[] scenes) : SceneServiceStu
 				new SceneMember(sceneId, MemberDbref, "God", "participant", string.Empty, true, 3))
 			: new NotFound());
 	}
+}
+
+/// <summary>
+/// The caller and scene shapes both authorization suites are written against. Shared for the same reason
+/// <see cref="FixedSceneService"/> is: the REST controller and the realtime hub answer visibility through
+/// one predicate, so a scene that is "public" or a caller that is "God" must mean the same thing on both
+/// sides. A second copy of either is how the two suites drift into proving different things.
+/// </summary>
+internal static class SceneFixture
+{
+	/// <summary>
+	/// Claim name carrying the acting character's dbref, spelled as the production auth handlers emit it.
+	/// A literal rather than a reference to <c>SceneVisibility.CharacterDbrefClaim</c>: the tests assert the
+	/// wire name, so reading it from the type under test would make a rename invisible here.
+	/// </summary>
+	public const string CharacterDbrefClaim = "character_dbref";
+
+	/// <summary>God's claim as the auth handlers actually mint it — objid, not bare dbref.</summary>
+	public const string GodObjid = "#1:1785989066109";
+
+	/// <summary>A different, unrelated character's claim.</summary>
+	public const string StrangerObjid = "#7:1700000000000";
+
+	/// <summary>A scene with the fixed id <c>scene-1</c>, owned by <paramref name="ownerDbref"/>.</summary>
+	public static Scene SceneOwnedBy(string? ownerDbref, bool isPublic) => new(
+		Id: "scene-1",
+		Status: "active",
+		IsPublic: isPublic,
+		IsTempRoom: false,
+		ScheduledFor: null,
+		StartedAt: 1,
+		LastActivityAt: 2,
+		PoseCount: 0,
+		OwnerDbref: ownerDbref,
+		OwnerName: "God",
+		StarterDbref: ownerDbref,
+		StarterName: "God",
+		RoomDbref: null,
+		RoomName: string.Empty,
+		Meta: new Dictionary<string, string>());
+
+	/// <summary>
+	/// The caller principal: <paramref name="claimValue"/> is the acting character, or null for a caller
+	/// with no character at all. <paramref name="authenticated"/> distinguishes the two null cases — an
+	/// identity with no authentication type (what an anonymous request carries) from a signed-in account
+	/// acting as no character (a guest, or an account whose only characters were unlinked). Both must be
+	/// refused, and neither surface is allowed to read anything but the claim to decide that.
+	/// </summary>
+	public static ClaimsPrincipal PrincipalFor(string? claimValue, bool authenticated = false) =>
+		new(claimValue is null
+			? authenticated ? new ClaimsIdentity(authenticationType: "TestScheme") : new ClaimsIdentity()
+			: new ClaimsIdentity([new Claim(CharacterDbrefClaim, claimValue)], "TestScheme"));
 }

--- a/SharpMUSH.Tests.ScenePlugin/SceneServiceStub.cs
+++ b/SharpMUSH.Tests.ScenePlugin/SceneServiceStub.cs
@@ -1,5 +1,6 @@
 using OneOf;
 using OneOf.Types;
+using SharpMUSH.Library.Models;
 using SharpMUSH.Plugins.Scene.Models;
 using SharpMUSH.Plugins.Scene.Storage;
 using Scene = SharpMUSH.Plugins.Scene.Models.Scene;
@@ -41,4 +42,52 @@ internal abstract class SceneServiceStub : ISceneService
 	public virtual Task<OneOf<None, NotFound>> UnlinkSceneFromPlotAsync(string plotId, string sceneId) => throw new NotSupportedException();
 	public virtual Task<OneOf<IReadOnlyList<string>, NotFound>> GetTagsAsync(string sceneId) => throw new NotSupportedException();
 	public virtual Task<OneOf<IReadOnlyList<string>, NotFound>> GetCastAsync(string sceneId) => throw new NotSupportedException();
+}
+
+/// <summary>
+/// Scene service over a fixed set of scenes, recording the dbrefs it was asked to look memberships up by
+/// (the second half of the dbref-spelling bug — a mangled reference resolves to no object at all).
+///
+/// <para>Shared by both authorization suites (<see cref="SceneControllerVisibilityTests"/> for REST,
+/// <see cref="SceneHubAuthorizationTests"/> for the realtime hub) on purpose: the two surfaces answer
+/// visibility through the one shared predicate, so they must be provable against the one fake.</para>
+/// </summary>
+internal sealed class FixedSceneService(params Scene[] scenes) : SceneServiceStub
+{
+	/// <summary>The member dbref that holds a membership edge on every scene, or null for none.</summary>
+	public string? MemberDbref { get; init; }
+
+	public List<string> MemberLookups { get; } = [];
+
+	public List<string> SceneLookups { get; } = [];
+
+	public override Task<OneOf<Scene, NotFound>> GetSceneAsync(string sceneId)
+	{
+		SceneLookups.Add(sceneId);
+
+		return Task.FromResult(scenes.FirstOrDefault(s => s.Id == sceneId) is { } scene
+			? OneOf<Scene, NotFound>.FromT0(scene)
+			: new NotFound());
+	}
+
+	public override Task<IReadOnlyList<Scene>> ListScenesAsync(string filter, string? viewerDbref = null,
+		long? fromUtcMillis = null, long? toUtcMillis = null, int count = 50) =>
+		Task.FromResult<IReadOnlyList<Scene>>(scenes);
+
+	public override Task<OneOf<SceneMember, NotFound>> GetMemberAsync(string sceneId, string playerDbref)
+	{
+		MemberLookups.Add(playerDbref);
+
+		// Match the storages, which resolve the reference through the live object rather than comparing
+		// strings: a bare dbref and its objid name the same player.
+		var matches = MemberDbref is { } member
+			&& DBRef.TryParse(member, out var expected)
+			&& DBRef.TryParse(playerDbref, out var actual)
+			&& expected!.Value.SameObjectAs(actual!.Value);
+
+		return Task.FromResult(matches
+			? OneOf<SceneMember, NotFound>.FromT0(
+				new SceneMember(sceneId, MemberDbref, "God", "participant", string.Empty, true, 3))
+			: new NotFound());
+	}
 }


### PR DESCRIPTION
Closes **F-17**, found while fixing #747 rather than by the route walk — that audit only exercised HTTP routes and never touched the SignalR surface, so this whole class of authorization sat outside its coverage.

**Targets `fix/portal-audit-02-server-side` (#747), not `main`**, and forks the stack there rather than extending it, so a security fix does not queue behind three unrelated PRs. It must sit on #747 because the visibility predicate it reuses is the one #747 fixed to use `DBRef.SameObjectAs`; based on `main` this would have reimplemented the exact string comparison #747 removed.

## The hole

`SceneHub` was 40 lines with **no `[Authorize]`**, and:

```csharp
public Task JoinScene(string sceneId) =>
    Groups.AddToGroupAsync(Context.ConnectionId, SceneGroupName(sceneId));
```

Any caller — including a fully anonymous one — could name any scene id and be added to its broadcast group, after which every pose sent to `scene:{id}` reached them. Private scenes leaked their live contents to whoever asked. The endpoint carried no authorization metadata at all.

This is the same trust boundary as #747 from the opposite side: that one wrongly locked owners **out** of their own private scenes; this let everyone **in**.

## The rule

Decided by the repo owner: *"Joining a Scene requires a Character. Guests cannot join scenes."*

Implemented as three deliberately separable layers:

1. **`[Authorize]` on the hub**, naming no scheme, so the host default — `AccountSession` in production, `DebugAuth` in development. This mirrors `GameHub` exactly; `MapHub<SceneHub>` picks the attribute up as endpoint metadata and the plugin's `MapEndpoints` runs after `UseAuthentication()`/`UseAuthorization()`.
2. **A usable `character_dbref` claim**, per method, read through the same accessor the REST side uses so the two cannot disagree about who is calling. Rejects guests and characterless accounts even for public scenes.
3. **Scene visibility** — public, owner, or member.

Layer 3 goes beyond the letter of the rule. Requiring a character stops guests but would still let any random player join someone else's private scene, which is the actual leak. It is written so that deleting one call from `JoinScene` relaxes it if that reading is wrong.

## Shared, not copied

The predicate moved to `SceneVisibility.cs` (internal static, same assembly). `SceneController.CanSeeAsync` is now a one-line delegation with the body moved verbatim. A duplicated authorization rule is how this class of bug recurs, so the controller and the hub now ask the same code. The 7 pre-existing `SceneControllerVisibilityTests` and #747's HTTP visibility tests pass untouched, which is the evidence the controller's behaviour did not shift.

## How refusal behaves

`HubException`, not a silent no-op — a quiet join leaves a dead subscription that is invisible in the browser. Missing and invisible scenes share one message so refusals cannot enumerate private scene ids; the no-character refusal names its reason, which leaks nothing. `SceneLive.razor` catches it and renders the existing scene-not-found card, so no new strings across 15 locales.

`LeaveScene` requires a character but **not** visibility, on purpose: dropping your own subscription only removes access, and requiring visibility would strand a player whose membership was revoked mid-scene — still receiving poses with no way to unsubscribe short of disconnecting. Both leave paths (navigation and `DisposeAsync`) tolerate refusal rather than throwing where nothing can catch it; previously an unhandled throw there would have left the page spinning.

## Verification

| Suite | Result |
|---|---|
| `SharpMUSH.Tests.ScenePlugin` | 20/20 (9 before, +11 new `SceneHubAuthorizationTests`) |
| `SharpMUSH.Tests` (full) | 5143 passed, 0 failed, 196 skipped |
| `SharpMUSH.Tests.Integration` `*Scene*` | 57/57 (56 before, +1 new) |
| `SharpMUSH.Tests.BUnit` | 404/404 |
| `dotnet build` | 0 errors; warnings-as-errors untouched, no suppressions |

Covered: anonymous rejected · account with no character rejected · owner of a private scene admitted · member admitted · non-member on a private scene rejected · any character admitted to a public scene · `LeaveScene` gated.

The new integration test is there because the hub gained constructor dependencies, and SignalR only activates a hub when a client connects — a hub that could not be built from the host container across the collectible plugin ALC would have passed every other test and failed in production. It does what `DefaultHubActivator` does, against the real running host.

## Two things to confirm

- **Anonymous rejection is proven at the attribute and method level, not over the wire.** The integration host runs Development, where `DebugAuthenticationHandler` auto-authenticates every request as God, so no wire-level anonymous connection is reachable in that suite.
- **A visible behaviour change:** a logged-out visitor can still read a public scene's archive over REST, but gets no live feed — `ConnectSceneHubAsync` now 401s. That follows directly from "Guests cannot join scenes", but it is worth confirming it is intended for public scenes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added secure real-time scene joining and leaving with validation for scene availability, visibility, and character access.
  - Added clear live-update availability messaging, with pose submission disabled when updates are unavailable.
  - Improved live scene navigation and cleanup when switching scenes or leaving the page.
  - Added localized messaging for unavailable live updates.

- **Bug Fixes**
  - Invalid or unauthorized scene operations are now rejected safely.
  - Connection interruptions during scene navigation no longer cause unnecessary errors.

- **Tests**
  - Added coverage for authorization, visibility, group membership, connection failures, and real-time hub activation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->