### PR TITLE
Portal audit 2/2: stop a session renewal from resurrecting a session that was just revoked

### DIFF
--- a/SharpMUSH.Database.ArangoDB/ArangoDatabase.Sessions.cs
+++ b/SharpMUSH.Database.ArangoDB/ArangoDatabase.Sessions.cs
@@ -54,6 +54,29 @@ public partial class ArangoDatabase
 						} }
 				}, cancellationToken: cancellationToken), cancellationToken);
 
+	/// <summary>
+	/// UPDATE, never UPSERT: the FOR/FILTER finds nothing when the document is gone, so the whole statement
+	/// is a no-op rather than an insert. Same exclusive transaction as the other session writes, so this
+	/// cannot interleave with a concurrent revoke either — it either runs before the delete and is undone
+	/// by it, or after and finds nothing.
+	/// </summary>
+	public async ValueTask<bool> TouchSessionExpiryAsync(string token, long expiryUnixMs,
+		CancellationToken cancellationToken = default)
+	{
+		var touched = false;
+		await InTransactionAsync(async tx =>
+		{
+			var updated = await arangoDb.Query.ExecuteAsync<string>(tx,
+				"FOR d IN @@c FILTER d._key == @key UPDATE d WITH { ExpiryUnixMs: @expiry } IN @@c RETURN NEW._key",
+				bindVars: new Dictionary<string, object>
+				{
+					{ "@c", DatabaseConstants.Sessions }, { "key", token }, { "expiry", expiryUnixMs }
+				}, cancellationToken: cancellationToken);
+			touched = updated.Count > 0;
+		}, cancellationToken);
+		return touched;
+	}
+
 	public async ValueTask<SharpSession?> GetSessionAsync(string token, CancellationToken cancellationToken = default)
 	{
 		var result = await arangoDb.Query.ExecuteAsync<JsonElement>(handle,

--- a/SharpMUSH.Database.Memgraph/MemgraphDatabase.Sessions.cs
+++ b/SharpMUSH.Database.Memgraph/MemgraphDatabase.Sessions.cs
@@ -24,6 +24,20 @@ public partial class MemgraphDatabase
 			}, cancellationToken);
 	}
 
+	/// <summary>
+	/// MATCH, never MERGE: the pattern binds nothing when the node is gone, so the SET never runs and no
+	/// node is created. <see cref="ExecuteWithRetryAsync"/> already retries the MVCC conflict a concurrent
+	/// revoke can raise, so a lost race here retries and then correctly finds nothing.
+	/// </summary>
+	public async ValueTask<bool> TouchSessionExpiryAsync(string token, long expiryUnixMs,
+		CancellationToken cancellationToken = default)
+	{
+		var result = await ExecuteWithRetryAsync(
+			"MATCH (s:Session {token: $token}) SET s.expiryUnixMs = $expiryUnixMs RETURN s.token AS token",
+			new { token, expiryUnixMs }, cancellationToken);
+		return result.Result.Count > 0;
+	}
+
 	public async ValueTask<SharpSession?> GetSessionAsync(string token, CancellationToken cancellationToken = default)
 	{
 		var result = await ExecuteWithRetryAsync(

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Sessions.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Sessions.cs
@@ -37,6 +37,21 @@ public partial class SurrealDatabase
 			parameters, cancellationToken);
 	}
 
