### PR TITLE
Surface a crashed command instead of swallowing it to silence

### DIFF
--- a/SharpMUSH.Documentation/Helpfiles/SharpMUSH/pennmush-compatibility.md
+++ b/SharpMUSH.Documentation/Helpfiles/SharpMUSH/pennmush-compatibility.md
@@ -45,6 +45,12 @@ function's name from evaluated output, so `[setq(0,add)]%q0(1,2)` calls `add`.
 SharpMUSH recognizes function names lexically, so a name that only appears after
 substitution is treated as ordinary text, not a call.
 
+**A command that crashes says so.** PennMUSH has no equivalent: when an internal
+error escapes a SharpMUSH command, the command returns
+`#-1 EXCEPTION: <json>` and the player is notified with the same text, instead of
+producing no output at all. See `help exception` for the payload and what a
+mortal versus a wizard is shown.
+
 **Unescaped commas are never absorbed by a final argument.** PennMUSH lets the
 last argument of functions such as `pemit()`, `emit()`, and `capstr()` swallow
 extra unescaped commas — `capstr(a,b,c)` capitalizes the string `a,b,c` — though

--- a/SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpcode.md
+++ b/SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpcode.md
@@ -14,6 +14,34 @@ For information about changes in versions of the code, see [changes].
 # download
 The latest version of this MUSH code is available from https://github.com/SharpMUSH/SharpMUSH/releases. 
 
+# exception
+# #-1 exception
+When an internal error escapes a command, SharpMUSH does **not** stay silent. The
+command returns, and you are notified with:
+
+```sharp
+  #-1 EXCEPTION: {"id":"7ac09f1a5b6f","command":"@switch","type":"KeyNotFoundException"}
+```
+
+The payload is a single-line JSON object. Everyone sees three fields:
+
+* `id` — a correlation id. The full error, including its stack trace, is in the
+  server log under this same id. Quote it when you report the bug; a wizard can
+  find the entry from it without you having to reproduce anything.
+* `command` — the command word that failed.
+* `type` — the class of error.
+
+A wizard or royalty additionally sees `message` (the error text) and `inner` (the
+chain of underlying errors). Those are withheld from everyone else because an
+error message can quote a file path or a database connection string. Stack traces
+are never sent to anyone in-game; they stay in the log, reachable by `id`.
+
+This is a real error return, so softcode can test for it — `#-1 EXCEPTION:` is
+always the prefix, and the rest is always valid JSON.
+
+**See Also:**
+- [pennmush compatibility]
+
 # i18n
 # internationalization
 # locale

