### PR TITLE
Fix the two defects every brand-new player hits, and the onboarding gap they sit inside

### DIFF
--- a/SharpMUSH.Client/Pages/CharacterCreate.razor
+++ b/SharpMUSH.Client/Pages/CharacterCreate.razor
@@ -11,6 +11,15 @@
 <div style="padding:var(--cpad);">
     <MudPaper Elevation="0" Class="pa-6"
               Style="max-width:560px;margin:0 auto;background:var(--surface);border:1px solid var(--border-soft);">
+        @* An account with no character yet is mid-onboarding, not short of a permission. Login
+           routes it straight here, and this line says why it landed here rather than the portal. *@
+        @if (_onboarding)
+        {
+            <MudAlert Severity="Severity.Info" Dense="true" Class="mb-4" id="onboarding-notice">
+                @Loc["OnboardingCreateFirstCharacter"]
+            </MudAlert>
+        }
+
         <MudText Typo="Typo.h5" GutterBottom="true">@Loc["NavCreateACharacter"]</MudText>
         <MudText Typo="Typo.body2" Style="color:var(--text-faint);">
             @Loc["NavCreateCharacterBlurb"]
@@ -39,6 +48,20 @@
     private string _password = string.Empty;
     private string? _error;
     private bool _busy;
+    private bool _onboarding;
+
+    /// <summary>
+    /// Loads the roster so the page knows whether this is the account's first character. A reloaded
+    /// tab hydrates its session from sessionStorage but not its roster, so without this the local
+    /// count is 0 for everyone — which would both show the onboarding line to an established player
+    /// and make CreateAsync below mistake their second character for their first.
+    /// A failed fetch is left alone: "we could not ask" must not render as "you have none".
+    /// </summary>
+    protected override async Task OnInitializedAsync()
+    {
+        var roster = await AccountAuth.GetCharactersAsync();
+        _onboarding = roster.Match(characters => characters.Count == 0, _ => false);
+    }
 
     private async Task CreateAsync()
     {

--- a/SharpMUSH.Client/Pages/Login.razor
+++ b/SharpMUSH.Client/Pages/Login.razor
@@ -90,6 +90,15 @@
     private const int SignInTabIndex = 0;
     private const int RegisterTabIndex = 1;
 
+    /// <summary>
+    /// Where an account with no character yet lands. "Registered, no character" is a step in
+    /// onboarding, not a degraded permission tier: dropping such an account into the full portal
+    /// shows it a shell where every gated surface refuses without saying why, while telnet's
+    /// `login` names the exact next command. This routes it to the one page that resolves the
+    /// state, which explains itself on arrival.
+    /// </summary>
+    private const string OnboardingUrl = "/characters/new";
+
     private int _tabIndex = SignInTabIndex;
     private bool _busy;
     private string? _error;
@@ -155,10 +164,10 @@
         }
         _busy = true;
         StateHasChanged();
-        var (success, error, _) = await AccountAuth.LoginAsync(_loginIdentifier, _loginPassword);
+        var (success, error, characters) = await AccountAuth.LoginAsync(_loginIdentifier, _loginPassword);
         _busy = false;
         if (success)
-            Nav.NavigateTo(SuccessUrl());
+            Nav.NavigateTo(characters.Count == 0 ? OnboardingUrl : SuccessUrl());
         else
             _error = error ?? Loc["AuthLoginFailed"];
         StateHasChanged();
@@ -174,10 +183,11 @@
         }
         _busy = true;
         StateHasChanged();
-        var (success, error, _) = await AccountAuth.RegisterAsync(_regUsername, _regEmail, _regPassword);
+        // A fresh account never has a character, so registration always continues into onboarding.
+        var (success, error, characters) = await AccountAuth.RegisterAsync(_regUsername, _regEmail, _regPassword);
         _busy = false;
         if (success)
-            Nav.NavigateTo(SuccessUrl());
+            Nav.NavigateTo(characters.Count == 0 ? OnboardingUrl : SuccessUrl());
         else
             _error = error ?? Loc["AuthRegistrationFailed"];
         StateHasChanged();

