### PR TITLE
Build the out-of-solution plugin fixtures in the configuration asked for

### DIFF
--- a/SharpMUSH.Tests.Integration/SharpMUSH.Tests.Integration.csproj
+++ b/SharpMUSH.Tests.Integration/SharpMUSH.Tests.Integration.csproj
@@ -9,6 +9,10 @@
 		<LangVersion>default</LangVersion>
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 		<NoWarn>TUnit0038</NoWarn>
+		<!-- SamplePlugin is not in SharpMUSH.sln; without this a solution build unsets Configuration for it
+		     and it lands in bin/Debug while the copy target looks in bin/$(Configuration). See the matching
+		     note in SharpMUSH.Tests.csproj. -->
+		<ShouldUnsetParentConfigurationAndPlatform>false</ShouldUnsetParentConfigurationAndPlatform>
 		<RootNamespace>SharpMUSH.Tests.Integration</RootNamespace>
 	</PropertyGroup>
 
@@ -30,7 +34,9 @@
 		<!-- Shared test infrastructure (ServerWebAppFactory, test containers, etc.) -->
 		<ProjectReference Include="..\SharpMUSH.Tests.Infrastructure\SharpMUSH.Tests.Infrastructure.csproj" />
 		<!-- Build the SamplePlugin fixture before this project so its DLL exists to copy into plugins/.
-		     ReferenceOutputAssembly=false: we do NOT link the plugin; we load it at runtime from plugins/. -->
+		     ReferenceOutputAssembly=false: we do NOT link the plugin; we load it at runtime from plugins/.
+		     This one is outside the solution, so it depends on ShouldUnsetParentConfigurationAndPlatform
+		     above to build into bin/$(Configuration) rather than its own default. -->
 		<ProjectReference Include="..\SharpMUSH.Tests\Fixtures\SamplePlugin\SamplePlugin.csproj" ReferenceOutputAssembly="false" Private="false" SkipGetTargetFrameworkProperties="true" />
 		<!-- Build the Scene plugin (the Phase-5 reference plugin) before this project so its DLL exists to
 		     copy into plugins/scene/. ReferenceOutputAssembly=false: it is loaded at runtime, not linked. -->

--- a/SharpMUSH.Tests/SharpMUSH.Tests.csproj
+++ b/SharpMUSH.Tests/SharpMUSH.Tests.csproj
@@ -9,6 +9,13 @@
     <LangVersion>default</LangVersion>
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 		<NoWarn>TUnit0038;TUnitAssertions0002;ASPDEPR004;ASPDEPR008</NoWarn>
+		<!-- The Fixtures/ plugin projects are deliberately not in SharpMUSH.sln. When MSBuild builds a
+		     solution it unsets Configuration for ProjectReferences outside that solution, so those fixtures
+		     fell back to their own default (Debug) even under `dotnet build -c Release`, while the copy
+		     targets below looked in bin/$(Configuration) — the MSB3030 failures. Keeping the parent's
+		     Configuration makes the reference build where the copy expects it. Building either .csproj
+		     directly always worked, which is why only the solution-level Release build ever broke. -->
+		<ShouldUnsetParentConfigurationAndPlatform>false</ShouldUnsetParentConfigurationAndPlatform>
 	</PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`dotnet build SharpMUSH.sln -c Release` has been failing on `main` with eight `MSB3030` errors. It is independent of the portal-audit stack and targets `main` directly.

## What was happening

The copy targets in `SharpMUSH.Tests` and `SharpMUSH.Tests.Integration` look for the fixture plugins at `Fixtures/<name>/bin/$(Configuration)/net10.0`, and under `-c Release` nothing was there.

`CommandOnlyPlugin`, `ApplicationSourcePlugin` and `SamplePlugin` are deliberately **not** listed in `SharpMUSH.sln`. When MSBuild builds a solution it unsets `Configuration` and `Platform` for `ProjectReference`s pointing outside that solution, so each fixture fell back to its own default and built into `bin/Debug` — while the copy target still resolved `bin/Release`. The files really were missing; the reference had built them somewhere else.

Confirmed directly rather than inferred. From a clean tree, after `dotnet build SharpMUSH.sln -c Release`:

```
bin/Debug:   YES
bin/Release: no
```

## Why nobody hit it

Two reasons, and they compound:

- `dotnet build SharpMUSH.Tests/SharpMUSH.Tests.csproj -c Release` passes `Configuration` straight down and has always worked. Only the *solution-level* Release build breaks.
- CI never noticed because all four jobs in `_dotnet-build-test.yml` build Debug, where the guessed path and the actual output happen to agree.

## The fix

`ShouldUnsetParentConfigurationAndPlatform=false` on the two referencing test projects, which keeps the parent's configuration.

Per-reference `SetConfiguration` metadata does **not** work here — it is applied before the unset and discarded. I tried that first and it left the fixtures in `bin/Debug`, so the property is the mechanism that actually applies.

`HelloUiPlugin` and `SharpMUSH.Plugins.Scene` need no change: both **are** in the solution, so its configuration mapping already covers them. That is also why #747's Scene-plugin publish fix has no equivalent hole.

## Verification

From a clean tree (`Fixtures/*/bin` and `obj` removed before each):

| Build | MSB3030 | Fixtures land in |
|---|---|---|
| `SharpMUSH.sln -c Release` | **0** | `bin/Release` |
| `SharpMUSH.sln -c Debug` | **0** | `bin/Debug` |

- Plugin-loading tests, which consume the copied fixtures: **30/30**
- `SharpMUSH.Tests.BUnit`: **396/396**
- Build: 0 errors, `TreatWarningsAsErrors` untouched, no suppressions

## Worth noting

The copy targets still reconstruct another project's output path by hand, including a hardcoded `net10.0` that will need editing at the next TFM bump. Consuming the reference's real output (`GetTargetPath`) would remove that whole class of assumption — the same class as the `CopyScenePlugin` bug fixed in #747, where a hand-written target assumed `$(OutDir)` and produced a publish output with no plugins. Left alone here to keep this change to the actual defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved integration and test project build consistency.
  - Referenced fixture and sample projects now build using the selected solution configuration and platform.
  - Ensures generated test outputs are placed in the expected configuration-specific directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->