+	/// <summary>
+	/// UPDATE, never UPSERT: since SurrealDB 2.0 the two are distinct statements, and UPDATE on a record
+	/// that does not exist affects nothing and creates nothing. The embedded engine serialises the
+	/// statement itself, so no extra guard is needed against a concurrent revoke.
+	/// </summary>
+	public async ValueTask<bool> TouchSessionExpiryAsync(string token, long expiryUnixMs,
+		CancellationToken cancellationToken = default)
+	{
+		var response = await ExecuteAsync(
+			"UPDATE type::thing('session', $token) SET expiryUnixMs = $expiryUnixMs RETURN AFTER",
+			new Dictionary<string, object?> { ["token"] = token, ["expiryUnixMs"] = expiryUnixMs },
+			cancellationToken);
+		return response.GetValue<List<SessionDbRecord>>(0) is { Count: > 0 };
+	}
+
 	public async ValueTask<SharpSession?> GetSessionAsync(string token, CancellationToken cancellationToken = default)
 	{
 		var response = await ExecuteAsync(

--- a/SharpMUSH.Library/ISharpDatabase.cs
+++ b/SharpMUSH.Library/ISharpDatabase.cs
@@ -832,6 +832,21 @@ public interface ISharpDatabase
 	/// <summary>Returns the session for a token, or null if absent.</summary>
 	ValueTask<SharpSession?> GetSessionAsync(string token, CancellationToken cancellationToken = default);
 
+	/// <summary>
+	/// Slides an existing session's expiry to <paramref name="expiryUnixMs"/>. Returns <c>true</c> if the
+	/// session was still there and was updated, <c>false</c> if it was gone.
+	/// </summary>
+	/// <remarks>
+	/// This exists because <see cref="UpsertSessionAsync"/> must not be used to renew a session. Renewal
+	/// is read-then-write, and the upsert's insert branch reinstates a document that a revocation deleted
+	/// in between — logout, <see cref="DeleteSessionsForAccountAsync"/>, or a ban — leaving a revoked
+	/// session alive for up to a full TTL. Renewal therefore has to be a conditional update that does
+	/// nothing at all when the document is absent, which is what this is. Only session creation may
+	/// insert.
+	/// </remarks>
+	ValueTask<bool> TouchSessionExpiryAsync(string token, long expiryUnixMs,
+		CancellationToken cancellationToken = default);
+
 	ValueTask DeleteSessionAsync(string token, CancellationToken cancellationToken = default);
 	ValueTask DeleteSessionsForAccountAsync(string accountId, CancellationToken cancellationToken = default);
 	ValueTask DeleteSessionsForIpAsync(string originIp, CancellationToken cancellationToken = default);

--- a/SharpMUSH.Library/Services/DatabaseAccountSessionStore.cs
+++ b/SharpMUSH.Library/Services/DatabaseAccountSessionStore.cs
@@ -70,8 +70,18 @@ public sealed class DatabaseAccountSessionStore(ISharpDatabase database) : IAcco
 		if (slid - s.ExpiryUnixMs < s.TtlMs * SlidePersistThresholdFractionOfTtl)
 			return identity;
 
-		s.ExpiryUnixMs = slid;
-		await database.UpsertSessionAsync(s, ct);
+		// TouchSessionExpiryAsync, not UpsertSessionAsync: the read above and this write are not atomic, and
+		// the upsert's insert branch would reinstate a session that a revocation deleted in between — a
+		// logout, an account ban, or a sitelock rule — keeping a revoked token alive for up to another full
+		// TTL. The conditional update does nothing when the document is gone, so the revocation stands.
+		//
+		// Losing that race also fails this validation. The false is not "no write was needed", it is the
+		// database stating that the session was already gone at the instant of the write; the caller learns
+		// that for free, and authenticating on a token that a ban has already revoked is exactly the
+		// outcome the ban exists to prevent. Only CreateTokenAsync may insert a session.
+		if (!await database.TouchSessionExpiryAsync(token, slid, ct))
+			return null;
+
 		return identity;
 	}
 

--- a/SharpMUSH.Library/Services/Interfaces/IAccountSessionStore.cs
+++ b/SharpMUSH.Library/Services/Interfaces/IAccountSessionStore.cs
@@ -27,7 +27,9 @@ public interface IAccountSessionStore
 
 	/// <summary>
 	/// Validates a token. If valid and unexpired, returns the bound account and acting character and
-	/// slides the expiry window by the original TTL. Returns <c>null</c> if unknown or expired.
+	/// slides the expiry window by the original TTL. Returns <c>null</c> if unknown, expired, or revoked
+	/// while this very call was in flight — a token a ban has already taken away must not authenticate
+	/// the request that was holding it.
 	/// </summary>
 	Task<SessionIdentity?> ValidateAsync(string token, CancellationToken ct = default);
 

--- a/SharpMUSH.Tests.Integration/Auth/BanEnforcementTests.cs
+++ b/SharpMUSH.Tests.Integration/Auth/BanEnforcementTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using SharpMUSH.Library;
 using SharpMUSH.Library.Services.Interfaces;
 using SharpMUSH.Server.Services;
 using SharpMUSH.Tests.Infrastructure;
@@ -61,5 +62,35 @@ public class BanEnforcementTests(ServerWebAppFactory factory)
 
 		// The session token no longer authenticates.
 		await Assert.That(await sessions.ValidateAsync(account.AccountSessionToken)).IsNull();
+	}
+
+	/// <summary>
+	/// The ban-evasion window, proved closed against whichever real provider the suite is running.
+	/// <see cref="IAccountSessionStore.ValidateAsync"/> renews a session by reading it and then writing a
+	/// slid expiry back, and the two halves are not atomic. Spelled out here in the same order the store
+	/// performs them, with the ban landing between: the renewal must find nothing and write nothing, or
+	/// the banned account keeps a working token for up to another full TTL.
+	/// </summary>
+	[Test]
+	public async Task AccountBan_CommittingBetweenASessionsReadAndItsRenewal_IsNotUndoneByTheRenewal()
+	{
+		var (_, account) = await RegisterAccountAsync();
+		var database = factory.Services.GetRequiredService<ISharpDatabase>();
+		var enforcement = factory.Services.GetRequiredService<BanEnforcementService>();
+		var sessions = factory.Services.GetRequiredService<IAccountSessionStore>();
+		var token = account.AccountSessionToken;
+
+		var read = await database.GetSessionAsync(token);
+		await Assert.That(read).IsNotNull();
+
+		await enforcement.EnforceAccountBanAsync(account.AccountId);
+
+		var renewed = await database.TouchSessionExpiryAsync(token, read!.ExpiryUnixMs + 60_000);
+
+		await Assert.That(renewed).IsFalse()
+			.Because("the renewal must report that the session was already gone, not put it back");
+		await Assert.That(await database.GetSessionAsync(token)).IsNull()
+			.Because("a ban that commits mid-validation must survive the renewal write that follows it");
+		await Assert.That(await sessions.ValidateAsync(token)).IsNull();
 	}
 }