--- a/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
+++ b/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
@@ -897,11 +897,15 @@ public class SharpMUSHParserVisitor(
 			logger.LogError(ex, nameof(CallFunction));
 			success = false;
 
-			var executor = await parser.CurrentState.KnownExecutorObject(Mediator);
+			// KnownExecutorObject throws when there is no executor — which is exactly the state at the
+			// connect screen. Using it here meant the error handler replaced the real exception with an
+			// ArgumentNullException of its own, hiding the actual failure. Resolve optionally instead.
+			var executor = await parser.CurrentState.ExecutorObject(Mediator);
 
-			if (executor.IsGod())
+			if (!executor.IsNone && executor.Known().IsGod())
 			{
-				await NotifyService.Notify(executor, string.Format(ErrorMessages.Returns.InternalErrorFormat, ex));
+				await NotifyService.Notify(executor.Known(),
+					string.Format(ErrorMessages.Returns.InternalErrorFormat, ex));
 			}
 
 			return CallState.Empty;
@@ -1021,6 +1025,9 @@ public class SharpMUSHParserVisitor(
 		bool isCommandList,
 		Func<IRuleNode, ValueTask<CallState?>> visitChildren)
 	{
+		// Hoisted out of the try so the catch can name the command that failed.
+		string? command = null;
+
 		try
 		{
 			var firstCommandMatch = context.evaluationString();
@@ -1028,7 +1035,7 @@ public class SharpMUSHParserVisitor(
 			if (firstCommandMatch?.SourceInterval.Length is null or 0)
 				return new None();
 
-			var command = firstCommandMatch.GetText().TrimStart();
+			command = firstCommandMatch.GetText().TrimStart();
 
 			var spaceIndex = command.AsSpan().IndexOf(' ');
 			if (spaceIndex != -1)
@@ -1380,8 +1387,57 @@ public class SharpMUSHParserVisitor(
 		}
 		catch (Exception ex)
 		{
-			logger.LogError(ex, nameof(EvaluateCommands));
-			return CallState.Empty;
+			// A command that throws used to be logged server-side and then swallowed to
+			// CallState.Empty, which is indistinguishable to the player from a command that simply
+			// had nothing to say. Surface it instead, following CallFunction's precedent above.
+			var correlationId = ExceptionReport.NewCorrelationId();
+			logger.LogError(ex, "{Method} threw for command {Command} (correlation {CorrelationId})",
+				nameof(EvaluateCommands), command ?? "(unknown)", correlationId);
+
+			return await ReportCommandException(ex, command, correlationId);
+		}
+	}
+
+	/// <summary>
+	/// Turns an escaped command exception into the player-visible <c>#-1 EXCEPTION: {json}</c>,
+	/// notifies whoever ran the command, and returns it so nested evaluations see it too.
+	/// </summary>
+	/// <remarks>
+	/// Notification targets, in order: the executor when there is one; otherwise the raw connection
+	/// handle, which is the only recipient available at the connect screen (where a pre-login command
+	/// such as <c>WHO</c> has no executor at all — precisely one of the cases this exists for).
+	/// The whole body is defensive: this runs because something already failed, so a second failure
+	/// here (a downed database behind <c>ExecutorObject</c>, say) must not escape and replace the
+	/// original exception.
+	/// </remarks>
+	private async ValueTask<Option<CallState>> ReportCommandException(Exception ex, string? command,
+		string correlationId)
+	{
+		try
+		{
+			var executor = await parser.CurrentState.ExecutorObject(Mediator);
+			var privileged = !executor.IsNone && await executor.Known().IsPriv();
+			var message = ExceptionReport.Format(ex, command, correlationId, privileged);
+
+			if (!executor.IsNone)
+			{
+				await NotifyService.Notify(executor.Known(), message);
+			}
+			else if (parser.CurrentState.Handle is not null)
+			{
+				await NotifyService.Notify(parser.CurrentState.Handle.Value, message);
+			}
+
+			return new CallState(message);
+		}
+		catch (Exception reportingFailure)
+		{
+			logger.LogError(reportingFailure,
+				"Failed to report command exception (correlation {CorrelationId})", correlationId);
+
+			// Still hand back an unprivileged payload: the player learns the command failed and gets
+			// the id that reaches the log, even though the notification could not be delivered.
+			return new CallState(ExceptionReport.Format(ex, command, correlationId, privileged: false));
 		}
 	}
 

--- a/SharpMUSH.Library/Definitions/ErrorMessages.cs
+++ b/SharpMUSH.Library/Definitions/ErrorMessages.cs
@@ -317,6 +317,15 @@ public static class ErrorMessages
 		public const string NotGoing = "#-1 OBJECT NOT MARKED FOR DESTRUCTION";
 		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
 		public const string InternalErrorFormat = "#-1 INTERNAL SHARPMUSH ERROR:\n{0}";
+
+		/// <summary>
+		/// A command threw. <c>{0}</c> is a single-line JSON object built by
+		/// <see cref="ExceptionReport"/>; see that type for the disclosure rule that decides which
+		/// fields a given recipient gets. Never build this string by hand — the whole point of the
+		/// builder is that the mortal payload is an allowlist rather than a scrubbed dump.
+		/// </summary>
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string ExceptionFormat = "#-1 EXCEPTION: {0}";
 	}
 
 	/// <summary>

--- a/SharpMUSH.Library/Definitions/ExceptionReport.cs
+++ b/SharpMUSH.Library/Definitions/ExceptionReport.cs
@@ -1,0 +1,102 @@
+using System.Buffers;
+using System.Text;
+using System.Text.Json;
+
+namespace SharpMUSH.Library.Definitions;
+
+/// <summary>
+/// Builds the JSON payload carried by <see cref="ErrorMessages.Returns.ExceptionFormat"/>
+/// (<c>#-1 EXCEPTION: {json}</c>) when a command throws.
+///
+/// <para><b>Disclosure rule.</b> The payload is built from an allowlist, never by scrubbing a
+/// formatted exception. A mortal receives only fields that cannot carry runtime data:</para>
+/// <list type="bullet">
+/// <item><description><c>id</c> — correlation id, also written to the server log entry that holds
+/// the full exception. This is what a player quotes in a bug report.</description></item>
+/// <item><description><c>command</c> — the command word the player typed.</description></item>
+/// <item><description><c>type</c> — the exception's simple CLR type name. A class name is a closed
+/// set of identifiers chosen at compile time; it never contains a path, a connection string, a
+/// dbref, or any other runtime value.</description></item>
+/// </list>
+/// <para>A privileged executor (God, Wizard, or Royalty — <c>IsPriv</c>) additionally receives
+/// <c>message</c> and the <c>inner</c> exception chain, which CAN contain paths and connection
+/// strings and so are withheld from everyone else.</para>
+/// <para>Stack frames are never sent to any player, privileged or not: they are unreadable on a
+/// MUSH line and the server log already has them, reachable by <c>id</c>.</para>
+/// </summary>
+public static class ExceptionReport
+{
+	/// <summary>Command words are short; a longer one is a parse artifact, not something to echo back.</summary>
+	private const int MaxCommandLength = 64;
+
+	/// <summary>Keeps a pathological exception message from filling a player's screen.</summary>
+	private const int MaxMessageLength = 500;
+
+	/// <summary>How far down the <see cref="Exception.InnerException"/> chain to report.</summary>
+	private const int MaxInnerDepth = 3;
+
+	/// <summary>
+	/// A short, unique token written both to the player-visible payload and to the server log entry
+	/// carrying the full exception, so the two can be tied together without disclosing anything.
+	/// </summary>
+	public static string NewCorrelationId() => Guid.NewGuid().ToString("N")[..12];
+
+	/// <summary>
+	/// The JSON object alone, without the <c>#-1 EXCEPTION: </c> prefix.
+	/// </summary>
+	/// <param name="exception">The exception that escaped the command.</param>
+	/// <param name="command">The command word that produced it, if known.</param>
+	/// <param name="correlationId">Token shared with the server log entry.</param>
+	/// <param name="privileged">Whether the recipient may see the exception message and inner chain.</param>
+	public static string Payload(Exception exception, string? command, string correlationId, bool privileged)
+	{
+		var buffer = new ArrayBufferWriter<byte>(256);
+
+		using (var writer = new Utf8JsonWriter(buffer))
+		{
+			writer.WriteStartObject();
+			writer.WriteString("id", correlationId);
+
+			if (!string.IsNullOrWhiteSpace(command))
+			{
+				writer.WriteString("command", Clamp(command, MaxCommandLength));
+			}
+
+			writer.WriteString("type", exception.GetType().Name);
+
+			if (privileged)
+			{
+				writer.WriteString("message", Clamp(exception.Message, MaxMessageLength));
+
+				var inner = exception.InnerException;
+				if (inner is not null)
+				{
+					writer.WriteStartArray("inner");
+					for (var depth = 0; inner is not null && depth < MaxInnerDepth; depth++, inner = inner.InnerException)
+					{
+						writer.WriteStartObject();
+						writer.WriteString("type", inner.GetType().Name);
+						writer.WriteString("message", Clamp(inner.Message, MaxMessageLength));
+						writer.WriteEndObject();
+					}
+
+					writer.WriteEndArray();
+				}
+			}
+
+			writer.WriteEndObject();
+		}
+
+		return Encoding.UTF8.GetString(buffer.WrittenSpan);
+	}
+
+	/// <summary>
+	/// The full player-visible return: <c>#-1 EXCEPTION: {json}</c>.
+	/// </summary>
+	public static string Format(Exception exception, string? command, string correlationId, bool privileged)
+		=> string.Format(ErrorMessages.Returns.ExceptionFormat,
+			Payload(exception, command, correlationId, privileged));
+
+	private static string Clamp(string value, int max)
+		=> value.Length <= max ? value : string.Concat(value.AsSpan(0, max), "...");
+}

--- a/SharpMUSH.Tests/Commands/CommandExceptionSurfacingTests.cs
+++ b/SharpMUSH.Tests/Commands/CommandExceptionSurfacingTests.cs
@@ -1,0 +1,229 @@
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.Core;
+using OneOf;
+using SharpMUSH.Library.DiscriminatedUnions;
+using SharpMUSH.Library.Extensions;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Services.Interfaces;
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace SharpMUSH.Tests.Commands;
+
+/// <summary>
+/// A command that throws used to be logged server-side and swallowed to <c>CallState.Empty</c>, so
+/// the player saw nothing at all — a crash was indistinguishable from a command with no output.
+/// These tests pin the replacement contract: the player gets <c>#-1 EXCEPTION: {json}</c>, the
+/// payload is valid JSON, a mortal's copy leaks no internals, and the server log still gets
+/// everything.
+///
+/// <para>The crashing command used here is bare <c>@switch</c>, which indexes <c>args["0"]</c>
+/// despite declaring <c>MinArgs = 3</c> and throws <c>KeyNotFoundException</c>. That underlying bug
+/// belongs to a later PR in this stack; when it is fixed, these tests must be re-pointed at another
+/// throwing command (or a deliberate one), NOT deleted — what they assert is the surfacing
+/// behaviour, not the bug.</para>
+/// </summary>
+[NotInParallel]
+public class CommandExceptionSurfacingTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactoryArg { get; init; }
+
+	private INotifyService NotifyService => WebAppFactoryArg.Services.GetRequiredService<INotifyService>();
+
+	private IConnectionService ConnectionService => WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
+
+	private IMediator Mediator => WebAppFactoryArg.Services.GetRequiredService<IMediator>();
+
+	/// <summary>Bare, so no <c>"0"</c> argument is ever put in the argument dictionary.</summary>
+	private const string CrashingCommand = "@switch";
+
+	[Test]
+	public async Task ACommandThatThrowsIsSurfacedInsteadOfSwallowed()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "ExcSurface");
+		var parser = WebAppFactoryArg.CommandParserFor(player.DbRef, player.Handle);
+
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single(CrashingCommand));
+
+		var message = NotificationTo(player.DbRef);
+
+		await Assert.That(message).IsNotNull();
+		await Assert.That(message!).StartsWith("#-1 EXCEPTION: ");
+	}
+
+	[Test]
+	public async Task ThePayloadIsValidJsonNamingTheExceptionAndTheCommand()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "ExcJson");
+		var parser = WebAppFactoryArg.CommandParserFor(player.DbRef, player.Handle);
+
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single(CrashingCommand));
+
+		var payload = PayloadOf(NotificationTo(player.DbRef));
+
+		using var document = JsonDocument.Parse(payload);
+
+		await Assert.That(document.RootElement.GetProperty("type").GetString())
+			.IsEqualTo(nameof(KeyNotFoundException));
+		await Assert.That(document.RootElement.GetProperty("command").GetString()).IsEqualTo(CrashingCommand);
+		await Assert.That(document.RootElement.GetProperty("id").GetString()!.Length).IsEqualTo(12);
+	}
+
+	[Test]
+	public async Task AMortalsPayloadLeaksNoInternals()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "ExcMortal");
+		var parser = WebAppFactoryArg.CommandParserFor(player.DbRef, player.Handle);
+
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single(CrashingCommand));
+
+		var payload = PayloadOf(NotificationTo(player.DbRef));
+
+		// Nothing path-like, and no stack frames.
+		await Assert.That(Regex.IsMatch(payload, @"[/\\]")).IsFalse();
+		await Assert.That(payload).DoesNotContain("   at ");
+		await Assert.That(payload).DoesNotContain(".cs");
+		await Assert.That(payload).DoesNotContain("SharpMUSH.");
+
+		// The exception message itself is withheld: it is the field that can carry a path or a
+		// connection string, so a mortal never receives it.
+		using var document = JsonDocument.Parse(payload);
+		await Assert.That(document.RootElement.TryGetProperty("message", out _)).IsFalse();
+		await Assert.That(document.RootElement.TryGetProperty("inner", out _)).IsFalse();
+
+		var keys = document.RootElement.EnumerateObject().Select(p => p.Name).ToArray();
+		await Assert.That(keys).IsEquivalentTo(new[] { "id", "command", "type" });
+	}
+
+	[Test]
+	public async Task APrivilegedExecutorAlsoGetsTheExceptionMessage()
+	{
+		// Handle 1 is bound to #1 (God), which IsPriv.
+		var parser = WebAppFactoryArg.CommandParser;
+
+		await parser.CommandParse(1, ConnectionService, MModule.single(CrashingCommand));
+
+		var payload = PayloadOf(NotificationTo(WebAppFactoryArg.ExecutorDBRef));
+
+		using var document = JsonDocument.Parse(payload);
+		await Assert.That(document.RootElement.TryGetProperty("message", out var message)).IsTrue();
+		await Assert.That(message.GetString()).IsNotNull().And.IsNotEmpty();
+	}
+
+	[Test]
+	public async Task APreLoginCommandWithNoExecutorNotifiesTheConnectionHandle()
+	{
+		// The connect screen: a registered handle with nothing bound to it, so CurrentState.Executor
+		// is null. WHO calls KnownExecutorObject unconditionally and throws ArgumentNullException.
+		var handle = Random.Shared.NextInt64(900_000, 999_999);
+		await ConnectionService.Register(handle, "localhost", "localhost", "test",
+			_ => ValueTask.CompletedTask, _ => ValueTask.CompletedTask, () => Encoding.UTF8);
+
+		await WebAppFactoryArg.CommandParser.CommandParse(handle, ConnectionService, MModule.single("WHO"));
+
+		var message = NotificationToHandle(handle);
+
+		await Assert.That(message).IsNotNull();
+		await Assert.That(message!).StartsWith("#-1 EXCEPTION: ");
+
+		using var document = JsonDocument.Parse(PayloadOf(message));
+		await Assert.That(document.RootElement.GetProperty("type").GetString())
+			.IsEqualTo(nameof(ArgumentNullException));
+
+		// No executor means no privilege, so the unprivileged allowlist applies.
+		var keys = document.RootElement.EnumerateObject().Select(p => p.Name).ToArray();
+		await Assert.That(keys).IsEquivalentTo(new[] { "id", "command", "type" });
+	}
+
+	[Test]
+	public async Task TheServerLogStillReceivesTheFullException()
+	{
+		// Startup calls ClearProviders() at registration time; adding a provider to the built
+		// LoggerFactory afterwards still reaches already-created ILogger instances.
+		var captured = new ConcurrentQueue<(string Category, LogLevel Level, string Message, Exception? Exception)>();
+		var loggerFactory = WebAppFactoryArg.Services.GetRequiredService<ILoggerFactory>();
+		using var provider = new CapturingLoggerProvider(captured);
+		loggerFactory.AddProvider(provider);
+
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "ExcLog");
+		var parser = WebAppFactoryArg.CommandParserFor(player.DbRef, player.Handle);
+
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single(CrashingCommand));
+
+		var correlationId = JsonDocument.Parse(PayloadOf(NotificationTo(player.DbRef)))
+			.RootElement.GetProperty("id").GetString()!;
+
+		var entry = captured.SingleOrDefault(e => e.Message.Contains(correlationId));
+
+		await Assert.That(entry.Message).IsNotNull();
+		await Assert.That(entry.Level).IsEqualTo(LogLevel.Error);
+		await Assert.That(entry.Category).IsEqualTo("SharpMUSH.Implementation.MUSHCodeParser");
+		await Assert.That(entry.Message).Contains(CrashingCommand);
+
+		// The full exception object — message and stack trace, neither of which the mortal saw.
+		await Assert.That(entry.Exception).IsNotNull();
+		await Assert.That(entry.Exception!.GetType().Name).IsEqualTo(nameof(KeyNotFoundException));
+		await Assert.That(entry.Exception.StackTrace).IsNotNull().And.IsNotEmpty();
+	}
+
+	/// <summary>
+	/// Plain text of the most recent Notify to <paramref name="target"/> that carries an exception
+	/// payload. The INotifyService substitute is shared for the whole test session, hence filtering
+	/// by an isolated player's DBRef.
+	/// </summary>
+	private string? NotificationTo(DBRef target) =>
+		LastMatching(call =>
+			call.GetArguments() is [AnySharpObject obj, ..] && obj.Object().DBRef == target);
+
+	private string? NotificationToHandle(long handle) =>
+		LastMatching(call => call.GetArguments() is [long h, ..] && h == handle);
+
+	private string? LastMatching(Func<ICall, bool> targetMatches) =>
+		NotifyService.ReceivedCalls()
+			.Where(call => call.GetMethodInfo().Name == nameof(INotifyService.Notify))
+			.Where(targetMatches)
+			.Select(call => call.GetArguments() is [_, OneOf<MString, string> msg, ..]
+				? msg.Match(ms => ms.ToPlainText(), s => s)
+				: null)
+			.LastOrDefault(text => text is not null && text.StartsWith("#-1 EXCEPTION: "));
+
+	private static string PayloadOf(string? notification)
+		=> notification!["#-1 EXCEPTION: ".Length..];
+
+	private sealed class CapturingLoggerProvider(
+		ConcurrentQueue<(string Category, LogLevel Level, string Message, Exception? Exception)> sink)
+		: ILoggerProvider
+	{
+		public ILogger CreateLogger(string categoryName) => new CapturingLogger(categoryName, sink);
+
+		public void Dispose() { }
+
+		private sealed class CapturingLogger(
+			string category,
+			ConcurrentQueue<(string Category, LogLevel Level, string Message, Exception? Exception)> sink)
+			: ILogger
+		{
+			public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+			public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Error;
+
+			public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+				Func<TState, Exception?, string> formatter)
+			{
+				if (!IsEnabled(logLevel)) return;
+				sink.Enqueue((category, logLevel, formatter(state, exception), exception));
+			}
+		}
+	}
+}