--- a/SharpMUSH.Client/Resources/SharedResource.bg.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.bg.resx
@@ -4472,4 +4472,8 @@
     <value>{count, plural, one {# дума} other {# думи}}</value>
     <comment>MT — «дума» is feminine, ordinary plural after the numeral</comment>
   </data>
+  <data name="OnboardingCreateFirstCharacter" xml:space="preserve">
+    <value>Вашият акаунт е готов. Създаването на герой е последната стъпка, преди да можете да играете.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.da.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.da.resx
@@ -4472,4 +4472,8 @@
     <value>{count, plural, one {# ord} other {# ord}}</value>
     <comment>MT — 'ord' is invariant in the plural</comment>
   </data>
+  <data name="OnboardingCreateFirstCharacter" xml:space="preserve">
+    <value>Din konto er klar. At oprette en karakter er det sidste trin, før du kan spille.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.de.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.de.resx
@@ -4472,4 +4472,8 @@
     <value>{count, plural, one {# Wort} other {# Wörter}}</value>
     <comment>MT</comment>
   </data>
+  <data name="OnboardingCreateFirstCharacter" xml:space="preserve">
+    <value>Ihr Konto ist bereit. Das Erstellen eines Charakters ist der letzte Schritt, bevor Sie spielen können.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.es.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.es.resx
@@ -4472,4 +4472,8 @@
     <value>{count, plural, one {# palabra} other {# palabras}}</value>
     <comment>MT — ICU categories one+other</comment>
   </data>
+  <data name="OnboardingCreateFirstCharacter" xml:space="preserve">
+    <value>Tu cuenta está lista. Crear un personaje es el último paso antes de poder jugar.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.fr.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.fr.resx
@@ -3665,4 +3665,8 @@
     <value>{count, plural, one {# mot} other {# mots}}</value>
     <comment>MT — ICU categories one+other; French 'one' also covers 0, so 0 correctly renders the singular</comment>
   </data>
+  <data name="OnboardingCreateFirstCharacter" xml:space="preserve">
+    <value>Votre compte est prêt. Créer un personnage est la dernière étape avant de pouvoir jouer.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.hr.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.hr.resx
@@ -4472,4 +4472,8 @@
     <value>{count, plural, one {# riječ} few {# riječi} other {# riječi}}</value>
     <comment>MT — «riječ» is syncretic here: the paucal (2–4) and the genitive plural are both «riječi», so few and other coincide.</comment>
   </data>
+  <data name="OnboardingCreateFirstCharacter" xml:space="preserve">
+    <value>Vaš je račun spreman. Stvaranje lika posljednji je korak prije nego što možete igrati.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.hu.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.hu.resx
@@ -4472,4 +4472,8 @@
     <value>{count, plural, one {# szó} other {# szó}}</value>
     <comment>MT — Hungarian keeps the noun singular after a numeral, so both categories are deliberately identical.</comment>
   </data>
+  <data name="OnboardingCreateFirstCharacter" xml:space="preserve">
+    <value>A fiókja készen áll. Egy karakter létrehozása az utolsó lépés, mielőtt játszhatna.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.nb.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.nb.resx
@@ -4472,4 +4472,8 @@
     <value>{count, plural, one {# ord} other {# ord}}</value>
     <comment>MT — 'ord' is invariant in the plural</comment>
   </data>
+  <data name="OnboardingCreateFirstCharacter" xml:space="preserve">
+    <value>Kontoen din er klar. Å opprette en karakter er det siste trinnet før du kan spille.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.nl.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.nl.resx
@@ -4472,4 +4472,8 @@
     <value>{count, plural, one {# woord} other {# woorden}}</value>
     <comment>MT</comment>
   </data>
+  <data name="OnboardingCreateFirstCharacter" xml:space="preserve">
+    <value>Je account is klaar. Een personage aanmaken is de laatste stap voordat je kunt spelen.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.pl.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.pl.resx
@@ -4472,4 +4472,8 @@
     <value>{count, plural, one {# słowo} few {# słowa} many {# słów} other {# słowa}}</value>
     <comment>MT</comment>
   </data>
+  <data name="OnboardingCreateFirstCharacter" xml:space="preserve">
+    <value>Twoje konto jest gotowe. Utworzenie postaci to ostatni krok przed rozpoczęciem gry.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.pt-BR.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.pt-BR.resx
@@ -4472,4 +4472,8 @@
     <value>{count, plural, one {# palavra} other {# palavras}}</value>
     <comment>MT — ICU categories one+other</comment>
   </data>
+  <data name="OnboardingCreateFirstCharacter" xml:space="preserve">
+    <value>Sua conta está pronta. Criar um personagem é o último passo antes de você poder jogar.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.resx
@@ -3495,4 +3495,7 @@
   <data name="AdmAccountStatusChanged" xml:space="preserve">
     <value>Account '{0}' status updated.</value>
   </data>
+  <data name="OnboardingCreateFirstCharacter" xml:space="preserve">
+    <value>Your account is ready. Creating a character is the last step before you can play.</value>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.ro.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.ro.resx
@@ -4472,4 +4472,8 @@
     <value>{count, plural, one {# cuvânt} few {# cuvinte} other {# de cuvinte}}</value>
     <comment>MT — ICU categories one+few+other; the "de" form now covers 20+</comment>
   </data>
+  <data name="OnboardingCreateFirstCharacter" xml:space="preserve">
+    <value>Contul tău este gata. Crearea unui personaj este ultimul pas înainte de a putea juca.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.ru.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.ru.resx
@@ -4472,4 +4472,8 @@
     <value>{count, plural, one {# слово} few {# слова} many {# слов} other {# слова}}</value>
     <comment>MT</comment>
   </data>
+  <data name="OnboardingCreateFirstCharacter" xml:space="preserve">
+    <value>Ваша учётная запись готова. Создание персонажа — последний шаг перед началом игры.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.sv.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.sv.resx
@@ -4472,4 +4472,8 @@
     <value>{count, plural, one {# ord} other {# ord}}</value>
     <comment>MT — 'ord' is invariant in the plural</comment>
   </data>
+  <data name="OnboardingCreateFirstCharacter" xml:space="preserve">
+    <value>Ditt konto är klart. Att skapa en karaktär är det sista steget innan du kan spela.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.zh-Hans.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.zh-Hans.resx
@@ -4472,4 +4472,8 @@
     <value>{count, plural, other {# 个词条}}</value>
     <comment>MT — Chinese has a single CLDR plural category, so one `other` branch is correct. 词条/词 are used inconsistently in this file; a reviewer should confirm the term.</comment>
   </data>
+  <data name="OnboardingCreateFirstCharacter" xml:space="preserve">
+    <value>您的账户已就绪。创建一个角色是开始游戏前的最后一步。</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Library/Services/AccountService.cs
+++ b/SharpMUSH.Library/Services/AccountService.cs
@@ -10,7 +10,8 @@ public class AccountService(
 	ISharpDatabase database,
 	IPasswordService passwordService,
 	IAccountSessionStore accountSessionStore,
-	IBanEnforcer? banEnforcer = null) : IAccountService
+	IBanEnforcer? banEnforcer = null,
+	IAccountClaimsInvalidator? claimsInvalidator = null) : IAccountService
 {
 	// Account IDs are used as the "user" salt key for hashing
 	private static string AccountKey(SharpAccount account) => $"account:{account.Id}:{account.CreatedAt}";
@@ -149,11 +150,30 @@ public class AccountService(
 	public ValueTask<IReadOnlyList<SharpPlayer>> GetCharactersAsync(string accountId, CancellationToken ct = default)
 		=> database.GetCharactersForAccountAsync(accountId, ct);
 
-	public ValueTask LinkCharacterAsync(string accountId, DBRef characterRef, CancellationToken ct = default)
-		=> database.LinkCharacterToAccountAsync(accountId, characterRef, ct);
+	/// <remarks>
+	/// The account's cached role and permission scopes are derived from its characters, so linking
+	/// one makes them stale. Invalidating here rather than at each caller is what makes a brand-new
+	/// player's first character take effect immediately instead of on the cache's next expiry:
+	/// every route to a link — the REST endpoints, the in-game MAKE command, bootstrap/setup — goes
+	/// through this method, so none of them can forget.
+	/// </remarks>
+	public async ValueTask LinkCharacterAsync(string accountId, DBRef characterRef, CancellationToken ct = default)
+	{
+		await database.LinkCharacterToAccountAsync(accountId, characterRef, ct);
+		if (claimsInvalidator is not null)
+			await claimsInvalidator.InvalidateAsync(accountId, ct);
+	}
 
-	public ValueTask UnlinkCharacterAsync(string accountId, DBRef characterRef, CancellationToken ct = default)
-		=> database.UnlinkCharacterFromAccountAsync(accountId, characterRef, ct);
+	/// <remarks>
+	/// The security-relevant direction: unlinking the last character drops the account back to Guest,
+	/// and leaving Player scopes cached would keep granting them after the entitlement is gone.
+	/// </remarks>
+	public async ValueTask UnlinkCharacterAsync(string accountId, DBRef characterRef, CancellationToken ct = default)
+	{
+		await database.UnlinkCharacterFromAccountAsync(accountId, characterRef, ct);
+		if (claimsInvalidator is not null)
+			await claimsInvalidator.InvalidateAsync(accountId, ct);
+	}
 
 	public ValueTask<SharpAccount?> GetAccountForCharacterAsync(DBRef characterRef, CancellationToken ct = default)
 		=> database.GetAccountForCharacterAsync(characterRef, ct);

--- a/SharpMUSH.Library/Services/Interfaces/IAccountClaimsInvalidator.cs
+++ b/SharpMUSH.Library/Services/Interfaces/IAccountClaimsInvalidator.cs
@@ -1,0 +1,21 @@
+namespace SharpMUSH.Library.Services.Interfaces;
+
+/// <summary>
+/// The wiring seam for dropping an account's cached role/permission claims. Lives in
+/// <c>SharpMUSH.Library</c> so the call sites that mutate the character set those claims are
+/// derived from (<c>AccountService.LinkCharacterAsync</c> / <c>UnlinkCharacterAsync</c>) don't need
+/// a dependency on <c>SharpMUSH.Server</c>, where the cache and the claim computation live.
+/// </summary>
+/// <remarks>
+/// Deliberately narrower than <c>AccountClaimsService</c>, which computes claims from
+/// <see cref="IAccountService"/>: an implementation of this interface must not depend on the
+/// account service, or the object graph would be circular the moment the account service invalidates.
+/// </remarks>
+public interface IAccountClaimsInvalidator
+{
+	/// <summary>
+	/// Drops every cached role/permission entry for <paramref name="accountId"/>, so the next
+	/// authenticated request recomputes them from the account's current characters.
+	/// </summary>
+	ValueTask InvalidateAsync(string accountId, CancellationToken ct = default);
+}

--- a/SharpMUSH.Server/Authentication/AccountClaimsInvalidator.cs
+++ b/SharpMUSH.Server/Authentication/AccountClaimsInvalidator.cs
@@ -1,0 +1,21 @@
+using SharpMUSH.Library.Services.Interfaces;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace SharpMUSH.Server.Authentication;
+
+/// <summary>
+/// The one place the <c>acct:{accountId}</c> cache tag is cleared. Everything that invalidates an
+/// account's claims — character link/unlink in <c>AccountService</c>, ban enforcement, and
+/// <see cref="AccountClaimsService.InvalidateAsync"/> itself — goes through here.
+/// </summary>
+/// <remarks>
+/// Split out of <see cref="AccountClaimsService"/> rather than implemented on it: that service
+/// computes claims from <see cref="IAccountService"/>, and <c>AccountService</c> is now a caller,
+/// so making it the invalidator would close a DI cycle. Clearing the tag needs nothing but the
+/// cache, so the seam costs nothing to keep separate.
+/// </remarks>
+public sealed class AccountClaimsInvalidator(IFusionCache cache) : IAccountClaimsInvalidator
+{
+	public ValueTask InvalidateAsync(string accountId, CancellationToken ct = default)
+		=> cache.RemoveByTagAsync(AccountClaimsService.AccountCacheTag(accountId), token: ct);
+}

--- a/SharpMUSH.Server/Authentication/AccountClaimsService.cs
+++ b/SharpMUSH.Server/Authentication/AccountClaimsService.cs
@@ -25,13 +25,13 @@ public class AccountClaimsService(
 	IRoleRegistryService roleRegistry,
 	IPermissionResolver permissionResolver,
 	IFusionCache cache,
+	IAccountClaimsInvalidator invalidator,
 	ILogger<AccountClaimsService> logger)
 {
 	/// <summary>
 	/// The single source of truth for the cache tag shared by every cached role/scope entry for
-	/// <paramref name="accountId"/>. Also used directly by <see cref="SharpMUSH.Server.Services.BanEnforcementService"/>
-	/// (via <see cref="ZiggyCreatures.Caching.Fusion.IFusionCache.RemoveByTagAsync"/>) so cache
-	/// invalidation doesn't require depending on this whole service.
+	/// <paramref name="accountId"/>. Read by <see cref="AccountClaimsInvalidator"/>, which is the
+	/// only thing that clears it.
 	/// </summary>
 	public static string AccountCacheTag(string accountId) => $"acct:{accountId}";
 
@@ -117,11 +117,13 @@ public class AccountClaimsService(
 
 	/// <summary>
 	/// Clears both the cached role and granted-scope entries for <paramref name="accountId"/>
-	/// (both are tagged <c>acct:{accountId}</c>). Called by ban/disable enforcement paths so a
-	/// freshly-revoked account doesn't keep its stale claims for the remainder of the 30s TTL.
+	/// (both are tagged <c>acct:{accountId}</c>), so the very next request recomputes them.
 	/// </summary>
-	public async ValueTask InvalidateAsync(string accountId)
-	{
-		await cache.RemoveByTagAsync(AccountCacheTag(accountId));
-	}
+	/// <remarks>
+	/// Server-layer convenience wrapper over <see cref="IAccountClaimsInvalidator"/>. The mutations
+	/// that actually make these entries stale — linking and unlinking characters — invalidate through
+	/// the interface from <c>AccountService</c>, because they happen in the Library layer.
+	/// </remarks>
+	public ValueTask InvalidateAsync(string accountId, CancellationToken ct = default)
+		=> invalidator.InvalidateAsync(accountId, ct);
 }

--- a/SharpMUSH.Server/Authentication/AccountSessionAuthenticationHandler.cs
+++ b/SharpMUSH.Server/Authentication/AccountSessionAuthenticationHandler.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SharpMUSH.Library.Authorization;
-using SharpMUSH.Library.Models;
 using SharpMUSH.Library.Services.Interfaces;
 using SharpMUSH.Server.Hubs;
 
@@ -15,6 +14,11 @@ namespace SharpMUSH.Server.Authentication;
 /// role/permission claims server-side (so bans/role changes take effect on the next request)
 /// and emitting the <see cref="GameHub.CharacterDbrefClaim"/> the hub authorizes on.
 /// </summary>
+/// <remarks>
+/// Nothing the client sends participates in choosing the acting character — there is no header or
+/// query hint to spoof. The choice is <see cref="ActingCharacterResolver"/>'s alone, made from the
+/// session the token names plus the account's live character roster.
+/// </remarks>
 public class AccountSessionAuthenticationHandler(
 	IOptionsMonitor<AuthenticationSchemeOptions> options,
 	ILoggerFactory logger,
@@ -54,7 +58,7 @@ public class AccountSessionAuthenticationHandler(
 		claims.AddRange(scopes.Select(s => new Claim(PortalPermission.ClaimType, s)));
 
 		var characters = await accountService.GetCharactersAsync(accountId);
-		var acting = ResolveActingCharacter(session.Value, characters);
+		var acting = ActingCharacterResolver.Resolve(session.Value, characters);
 		if (acting is not null)
 		{
 			claims.Add(new Claim(GameHub.CharacterDbrefClaim, acting.Object.DBRef.ToString()));
@@ -65,26 +69,6 @@ public class AccountSessionAuthenticationHandler(
 
 		var identity = new ClaimsIdentity(claims, SchemeName);
 		return AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName));
-	}
-
-	/// <summary>
-	/// The character this request acts as, taken from the session the token names. The binding is
-	/// established when the token is minted (login binds the primary; switch-character mints a new
-	/// token bound to the target), so nothing the client sends participates in the decision — there is
-	/// no header or query hint to spoof, and no silent fallback to the primary when one doesn't match.
-	/// </summary>
-	/// <remarks>
-	/// Membership is still re-checked against the live roster on every request: a character unlinked
-	/// from the account after the token was minted must stop being actable immediately, without
-	/// waiting for the session to expire.
-	/// </remarks>
-	private static SharpPlayer? ResolveActingCharacter(
-		IAccountSessionStore.SessionIdentity session, IReadOnlyList<SharpPlayer> characters)
-	{
-		if (session.CharacterKey is not { } key || session.CharacterCreationTime is not { } created)
-			return null;
-
-		return characters.FirstOrDefault(c => c.Object.Key == key && c.Object.CreationTime == created);
 	}
 
 	private string? ExtractToken()

--- a/SharpMUSH.Server/Authentication/ActingCharacterResolver.cs
+++ b/SharpMUSH.Server/Authentication/ActingCharacterResolver.cs
@@ -1,0 +1,62 @@
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.Services.Interfaces;
+
+namespace SharpMUSH.Server.Authentication;
+
+/// <summary>
+/// The single rule for "which character is this session acting as", shared by every caller that
+/// answers it: <see cref="AccountSessionAuthenticationHandler"/> (which turns it into claims),
+/// <c>AccountController.GetCharacters</c> (which reports it as <c>isActing</c> on the roster), and
+/// <c>AuthController.AccountLogin</c> (which binds it into the token it mints). They used to derive
+/// it separately and could disagree.
+/// </summary>
+public static class ActingCharacterResolver
+{
+	/// <summary>
+	/// The character a session with no explicit binding falls back to: the account's lowest-dbref
+	/// character.
+	/// </summary>
+	/// <remarks>
+	/// The tie-break has to be defined rather than incidental, because <c>GetCharactersAsync</c>
+	/// passes the backend query through unsorted — an unordered pick would name a different
+	/// character on different requests for a multi-character account. Lowest dbref is the account's
+	/// oldest surviving character, and it is the same rule login has always used to choose the
+	/// character it binds, so an implicitly-resolved session and a freshly-logged-in one always
+	/// agree on who they are.
+	/// </remarks>
+	public static SharpPlayer? Primary(IReadOnlyList<SharpPlayer> characters)
+		=> characters.OrderBy(c => c.Object.Key).FirstOrDefault();
+
+	/// <summary>
+	/// The character <paramref name="session"/> acts as, re-checked against the live
+	/// <paramref name="characters"/> roster on every call.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// An explicit binding always wins and never falls back: a session that names a character acts
+	/// as that character or as nobody. That keeps <c>AuthController.SwitchCharacter</c> — the only
+	/// way to choose a character — authoritative, and it keeps a character unlinked after the token
+	/// was minted from silently redirecting to a different one.
+	/// </para>
+	/// <para>
+	/// A session that names NO character is the "registered, no character yet" case: the session is
+	/// minted at registration, before the account owns anything to bind. It resolves to
+	/// <see cref="Primary"/> so that creating the first character takes effect on the very next
+	/// request, instead of leaving the registration session permanently characterless — every write
+	/// needing a character identity refused it, and the roster reported the account's only character
+	/// as not acting, until the player logged out and back in.
+	/// </para>
+	/// </remarks>
+	public static SharpPlayer? Resolve(
+		IAccountSessionStore.SessionIdentity? session, IReadOnlyList<SharpPlayer> characters)
+	{
+		if (session is not { } identity)
+			return null;
+
+		if (identity.CharacterKey is not { } key)
+			return Primary(characters);
+
+		return characters.FirstOrDefault(c => c.Object.Key == key
+			&& c.Object.CreationTime == identity.CharacterCreationTime);
+	}
+}

--- a/SharpMUSH.Server/Controllers/AccountController.cs
+++ b/SharpMUSH.Server/Controllers/AccountController.cs
@@ -8,6 +8,7 @@ using SharpMUSH.Library.Queries.Database;
 using SharpMUSH.Library.Services.Interfaces;
 using Microsoft.Extensions.Options;
 using SharpMUSH.Configuration.Options;
+using SharpMUSH.Server.Authentication;
 using SharpMUSH.Server.Helpers;
 
 namespace SharpMUSH.Server.Controllers;
@@ -36,7 +37,7 @@ public class AccountController(
 	/// roster entry the caller is acting as — the session token is opaque to the client, so the roster
 	/// response is where a reloaded tab finds out.
 	/// </summary>
-	private async Task<IAccountSessionStore.SessionIdentity?> ActingCharacterAsync()
+	private async Task<IAccountSessionStore.SessionIdentity?> SessionAsync()
 	{
 		var header = Request.Headers.Authorization.FirstOrDefault();
 		if (header is null || !header.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
@@ -75,9 +76,11 @@ public class AccountController(
 		if (failure is not null) return failure;
 
 		var characters = await accountService.GetCharactersAsync(accountId!);
-		var acting = await ActingCharacterAsync();
+		// Resolved through the same rule the authentication handler applies, so the roster's
+		// isActing flag can never disagree with the identity a write actually runs as.
+		var acting = ActingCharacterResolver.Resolve(await SessionAsync(), characters);
 		var summaries = await CharacterSummaryMapper.BuildSummariesAsync(characters,
-			actingKey: acting?.CharacterKey, actingCreationTime: acting?.CharacterCreationTime);
+			actingKey: acting?.Object.Key, actingCreationTime: acting?.Object.CreationTime);
 		return Ok(summaries);
 	}
 

--- a/SharpMUSH.Server/Controllers/AuthController.cs
+++ b/SharpMUSH.Server/Controllers/AuthController.cs
@@ -250,9 +250,9 @@ public class AuthController(
 
 		// Bind the session to the primary character up front, so there is never a "has characters but
 		// the token names none" state for a request handler to paper over. Switching mints a new token.
-		// Ordered by dbref: GetCharactersAsync passes the backend query through unsorted, so an
-		// unordered pick could bind a different character on each login for a multi-character account.
-		var primary = characters.OrderBy(c => c.Object.Key).FirstOrDefault();
+		// The pick goes through ActingCharacterResolver so that this binding and the implicit
+		// resolution a characterless session falls back to can never name different characters.
+		var primary = ActingCharacterResolver.Primary(characters);
 
 		// The roster carries the binding too — the token is opaque to the client, so this response is
 		// where the tab learns who it starts as.

--- a/SharpMUSH.Server/Services/BanEnforcementService.cs
+++ b/SharpMUSH.Server/Services/BanEnforcementService.cs
@@ -4,11 +4,9 @@ using SharpMUSH.Library.Services;
 using SharpMUSH.Library.Services.Interfaces;
 using SharpMUSH.Messaging.Abstractions;
 using SharpMUSH.Messaging.Messages;
-using SharpMUSH.Server.Authentication;
 using SharpMUSH.Server.Helpers;
 using SharpMUSH.Server.Hubs;
 using System.Diagnostics.CodeAnalysis;
-using ZiggyCreatures.Caching.Fusion;
 
 namespace SharpMUSH.Server.Services;
 
@@ -28,7 +26,7 @@ namespace SharpMUSH.Server.Services;
 /// </remarks>
 public sealed class BanEnforcementService(
 	IAccountSessionStore sessionStore,
-	IFusionCache cache,
+	IAccountClaimsInvalidator claimsInvalidator,
 	IConnectionService connectionService,
 	IMessageBus messageBus,
 	HubConnectionRegistry registry,
@@ -59,7 +57,7 @@ public sealed class BanEnforcementService(
 	{
 		await RunGuardedAsync("revoke sessions", accountId, () => sessionStore.RevokeAllForAccountAsync(accountId, ct));
 		await RunGuardedAsync("invalidate claims cache", accountId,
-			() => cache.RemoveByTagAsync(AccountClaimsService.AccountCacheTag(accountId)).AsTask());
+			() => claimsInvalidator.InvalidateAsync(accountId, ct).AsTask());
 		await RunGuardedAsync("abort SignalR connections", accountId, () =>
 		{
 			registry.AbortConnectionsForAccount(accountId);

--- a/SharpMUSH.Server/Startup.cs
+++ b/SharpMUSH.Server/Startup.cs
@@ -256,6 +256,10 @@ public class Startup(
 		// Unconditional (not gated on JWT config) — AuthController's account-login/register and
 		// AdminAccountsController's Wizard gate need it even when JWT auth isn't configured.
 		services.AddSingleton<AccountClaimsService>();
+		// Kept separate from AccountClaimsService so AccountService — which computes nothing but
+		// must invalidate whenever it links or unlinks a character — can depend on it without
+		// closing a cycle back through IAccountService. Library stays off Server.
+		services.AddSingleton<IAccountClaimsInvalidator, AccountClaimsInvalidator>();
 		// Task 15: gates AuthController/SetupController/GameHub on sitelock rules (!connect/!create/!guest).
 		services.AddSingleton<SitelockGuard>();
 		services.AddSingleton<BanEnforcementService>();

--- a/SharpMUSH.Tests.BUnit/Pages/LoginReturnUrlTests.cs
+++ b/SharpMUSH.Tests.BUnit/Pages/LoginReturnUrlTests.cs
@@ -28,7 +28,10 @@ file sealed class LoginApiHandler : HttpMessageHandler
 				{
 					accountId = "test-account-id",
 					username = "headwiz",
-					characters = Array.Empty<object>(),
+					// One character, deliberately: an account with an EMPTY roster is routed into
+					// onboarding instead of the return URL (see OnboardingRoutingTests), which is a
+					// different question from the URL sanitizing these tests are about.
+					characters = new[] { new { dbrefNumber = 5, creationTime = 5L, name = "Gwendolyn", flags = "", isActing = true } },
 					accountSessionToken = "test-session-token",
 					mustChangePassword = false,
 					role = "God",

--- a/SharpMUSH.Tests.BUnit/Pages/OnboardingRoutingTests.cs
+++ b/SharpMUSH.Tests.BUnit/Pages/OnboardingRoutingTests.cs
@@ -1,0 +1,210 @@
+using System.Net;
+using System.Net.Http.Json;
+using Bunit;
+using Bunit.TestDoubles;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging.Abstractions;
+using MudBlazor.Services;
+using NSubstitute;
+using SharpMUSH.Client.Resources;
+using SharpMUSH.Client.Services;
+using SharpMUSH.Tests.BUnit.Resources;
+
+namespace SharpMUSH.Tests.BUnit.Pages;
+
+/// <summary>
+/// Fakes account-login/register and the character roster. <paramref name="characters"/> is what the
+/// account owns: an empty roster is the "registered, no character yet" state.
+/// </summary>
+file sealed class OnboardingApiHandler(object[] characters) : HttpMessageHandler
+{
+	protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+	{
+		var path = request.RequestUri!.AbsolutePath.TrimStart('/');
+
+		if (request.Method == HttpMethod.Post && path is "api/auth/account-login" or "api/auth/account-register")
+			return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+			{
+				Content = JsonContent.Create(new
+				{
+					accountId = "test-account-id",
+					username = "newbie",
+					characters,
+					accountSessionToken = "test-session-token",
+					mustChangePassword = false,
+					role = "Guest",
+					permissions = Array.Empty<string>()
+				})
+			});
+
+		if (request.Method == HttpMethod.Get && path == "api/account/characters")
+			return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent.Create(characters) });
+
+		return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+	}
+}
+
+/// <summary>
+/// "Registered, but no character yet" is a step in onboarding, not a permission failure. Cover for
+/// the routing that treats it as one: login/registration with an empty roster lands on
+/// <c>/characters/new</c>, which explains why, while an account that owns a character is unaffected.
+/// </summary>
+/// <remarks>
+/// These assert routing and rendering directly rather than going through <c>[Authorize]</c>: bUnit
+/// renders a page component BELOW <c>AuthorizeRouteView</c>, so the attribute has no runtime effect
+/// here and a "render anonymously, expect a redirect" test would pass while proving nothing.
+/// </remarks>
+public class OnboardingRoutingTests : BunitContext, IAsyncDisposable
+{
+	private readonly List<HttpClient> _ownedHttpClients = [];
+
+	private static readonly object[] OneCharacter =
+	[
+		new { dbrefNumber = 5, creationTime = 5L, name = "Gwendolyn", flags = "", isActing = true }
+	];
+
+	private void SeedServices(object[] characters)
+	{
+		var apiClient = new HttpClient(new OnboardingApiHandler(characters)) { BaseAddress = new Uri("https://localhost:8081/") };
+		_ownedHttpClients.Add(apiClient);
+
+		var factory = Substitute.For<IHttpClientFactory>();
+		factory.CreateClient("api").Returns(apiClient);
+
+		Services
+			.AddMudServices()
+			.AddSingleton(factory)
+			.AddSingleton(sp => new AccountAuthService(
+				sp.GetRequiredService<IHttpClientFactory>(),
+				sp.GetRequiredService<Microsoft.JSInterop.IJSRuntime>(),
+				NullLogger<AccountAuthService>.Instance, Substitute.For<ITerminalService>(), Substitute.For<IPlayTerminalService>()))
+			.AddSingleton(Substitute.For<ITerminalService>())
+			.AddSingleton<IStringLocalizer<SharedResource>, EchoLocalizer<SharedResource>>();
+
+		JSInterop.Mode = JSRuntimeMode.Loose;
+	}
+
+	private BunitNavigationManager Nav => (BunitNavigationManager)Services.GetRequiredService<NavigationManager>();
+
+	private IRenderedComponent<SharpMUSH.Client.Pages.Login> SubmitLoginFrom(string startingUri, object[] characters)
+	{
+		SeedServices(characters);
+		Nav.NavigateTo(startingUri);
+
+		var cut = Render<SharpMUSH.Client.Pages.Login>();
+		cut.Find("#login-username").Change("newbie");
+		cut.Find("#login-password").Change("hunter2");
+		cut.Find("button.login-submit").Click();
+		return cut;
+	}
+
+	private void WaitForNavigation(IRenderedComponent<IComponent> cut, string relativeUrl)
+	{
+		var expected = new Uri(new Uri(Nav.BaseUri), relativeUrl).ToString();
+		cut.WaitForAssertion(() =>
+		{
+			if (Nav.Uri != expected)
+				throw new InvalidOperationException($"expected {expected}, still at {Nav.Uri}");
+		});
+	}
+
+	[TUnit.Core.Test]
+	public async Task Login_WithNoCharacters_LandsOnCharacterCreation()
+	{
+		var cut = SubmitLoginFrom("/login", characters: []);
+
+		WaitForNavigation(cut, "/characters/new");
+
+		await Assert.That(Nav.Uri).EndsWith("/characters/new");
+	}
+
+	/// <summary>
+	/// Onboarding wins over the return URL: the gated page the visitor was heading for would refuse
+	/// them anyway, and refusing without explanation is the state this replaces.
+	/// </summary>
+	[TUnit.Core.Test]
+	public async Task Login_WithNoCharacters_PrefersOnboardingOverReturnUrl()
+	{
+		var cut = SubmitLoginFrom($"/login?returnUrl={Uri.EscapeDataString("/wiki")}", characters: []);
+
+		WaitForNavigation(cut, "/characters/new");
+
+		await Assert.That(Nav.Uri).EndsWith("/characters/new");
+	}
+
+	[TUnit.Core.Test]
+	public async Task Login_WithACharacter_StillHonoursTheReturnUrl()
+	{
+		var cut = SubmitLoginFrom($"/login?returnUrl={Uri.EscapeDataString("/wiki")}", OneCharacter);
+
+		WaitForNavigation(cut, "/wiki");
+
+		await Assert.That(Nav.Uri).EndsWith("/wiki");
+	}
+
+	[TUnit.Core.Test]
+	public async Task Registration_AlwaysContinuesIntoOnboarding()
+	{
+		SeedServices(characters: []);
+		Nav.NavigateTo("/login?tab=register");
+
+		var cut = Render<SharpMUSH.Client.Pages.Login>();
+		var inputs = cut.FindAll("input");
+		inputs[0].Change("newbie");
+		inputs[2].Change("hunter2");
+		cut.Find("button.register-submit").Click();
+
+		WaitForNavigation(cut, "/characters/new");
+
+		await Assert.That(Nav.Uri).EndsWith("/characters/new");
+	}
+
+	[TUnit.Core.Test]
+	public async Task CharacterCreate_WithNoCharacters_ExplainsWhyYouAreHere()
+	{
+		SeedServices(characters: []);
+		SeedSession();
+
+		var cut = Render<SharpMUSH.Client.Pages.CharacterCreate>();
+
+		cut.WaitForAssertion(() => cut.Find("#onboarding-notice"));
+		await Assert.That(cut.Markup).Contains("OnboardingCreateFirstCharacter");
+	}
+
+	/// <summary>An account that already plays someone is adding a character, not being onboarded.</summary>
+	[TUnit.Core.Test]
+	public async Task CharacterCreate_WithACharacter_ShowsNoOnboardingNotice()
+	{
+		SeedServices(OneCharacter);
+		SeedSession();
+
+		var cut = Render<SharpMUSH.Client.Pages.CharacterCreate>();
+
+		cut.WaitForAssertion(() =>
+		{
+			if (!cut.Markup.Contains("NavCreateACharacter", StringComparison.Ordinal))
+				throw new InvalidOperationException("the create form has not rendered yet");
+		});
+		await Assert.That(cut.FindAll("#onboarding-notice")).IsEmpty();
+	}
+
+	private void SeedSession()
+	{
+		Services.AddSingleton(Substitute.For<ICharacterUpgradeService>());
+		JSInterop.Setup<string?>("sessionStorage.getItem", "sharpmush.account.loggedOut").SetResult(null);
+		JSInterop.Setup<string?>("sessionStorage.getItem", "sharpmush.account.sessionToken").SetResult("session-token-1");
+		JSInterop.Setup<string?>("sessionStorage.getItem", "sharpmush.account.username").SetResult("newbie");
+		JSInterop.Setup<string?>("sessionStorage.getItem", "sharpmush.account.mustChangePassword").SetResult(bool.FalseString);
+		JSInterop.Setup<string?>("sessionStorage.getItem", "sharpmush.account.role").SetResult("Player");
+		JSInterop.Setup<string?>("sessionStorage.getItem", "sharpmush.account.permissions").SetResult("[]");
+	}
+
+	public new async ValueTask DisposeAsync()
+	{
+		foreach (var client in _ownedHttpClients)
+			client.Dispose();
+		await base.DisposeAsync();
+	}
+}

--- a/SharpMUSH.Tests.Integration/Auth/NewPlayerSessionTests.cs
+++ b/SharpMUSH.Tests.Integration/Auth/NewPlayerSessionTests.cs
@@ -1,0 +1,135 @@
+using SharpMUSH.Tests.Infrastructure;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+
+namespace SharpMUSH.Tests.Integration.Auth;
+
+/// <summary>
+/// The two defects every brand-new player hit in sequence, reproduced end to end against the real
+/// host: a session minted at registration carries no character binding (the account had none yet),
+/// and the cached role/scope claims the session authenticates with are derived from a character set
+/// that has just changed.
+/// <para>
+/// N-02: the registration session never bound the character created under it, so the roster reported
+/// the account's only character as <c>isActing:false</c> and every write needing a character
+/// identity answered <c>401 Missing character identity.</c> — until the player logged out and back
+/// in, at which point login bound one and everything worked.
+/// </para>
+/// </summary>
+[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+public class NewPlayerSessionTests(ServerWebAppFactory factory)
+{
+	private record CharacterSummary(int DbrefNumber, long CreationTime, string Name, string Flags, bool IsActing);
+
+	private record AccountLoginResponse(string AccountId, string Username, List<CharacterSummary> Characters,
+		string AccountSessionToken, bool MustChangePassword, string Role, List<string> Permissions);
+
+	private record AccountRegisterRequest(string Username, string? Email, string Password);
+
+	private record CreateCharacterRequest(string Name, string Password);
+
+	private record CreatedCharacterResponse(int DbrefNumber, long CreationTime);
+
+	private const string Password = "Integration-Test-Pw-1!";
+
+	/// <summary>
+	/// Pinned to https for the same reason as <see cref="SwitchCharacterTests"/>: UseHttpsRedirection
+	/// answers http with a 307, and following it makes HttpClient drop the Authorization header.
+	/// </summary>
+	private HttpClient CreateClient()
+	{
+		var http = factory.CreateHttpClient();
+		http.BaseAddress = new Uri("https://localhost/");
+		return http;
+	}
+
+	private static string UniqueName(string prefix) => $"{prefix}{Guid.NewGuid():N}"[..20];
+
+	/// <summary>Registers a brand-new account and returns the session token minted for it — the one
+	/// that names no character, because the account owns none at that moment.</summary>
+	private static async Task<(HttpClient Http, AccountLoginResponse Account)> RegisterAsync(HttpClient http)
+	{
+		using var response = await http.PostAsJsonAsync("api/auth/account-register",
+			new AccountRegisterRequest(UniqueName("newpl"), null, Password));
+		await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+		var account = await response.Content.ReadFromJsonAsync<AccountLoginResponse>();
+		await Assert.That(account).IsNotNull();
+		await Assert.That(account!.Characters).IsEmpty();
+		return (http, account);
+	}
+
+	private static async Task<CreatedCharacterResponse> CreateCharacterAsync(HttpClient http, string token, string name)
+	{
+		using var request = new HttpRequestMessage(HttpMethod.Post, "api/account/characters")
+		{
+			Content = JsonContent.Create(new CreateCharacterRequest(name, Password))
+		};
+		request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		using var response = await http.SendAsync(request);
+		await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK)
+			.Because(await response.Content.ReadAsStringAsync());
+		var created = await response.Content.ReadFromJsonAsync<CreatedCharacterResponse>();
+		await Assert.That(created).IsNotNull();
+		return created!;
+	}
+
+	private static async Task<List<CharacterSummary>> RosterAsync(HttpClient http, string token)
+	{
+		using var request = new HttpRequestMessage(HttpMethod.Get, "api/account/characters");
+		request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		using var response = await http.SendAsync(request);
+		await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+		var roster = await response.Content.ReadFromJsonAsync<List<CharacterSummary>>();
+		await Assert.That(roster).IsNotNull();
+		return roster!;
+	}
+
+	/// <summary>
+	/// The measured reproduction: under the registration session the roster answered
+	/// <c>[{"name":"Gwendolyn","isActing":false}]</c>, and only a logout/login round trip turned it
+	/// true. No re-authentication happens anywhere in this test.
+	/// </summary>
+	[Test]
+	public async Task RegistrationSession_AfterCreatingItsFirstCharacter_ActsAsThatCharacter()
+	{
+		var (http, account) = await RegisterAsync(CreateClient());
+		var created = await CreateCharacterAsync(http, account.AccountSessionToken, UniqueName("Gwen"));
+
+		var roster = await RosterAsync(http, account.AccountSessionToken);
+
+		await Assert.That(roster).Count().IsEqualTo(1);
+		await Assert.That(roster[0].DbrefNumber).IsEqualTo(created.DbrefNumber);
+		await Assert.That(roster[0].IsActing).IsTrue()
+			.Because("the session minted at registration must adopt the account's character without a re-login");
+	}
+
+	/// <summary>
+	/// An account that already owns characters keeps the one its token names. This is the property
+	/// that stops the implicit fallback from quietly undoing <c>POST api/auth/switch-character</c>.
+	/// </summary>
+	[Test]
+	public async Task SwitchedSession_KeepsItsChosenCharacter_NotTheLowestDbref()
+	{
+		var (http, account) = await RegisterAsync(CreateClient());
+		var first = await CreateCharacterAsync(http, account.AccountSessionToken, UniqueName("Aaa"));
+		var second = await CreateCharacterAsync(http, account.AccountSessionToken, UniqueName("Bbb"));
+		await Assert.That(second.DbrefNumber).IsGreaterThan(first.DbrefNumber);
+
+		using var switchRequest = new HttpRequestMessage(HttpMethod.Post, "api/auth/switch-character")
+		{
+			Content = JsonContent.Create(new { CharacterKey = second.DbrefNumber, CharacterCreationTime = second.CreationTime })
+		};
+		switchRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", account.AccountSessionToken);
+		using var switchResponse = await http.SendAsync(switchRequest);
+		await Assert.That(switchResponse.StatusCode).IsEqualTo(HttpStatusCode.OK)
+			.Because(await switchResponse.Content.ReadAsStringAsync());
+		var switched = await switchResponse.Content.ReadFromJsonAsync<SwitchCharacterResponse>();
+
+		var roster = await RosterAsync(http, switched!.AccountSessionToken);
+
+		await Assert.That(roster.Single(c => c.IsActing).DbrefNumber).IsEqualTo(second.DbrefNumber);
+	}
+
+	private record SwitchCharacterResponse(string Ott, int ExpiresIn, string AccountSessionToken);
+}

--- a/SharpMUSH.Tests.Integration/Auth/NewPlayerSessionTests.cs
+++ b/SharpMUSH.Tests.Integration/Auth/NewPlayerSessionTests.cs
@@ -1,7 +1,16 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using SharpMUSH.Library.Authorization;
+using SharpMUSH.Server.Authentication;
+using SharpMUSH.Server.Controllers;
 using SharpMUSH.Tests.Infrastructure;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Security.Claims;
 
 namespace SharpMUSH.Tests.Integration.Auth;
 
@@ -15,6 +24,17 @@ namespace SharpMUSH.Tests.Integration.Auth;
 /// the account's only character as <c>isActing:false</c> and every write needing a character
 /// identity answered <c>401 Missing character identity.</c> — until the player logged out and back
 /// in, at which point login bound one and everything worked.
+/// </para>
+/// <para>
+/// N-03: the role and scopes the session authenticates with are cached for 30s and were never
+/// invalidated when the character set changed, so the same first login answered <c>role=Guest</c>
+/// with 0 scopes and, thirty-five seconds later, <c>role=Player</c> with 5.
+/// </para>
+/// <para>
+/// The claim-level tests below drive the real <c>AccountSession</c> handler out of the host's own
+/// DI container rather than over HTTP, because the test host runs in Development, where
+/// <c>DebugAuth</c> is the DEFAULT scheme and would authenticate any <c>[Authorize]</c> endpoint as
+/// the bootstrap admin regardless of the bearer — proving nothing about the token under test.
 /// </para>
 /// </summary>
 [ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
@@ -132,4 +152,124 @@ public class NewPlayerSessionTests(ServerWebAppFactory factory)
 	}
 
 	private record SwitchCharacterResponse(string Ott, int ExpiresIn, string AccountSessionToken);
+
+	/// <summary>
+	/// Runs the real <c>AccountSession</c> authentication handler over <paramref name="token"/>
+	/// through the host's DI container, returning the principal a request bearing that token would
+	/// carry — role claim, permission-scope claims and acting-character claims included.
+	/// </summary>
+	/// <remarks>
+	/// A fresh DI scope per call, deliberately: <c>IAuthenticationHandlerProvider</c> is scoped and
+	/// memoizes handlers, and <c>AuthenticationHandler&lt;T&gt;</c> memoizes its own authenticate
+	/// result — so reusing one scope would replay the first answer and quietly assert nothing about
+	/// the second.
+	/// </remarks>
+	private async Task<ClaimsPrincipal> AuthenticateAsync(string token)
+	{
+		using var scope = factory.Services.CreateScope();
+		var context = new DefaultHttpContext { RequestServices = scope.ServiceProvider };
+		context.Request.Headers.Authorization = $"Bearer {token}";
+
+		var result = await context.AuthenticateAsync(AccountSessionAuthenticationHandler.SchemeName);
+
+		await Assert.That(result.Succeeded).IsTrue().Because(result.Failure?.Message ?? "no failure reported");
+		return result.Principal!;
+	}
+
+	private static string[] ScopesOf(ClaimsPrincipal principal) =>
+		[.. principal.FindAll(PortalPermission.ClaimType).Select(c => c.Value).Order(StringComparer.Ordinal)];
+
+	/// <summary>
+	/// The measured reproduction: create your first character and authenticate immediately, and the
+	/// answer was <c>role=Guest</c> with 0 scopes for the remainder of the 30s cache window. The
+	/// account role was already cached as Guest by registration, moments earlier.
+	/// </summary>
+	[Test]
+	public async Task FirstCharacter_LiftsRoleAndScopes_OnTheVeryNextRequest()
+	{
+		var (http, account) = await RegisterAsync(CreateClient());
+
+		// Registration itself authenticates, which is what seeds the Guest role/scope cache entries
+		// that used to survive the character creation below.
+		var before = await AuthenticateAsync(account.AccountSessionToken);
+		await Assert.That(before.FindFirstValue(ClaimTypes.Role)).IsEqualTo(nameof(PortalRole.Guest));
+		await Assert.That(ScopesOf(before)).IsEmpty();
+
+		await CreateCharacterAsync(http, account.AccountSessionToken, UniqueName("Gwen"));
+
+		var after = await AuthenticateAsync(account.AccountSessionToken);
+
+		await Assert.That(after.FindFirstValue(ClaimTypes.Role)).IsEqualTo(nameof(PortalRole.Player));
+		await Assert.That(ScopesOf(after)).IsEquivalentTo(new[]
+		{
+			PortalPermission.MediaUpload,
+			PortalPermission.SoftcodeUse,
+			PortalPermission.WikiCreate,
+			PortalPermission.WikiEdit,
+			PortalPermission.WikiRead,
+		});
+	}
+
+	/// <summary>
+	/// The unlink direction, which is the security-relevant one: dropping the last character drops
+	/// the account back to Guest, and the Player scopes must not outlive it.
+	/// </summary>
+	[Test]
+	public async Task UnlinkingTheLastCharacter_DropsScopes_OnTheVeryNextRequest()
+	{
+		var (http, account) = await RegisterAsync(CreateClient());
+		var created = await CreateCharacterAsync(http, account.AccountSessionToken, UniqueName("Temp"));
+
+		var withCharacter = await AuthenticateAsync(account.AccountSessionToken);
+		await Assert.That(ScopesOf(withCharacter)).IsNotEmpty();
+
+		using var unlink = new HttpRequestMessage(HttpMethod.Delete, $"api/account/characters/{created.DbrefNumber}");
+		unlink.Headers.Authorization = new AuthenticationHeaderValue("Bearer", account.AccountSessionToken);
+		using var unlinkResponse = await http.SendAsync(unlink);
+		await Assert.That(unlinkResponse.StatusCode).IsEqualTo(HttpStatusCode.NoContent);
+
+		var afterUnlink = await AuthenticateAsync(account.AccountSessionToken);
+
+		await Assert.That(afterUnlink.FindFirstValue(ClaimTypes.Role)).IsEqualTo(nameof(PortalRole.Guest));
+		await Assert.That(ScopesOf(afterUnlink)).IsEmpty();
+	}
+
+	/// <summary>
+	/// Both defects at once, in the shape the player actually met them: under the registration
+	/// session, <c>POST /api/wiki</c> answered <c>401 Missing character identity.</c> (N-02) behind a
+	/// <c>wiki.create</c> gate the account did not yet hold (N-03). Neither this test nor the player
+	/// re-authenticates anywhere.
+	/// </summary>
+	[Test]
+	public async Task RegistrationSession_CanCreateAWikiPage_WithoutReAuthenticating()
+	{
+		using var scope = factory.Services.CreateScope();
+		var (http, account) = await RegisterAsync(CreateClient());
+		await CreateCharacterAsync(http, account.AccountSessionToken, UniqueName("Scribe"));
+
+		var principal = await AuthenticateAsync(account.AccountSessionToken);
+
+		// The gate WikiController.CreatePage sits behind, evaluated against the real policy provider.
+		var authorization = scope.ServiceProvider.GetRequiredService<IAuthorizationService>();
+		var gate = await authorization.AuthorizeAsync(principal, resource: null, PortalPermission.WikiCreate);
+		await Assert.That(gate.Succeeded).IsTrue().Because("wiki.create must be granted on the first request");
+
+		var controller = new WikiController(
+			scope.ServiceProvider.GetRequiredService<SharpMUSH.Library.Services.Interfaces.IWikiService>(),
+			scope.ServiceProvider.GetRequiredService<SharpMUSH.Library.Services.Interfaces.IWikiLocalizationService>(),
+			scope.ServiceProvider.GetRequiredService<SharpMUSH.Server.Services.IPrerenderCacheService>(),
+			scope.ServiceProvider.GetRequiredService<Microsoft.Extensions.Logging.ILogger<WikiController>>())
+		{
+			ControllerContext = new ControllerContext
+			{
+				HttpContext = new DefaultHttpContext { User = principal, RequestServices = scope.ServiceProvider }
+			}
+		};
+
+		var result = await controller.CreatePage(new WikiController.CreatePageRequest(
+			UniqueName("Page"), "Written by a brand-new player.", null, null));
+
+		await Assert.That(result).IsTypeOf<CreatedAtActionResult>()
+			.Because($"expected the page to be created, got: {result}");
+	}
 }

--- a/SharpMUSH.Tests/Authentication/AccountClaimsCacheTests.cs
+++ b/SharpMUSH.Tests/Authentication/AccountClaimsCacheTests.cs
@@ -37,7 +37,7 @@ public class AccountClaimsCacheTests
 		var cache = new FusionCache(new Microsoft.Extensions.Options.OptionsWrapper<FusionCacheOptions>(new FusionCacheOptions()));
 
 		var svc = new AccountClaimsService(accountSvc, roleDerivation, roleRegistry, permissionResolver, cache,
-			NullLogger<AccountClaimsService>.Instance);
+			new AccountClaimsInvalidator(cache), NullLogger<AccountClaimsService>.Instance);
 
 		return (svc, accountSvc, roleRegistry);
 	}

--- a/SharpMUSH.Tests/Authentication/AccountSessionAuthHandlerTests.cs
+++ b/SharpMUSH.Tests/Authentication/AccountSessionAuthHandlerTests.cs
@@ -286,6 +286,87 @@ public class AccountSessionAuthHandlerTests
 		await Assert.That(result.Principal!.FindFirst(GameHub.CharacterDbrefClaim)).IsNull();
 	}
 
+	/// <summary>
+	/// N-02 regression: the session minted at REGISTRATION names no character, because the account
+	/// owned none yet. Creating one afterwards never rebound it, so that session acted as nobody
+	/// forever — the roster reported the account's only character as not acting, and every write
+	/// needing a character identity answered "Missing character identity." until the player logged
+	/// out and back in.
+	/// </summary>
+	[Test]
+	public async Task SessionWithNoBoundCharacter_ActsAsTheAccountsOnlyCharacter()
+	{
+		var sessionStore = Substitute.For<IAccountSessionStore>();
+		var accountService = Substitute.For<IAccountService>();
+		var accountServiceForClaims = Substitute.For<IAccountService>();
+
+		// Minted before the account had any character; the character arrived afterwards.
+		sessionStore.ValidateAsync("registration-token").Returns(Task.FromResult<IAccountSessionStore.SessionIdentity?>(
+			new IAccountSessionStore.SessionIdentity("node_accounts/1", null, null)));
+		IReadOnlyList<SharpPlayer> roster = [MakePlayer(12, "Gwendolyn", 555L)];
+		accountService.GetByIdAsync("node_accounts/1").Returns(new ValueTask<SharpAccount?>(MakeAccount()));
+		accountService.GetCharactersAsync("node_accounts/1").Returns(new ValueTask<IReadOnlyList<SharpPlayer>>(roster));
+		accountServiceForClaims.GetCharactersAsync("node_accounts/1").Returns(new ValueTask<IReadOnlyList<SharpPlayer>>(roster));
+
+		var handler = await CreateHandlerWithHeaderAsync(sessionStore, accountService,
+			MakeAccountClaims(accountServiceForClaims, PortalRole.Player), authorizationHeader: "Bearer registration-token");
+
+		var result = await handler.AuthenticateAsync();
+
+		await Assert.That(result.Succeeded).IsTrue();
+		await Assert.That(result.Principal!.FindFirst(GameHub.CharacterDbrefClaim)!.Value).IsEqualTo("#12:555");
+		await Assert.That(result.Principal!.FindFirst("character_name")!.Value).IsEqualTo("Gwendolyn");
+	}
+
+	/// <summary>
+	/// The multi-character rule for an unbound session: lowest dbref, the same character login binds.
+	/// The roster is deliberately supplied out of order — <c>GetCharactersAsync</c> passes the backend
+	/// query through unsorted, so an unordered pick would name a different character per request.
+	/// </summary>
+	[Test]
+	public async Task SessionWithNoBoundCharacter_MultipleCharacters_ActsAsTheLowestDbref()
+	{
+		var sessionStore = Substitute.For<IAccountSessionStore>();
+		var accountService = Substitute.For<IAccountService>();
+		var accountServiceForClaims = Substitute.For<IAccountService>();
+
+		sessionStore.ValidateAsync("unbound").Returns(Task.FromResult<IAccountSessionStore.SessionIdentity?>(
+			new IAccountSessionStore.SessionIdentity("node_accounts/1", null, null)));
+		IReadOnlyList<SharpPlayer> roster = [MakePlayer(9, "Zed", 999L), MakePlayer(3, "Alice", 333L)];
+		accountService.GetByIdAsync("node_accounts/1").Returns(new ValueTask<SharpAccount?>(MakeAccount()));
+		accountService.GetCharactersAsync("node_accounts/1").Returns(new ValueTask<IReadOnlyList<SharpPlayer>>(roster));
+		accountServiceForClaims.GetCharactersAsync("node_accounts/1").Returns(new ValueTask<IReadOnlyList<SharpPlayer>>(roster));
+
+		var handler = await CreateHandlerWithHeaderAsync(sessionStore, accountService,
+			MakeAccountClaims(accountServiceForClaims, PortalRole.Player), authorizationHeader: "Bearer unbound");
+
+		var result = await handler.AuthenticateAsync();
+
+		await Assert.That(result.Succeeded).IsTrue();
+		await Assert.That(result.Principal!.FindFirst(GameHub.CharacterDbrefClaim)!.Value).IsEqualTo("#3:333");
+	}
+
+	/// <summary>
+	/// The implicit fallback must never override an explicit choice: a session bound by
+	/// <c>AuthController.SwitchCharacter</c> keeps acting as the character it names even though a
+	/// lower-dbref one exists. Sibling of <see cref="SessionBoundToANonPrimaryCharacter_ActsAsIt"/>,
+	/// pinned separately because the fallback added in N-02 is what could regress it.
+	/// </summary>
+	[Test]
+	public async Task AnExplicitlyChosenCharacter_BeatsTheImplicitFallback()
+	{
+		var (sessionStore, accountService, accountClaims) = TwoCharacterAccount();
+
+		var handler = await CreateHandlerWithHeaderAsync(sessionStore, accountService, accountClaims,
+			authorizationHeader: "Bearer good");
+
+		var result = await handler.AuthenticateAsync();
+
+		// Roster is [#1 Alice, #7 Bob]; the session names Bob. Falling back to the lowest dbref here
+		// would silently undo a character switch.
+		await Assert.That(result.Principal!.FindFirst(GameHub.CharacterDbrefClaim)!.Value).IsEqualTo("#7:777");
+	}
+
 	[Test]
 	public async Task UnknownToken_Fails()
 	{

--- a/SharpMUSH.Tests/Authentication/AccountSessionAuthHandlerTests.cs
+++ b/SharpMUSH.Tests/Authentication/AccountSessionAuthHandlerTests.cs
@@ -88,9 +88,10 @@ public class AccountSessionAuthHandlerTests
 		roleRegistry.GetRolesForAccountAsync(Arg.Any<string>()).Returns(Task.FromResult<IReadOnlyList<SharpRole>>([]));
 		permissionResolver.Resolve(Arg.Any<IEnumerable<SharpRole>>()).Returns(new HashSet<string>(scopes));
 
+		var cache = new FusionCache(
+			new Microsoft.Extensions.Options.OptionsWrapper<FusionCacheOptions>(new FusionCacheOptions()));
 		return new AccountClaimsService(accountServiceForClaims, roleDerivation, roleRegistry, permissionResolver,
-			new FusionCache(new Microsoft.Extensions.Options.OptionsWrapper<FusionCacheOptions>(new FusionCacheOptions())),
-			NullLogger<AccountClaimsService>.Instance);
+			cache, new AccountClaimsInvalidator(cache), NullLogger<AccountClaimsService>.Instance);
 	}
 
 	private static async Task<AccountSessionAuthenticationHandler> CreateHandlerWithHeaderAsync(

--- a/SharpMUSH.Tests/Controllers/AuthControllerDebugOttTests.cs
+++ b/SharpMUSH.Tests/Controllers/AuthControllerDebugOttTests.cs
@@ -15,6 +15,9 @@ public class AuthControllerDebugOttTests
 
 		var options = Substitute.For<SharpMUSH.Library.Services.Interfaces.IOptionsWrapper<SharpMUSHOptions>>();
 
+		var claimsCache = new ZiggyCreatures.Caching.Fusion.FusionCache(
+			new Microsoft.Extensions.Options.OptionsWrapper<ZiggyCreatures.Caching.Fusion.FusionCacheOptions>(
+				new ZiggyCreatures.Caching.Fusion.FusionCacheOptions()));
 		return new AuthController(
 			Substitute.For<Mediator.IMediator>(),
 			Substitute.For<SharpMUSH.Library.Services.Interfaces.IPasswordService>(),
@@ -27,9 +30,8 @@ public class AuthControllerDebugOttTests
 				Substitute.For<SharpMUSH.Library.Authorization.IRoleDerivationService>(),
 				Substitute.For<SharpMUSH.Library.Services.Interfaces.IRoleRegistryService>(),
 				Substitute.For<SharpMUSH.Library.Authorization.IPermissionResolver>(),
-				new ZiggyCreatures.Caching.Fusion.FusionCache(
-					new Microsoft.Extensions.Options.OptionsWrapper<ZiggyCreatures.Caching.Fusion.FusionCacheOptions>(
-						new ZiggyCreatures.Caching.Fusion.FusionCacheOptions())),
+				claimsCache,
+				new SharpMUSH.Server.Authentication.AccountClaimsInvalidator(claimsCache),
 				Substitute.For<Microsoft.Extensions.Logging.ILogger<SharpMUSH.Server.Authentication.AccountClaimsService>>()),
 			options,
 			env,

--- a/SharpMUSH.Tests/Services/AccountClaimsInvalidationTests.cs
+++ b/SharpMUSH.Tests/Services/AccountClaimsInvalidationTests.cs
@@ -1,0 +1,111 @@
+using NSubstitute;
+using SharpMUSH.Library;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.Services;
+using SharpMUSH.Library.Services.Interfaces;
+
+namespace SharpMUSH.Tests.Services;
+
+/// <summary>
+/// N-03 regression cover: the cached role/permission claims for an account are derived from the
+/// characters it owns, so linking or unlinking one makes them stale. Nothing invalidated them, and
+/// the 30s FusionCache TTL was the only thing that eventually did — a brand-new player who created
+/// their first character and logged straight in got <c>role=Guest</c> with zero scopes, and an
+/// account that unlinked its last character kept its Player scopes for up to 30s afterwards.
+/// <para>
+/// The invalidation lives on <see cref="AccountService"/>, where the link is actually written, so
+/// no caller can forget it. <see cref="EveryCharacterLinkWriteGoesThroughAccountService"/> is what
+/// keeps that true: it fails if a future call site reaches past the service to the database.
+/// </para>
+/// </summary>
+public class AccountClaimsInvalidationTests
+{
+	private static (AccountService Service, ISharpDatabase Database, IAccountClaimsInvalidator Invalidator) Build()
+	{
+		var database = Substitute.For<ISharpDatabase>();
+		var invalidator = Substitute.For<IAccountClaimsInvalidator>();
+		var service = new AccountService(database, Substitute.For<IPasswordService>(),
+			Substitute.For<IAccountSessionStore>(), banEnforcer: null, claimsInvalidator: invalidator);
+
+		return (service, database, invalidator);
+	}
+
+	[Test]
+	public async Task LinkCharacterAsync_InvalidatesCachedClaims()
+	{
+		var (service, database, invalidator) = Build();
+
+		await service.LinkCharacterAsync("node_accounts/1", new DBRef(7, 777L));
+
+		await database.Received(1).LinkCharacterToAccountAsync("node_accounts/1", new DBRef(7, 777L),
+			Arg.Any<CancellationToken>());
+		await invalidator.Received(1).InvalidateAsync("node_accounts/1", Arg.Any<CancellationToken>());
+	}
+
+	/// <summary>
+	/// The security-relevant direction: unlinking the last character drops the account to Guest, and
+	/// a stale cache entry would keep granting Player scopes it is no longer entitled to.
+	/// </summary>
+	[Test]
+	public async Task UnlinkCharacterAsync_InvalidatesCachedClaims()
+	{
+		var (service, database, invalidator) = Build();
+
+		await service.UnlinkCharacterAsync("node_accounts/1", new DBRef(7, 777L));
+
+		await database.Received(1).UnlinkCharacterFromAccountAsync("node_accounts/1", new DBRef(7, 777L),
+			Arg.Any<CancellationToken>());
+		await invalidator.Received(1).InvalidateAsync("node_accounts/1", Arg.Any<CancellationToken>());
+	}
+
+	/// <summary>
+	/// A cache invalidation placed on the service only helps for as long as everything that links a
+	/// character goes through the service. This fails the moment production code calls the database's
+	/// link/unlink directly — the one way a future call site could silently skip the invalidation.
+	/// </summary>
+	[Test]
+	public async Task EveryCharacterLinkWriteGoesThroughAccountService()
+	{
+		string[] databaseWrites = ["LinkCharacterToAccountAsync", "UnlinkCharacterFromAccountAsync"];
+
+		// The declaration, the one implementation allowed to call it, and the providers that define it.
+		string[] permitted =
+		[
+			Path.Combine("SharpMUSH.Library", "ISharpDatabase.cs"),
+			Path.Combine("SharpMUSH.Library", "Services", "AccountService.cs"),
+		];
+
+		var offenders = ProductionSourceFiles(RepositoryRoot())
+			.Where(file => !permitted.Any(p => file.EndsWith(p, StringComparison.Ordinal)))
+			.Select(file => (File: file, Text: File.ReadAllText(file)))
+			.Where(f => databaseWrites.Any(w => f.Text.Contains(w, StringComparison.Ordinal)))
+			.Select(f => Path.GetRelativePath(RepositoryRoot(), f.File))
+			.Order(StringComparer.Ordinal)
+			.ToArray();
+
+		await Assert.That(offenders).IsEmpty()
+			.Because("character link/unlink must go through IAccountService, which invalidates the "
+				+ "account's cached role/permission claims; these call the database directly and skip it: "
+				+ string.Join(", ", offenders));
+	}
+
+	/// <summary>Every <c>.cs</c> file in a shipped project — test and database-provider projects excluded.</summary>
+	private static IEnumerable<string> ProductionSourceFiles(string root) =>
+		Directory.EnumerateDirectories(root, "SharpMUSH.*")
+			.Where(d => !Path.GetFileName(d).Contains("Tests", StringComparison.Ordinal))
+			.Where(d => !Path.GetFileName(d).StartsWith("SharpMUSH.Database", StringComparison.Ordinal))
+			.SelectMany(d => Directory.EnumerateFiles(d, "*.cs", SearchOption.AllDirectories))
+			.Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+			.Where(f => !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal));
+
+	/// <summary>Walks up from the test binaries to the directory holding <c>SharpMUSH.sln</c>.</summary>
+	private static string RepositoryRoot()
+	{
+		var directory = new DirectoryInfo(AppContext.BaseDirectory);
+		while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "SharpMUSH.sln")))
+			directory = directory.Parent;
+
+		return directory?.FullName
+			?? throw new InvalidOperationException("Could not locate the repository root (no SharpMUSH.sln above the test binaries).");
+	}
+}

--- a/SharpMUSH.Tests/Services/BanEnforcementServiceTests.cs
+++ b/SharpMUSH.Tests/Services/BanEnforcementServiceTests.cs
@@ -8,10 +8,8 @@ using SharpMUSH.Library.Services;
 using SharpMUSH.Library.Services.Interfaces;
 using SharpMUSH.Messaging.Abstractions;
 using SharpMUSH.Messaging.Messages;
-using SharpMUSH.Server.Authentication;
 using SharpMUSH.Server.Hubs;
 using SharpMUSH.Server.Services;
-using ZiggyCreatures.Caching.Fusion;
 
 namespace SharpMUSH.Tests.Services;
 
@@ -19,8 +17,8 @@ namespace SharpMUSH.Tests.Services;
 /// Unit tests for <see cref="BanEnforcementService"/>. Every dependency is an NSubstitute double
 /// except <see cref="HubConnectionRegistry"/>, a real instance wired to substituted
 /// collaborators — it isn't interface-shaped, so its real behavior is exercised directly rather
-/// than mocked. Cache invalidation is verified against a real <see cref="FusionCache"/> instance
-/// (tag-based removal isn't meaningfully observable through a bare substitute).
+/// than mocked. Cache invalidation is verified through the <see cref="IAccountClaimsInvalidator"/>
+/// seam the service now calls, rather than against the FusionCache tag API directly.
 /// </summary>
 public class BanEnforcementServiceTests
 {
@@ -51,7 +49,7 @@ public class BanEnforcementServiceTests
 	private static (
 		BanEnforcementService Service,
 		IAccountSessionStore Sessions,
-		IFusionCache Cache,
+		IAccountClaimsInvalidator ClaimsInvalidator,
 		IConnectionService Connections,
 		IMessageBus Bus,
 		HubConnectionRegistry Registry,
@@ -61,7 +59,7 @@ public class BanEnforcementServiceTests
 			IAccountSessionStore? sessionStore = null)
 	{
 		var sessions = sessionStore ?? Substitute.For<IAccountSessionStore>();
-		var cache = Substitute.For<IFusionCache>();
+		var claimsInvalidator = Substitute.For<IAccountClaimsInvalidator>();
 		var connections = Substitute.For<IConnectionService>();
 		connections.GetAll().Returns((liveConnections ?? []).ToAsyncEnumerable());
 		var bus = Substitute.For<IMessageBus>();
@@ -70,10 +68,10 @@ public class BanEnforcementServiceTests
 		database.GetCharactersForAccountAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
 			.Returns(ValueTask.FromResult(linkedCharacters ?? (IReadOnlyList<SharpPlayer>)[]));
 
-		var svc = new BanEnforcementService(sessions, cache, connections, bus, registry, database,
+		var svc = new BanEnforcementService(sessions, claimsInvalidator, connections, bus, registry, database,
 			NullLogger<BanEnforcementService>.Instance);
 
-		return (svc, sessions, cache, connections, bus, registry, database);
+		return (svc, sessions, claimsInvalidator, connections, bus, registry, database);
 	}
 
 	[Test]
@@ -89,15 +87,13 @@ public class BanEnforcementServiceTests
 	[Test]
 	public async Task EnforceAccountBanAsync_InvalidatesCachedClaims()
 	{
-		var (svc, _, cache, _, _, _, _) = Build();
+		var (svc, _, claimsInvalidator, _, _, _, _) = Build();
 
 		await svc.EnforceAccountBanAsync("accounts/1");
 
-		// BanEnforcementService no longer depends on AccountClaimsService directly; it invalidates
-		// the same cache tag AccountClaimsService's cached role/scope entries are tagged with, via
-		// IFusionCache.RemoveByTagAsync — the shared AccountCacheTag() is the single source of truth
-		// for that tag, so both classes always agree on it.
-		await cache.Received(1).RemoveByTagAsync(AccountClaimsService.AccountCacheTag("accounts/1"));
+		// Ban enforcement and character link/unlink drop the same cached claims, so they share one
+		// invalidator rather than each reaching for the cache tag themselves.
+		await claimsInvalidator.Received(1).InvalidateAsync("accounts/1", Arg.Any<CancellationToken>());
 	}
 
 	[Test]


### PR DESCRIPTION
PR 3 of a 10-PR stack. **Targets `fix/audit2-02-session-revocation`, not `main`** — it builds on #754 (session writes on the exclusive-transaction pattern) and #755 (`TouchSessionExpiryAsync`; `ValidateAsync` returns null when the session is gone). Review only the three commits on top of that base.

Two defects that every brand-new player hits in sequence, plus the onboarding gap they sit inside. Both were reproduced live against a Release build in Production mode, and both reproductions are now regression tests that were confirmed to fail before the fix.

---

## N-02 — a session minted before the account had a character never bound one

`AccountSessionAuthenticationHandler.ResolveActingCharacter` resolved the acting character from the key stored on the session. A session created at **registration** has no character key, because the account had no characters yet. Creating a character afterwards did not rebind it, so that session acted as nobody for its whole life.

**Measured, same account and character throughout:**

```
under the session minted at registration
  GET  /api/account/characters  200  [{"name":"Gwendolyn","isActing":false}]
  POST /api/wiki                401  Missing character identity.
after logging out and back in
  GET  /api/account/characters  200  [{"name":"Gwendolyn","isActing":true}]
  POST /api/wiki                201
```

`WikiController.CreatePage` was one of several writers behind that bare 401 (`UpdatePage`, rollback, metadata and the translation endpoints share the guard).

### The multi-character resolution rule, and why

`ActingCharacterResolver` now holds the one rule, shared by the authentication handler, the roster endpoint and login:

- **A session that names a character acts as that character, or as nobody.** No fallback. This is what keeps `AuthController.SwitchCharacter` authoritative — an explicitly chosen character always wins over any implicit resolution — and what keeps a character unlinked after the token was minted from silently redirecting to a different one.
- **A session that names no character resolves to the account's lowest-dbref character.**

Lowest dbref, not "the first one the backend happened to return": `GetCharactersAsync` passes the query through unsorted, so an unordered pick would name a different character on different requests for a multi-character account. It is the account's oldest surviving character, and — the reason it is *this* rule and not some other defensible one — it is **exactly the rule `AuthController.AccountLogin` has always used** to choose the character it binds into a freshly minted token. Picking anything else would mean an implicitly-resolved session and a re-logged-in session disagreeing about who you are. `AccountLogin` now calls the same helper, so the two cannot drift.

The roster's `isActing` flag goes through the same resolver as the handler, so it can no longer advertise an identity that a write would refuse.

---

## N-03 — the claims cache was never invalidated when characters were linked or unlinked

`AccountClaimsService` caches an account's derived role and permission scopes for 30s. Both are tagged `acct:{accountId}`, and `InvalidateAsync` existed for exactly this — called by nothing. Only `BanEnforcementService` cleared the tag, and it did so by reaching for the cache directly.

**Measured:** create your first character, log in immediately → `role=Guest`, 0 scopes. Thirty-five seconds later, same login → `role=Player`, 5 scopes. The unlink direction is the security-relevant one: unlinking your last character left Player scopes cached for up to 30s after the entitlement was gone.

Per the repo owner's directive, the TTL is untouched and the client does not poll or retry — the mutation invalidates, so the very next request is already correct.

### Where the invalidation went, and why

**On `AccountService.LinkCharacterAsync` / `UnlinkCharacterAsync`, where the link is actually written**, so no caller can forget: the REST endpoints (`CreateCharacter`, `LinkCharacter`, `UnlinkCharacter`), `AdminAccountsController`, the in-game `MAKE` command, and bootstrap/setup all route through there.

`AccountService` lives in `SharpMUSH.Library`, so it invalidates through a new `IAccountClaimsInvalidator` seam rather than depending on the Server layer — the same shape as the existing `IBanEnforcer`. No Server dependency is dragged into the Library.

The implementation is a small class of its own (`AccountClaimsInvalidator`, over `IFusionCache`) rather than `AccountClaimsService` itself: **that service computes claims from `IAccountService`, so making it the invalidator would close a DI cycle the moment `AccountService` called it.** `AccountClaimsService.InvalidateAsync` is now a thin wrapper over the same seam, and `BanEnforcementService` clears the tag through it too — one implementation of "drop this account's claims" instead of two spellings of it.

`AccountClaimsInvalidationTests.EveryCharacterLinkWriteGoesThroughAccountService` fails if a future call site reaches past the service to `ISharpDatabase.LinkCharacterToAccountAsync` / `UnlinkCharacterFromAccountAsync` and skips the invalidation. Verified by adding such a call and watching it fail, naming the offending file.

---

## Onboarding — "registered, no character yet" is a step, not a permission tier

Telnet already handles this better: `login` names the exact next command and `make <name> <password>` resolves it in one line. The portal dropped the same account into the full shell as `role=Guest` with zero scopes, where every gated surface refused without explaining why.

Login and registration with an empty roster now land on `/characters/new`, which says on arrival that creating a character is the last step before playing. Onboarding wins over a `returnUrl` — the gated page the visitor was heading for would refuse them anyway. An account that owns a character is routed exactly as before.

One new user-facing string, `OnboardingCreateFirstCharacter`, added to all 16 locale files.

`/characters/new` now loads the roster on init instead of trusting the local copy. A reloaded tab hydrates its session from sessionStorage but not its roster, so the local count was 0 for everyone — which also made the page mistake an established player's second character for their first and switch them onto it. That is fixed here as a side effect.

### Seam noted, deliberately not fixed

`PortalRole.Guest` still means both "anonymous visitor" and "registered but characterless", which is why this state reads as a permission failure rather than a next step. This PR routes around that. Re-modelling the role system is its own change and is not in scope here.

---

## Verification

All numbers below are real runs on this branch. Integration tests ran locally against Podman (Testcontainers; `DOCKER_HOST` set, no `docker` binary).

| Suite | Result |
|---|---|
| `SharpMUSH.Tests` | **5346 total — 0 failed**, 5150 succeeded, 196 skipped |
| `SharpMUSH.Tests.Integration` | **298 total — 0 failed**, 298 succeeded (3m 59s) |
| `SharpMUSH.Tests.BUnit` | **463 total — 0 failed**, 463 succeeded |
| `dotnet build` | **0 errors**, no new warnings (CS0067 ×14 / MSB3277 / NU1510 / NU1603 all pre-existing, none in touched files) |
| `python3 tools/i18n/validate_resx.py` | **all gates passed** — 1116 keys, 16 locales at 100% |

`TreatWarningsAsErrors` untouched; no suppressions added.

### Confirmed pre-fix failures

Each fix was reverted in isolation and the new tests re-run.

**N-02** — reverting `SharpMUSH.Server/` only:

```
AccountSessionAuthHandlerTests            total: 12  failed: 2  succeeded: 10
NewPlayerSessionTests (integration)       total:  2  failed: 1  succeeded:  1
```

The two unit failures are `SessionWithNoBoundCharacter_ActsAsTheAccountsOnlyCharacter` and `SessionWithNoBoundCharacter_MultipleCharacters_ActsAsTheLowestDbref`; the integration failure is `RegistrationSession_AfterCreatingItsFirstCharacter_ActsAsThatCharacter`. `SwitchedSession_KeepsItsChosenCharacter_NotTheLowestDbref` passes both before and after, which is the point — the fallback must not change it.

**N-03** — reverting `AccountService.cs` only:

```
NewPlayerSessionTests (integration)       total:  5  failed: 3  succeeded:  2

  FirstCharacter_LiftsRoleAndScopes_OnTheVeryNextRequest
    Expected to be equal to "Player" but received "Guest"
  UnlinkingTheLastCharacter_DropsScopes_OnTheVeryNextRequest
    Expected to not be empty but received empty collection
  RegistrationSession_CanCreateAWikiPage_WithoutReAuthenticating
    Expected to be true, because wiki.create must be granted on the first request; but found False
```

`AccountClaimsInvalidationTests` does not compile against the reverted service — the `claimsInvalidator` parameter it asserts on does not exist — so its failure is at build time rather than a red test.

**Onboarding** — reverting `SharpMUSH.Client/` only:

```
OnboardingRoutingTests                    total:  6  failed: 4  succeeded:  2
```

`Login_WithACharacter_StillHonoursTheReturnUrl` and `CharacterCreate_WithACharacter_ShowsNoOnboardingNotice` pass both before and after, which is what pins the no-regression half.

### On the specific evidence asked for

- **Role must be Player with 5 scopes on the FIRST login** — `FirstCharacter_LiftsRoleAndScopes_OnTheVeryNextRequest` asserts `role=Player` and the exact five scopes (`wiki.read`, `wiki.create`, `wiki.edit`, `media.upload`, `softcode.use`), having first asserted `Guest`/0 before the character exists so the stale entry is genuinely present.
- **The registration session must POST /api/wiki successfully without re-authenticating** — `RegistrationSession_CanCreateAWikiPage_WithoutReAuthenticating` authenticates the registration token through the real `AccountSession` handler, checks the `wiki.create` policy against the real policy provider, then drives `WikiController.CreatePage` with that principal and asserts a `CreatedAtActionResult`.
- **Unlink drops scopes on the very next request** — `UnlinkingTheLastCharacter_DropsScopes_OnTheVeryNextRequest`.
- **A test that fails if a future call site forgets** — `EveryCharacterLinkWriteGoesThroughAccountService`, demonstrated failing above.
- **bUnit routing** — asserted as routing and rendering directly. `[Authorize]` has no runtime effect below `AuthorizeRouteView` in bUnit, so a "render anonymously, expect a redirect" test would pass while proving nothing; this is called out in the test class remarks.

### Two things worth a reviewer's eye

The claim-level integration tests drive the `AccountSession` handler out of the host's DI container rather than over HTTP. The test host runs in **Development**, where `DebugAuth` is the *default* scheme and would authenticate any `[Authorize]` endpoint as the bootstrap admin regardless of the bearer — an HTTP-level assertion there proves nothing about the token under test.

`LoginReturnUrlTests`' fake login response was changed to return one character. Its subject is the return-URL sanitizer, and an empty roster now means "route to onboarding" — a different question. Without the change those four tests fail for a reason unrelated to what they cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MPRzndB5egy4F2A3q5852