--- a/SharpMUSH.Tests/Database/SessionStoreDbTests.cs
+++ b/SharpMUSH.Tests/Database/SessionStoreDbTests.cs
@@ -32,6 +32,33 @@ public class SessionStoreDbTests
 		await Assert.That(await Db.GetSessionAsync("tok-rt-1")).IsNull();
 	}
 
+	/// <summary>
+	/// The provider-level contract behind the revocation race: renewal slides a live session but is a
+	/// no-op — never an insert — once the document is gone. An insert here is what resurrects a session
+	/// that a logout or a ban deleted while a request was mid-validation.
+	/// </summary>
+	[Test, NotInParallel(nameof(SessionStoreDbTests))]
+	public async Task TouchSessionExpiry_SlidesALiveSession_AndNeverInsertsARevokedOne()
+	{
+		var s = Make("tok-touch-1", "acctTouch", "203.0.113.40");
+		await Db.UpsertSessionAsync(s);
+
+		var slid = s.ExpiryUnixMs + 60_000;
+		await Assert.That(await Db.TouchSessionExpiryAsync("tok-touch-1", slid)).IsTrue();
+
+		var touched = await Db.GetSessionAsync("tok-touch-1");
+		await Assert.That(touched!.ExpiryUnixMs).IsEqualTo(slid);
+		await Assert.That(touched.AccountId).IsEqualTo("acctTouch")
+			.Because("a touch slides the expiry and leaves the rest of the document alone");
+		await Assert.That(touched.OriginIp).IsEqualTo("203.0.113.40");
+
+		await Db.DeleteSessionAsync("tok-touch-1");
+
+		await Assert.That(await Db.TouchSessionExpiryAsync("tok-touch-1", slid + 60_000)).IsFalse();
+		await Assert.That(await Db.GetSessionAsync("tok-touch-1")).IsNull()
+			.Because("renewal must never insert — that is exactly what resurrects a revoked session");
+	}
+
 	[Test, NotInParallel(nameof(SessionStoreDbTests))]
 	public async Task DeleteForAccount_And_ForIp()
 	{

--- a/SharpMUSH.Tests/Database/SurrealSessionStoreTests.cs
+++ b/SharpMUSH.Tests/Database/SurrealSessionStoreTests.cs
@@ -89,6 +89,35 @@ public class SurrealSessionStoreTests
 		await Assert.That(await db.GetSessionAsync("tok-conc")).IsNotNull();
 	}
 