--- a/SharpMUSH.Tests/Internal/ExceptionReportTests.cs
+++ b/SharpMUSH.Tests/Internal/ExceptionReportTests.cs
@@ -1,0 +1,159 @@
+using SharpMUSH.Library.Definitions;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace SharpMUSH.Tests.Internal;
+
+/// <summary>
+/// Contract tests for the <c>#-1 EXCEPTION: {json}</c> payload builder, in particular the
+/// disclosure rule: a mortal's payload is assembled from an allowlist, so it cannot carry a file
+/// path, a stack frame, or a connection string no matter what the exception contains.
+/// </summary>
+public class ExceptionReportTests
+{
+	/// <summary>
+	/// An exception deliberately stuffed with everything a mortal must never see: an absolute path,
+	/// a Windows path, a connection string with credentials, and (via <see cref="Thrown"/>) a real
+	/// stack trace with frame markers.
+	/// </summary>
+	private const string LeakyMessage =
+		"Could not open /opt/sharpmush/game/data/secrets.json or C:\\SharpMUSH\\db.dat using " +
+		"Server=db.internal;Database=mush;User Id=sa;Password=hunter2;";
+
+	private static Exception Thrown()
+	{
+		try
+		{
+			throw new InvalidOperationException(LeakyMessage,
+				new IOException("/var/lib/sharpmush/arangodb.sock is unavailable"));
+		}
+		catch (InvalidOperationException caught)
+		{
+			return caught;
+		}
+	}
+
+	[Test]
+	public async Task FormatUsesTheEstablishedErrorPrefix()
+	{
+		var formatted = ExceptionReport.Format(Thrown(), "@CHANNEL", "abc123abc123", privileged: false);
+
+		await Assert.That(formatted).StartsWith("#-1 EXCEPTION: {");
+	}
+
+	[Test]
+	public async Task PayloadIsValidJson()
+	{
+		var payload = ExceptionReport.Payload(Thrown(), "@CHANNEL", "abc123abc123", privileged: true);
+
+		using var document = JsonDocument.Parse(payload);
+
+		await Assert.That(document.RootElement.ValueKind).IsEqualTo(JsonValueKind.Object);
+		await Assert.That(document.RootElement.GetProperty("id").GetString()).IsEqualTo("abc123abc123");
+		await Assert.That(document.RootElement.GetProperty("command").GetString()).IsEqualTo("@CHANNEL");
+		await Assert.That(document.RootElement.GetProperty("type").GetString())
+			.IsEqualTo(nameof(InvalidOperationException));
+	}
+
+	[Test]
+	public async Task PayloadIsASingleLineEvenWhenTheMessageIsNot()
+	{
+		var multiline = new Exception("first line\nsecond line\r\nthird line");
+
+		var payload = ExceptionReport.Payload(multiline, "@SWITCH", "abc123abc123", privileged: true);
+
+		await Assert.That(payload).DoesNotContain("\n");
+		await Assert.That(payload).DoesNotContain("\r");
+	}
+
+	[Test]
+	public async Task MortalPayloadLeaksNoInternals()
+	{
+		var payload = ExceptionReport.Payload(Thrown(), "@CHANNEL", "abc123abc123", privileged: false);
+
+		// The exception message and every fragment of it stay server-side.
+		await Assert.That(payload).DoesNotContain("secrets.json");
+		await Assert.That(payload).DoesNotContain("/opt/sharpmush");
+		await Assert.That(payload).DoesNotContain("C:\\SharpMUSH");
+		await Assert.That(payload).DoesNotContain("Password=");
+		await Assert.That(payload).DoesNotContain("arangodb.sock");
+		await Assert.That(payload).DoesNotContain(nameof(IOException));
+
+		// No stack frames: neither the "at Namespace.Type.Method" form nor a source-line reference.
+		await Assert.That(payload).DoesNotContain("   at ");
+		await Assert.That(payload).DoesNotContain(".cs:line");
+		await Assert.That(payload).DoesNotContain("ExceptionReportTests");
+
+		// Nothing path-like at all: no directory separators, no drive letter, no file extension.
+		// JSON escapes a backslash as \\, so a raw '\' cannot appear except as an escape - and the
+		// allowlisted fields (hex id, command word, CLR type name) never need one.
+		await Assert.That(Regex.IsMatch(payload, @"[/\\]")).IsFalse();
+		await Assert.That(Regex.IsMatch(payload, @"\.(cs|json|dat|dll|sock|log)\b")).IsFalse();
+
+		// And only the three allowlisted keys are present.
+		using var document = JsonDocument.Parse(payload);
+		var keys = document.RootElement.EnumerateObject().Select(p => p.Name).ToArray();
+		await Assert.That(keys).IsEquivalentTo(new[] { "id", "command", "type" });
+	}
+
+	[Test]
+	public async Task PrivilegedPayloadCarriesMessageAndInnerChain()
+	{
+		var payload = ExceptionReport.Payload(Thrown(), "@CHANNEL", "abc123abc123", privileged: true);
+
+		using var document = JsonDocument.Parse(payload);
+
+		await Assert.That(document.RootElement.GetProperty("message").GetString()).IsEqualTo(LeakyMessage);
+
+		var inner = document.RootElement.GetProperty("inner");
+		await Assert.That(inner.GetArrayLength()).IsEqualTo(1);
+		await Assert.That(inner[0].GetProperty("type").GetString()).IsEqualTo(nameof(IOException));
+		await Assert.That(inner[0].GetProperty("message").GetString())
+			.IsEqualTo("/var/lib/sharpmush/arangodb.sock is unavailable");
+	}
+
+	[Test]
+	public async Task PrivilegedPayloadNeverCarriesAStackTrace()
+	{
+		var payload = ExceptionReport.Payload(Thrown(), "@CHANNEL", "abc123abc123", privileged: true);
+
+		// Stack frames are unreadable on a MUSH line; the server log keeps them, reachable by id.
+		await Assert.That(payload).DoesNotContain("   at ");
+		await Assert.That(payload).DoesNotContain(".cs:line");
+		await Assert.That(payload).DoesNotContain("stack");
+	}
+
+	[Test]
+	public async Task LongMessagesAreClamped()
+	{
+		var payload = ExceptionReport.Payload(new Exception(new string('x', 5000)), "@SWITCH",
+			"abc123abc123", privileged: true);
+
+		using var document = JsonDocument.Parse(payload);
+		var message = document.RootElement.GetProperty("message").GetString()!;
+
+		await Assert.That(message.Length).IsEqualTo(503);
+		await Assert.That(message).EndsWith("...");
+	}
+
+	[Test]
+	public async Task CommandIsOmittedWhenUnknown()
+	{
+		var payload = ExceptionReport.Payload(new Exception("boom"), null, "abc123abc123", privileged: false);
+
+		using var document = JsonDocument.Parse(payload);
+
+		await Assert.That(document.RootElement.TryGetProperty("command", out _)).IsFalse();
+		await Assert.That(document.RootElement.GetProperty("id").GetString()).IsEqualTo("abc123abc123");
+	}
+
+	[Test]
+	public async Task CorrelationIdsAreUniqueAndOpaque()
+	{
+		var ids = Enumerable.Range(0, 1000).Select(_ => ExceptionReport.NewCorrelationId()).ToArray();
+
+		await Assert.That(ids.Distinct().Count()).IsEqualTo(1000);
+		await Assert.That(ids.All(id => id.Length == 12)).IsTrue();
+		await Assert.That(ids.All(id => Regex.IsMatch(id, "^[0-9a-f]{12}$"))).IsTrue();
+	}
+}


### PR DESCRIPTION
**PR 4 of a 10-PR stack. Base is `fix/audit2-03-new-player-session`, not `main`.**

## The problem: a crashed command was silent

`SharpMUSHParserVisitor.EvaluateCommands` wrapped all command dispatch in:

```csharp
catch (Exception ex)
{
	logger.LogError(ex, nameof(EvaluateCommands));
	return CallState.Empty;
}
```

Every exception a command threw was logged server-side and then swallowed. The
player received **nothing at all** — no error, no `Huh?`, no prompt. A crashed
command was indistinguishable from a command that legitimately had no output,
which is why these bugs survive: nobody reports what looks like a no-op.

A live audit hit this five times in one short session, and every one looked to
the player like a command with nothing to say:

| Command | Exception | Cause |
|---|---|---|
| `WHO` at the connect screen | `ArgumentNullException` | unconditional `KnownExecutorObject` with no executor |
| bare `@mail` | `NullReferenceException` | pattern-arm guard `arg0?.Length != 0` is *true* when `arg0` is null |
| bare `@channel/list` | `KeyNotFoundException` | indexes `args["0"]`/`args["1"]` despite `MinArgs = 0` |
| bare `@switch` | `KeyNotFoundException` | indexes `args["0"]` despite `MinArgs = 3` |
| (`@channel` bare) | — | **corrected**: this one does not throw; it falls to the discard arm and returns "What do you want to do with the channel?" |