+	/// <summary>
+	/// Same contract as <see cref="SessionStoreDbTests.TouchSessionExpiry_SlidesALiveSession_AndNeverInsertsARevokedOne"/>,
+	/// pinned here because the ArangoDB/Memgraph test host has no SurrealDB leg. It also pins the
+	/// SurrealDB-specific premise: since 2.0, UPDATE and UPSERT are distinct statements and UPDATE on a
+	/// record that does not exist creates nothing.
+	/// </summary>
+	[Test]
+	public async Task TouchSessionExpiry_SlidesALiveSession_AndNeverInsertsARevokedOne()
+	{
+		var db = await CreateFreshMigratedSurrealDatabaseAsync("touch");
+		var s = Make("tok-touch-1", "acctTouch", "203.0.113.40");
+		await db.UpsertSessionAsync(s);
+
+		var slid = s.ExpiryUnixMs + 60_000;
+		await Assert.That(await db.TouchSessionExpiryAsync("tok-touch-1", slid)).IsTrue();
+
+		var touched = await db.GetSessionAsync("tok-touch-1");
+		await Assert.That(touched!.ExpiryUnixMs).IsEqualTo(slid);
+		await Assert.That(touched.AccountId).IsEqualTo("acctTouch")
+			.Because("a touch slides the expiry and leaves the rest of the document alone");
+		await Assert.That(touched.OriginIp).IsEqualTo("203.0.113.40");
+
+		await db.DeleteSessionAsync("tok-touch-1");
+
+		await Assert.That(await db.TouchSessionExpiryAsync("tok-touch-1", slid + 60_000)).IsFalse();
+		await Assert.That(await db.GetSessionAsync("tok-touch-1")).IsNull()
+			.Because("renewal must never insert — that is exactly what resurrects a revoked session");
+	}
+
 	[Test]
 	public async Task DeleteForAccount_And_ForIp()
 	{

--- a/SharpMUSH.Tests/Services/BanEnforcementServiceTests.cs
+++ b/SharpMUSH.Tests/Services/BanEnforcementServiceTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using SharpMUSH.Library;
 using SharpMUSH.Library.Models;
+using SharpMUSH.Library.Services;
 using SharpMUSH.Library.Services.Interfaces;
 using SharpMUSH.Messaging.Abstractions;
 using SharpMUSH.Messaging.Messages;
@@ -56,9 +57,10 @@ public class BanEnforcementServiceTests
 		HubConnectionRegistry Registry,
 		ISharpDatabase Database)
 		Build(IEnumerable<IConnectionService.ConnectionData>? liveConnections = null,
-			IReadOnlyList<SharpPlayer>? linkedCharacters = null)
+			IReadOnlyList<SharpPlayer>? linkedCharacters = null,
+			IAccountSessionStore? sessionStore = null)
 	{
-		var sessions = Substitute.For<IAccountSessionStore>();
+		var sessions = sessionStore ?? Substitute.For<IAccountSessionStore>();
 		var cache = Substitute.For<IFusionCache>();
 		var connections = Substitute.For<IConnectionService>();
 		connections.GetAll().Returns((liveConnections ?? []).ToAsyncEnumerable());
@@ -294,5 +296,36 @@ public class BanEnforcementServiceTests
 			Arg.Is<string>(ip => string.Equals(ip, "unknown", StringComparison.OrdinalIgnoreCase)),
 			Arg.Any<CancellationToken>());
 		await Assert.That(abortedUnknown).IsFalse();
+	}
+
+	/// <summary>
+	/// The ban-evasion window this whole conditional-renewal change exists to close. A ban revokes an
+	/// account's sessions, but session renewal is read-then-write and the two halves are not atomic: a ban
+	/// landing between them used to be undone by the insert branch of the upsert that wrote the slid expiry
+	/// back, and the banned account kept a working token for up to another full TTL.
+	/// </summary>
+	/// <remarks>
+	/// Run against a real <see cref="DatabaseAccountSessionStore"/> rather than the substituted session
+	/// store the rest of this class uses, because the defect lives in how the store sequences its two
+	/// database calls — a substitute would assert nothing about it.
+	/// </remarks>
+	[Test]
+	public async Task EnforceAccountBanAsync_CommittingBetweenARenewalsReadAndItsWrite_LeavesTheSessionRevoked()
+	{
+		var spy = new SessionSpy();
+		var store = new DatabaseAccountSessionStore(spy.Database);
+		var (svc, _, _, _, _, _, _) = Build(sessionStore: store);
+
+		var token = await store.CreateTokenAsync("accounts/1", TimeSpan.FromMinutes(15), "203.0.113.66");
+		spy.AgeBy(TimeSpan.FromMinutes(1)); // past the coalescing threshold, so this validation really writes
+
+		spy.AfterNextRead = async () => await svc.EnforceAccountBanAsync("accounts/1");
+
+		var identity = await store.ValidateAsync(token);
+
+		await Assert.That(spy.Stored).IsNull()
+			.Because("a ban that commits mid-validation must not be undone by the renewal write");
+		await Assert.That(identity).IsNull()
+			.Because("a banned account's token must not authenticate the request that was already holding it");
 	}
 }