Those individual bugs are not fixed here — later PRs in the stack own them. This
PR fixes the silence that hides them. Precedent for the shape is `CallFunction`
in the same file, which already catches and notifies.

## What a player now sees

```
> @switch
#-1 EXCEPTION: {"id":"7ac09f1a5b6f","command":"@switch","type":"KeyNotFoundException"}
```

`#-1 ...` is the established MUSH error convention, so the string is a new
`ErrorMessages.Returns.ExceptionFormat` constant alongside the other ~250
`#-1` returns, and it is a real error return that softcode can test for.

## Payload shape

Single-line JSON, built by `SharpMUSH.Library/Definitions/ExceptionReport.cs`.

Everyone gets:

- `id` — 12-hex correlation id, written to the server log entry holding the full
  exception. This is what a player quotes in a bug report; a wizard finds the
  entry from it without needing a repro.
- `command` — the command word that failed (clamped to 64 chars).
- `type` — the exception's simple CLR type name.

A **privileged** executor (`IsPriv`: God, Wizard, or Royalty) additionally gets:

- `message` — the exception message (clamped to 500 chars).
- `inner` — the `InnerException` chain, up to 3 deep, as `{type, message}`.

## Disclosure rule, and why

**The mortal payload is an allowlist, not a scrubbed dump.** Nothing is
regex-stripped out of a formatted exception; the three mortal fields are written
one at a time and no other field is ever emitted. That is a structural
guarantee: a leak would require adding a field, not defeating a filter.

- `message` and `inner` are withheld from mortals because an exception message is
  exactly where a path (`/opt/sharpmush/...`), a connection string
  (`Server=...;Password=...`), or a socket path shows up.
- `type` **is** disclosed to mortals. A CLR class name is chosen at compile time
  from a closed set; it carries no runtime value — no path, no credential, no
  dbref. It is also the single field that turns "something broke" into an
  actionable report.
- **Stack frames go to nobody in-game**, privileged or not. They are unreadable
  on a MUSH line and full of build-machine paths. They stay in the log, reachable
  by `id`.
- No executor at all (the connect screen) is treated as unprivileged, and the
  notification is delivered to the raw connection handle — the only recipient
  that exists pre-login, and precisely the `WHO` case above.

The full exception, message and stack trace included, is logged server-side in
every case, tagged with the same `id`.

## Also fixed here (adjacent, one line)

`CallFunction`'s existing catch block called `KnownExecutorObject` **inside the
catch**, which throws `ArgumentNullException` when there is no executor. So a
function that threw at the connect screen had its real exception replaced by a
bogus one from the error handler — and with this PR that bogus exception is what
the player would have been shown. Changed to resolve the executor optionally.
Its God-only disclosure policy is left alone (see follow-ups).

## Tests whose expectations changed

**None.** The full `SharpMUSH.Tests` suite passes unchanged — no existing test
asserted empty output or `DidNotReceive` for any command that throws. This was
verified rather than assumed: the three suite tests that touch the crashing
commands (`ChannelCommandTests.ChannelList`, `MiscCommandTests` `who`,
`MailCommandTests` `@mail`) are all `[Skip("Not Yet Implemented")]` and assert
*positive* output, so they are aspirational specs, not bug documentation.
`MogrifierTests` runs `@channel/mogrifier` with no arguments and is unaffected
(that arm uses `args.GetValueOrDefault`).