--- a/SharpMUSH.Tests/Services/DatabaseAccountSessionStoreTests.cs
+++ b/SharpMUSH.Tests/Services/DatabaseAccountSessionStoreTests.cs
@@ -1,58 +1,15 @@
-using NSubstitute;
-using SharpMUSH.Library;
-using SharpMUSH.Library.Models;
 using SharpMUSH.Library.Services;
 
 namespace SharpMUSH.Tests.Services;
 
 /// <summary>
-/// Unit cover for the write-coalescing half of the session-concurrency fix. The exclusive transaction in
-/// the ArangoDB provider stops concurrent slides from failing; this is what stops them from happening at
-/// all, so it is asserted by counting writes rather than by observing latency.
+/// Unit cover for the two halves of the session-renewal contract: the write-coalescing that keeps a burst
+/// of validations from writing at all (asserted by counting writes rather than by observing latency), and
+/// the rule that a renewal may never insert — so a revocation landing between the read and the write is
+/// not undone by it.
 /// </summary>
 public class DatabaseAccountSessionStoreTests
 {
-	/// <summary>
-	/// A substituted <see cref="ISharpDatabase"/> holding exactly one session, counting the writes the
-	/// store issues against it.
-	/// </summary>
-	private sealed class SessionSpy
-	{
-		public ISharpDatabase Database { get; } = Substitute.For<ISharpDatabase>();
-		public SharpSession? Stored { get; private set; }
-		public int Upserts { get; private set; }
-		public int Deletes { get; private set; }
-
-		public SessionSpy()
-		{
-			Database.GetSessionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-				.Returns(_ => ValueTask.FromResult(Stored));
-			Database.When(x => x.UpsertSessionAsync(Arg.Any<SharpSession>(), Arg.Any<CancellationToken>()))
-				.Do(call =>
-				{
-					Upserts++;
-					var s = call.Arg<SharpSession>();
-					// Copy: the store mutates the instance it read back, so keeping the reference would
-					// make the "stored" expiry follow un-persisted slides.
-					Stored = new SharpSession
-					{
-						Token = s.Token, AccountId = s.AccountId, OriginIp = s.OriginIp,
-						ExpiryUnixMs = s.ExpiryUnixMs, TtlMs = s.TtlMs,
-						CharacterKey = s.CharacterKey, CharacterCreationTime = s.CharacterCreationTime
-					};
-				});
-			Database.When(x => x.DeleteSessionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
-				.Do(_ =>
-				{
-					Deletes++;
-					Stored = null;
-				});
-		}
-
-		/// <summary>Backdates the persisted expiry, standing in for time passing since the last write.</summary>
-		public void AgeBy(TimeSpan elapsed) => Stored!.ExpiryUnixMs -= (long)elapsed.TotalMilliseconds;
-	}
-
 	[Test]
 	public async Task Validate_RepeatedlyWithinTheThreshold_WritesNothing()
 	{
@@ -66,6 +23,7 @@ public class DatabaseAccountSessionStoreTests
 
 		await Assert.That(spy.Upserts).IsEqualTo(1)
 			.Because("a burst of validations inside the threshold must not re-persist the same expiry");
+		await Assert.That(spy.Touches).IsEqualTo(0);
 	}
 
 	[Test]
@@ -80,7 +38,9 @@ public class DatabaseAccountSessionStoreTests
 		spy.AgeBy(TimeSpan.FromMinutes(1));
 
 		await Assert.That((await store.ValidateAsync(token))?.AccountId).IsEqualTo("acct-1");
-		await Assert.That(spy.Upserts).IsEqualTo(2);
+		await Assert.That(spy.Touches).IsEqualTo(1);
+		await Assert.That(spy.Upserts).IsEqualTo(1)
+			.Because("only minting a token may insert one; renewal is a conditional update");
 		await Assert.That(spy.Stored!.ExpiryUnixMs).IsGreaterThanOrEqualTo(expiryAtMint);
 	}
 
@@ -97,5 +57,29 @@ public class DatabaseAccountSessionStoreTests
 		await Assert.That(spy.Deletes).IsEqualTo(1);
 		await Assert.That(spy.Upserts).IsEqualTo(1)
 			.Because("an expired session is removed, never slid");
+		await Assert.That(spy.Touches).IsEqualTo(0);
+	}
+
+	/// <summary>
+	/// The resurrection race. Renewal is read-then-write and the two are not atomic, so a logout committing
+	/// in between used to be undone by the insert branch of the upsert that wrote the slid expiry back —
+	/// leaving a token the user had explicitly given up alive for up to another full TTL.
+	/// </summary>
+	[Test]
+	public async Task Validate_WhenALogoutCommitsBetweenTheReadAndTheRenewal_DoesNotResurrectTheSession()
+	{
+		var spy = new SessionSpy();
+		var store = new DatabaseAccountSessionStore(spy.Database);
+		var token = await store.CreateTokenAsync("acct-1", TimeSpan.FromMinutes(15), "203.0.113.1");
+		spy.AgeBy(TimeSpan.FromMinutes(1)); // past the coalescing threshold, so this validation really writes
+
+		spy.AfterNextRead = async () => await store.RevokeAsync(token);
+
+		var identity = await store.ValidateAsync(token);
+
+		await Assert.That(spy.Stored).IsNull()
+			.Because("a revocation that commits mid-validation must not be undone by the renewal write");
+		await Assert.That(identity).IsNull()
+			.Because("a request holding a token that has already been revoked must not authenticate");
 	}
 }

--- a/SharpMUSH.Tests/Services/SessionSpy.cs
+++ b/SharpMUSH.Tests/Services/SessionSpy.cs
@@ -1,0 +1,79 @@
+using NSubstitute;
+using SharpMUSH.Library;
+using SharpMUSH.Library.Models;
+
+namespace SharpMUSH.Tests.Services;
+
+/// <summary>
+/// A substituted <see cref="ISharpDatabase"/> holding exactly one session, counting the writes a
+/// <see cref="Library.Services.DatabaseAccountSessionStore"/> issues against it and distinguishing the
+/// two kinds: the insert-capable upsert and the conditional expiry touch.
+/// </summary>
+internal sealed class SessionSpy
+{
+	public ISharpDatabase Database { get; } = Substitute.For<ISharpDatabase>();
+	public SharpSession? Stored { get; private set; }
+	public int Upserts { get; private set; }
+	public int Touches { get; private set; }
+	public int Deletes { get; private set; }
+
+	/// <summary>
+	/// Runs once, immediately after a read returns, before the caller can act on it. This is the seam that
+	/// pins the read-then-write race: whatever it does commits strictly between the two halves.
+	/// </summary>
+	public Func<ValueTask>? AfterNextRead { get; set; }
+
+	public SessionSpy()
+	{
+		Database.GetSessionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+			.Returns(_ => new ValueTask<SharpSession?>(ReadAsync()));
+		Database.When(x => x.UpsertSessionAsync(Arg.Any<SharpSession>(), Arg.Any<CancellationToken>()))
+			.Do(call =>
+			{
+				Upserts++;
+				var s = call.Arg<SharpSession>();
+				// Copy: the store mutates the instance it read back, so keeping the reference would
+				// make the "stored" expiry follow un-persisted slides.
+				Stored = new SharpSession
+				{
+					Token = s.Token, AccountId = s.AccountId, OriginIp = s.OriginIp,
+					ExpiryUnixMs = s.ExpiryUnixMs, TtlMs = s.TtlMs,
+					CharacterKey = s.CharacterKey, CharacterCreationTime = s.CharacterCreationTime
+				};
+			});
+		Database.TouchSessionExpiryAsync(Arg.Any<string>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+			.Returns(call =>
+			{
+				Touches++;
+				// The whole point of the method: absent document, no write, no insert.
+				if (Stored is null) return new ValueTask<bool>(false);
+				Stored.ExpiryUnixMs = call.Arg<long>();
+				return new ValueTask<bool>(true);
+			});
+		Database.When(x => x.DeleteSessionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+			.Do(_ =>
+			{
+				Deletes++;
+				Stored = null;
+			});
+		Database.When(x => x.DeleteSessionsForAccountAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+			.Do(call =>
+			{
+				if (Stored?.AccountId != call.Arg<string>()) return;
+				Deletes++;
+				Stored = null;
+			});
+	}
+
+	private async Task<SharpSession?> ReadAsync()
+	{
+		var read = Stored;
+		var hook = AfterNextRead;
+		AfterNextRead = null;
+		if (hook is not null) await hook();
+		return read;
+	}
+
+	/// <summary>Backdates the persisted expiry, standing in for time passing since the last write.</summary>
+	public void AgeBy(TimeSpan elapsed) => Stored!.ExpiryUnixMs -= (long)elapsed.TotalMilliseconds;
+}


### PR DESCRIPTION
**PR 2 of a 10-PR stack. It targets `fix/audit2-01-session-concurrency` (#754), not `main`** — the diff below is only this PR's two commits; #754's changes ride underneath.

Closes the resurrection race that #754 identified, narrowed, and deliberately left alone.

## The race

`DatabaseAccountSessionStore.ValidateAsync` renews a session in two steps that are not atomic:

1. `GetSessionAsync(token)` — read
2. write the slid expiry back

Step 2 used `UpsertSessionAsync`, whose AQL is `UPSERT { _key: @key } INSERT @doc REPLACE @doc IN @@c` (and, in the other two providers, a Cypher `MERGE` and a SurrealQL `UPSERT`). All three create the document when it is absent.

So if a revocation commits between 1 and 2, the write takes the **insert** branch and puts the deleted document straight back — with a *freshly slid* expiry. The revoked session then lives for up to another full TTL.

Every revocation path can lose it: `RevokeAsync` (logout), `RevokeAllForAccountAsync`, `RevokeAllForIpAsync`, and `BanEnforcementService`.

## Why it is a ban-evasion window, not just an untidy write

`BanEnforcementService` is the chokepoint every ban flows through, and its first fan-out is `RevokeAllForAccountAsync`. Every step is independently guarded so a ban "lands as completely as possible" — and it will report having landed completely. It drops the telnet handles, aborts the SignalR connections, invalidates the cached claims, deletes the session rows.

Then an in-flight REST request that had already read its session row writes it back, and the banned account holds a working bearer token again. Nothing logs anything; nothing failed. The next request re-slides it, so as long as the account keeps browsing, the token never expires. The admin's ban is silently undone by ordinary traffic from the person being banned.

#754 narrowed the window by roughly the factor it cut write volume (only a validation past the 2%-of-TTL coalescing threshold writes at all), which is a real reduction and not a fix: the window is still open on exactly the requests that do write.

## The fix

New on `ISharpDatabase`:

```csharp
ValueTask<bool> TouchSessionExpiryAsync(string token, long expiryUnixMs, CancellationToken ct = default);
```

A conditional update: slides the expiry of a session that is still there, does nothing at all when it is not, and reports which happened. `CreateTokenAsync` legitimately inserts and keeps `UpsertSessionAsync`; renewal is now the only other session write and it can no longer create anything.

Per provider, following each one's established idiom:

| Provider | Statement | Why it cannot insert |
|---|---|---|
| ArangoDB | `FOR d IN @@c FILTER d._key == @key UPDATE d WITH { ExpiryUnixMs: @expiry } IN @@c RETURN NEW._key` | `FOR`/`FILTER` binds nothing when the document is gone, so the whole statement is a no-op. Runs in the same exclusive transaction #754 put the other session writes in (`InTransactionAsync`), so it cannot interleave with a concurrent revoke either. |
| Memgraph | `MATCH (s:Session {token: $token}) SET s.expiryUnixMs = $expiryUnixMs RETURN s.token` | `MATCH` binds nothing, so the `SET` never runs — unlike the `MERGE` the upsert uses. Goes through `ExecuteWithRetryAsync`, which #754 noted already retries MVCC write-write conflicts, so a lost race retries and then correctly finds nothing. |
| SurrealDB | `UPDATE type::thing('session', $token) SET expiryUnixMs = $expiryUnixMs RETURN AFTER` | Since SurrealDB 2.0 `UPDATE` and `UPSERT` are distinct statements and `UPDATE` on a nonexistent record creates nothing. The provider already uses 2.x syntax. Pinned by test rather than assumed. |

## The decision: a session revoked mid-request does not authenticate that request

`TouchSessionExpiryAsync` returns `bool`, and `ValidateAsync` returns `null` when it comes back `false`.

The alternative — swallow the `false` and authenticate anyway, since the read did find a live session — was rejected. The `false` is not "no write was needed"; it is the database stating authoritatively, at the instant of the write, that the session was already gone. Authenticating a request on a token a ban has already taken away is precisely the outcome the ban exists to prevent, and the store learns it for free: no extra round trip, no extra read. Rejecting is the strictly-more-correct reading of information already in hand.

The cost is bounded and correct: the only request that can be turned away is one whose session was revoked while it was in flight, which is a request that *should* be turned away. A logout that races its own last request loses that request — the user is logging out.

Note that write-coalescing means a validation inside the 2%-of-TTL threshold does not write and therefore cannot detect a concurrent revoke. That is not a gap in this fix: such a request read a live session and does not resurrect anything. The damage was never "one request slipped through", it was "the session came back to life for a full TTL".

Also removed a dead `s.ExpiryUnixMs = slid` assignment left with nothing downstream of it.

## Verification

### The regression tests fail before the fix

Confirmed by reverting **only** `ValidateAsync`'s write call back to `await database.UpsertSessionAsync(s, ct)` — the new provider methods left in place so the tests still compile — and re-running:

```
failed Validate_WhenALogoutCommitsBetweenTheReadAndTheRenewal_DoesNotResurrectTheSession (95ms)
  AssertionException: Expected to be null, because a revocation that commits mid-validation
  must not be undone by the renewal write
  at Assert.That(spy.Stored).IsNull()

failed Validate_AfterTheThresholdElapses_PersistsTheSlide (95ms)
  AssertionException: Expected to be 1
  at Assert.That(spy.Touches).IsEqualTo(1)

failed EnforceAccountBanAsync_CommittingBetweenARenewalsReadAndItsWrite_LeavesTheSessionRevoked (71ms)
  AssertionException: Expected to be null, because a ban that commits mid-validation must not
  be undone by the renewal write
  at Assert.That(spy.Stored).IsNull()
```

`spy.Stored` being non-null there *is* the resurrection: the session document existed again after a revocation had deleted it.

### The interleaving is pinned, not hoped for

`SessionSpy` (extracted from #754's nested spy into `SharpMUSH.Tests/Services/SessionSpy.cs` so the ban test can share it) gained an `AfterNextRead` hook that runs once, immediately after a read returns and before the caller can act on it. Whatever it does commits strictly between the two halves of the renewal. No sleeps, no thread racing, deterministic every run.

- **Logout path** — `AfterNextRead` calls `store.RevokeAsync(token)`.
- **Ban path** — `AfterNextRead` calls the real `BanEnforcementService.EnforceAccountBanAsync`, wired to a real `DatabaseAccountSessionStore` (the rest of that test class substitutes the session store; this test cannot, because the defect is in how the store sequences its two database calls).

### Test runs (all observed locally, Podman/Testcontainers)

| Suite | Provider | Result |
|---|---|---|
| `DatabaseAccountSessionStoreTests` | — (unit) | 4/4 passed |
| `BanEnforcementServiceTests` | — (unit) | 13/13 passed |
| `SessionStoreDbTests` | arangodb | 3/3 passed (25.5s) |
| `SessionStoreDbTests` | memgraph | 3/3 passed (14.2s) |
| `SurrealSessionStoreTests` | surrealdb | 4/4 passed |
| `BanEnforcementTests` (integration) | arangodb | 2/2 passed (28.0s) |
| `BanEnforcementTests` (integration) | memgraph | 2/2 passed (19.3s) |
| `BanEnforcementTests` (integration) | surrealdb | 2/2 passed (13.1s) |
| Whole `SharpMUSH.Tests.Integration.Auth` namespace | arangodb | 68/68 passed |
| Whole `SharpMUSH.Tests.Integration.Auth` namespace | memgraph | 68/68 passed |
| Whole `SharpMUSH.Tests.Integration.Auth` namespace | surrealdb | 68/68 passed |
| Whole `SharpMUSH.Tests.Services` namespace | — | 0 failed / 390 succeeded |
| Whole `SharpMUSH.Tests.Database` namespace | arangodb | 116/116 passed |

Provider coverage note: `SharpMUSH.Tests`'s own `ServerWebAppFactory` has no SurrealDB leg (only arangodb/memgraph), which is why `SurrealSessionStoreTests` exists as a separate in-memory suite — the new provider-contract test is duplicated there so all three providers are covered. `SharpMUSH.Tests.Integration`'s factory does have all three, so the end-to-end ban test genuinely runs on each.

### Build

`dotnet build -t:Rebuild`: **0 errors, 33 warnings** — byte-identical to the same rebuild with these changes stashed. No suppressions added, `TreatWarningsAsErrors` untouched. `dotnet format whitespace` reports no changes (two passes, per CLAUDE.md).

## Found but left out of scope

`RevokeAllForIpAsync` is keyed on exact IP equality, so a session created from one address and later used from another is not revoked by a sitelock rule matching the *current* address. `BanEnforcementService` already compensates by collecting concrete IPs from live connections, but a session with no live connection at ban time is missed. That is a different bug with a different fix (re-checking sitelock at validation time) and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MPRzndB5egy4F2A3q5852