## Tests added

`SharpMUSH.Tests/Internal/ExceptionReportTests.cs` (9) — payload contract:

- `FormatUsesTheEstablishedErrorPrefix`
- `PayloadIsValidJson`
- `PayloadIsASingleLineEvenWhenTheMessageIsNot`
- `MortalPayloadLeaksNoInternals` — an exception stuffed with an absolute path, a
  Windows path, a credentialed connection string, and a real stack trace; asserts
  the mortal payload matches no `[/\\]`, no `.cs`/`.sock`/`.json`, no `   at `,
  and has exactly the keys `id`/`command`/`type`
- `PrivilegedPayloadCarriesMessageAndInnerChain`
- `PrivilegedPayloadNeverCarriesAStackTrace`
- `LongMessagesAreClamped`
- `CommandIsOmittedWhenUnknown`
- `CorrelationIdsAreUniqueAndOpaque`

`SharpMUSH.Tests/Commands/CommandExceptionSurfacingTests.cs` (6) — end to end
through the real parser and DB:

- `ACommandThatThrowsIsSurfacedInsteadOfSwallowed` — the core regression
- `ThePayloadIsValidJsonNamingTheExceptionAndTheCommand`
- `AMortalsPayloadLeaksNoInternals` — against a real non-wizard player
- `APrivilegedExecutorAlsoGetsTheExceptionMessage`
- `APreLoginCommandWithNoExecutorNotifiesTheConnectionHandle` — real `WHO` on an
  unbound handle
- `TheServerLogStillReceivesTheFullException` — attaches an `ILoggerProvider` to
  the live `ILoggerFactory`, then asserts the `Error` entry from
  `SharpMUSH.Implementation.MUSHCodeParser` carries the correlation id, the
  command, the exception object, and a non-empty stack trace

## Verification

### Build

`dotnet build` (whole solution): **0 errors, 32 warnings — none in any file this
PR touches.** The 32 are the pre-existing baseline: 14 × `CS0067` (unused events
in `SharpMUSH.Tests.BUnit` fakes) plus `MSB3277`/`NU1603` package-resolution
noise. No suppressions added, `TreatWarningsAsErrors` untouched.

Formatter: `dotnet format whitespace --folder` run to convergence (two passes)
over `SharpMUSH.Library`, `SharpMUSH.Implementation`, `SharpMUSH.Tests`.

### Tests

Ran locally against real containers (Podman + Testcontainers, `DOCKER_HOST` set).

| Suite | Total | Passed | Failed | Skipped |
|---|---|---|---|---|
| `SharpMUSH.Tests` | 5361 | 5165 | **0** | 196 |
| `SharpMUSH.Tests.Integration` | 298 | 298 | **0** | 0 |

Full disclosure on a flake: the *first* full run of `SharpMUSH.Tests` had 1
failure — `AliasTests.FunctionAlias_U_WorksAsUfun`, a
`NotSupportedException: Specified method is not supported.` thrown from
`ArangoDatabase.GetObjectFlagsAsync`'s **async-enumerator disposal**, reached
via `HelperFunctions.HasFlag` on the `VisitFunction` path
(`SharpMUSHParserVisitor.cs:563`). That path is not touched by this PR. It
passes in isolation (5/5) and the second full run was 0 failed / 5165 passed.
Recording it rather than hiding it; it looks like a pre-existing DB
enumerator-disposal race, worth its own issue.

### Demonstrated player-visible output

Driven through the real parser, real database, real command dispatch — the
actual notification text each recipient received:

```
mortal, bare @switch
  #-1 EXCEPTION: {"id":"7ac09f1a5b6f","command":"@switch","type":"KeyNotFoundException"}

mortal, bare @mail
  #-1 EXCEPTION: {"id":"ccf2760798c3","command":"@mail","type":"NullReferenceException"}

mortal, bare @channel/list
  #-1 EXCEPTION: {"id":"17eace53fb2f","command":"@channel/list","type":"KeyNotFoundException"}

connect screen (no executor), WHO
  #-1 EXCEPTION: {"id":"878ba06603cf","command":"WHO","type":"ArgumentNullException"}

wizard (#1), bare @switch
  #-1 EXCEPTION: {"id":"20aae27bc72b","command":"@switch","type":"KeyNotFoundException","message":"The given key \u00270\u0027 was not present in the dictionary."}

mortal, bare @channel
  (no exception - falls to the discard arm, as noted above)
```

Every one of those was **complete silence** before this change.

(`\u0027` is `'`. `Utf8JsonWriter`'s default encoder escapes HTML-sensitive
characters. Kept deliberately rather than switching to
`UnsafeRelaxedJsonEscaping`: this text also reaches the browser portal terminal,
and readability of one wizard-only field is not worth relaxing output encoding.)

## Follow-ups, deliberately not in this PR

1. **`CallFunction` still discloses to God only.** A non-god player gets silence
   for any internal *function* error — the function-path twin of the bug this PR
   fixes on the command path. Highest-value follow-up; it should adopt the same
   `ExceptionReport` payload and `IsPriv` rule.
   (`SharpMUSHParserVisitor.cs`, `CallFunction` catch)
2. `BuildingCommands.cs` — `@adestroy` and `@startup` evaluation errors are
   caught and discarded with `// Ignore errors`, returning `CallState.Empty`.
3. `EvaluateAttributeForLockQueryHandler.cs` — a failing lock attribute logs a
   warning and returns `null`, i.e. evaluates as no-result. Security-relevant,
   since it changes lock outcomes silently.
4. `ParserErrorListener.cs` — `catch (Exception ex) when (ex is
   NullReferenceException or InvalidOperationException) { return null; }` uses an
   NRE as control flow.
5. **Command `MinArgs` is never enforced.** Only the *function* path validates
   it. `@switch` declares `MinArgs = 3` and still reaches its body with zero
   arguments — the root cause of the whole `args["0"]` family. Enforcing it at
   dispatch would fix several of the five at once, but it changes behaviour for
   every command and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MPRzndB5egy4F2A3q5852
