### PR TITLE
Fix what a telnet player sees first: the login banner, WHO/QUIT at the connect screen, and the login greeting

### DIFF
--- a/SharpMUSH.ConnectionServer/Services/ConnectionServerService.cs
+++ b/SharpMUSH.ConnectionServer/Services/ConnectionServerService.cs
@@ -44,7 +44,8 @@ public class ConnectionServerService(
 				gmcpFunction,
 				capabilities ?? new ProtocolCapabilities(),
 				null,
-				connectionType);
+				connectionType,
+				presenceClass);
 
 			_sessionState.AddOrUpdate(handle, data, (_, _) =>
 				throw new InvalidOperationException("Handle already registered"));
@@ -69,7 +70,12 @@ public class ConnectionServerService(
 							{ "LastConnectionSignal", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString() },
 							{ "InternetProtocolAddress", ipAddress },
 							{ "HostName", hostname },
-							{ "ConnectionType", connectionType }
+							{ "ConnectionType", connectionType },
+							// Without this the engine rebuilds a reconciled connection with the
+							// IConnectionService default of "play", so a portal-class socket comes
+							// back visible to mortal WHO. It is the one field of the established
+							// message that the store did not carry.
+							{ "PresenceClass", presenceClass }
 						}
 					});
 				}
@@ -195,7 +201,8 @@ public class ConnectionServerService(
 		Func<string, string, ValueTask>? GMCPFunction,
 		ProtocolCapabilities Capabilities,
 		PlayerOutputPreferences? Preferences,
-		string ConnectionType = "telnet");
+		string ConnectionType = "telnet",
+		string PresenceClass = "play");
 
 	public enum ConnectionState
 	{

--- a/SharpMUSH.Implementation/Commands/AccountSocketCommands.cs
+++ b/SharpMUSH.Implementation/Commands/AccountSocketCommands.cs
@@ -235,7 +235,9 @@ public partial class Commands
 
 		await AccountService!.LinkCharacterAsync(accountId, playerDbRef);
 
-		await ConnectionService.Bind(handle, playerDbRef);
+		// The character was created a line ago, so this is its first ever entry into play: it gets
+		// the first-login greeting, not "Welcome back".
+		await ConnectionService.Bind(handle, playerDbRef, firstLogin: true);
 
 		var playerNode = await Mediator.Send(new Library.Queries.Database.GetObjectNodeQuery(playerDbRef));
 		if (!playerNode.IsPlayer)

--- a/SharpMUSH.Implementation/Commands/SocketCommands.cs
+++ b/SharpMUSH.Implementation/Commands/SocketCommands.cs
@@ -25,8 +25,12 @@ public partial class Commands
 	[SharpCommand(Name = "WHO", Behavior = CommandBehavior.SOCKET | CommandBehavior.NoParse, MinArgs = 0, MaxArgs = 1, ParameterNames = [])]
 	public static async ValueTask<Option<CallState>> Who(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
-		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
-		var isWizard = await executor.IsWizard();
+		// WHO is CommandBehavior.SOCKET precisely so it answers at the connect screen, where nothing
+		// is bound to the handle yet. KnownExecutorObject() throws on that None, so resolve the
+		// executor optionally: an anonymous viewer is never a wizard and gets the mortal listing.
+		var executorOption = await parser.CurrentState.ExecutorObject(Mediator!);
+		var executor = executorOption.IsNone ? null : executorOption.Known();
+		var isWizard = executor is not null && await executor.IsWizard();
 
 		var everyone = ConnectionService!.GetAll();
 
@@ -63,13 +67,20 @@ public partial class Commands
 				}
 				else
 				{
-					var doingText = await Commands.GetDoingText(executor, known);
+					// No executor at the connect screen: read DOING as the listed player reads it on
+					// itself. @doing is public in PennMUSH, and it is the one column the connect-screen
+					// listing exists to show.
+					var doingText = await Commands.GetDoingText(executor ?? known, known);
 					line = $"{namePadded} {onFor,10}   {idle,4}{(isDark ? 'D' : ' ')} {doingText}";
 				}
 
 				return (Line: line, Known: known);
 			})
-			.Where(async (player, _) => await PermissionService!.CanSee(executor, player.Known))
+			// CanSee needs a viewer; an anonymous connect-screen viewer has none and is neither
+			// privileged nor SEE_ALL, so it reduces to the DARK check CanSee would have made.
+			.Where(async (player, _) => executor is null
+				? !await player.Known.IsDark()
+				: await PermissionService!.CanSee(executor, player.Known))
 			.ToListAsync();
 
 		var count = filteredPlayers.Count;
@@ -425,13 +436,19 @@ public partial class Commands
 	public static async ValueTask<Option<CallState>> Quit(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
 		var handle = parser.CurrentState.Handle!.Value;
-		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
-		await NotifyService!.Notify(executor, MModule.single("GOODBYE."), executor);
+
+		// QUIT is a SOCKET command: it must also work at the connect screen, where the handle has
+		// no executor bound and KnownExecutorObject() would throw. Fall back to notifying the
+		// socket directly in that case.
+		var executorOption = await parser.CurrentState.ExecutorObject(Mediator!);
+		var executor = executorOption.IsNone ? null : executorOption.Known();
+
+		await NotifyQuitAsync(MModule.single("GOODBYE."));
 
 		var quitText = await ReadMessageFileAsync(Configuration!.CurrentValue.Message.QuitFile);
 		if (!string.IsNullOrWhiteSpace(quitText))
 		{
-			await NotifyService!.Notify(executor, quitText, executor);
+			await NotifyQuitAsync(MModule.single(quitText));
 		}
 
 		await ConnectionService!.Disconnect(handle);
@@ -443,6 +460,18 @@ public partial class Commands
 		}
 
 		return new None();
+
+		async ValueTask NotifyQuitAsync(MString what)
+		{
+			if (executor is null)
+			{
+				await NotifyService!.Notify(handle, what);
+			}
+			else
+			{
+				await NotifyService!.Notify(executor, what, executor);
+			}
+		}
 	}
 
 	/// <summary>

--- a/SharpMUSH.Library/Definitions/ErrorMessages.cs
+++ b/SharpMUSH.Library/Definitions/ErrorMessages.cs
@@ -579,6 +579,8 @@ public static class ErrorMessages
 		public const string Connected = "Connected!";
 		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
 		public const string WelcomeBackFormat = "Welcome back, {0}!";
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string WelcomeFirstLoginFormat = "Welcome, {0}! This is your first time connecting.";
 
 		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
 		public const string CannotNameObjectFormat = "You cannot name that object {0}.";

--- a/SharpMUSH.Library/Notifications/ConnectionStateChangeNotification.cs
+++ b/SharpMUSH.Library/Notifications/ConnectionStateChangeNotification.cs
@@ -7,8 +7,14 @@ namespace SharpMUSH.Library.Notifications;
 /// <summary>
 /// Notification published when a connection state changes.
 /// </summary>
+/// <param name="FirstLogin">
+/// True when this transition to <see cref="IConnectionService.ConnectionState.LoggedIn"/> is the
+/// character's entry into play immediately after it was created, so it can be greeted as new
+/// rather than welcomed "back" to a game it has never seen.
+/// </param>
 public record ConnectionStateChangeNotification(
 	long Handle,
 	DBRef? PlayerRef,
 	IConnectionService.ConnectionState OldState,
-	IConnectionService.ConnectionState NewState) : INotification;
+	IConnectionService.ConnectionState NewState,
+	bool FirstLogin = false) : INotification;

--- a/SharpMUSH.Library/Resources/Notifications.fr.resx
+++ b/SharpMUSH.Library/Resources/Notifications.fr.resx
@@ -21,6 +21,9 @@
   <data name="WelcomeBackFormat" xml:space="preserve">
     <value>Bienvenue, {0} !</value>
   </data>
+  <data name="WelcomeFirstLoginFormat" xml:space="preserve">
+    <value>Bienvenue, {0} ! C'est votre première connexion.</value>
+  </data>
 
   <!-- ── @locale command ─────────────────────────────────────────────── -->
   <data name="LocaleSetFormat" xml:space="preserve">

--- a/SharpMUSH.Library/Resources/Notifications.resx
+++ b/SharpMUSH.Library/Resources/Notifications.resx
@@ -527,6 +527,9 @@
   <data name="WelcomeBackFormat" xml:space="preserve">
     <value>Welcome back, {0}!</value>
   </data>
+  <data name="WelcomeFirstLoginFormat" xml:space="preserve">
+    <value>Welcome, {0}! This is your first time connecting.</value>
+  </data>
 
   <!-- Name / Password -->
   <data name="CannotNameObjectFormat" xml:space="preserve">

--- a/SharpMUSH.Library/Services/ConnectionService.cs
+++ b/SharpMUSH.Library/Services/ConnectionService.cs
@@ -55,7 +55,7 @@ public class ConnectionService(
 	public void ListenState(Action<(long, DBRef?, IConnectionService.ConnectionState, IConnectionService.ConnectionState)> handler) =>
 		_handlers.Add(handler);
 
-	public async ValueTask Bind(long handle, DBRef player)
+	public async ValueTask Bind(long handle, DBRef player, bool firstLogin = false)
 	{
 		var get = Get(handle);
 		if (get is null) return;
@@ -78,7 +78,7 @@ public class ConnectionService(
 		UpdateConnectionMetrics();
 
 		await publisher.Publish(new ConnectionStateChangeNotification(handle, player, get.State,
-			IConnectionService.ConnectionState.LoggedIn));
+			IConnectionService.ConnectionState.LoggedIn, firstLogin));
 	}
 
 	public async ValueTask BindAccount(long handle, string accountId)

--- a/SharpMUSH.Library/Services/Interfaces/IConnectionService.cs
+++ b/SharpMUSH.Library/Services/Interfaces/IConnectionService.cs
@@ -54,7 +54,14 @@ public interface IConnectionService
 	ValueTask Register(long handle, string ipaddr, string host, string connectionType, Func<byte[], ValueTask> outputFunction, Func<byte[], ValueTask> promptOutputFunction, Func<Encoding> encoding,
 		ConcurrentDictionary<string, string>? metaData = null);
 
-	ValueTask Bind(long handle, DBRef player);
+	/// <summary>
+	/// Binds a handle to a character and moves it to <see cref="ConnectionState.LoggedIn"/>.
+	/// </summary>
+	/// <param name="firstLogin">
+	/// True when the character was just created and is entering play for the very first time, so
+	/// the greeting can welcome it rather than welcome it "back".
+	/// </param>
+	ValueTask Bind(long handle, DBRef player, bool firstLogin = false);
 
 	/// <summary>
 	/// Transitions a connection to <see cref="ConnectionState.AccountMode"/>, storing the account ID in metadata.

--- a/SharpMUSH.Server/Handlers/ConnectionStateChangeHandler.cs
+++ b/SharpMUSH.Server/Handlers/ConnectionStateChangeHandler.cs
@@ -2,6 +2,8 @@ using Mediator;
 using Microsoft.Extensions.Logging;
 using SharpMUSH.Library;
 using SharpMUSH.Library.Definitions;
+using SharpMUSH.Library.Extensions;
+using SharpMUSH.Library.Models;
 using SharpMUSH.Library.Notifications;
 using SharpMUSH.Library.Services.Interfaces;
 
@@ -64,7 +66,7 @@ public class ConnectionStateChangeHandler(
 						}
 					}
 
-					await notifyService.NotifyLocalized(notification.Handle, nameof(ErrorMessages.Notifications.WelcomeBackFormat), notification.PlayerRef!);
+					await GreetAsync(notification, cancellationToken);
 
 					logger.LogInformation("[{ConnectionId}] Successfully sent login message to handle {Handle}",
 						connectionId, notification.Handle);
@@ -86,5 +88,33 @@ public class ConnectionStateChangeHandler(
 			logger.LogError(ex, "[{ConnectionId}] Error handling connection state change for handle {Handle}",
 				connectionId, notification.Handle);
 		}
+	}
+
+	/// <summary>
+	/// The first line of every session. It is addressed to the player by NAME — passing the
+	/// <see cref="DBRef"/> straight in as the format argument rendered its <c>ToString()</c>, so
+	/// players were greeted with "Welcome back, #12:1786227218582!".
+	/// </summary>
+	private async ValueTask GreetAsync(ConnectionStateChangeNotification notification, CancellationToken cancellationToken)
+	{
+		var name = await ResolveNameAsync(notification.PlayerRef, cancellationToken);
+		if (name is null)
+		{
+			// Better to say nothing than to greet somebody by database key.
+			logger.LogWarning("Could not resolve a name for {Ref} on handle {Handle}; skipping the greeting",
+				notification.PlayerRef, notification.Handle);
+			return;
+		}
+
+		await notifyService.NotifyLocalized(notification.Handle,
+			nameof(ErrorMessages.Notifications.WelcomeBackFormat), name);
+	}
+
+	private async ValueTask<string?> ResolveNameAsync(DBRef? playerRef, CancellationToken cancellationToken)
+	{
+		if (!playerRef.HasValue) return null;
+
+		var node = await database.GetObjectNodeAsync(playerRef.Value, cancellationToken);
+		return node.IsNone() ? null : node.Known().Object().Name;
 	}
 }

--- a/SharpMUSH.Server/Handlers/ConnectionStateChangeHandler.cs
+++ b/SharpMUSH.Server/Handlers/ConnectionStateChangeHandler.cs
@@ -93,7 +93,9 @@ public class ConnectionStateChangeHandler(
 	/// <summary>
 	/// The first line of every session. It is addressed to the player by NAME — passing the
 	/// <see cref="DBRef"/> straight in as the format argument rendered its <c>ToString()</c>, so
-	/// players were greeted with "Welcome back, #12:1786227218582!".
+	/// players were greeted with "Welcome back, #12:1786227218582!". A character that has just been
+	/// created and walked straight into play has never been here, so it is welcomed rather than
+	/// welcomed back.
 	/// </summary>
 	private async ValueTask GreetAsync(ConnectionStateChangeNotification notification, CancellationToken cancellationToken)
 	{
@@ -106,8 +108,11 @@ public class ConnectionStateChangeHandler(
 			return;
 		}
 
-		await notifyService.NotifyLocalized(notification.Handle,
-			nameof(ErrorMessages.Notifications.WelcomeBackFormat), name);
+		var key = notification.FirstLogin
+			? nameof(ErrorMessages.Notifications.WelcomeFirstLoginFormat)
+			: nameof(ErrorMessages.Notifications.WelcomeBackFormat);
+
+		await notifyService.NotifyLocalized(notification.Handle, key, name);
 	}
 
 	private async ValueTask<string?> ResolveNameAsync(DBRef? playerRef, CancellationToken cancellationToken)

--- a/SharpMUSH.Server/connect.txt
+++ b/SharpMUSH.Server/connect.txt
@@ -1,18 +1,18 @@
           ==         ==          
          ====       ====         
-       =======     =======                  Welcome to SharpMUSH!
+       =======     =======           Welcome to SharpMUSH!
       =========   =========      
-     =========== ===========         
-    =================== =====          
-  ======-  ===========   ======      The following commands are available:
- ======     =========     ======       
-======   =   =======   =   ======    - Connect to a Character
-======   ==   =====   ==   ======        connect <name> <password>
- =====   ===   ===   ===   =====     - Create a new Character  
- =====   ====   =   ====   =====         create <name> <password>
-  ====   =====     =====   ====      - See who is online
-   ===    ====     ====    ===           WHO
-   ===     ===     ===-    ===   
-    ==     ===     ===     ==        
-     =      ==     ==      =     
+     =========== ===========         ACCOUNT - one account, many characters:
+    =================== =====            register <name> [email] <password>
+  ======-  ===========   ======          login <name-or-email> <password>
+ ======     =========     ======         make <character> <password>
+======   =   =======   =   ======        play <character>
+======   ==   =====   ==   ======
+ =====   ===   ===   ===   =====     CHARACTER - classic MUSH login:
+ =====   ====   =   ====   =====         connect <character> <password>
+  ====   =====     =====   ====          connect guest
+   ===    ====     ====    ===   
+   ===     ===     ===-    ===       ANY TIME:
+    ==     ===     ===     ==            WHO      see who is online
+     =      ==     ==      =             QUIT     disconnect
              =     =             

--- a/SharpMUSH.Server/newuser.txt
+++ b/SharpMUSH.Server/newuser.txt
@@ -1,3 +1,8 @@
 
-Welcome, new player! A wizard will create a character for you shortly.
+Welcome, new player!
 
+Your account is ready. Create your first character with:
+    make <character-name> <password>
+
+Then enter play with:
+    play <character-name>

--- a/SharpMUSH.Tests/Commands/CommandExceptionSurfacingTests.cs
+++ b/SharpMUSH.Tests/Commands/CommandExceptionSurfacingTests.cs
@@ -120,16 +120,27 @@ public class CommandExceptionSurfacingTests
 		await Assert.That(message.GetString()).IsNotNull().And.IsNotEmpty();
 	}
 
+	/// <summary>
+	/// A connection whose executor cannot be resolved — bound to a dbref that is not in the
+	/// database — has nobody to notify by object, so the report goes to the raw socket instead.
+	/// This used to be demonstrated with pre-login <c>WHO</c>, which threw
+	/// <see cref="ArgumentNullException"/> out of <c>KnownExecutorObject()</c>; that was a bug in
+	/// <c>WHO</c> and is fixed, so the handle-targeted path is exercised here instead.
+	/// <para>The throw comes from the visitor's own <c>WithoutNone()</c> on the unresolvable
+	/// executor, before the command body runs — a separate robustness gap that is only visible at
+	/// all because of the surfacing this class covers. What is asserted here is the delivery
+	/// target, not which line threw.</para>
+	/// </summary>
 	[Test]
-	public async Task APreLoginCommandWithNoExecutorNotifiesTheConnectionHandle()
+	public async Task ACommandWithNoResolvableExecutorNotifiesTheConnectionHandle()
 	{
-		// The connect screen: a registered handle with nothing bound to it, so CurrentState.Executor
-		// is null. WHO calls KnownExecutorObject unconditionally and throws ArgumentNullException.
 		var handle = Random.Shared.NextInt64(900_000, 999_999);
 		await ConnectionService.Register(handle, "localhost", "localhost", "test",
 			_ => ValueTask.CompletedTask, _ => ValueTask.CompletedTask, () => Encoding.UTF8);
+		await ConnectionService.Bind(handle, new DBRef(999_999_999));
 
-		await WebAppFactoryArg.CommandParser.CommandParse(handle, ConnectionService, MModule.single("WHO"));
+		await WebAppFactoryArg.CommandParser.CommandParse(handle, ConnectionService,
+			MModule.single(CrashingCommand));
 
 		var message = NotificationToHandle(handle);
 
@@ -138,9 +149,10 @@ public class CommandExceptionSurfacingTests
 
 		using var document = JsonDocument.Parse(PayloadOf(message));
 		await Assert.That(document.RootElement.GetProperty("type").GetString())
-			.IsEqualTo(nameof(ArgumentNullException));
+			.IsEqualTo(nameof(ArgumentException));
+		await Assert.That(document.RootElement.GetProperty("command").GetString()).IsEqualTo(CrashingCommand);
 
-		// No executor means no privilege, so the unprivileged allowlist applies.
+		// No resolvable executor means no privilege, so the unprivileged allowlist applies.
 		var keys = document.RootElement.EnumerateObject().Select(p => p.Name).ToArray();
 		await Assert.That(keys).IsEquivalentTo(new[] { "id", "command", "type" });
 	}

--- a/SharpMUSH.Tests/Commands/ConnectBannerTests.cs
+++ b/SharpMUSH.Tests/Commands/ConnectBannerTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.DependencyInjection;
+using SharpMUSH.Library.Definitions;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Services.Interfaces;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace SharpMUSH.Tests.Commands;
+
+/// <summary>
+/// connect.txt is the first thing a telnet player reads. It advertised
+/// <c>create &lt;name&gt; &lt;password&gt;</c>, which is not a command — typing it answers
+/// "No such command available at login." — and said nothing at all about the account flow
+/// (register / login / make / play), which is the only route to a character for someone who has
+/// never played here.
+/// </summary>
+public class ConnectBannerTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactoryArg { get; init; }
+
+	private IConnectionService ConnectionService => WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
+	private IMUSHCodeParser Parser => WebAppFactoryArg.CommandParser;
+
+	/// <summary>The banner as shipped, copied into the test output by the csproj as <c>txt/</c>.</summary>
+	private static string BannerPath => Path.Combine(AppContext.BaseDirectory, "txt", "connect.txt");
+
+	/// <summary>Every command word the banner tells a player to type must exist pre-login.</summary>
+	[Test]
+	public async Task TheBannerOnlyAdvertisesCommandsThatExist()
+	{
+		var socketCommands = Parser.CommandLibrary
+			.Where(x => x.Value.IsSystem
+				&& x.Value.LibraryInformation.Attribute.Behavior.HasFlag(CommandBehavior.SOCKET))
+			.Select(x => x.Key)
+			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+		foreach (var advertised in AdvertisedCommands(await File.ReadAllTextAsync(BannerPath)))
+		{
+			await Assert.That(socketCommands).Contains(advertised);
+		}
+	}
+
+	/// <summary>
+	/// The account flow is the telnet mirror of the portal's register / login / create-character.
+	/// </summary>
+	[Test]
+	public async Task TheBannerDocumentsTheAccountFlow()
+	{
+		var advertised = AdvertisedCommands(await File.ReadAllTextAsync(BannerPath));
+
+		await Assert.That(advertised).Contains("register");
+		await Assert.That(advertised).Contains("login");
+		await Assert.That(advertised).Contains("make");
+		await Assert.That(advertised).Contains("play");
+		await Assert.That(advertised).Contains("connect");
+		await Assert.That(advertised).Contains("WHO");
+		await Assert.That(advertised).Contains("QUIT");
+	}
+
+	/// <summary>The banner really is what a freshly opened socket receives.</summary>
+	[Test]
+	public async Task AFreshConnectionReceivesTheBanner()
+	{
+		var handle = Random.Shared.NextInt64(600_000, 699_999);
+		await ConnectionService.Register(handle, "localhost", "localhost", "test",
+			_ => ValueTask.CompletedTask, _ => ValueTask.CompletedTask, () => Encoding.UTF8);
+
+		var messages = ConnectScreenTests.NotificationsTo(WebAppFactoryArg, handle);
+
+		await Assert.That(messages.Any(m => m.Contains("Welcome to SharpMUSH!"))).IsTrue();
+		await Assert.That(messages.Any(m => m.Contains("play <character>"))).IsTrue();
+	}
+
+	/// <summary>
+	/// Command words the banner instructs a player to type: the first word of any line that is
+	/// indented past the ASCII art and is not a section heading.
+	/// </summary>
+	private static string[] AdvertisedCommands(string banner) =>
+		banner.Split('\n')
+			.Select(line => line.Length > 37 ? line[37..].Trim() : string.Empty)
+			.Where(text => text.Length > 0 && !text.EndsWith(':') && !text.EndsWith('!'))
+			.Select(text => text.Split(' ', StringSplitOptions.RemoveEmptyEntries)[0])
+			.Where(word => Regex.IsMatch(word, "^[A-Za-z]+$"))
+			.Distinct()
+			.ToArray();
+}

--- a/SharpMUSH.Tests/Commands/ConnectScreenTests.cs
+++ b/SharpMUSH.Tests/Commands/ConnectScreenTests.cs
@@ -1,0 +1,108 @@
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NSubstitute.Core;
+using OneOf;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Services.Interfaces;
+using System.Text;
+
+namespace SharpMUSH.Tests.Commands;
+
+/// <summary>
+/// The commands a telnet player can run before logging in. <c>WHO</c> and <c>QUIT</c> are
+/// <c>CommandBehavior.SOCKET</c> precisely so they answer at the connect screen, but both opened
+/// with an unconditional <c>KnownExecutorObject()</c>, which throws
+/// <see cref="ArgumentNullException"/> because a handle at the connect screen has no executor.
+/// </summary>
+public class ConnectScreenTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactoryArg { get; init; }
+
+	private IConnectionService ConnectionService => WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
+	private IMediator Mediator => WebAppFactoryArg.Services.GetRequiredService<IMediator>();
+	private IMUSHCodeParser Parser => WebAppFactoryArg.CommandParser;
+
+	private async ValueTask<long> AnonymousHandleAsync()
+	{
+		var handle = Random.Shared.NextInt64(700_000, 799_999);
+		await ConnectionService.Register(handle, "localhost", "localhost", "test",
+			_ => ValueTask.CompletedTask, _ => ValueTask.CompletedTask, () => Encoding.UTF8);
+		return handle;
+	}
+
+	[Test]
+	public async Task WhoAtTheConnectScreenListsPlayersInsteadOfThrowing()
+	{
+		await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "WhoVisible");
+
+		var anonymous = await AnonymousHandleAsync();
+		await Parser.CommandParse(anonymous, ConnectionService, MModule.single("WHO"));
+
+		var listing = LastNotificationTo(anonymous);
+
+		await Assert.That(listing).IsNotNull();
+		await Assert.That(listing!).DoesNotStartWith("#-1 EXCEPTION: ");
+		await Assert.That(listing).Contains("WhoVisible");
+		await Assert.That(listing).Contains("player");
+	}
+
+	/// <summary>
+	/// An anonymous viewer must get the mortal layout. The wizard layout carries host names and
+	/// descriptors, which is exactly what a nobody at the connect screen must not be handed.
+	/// </summary>
+	[Test]
+	public async Task WhoAtTheConnectScreenUsesTheMortalHeaderNotTheWizardOne()
+	{
+		var anonymous = await AnonymousHandleAsync();
+		await Parser.CommandParse(anonymous, ConnectionService, MModule.single("WHO"));
+
+		var header = LastNotificationTo(anonymous)!.Split('\n')[0];
+
+		await Assert.That(header).Contains("Player Name");
+		await Assert.That(header).Contains("Doing");
+		await Assert.That(header).DoesNotContain("Host");
+		await Assert.That(header).DoesNotContain("Loc #");
+		await Assert.That(header).DoesNotContain("Des");
+	}
+
+	/// <summary>
+	/// QUIT threw at its second statement, before <c>Disconnect()</c> and the
+	/// <c>DisconnectConnectionMessage</c> — so the connection also survived a QUIT it had just
+	/// refused to acknowledge.
+	/// </summary>
+	[Test]
+	public async Task QuitAtTheConnectScreenSaysGoodbyeAndDropsTheConnection()
+	{
+		var anonymous = await AnonymousHandleAsync();
+		await Parser.CommandParse(anonymous, ConnectionService, MModule.single("QUIT"));
+
+		var messages = NotificationsTo(WebAppFactoryArg, anonymous);
+
+		await Assert.That(messages).Contains("GOODBYE.");
+		await Assert.That(messages.Any(m => m.StartsWith("#-1 EXCEPTION: "))).IsFalse();
+		await Assert.That(ConnectionService.Get(anonymous)).IsNull();
+	}
+
+	private string? LastNotificationTo(long handle) =>
+		NotificationsTo(WebAppFactoryArg, handle).LastOrDefault();
+
+	/// <summary>
+	/// Plain text of every <c>Notify</c> aimed at <paramref name="handle"/>. The INotifyService
+	/// substitute is shared for the whole test session, hence filtering by an isolated handle.
+	/// </summary>
+	internal static string[] NotificationsTo(ServerWebAppFactory factory, long handle) =>
+		factory.Services.GetRequiredService<INotifyService>().ReceivedCalls()
+			.Where(call => call.GetMethodInfo().Name == nameof(INotifyService.Notify))
+			.Where(call => call.GetArguments() is [long h, ..] && h == handle)
+			.Select(TextOf)
+			.OfType<string>()
+			.ToArray();
+
+	private static string? TextOf(ICall call) =>
+		call.GetArguments() is [_, OneOf<MString, string> message, ..]
+			? message.Match(ms => ms.ToPlainText(), s => s)
+			: null;
+}

--- a/SharpMUSH.Tests/ConnectionServer/PresenceClassPlumbingTests.cs
+++ b/SharpMUSH.Tests/ConnectionServer/PresenceClassPlumbingTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Text;
+using Mediator;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using SharpMUSH.ConnectionServer.Services;
@@ -88,5 +89,108 @@ public class PresenceClassPlumbingTests
 		await bus.Received(1).Publish(
 			Arg.Is<ConnectionEstablishedMessage>(m => m.Handle == 43 && m.PresenceClass == "play"),
 			Arg.Any<CancellationToken>());
+	}
+
+	/// <summary>
+	/// The presence class was forwarded on the NATS message but dropped from the ConnectionServer's
+	/// own session record, so anything reading it back locally saw the "play" default.
+	/// </summary>
+	[Test]
+	public async Task RegisterAsync_records_the_presence_class_on_the_session_it_keeps()
+	{
+		var bus = Substitute.For<IMessageBus>();
+		var service = new ConnectionServerService(NullLogger<ConnectionServerService>.Instance, bus);
+
+		await service.RegisterAsync(
+			44, "1.2.3.4", "host", "websocket",
+			_ => ValueTask.CompletedTask, _ => ValueTask.CompletedTask, () => Encoding.UTF8, () => { },
+			presenceClass: "portal");
+
+		await Assert.That(service.Get(44)!.PresenceClass).IsEqualTo("portal");
+	}
+
+	/// <summary>
+	/// The failure N-13 describes, reproduced without a process restart: the ConnectionServer
+	/// persists a portal connection, the engine rebuilds it from that store, and the rebuilt
+	/// connection must still be portal-class. The store omitted <c>PresenceClass</c> entirely, and
+	/// <c>IConnectionService.ConnectionData.PresenceClass</c> defaults a missing key to "play", so
+	/// the reconciled connection came back visible to a mortal WHO.
+	/// </summary>
+	[Test]
+	public async Task APortalConnectionSurvivesAStateStoreRoundTripAsPortal()
+	{
+		var store = new InMemoryConnectionStateStore();
+		var bus = Substitute.For<IMessageBus>();
+		var connectionServer = new ConnectionServerService(NullLogger<ConnectionServerService>.Instance, bus, store);
+
+		await connectionServer.RegisterAsync(
+			45, "1.2.3.4", "host", "websocket",
+			_ => ValueTask.CompletedTask, _ => ValueTask.CompletedTask, () => Encoding.UTF8, () => { },
+			presenceClass: "portal");
+
+		var engine = new SharpMUSH.Library.Services.ConnectionService(Substitute.For<IPublisher>(), store);
+		await engine.ReconcileFromStateStoreAsync(
+			_ => _ => ValueTask.CompletedTask, _ => _ => ValueTask.CompletedTask, () => Encoding.UTF8);
+
+		await Assert.That(engine.Get(45)!.PresenceClass).IsEqualTo("portal");
+	}
+
+	[Test]
+	public async Task ATelnetConnectionSurvivesAStateStoreRoundTripAsPlay()
+	{
+		var store = new InMemoryConnectionStateStore();
+		var bus = Substitute.For<IMessageBus>();
+		var connectionServer = new ConnectionServerService(NullLogger<ConnectionServerService>.Instance, bus, store);
+
+		await connectionServer.RegisterAsync(
+			46, "1.2.3.4", "host", "telnet",
+			_ => ValueTask.CompletedTask, _ => ValueTask.CompletedTask, () => Encoding.UTF8, () => { });
+
+		var engine = new SharpMUSH.Library.Services.ConnectionService(Substitute.For<IPublisher>(), store);
+		await engine.ReconcileFromStateStoreAsync(
+			_ => _ => ValueTask.CompletedTask, _ => _ => ValueTask.CompletedTask, () => Encoding.UTF8);
+
+		await Assert.That(engine.Get(46)!.PresenceClass).IsEqualTo("play");
+	}
+
+	/// <summary>The store contract only; no Redis, no container.</summary>
+	private sealed class InMemoryConnectionStateStore : IConnectionStateStore
+	{
+		private readonly ConcurrentDictionary<long, ConnectionStateData> _state = [];
+
+		public Task SetConnectionAsync(long handle, ConnectionStateData data, CancellationToken ct = default)
+		{
+			_state[handle] = data;
+			return Task.CompletedTask;
+		}
+
+		public Task<ConnectionStateData?> GetConnectionAsync(long handle, CancellationToken ct = default) =>
+			Task.FromResult(_state.GetValueOrDefault(handle));
+
+		public Task RemoveConnectionAsync(long handle, CancellationToken ct = default)
+		{
+			_state.TryRemove(handle, out _);
+			return Task.CompletedTask;
+		}
+
+		public Task<IEnumerable<long>> GetAllHandlesAsync(CancellationToken ct = default) =>
+			Task.FromResult<IEnumerable<long>>(_state.Keys.ToArray());
+
+		public Task<IEnumerable<(long Handle, ConnectionStateData Data)>> GetAllConnectionsAsync(
+			CancellationToken ct = default) =>
+			Task.FromResult<IEnumerable<(long, ConnectionStateData)>>(
+				_state.Select(x => (x.Key, x.Value)).ToArray());
+
+		public Task SetPlayerBindingAsync(long handle, string? playerObjid, CancellationToken ct = default)
+		{
+			if (_state.TryGetValue(handle, out var data)) data.PlayerObjid = playerObjid;
+			return Task.CompletedTask;
+		}
+
+		public Task UpdateMetadataAsync(long handle, string key, string value, CancellationToken ct = default)
+		{
+			if (_state.TryGetValue(handle, out var data)) data.Metadata[key] = value;
+			return Task.CompletedTask;
+		}
 	}
 }

--- a/SharpMUSH.Tests/Server/LoginGreetingTests.cs
+++ b/SharpMUSH.Tests/Server/LoginGreetingTests.cs
@@ -1,0 +1,94 @@
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NSubstitute.Core;
+using SharpMUSH.Library.Definitions;
+using SharpMUSH.Library.Extensions;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.Queries.Database;
+using SharpMUSH.Library.Services;
+using SharpMUSH.Library.Services.Interfaces;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace SharpMUSH.Tests.Server;
+
+/// <summary>
+/// The first line of every telnet session. It used to be
+/// <c>"Welcome back, #12:1786227218582!"</c> — the <see cref="DBRef"/> was passed straight in as
+/// the format argument, so its <c>ToString()</c> rendered.
+/// </summary>
+public class LoginGreetingTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactoryArg { get; init; }
+
+	private INotifyService NotifyService => WebAppFactoryArg.Services.GetRequiredService<INotifyService>();
+	private IConnectionService ConnectionService => WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
+	private IMediator Mediator => WebAppFactoryArg.Services.GetRequiredService<IMediator>();
+
+	private static readonly LocalizationService Localization = new();
+
+	/// <summary>A raw dbref or objid rendered into player-facing text: <c>#12</c>, <c>#12:1786…</c>.</summary>
+	private static readonly Regex RawDbRef = new(@"#\d+(:\d+)?");
+
+	private async ValueTask<long> RegisterHandleAsync()
+	{
+		var handle = Random.Shared.NextInt64(800_000, 899_999);
+		await ConnectionService.Register(handle, "localhost", "localhost", "test",
+			_ => ValueTask.CompletedTask, _ => ValueTask.CompletedTask, () => Encoding.UTF8);
+		return handle;
+	}
+
+	[Test]
+	public async Task AReturningPlayerIsGreetedByNameAndNotByDbref()
+	{
+		var playerRef = await TestIsolationHelpers.CreateTestPlayerAsync(
+			WebAppFactoryArg.Services, Mediator, "GreetByName");
+		var name = await NameOfAsync(playerRef);
+
+		var handle = await RegisterHandleAsync();
+		await ConnectionService.Bind(handle, playerRef);
+
+		var greeting = GreetingTo(handle);
+
+		await Assert.That(greeting).IsNotNull();
+		await Assert.That(greeting!).Contains(name);
+		await Assert.That(RawDbRef.IsMatch(greeting)).IsFalse();
+	}
+
+	[Test]
+	public async Task AReturningPlayerIsWelcomedBack()
+	{
+		var playerRef = await TestIsolationHelpers.CreateTestPlayerAsync(
+			WebAppFactoryArg.Services, Mediator, "GreetReturning");
+
+		var handle = await RegisterHandleAsync();
+		await ConnectionService.Bind(handle, playerRef);
+
+		await Assert.That(GreetingKeyTo(handle))
+			.IsEqualTo(nameof(ErrorMessages.Notifications.WelcomeBackFormat));
+	}
+
+	private async ValueTask<string> NameOfAsync(DBRef dbref) =>
+		(await Mediator.Send(new GetObjectNodeQuery(dbref))).Known().Object().Name;
+
+	/// <summary>The resource key of the last greeting sent to <paramref name="handle"/>.</summary>
+	private string? GreetingKeyTo(long handle) => GreetingCallTo(handle)?.GetArguments()[1] as string;
+
+	/// <summary>The last greeting sent to <paramref name="handle"/>, rendered in the neutral locale.</summary>
+	private string? GreetingTo(long handle)
+	{
+		var call = GreetingCallTo(handle);
+		return call is null
+			? null
+			: Localization.Format((string)call.GetArguments()[1]!, null, (object[])call.GetArguments()[2]!);
+	}
+
+	private ICall? GreetingCallTo(long handle) =>
+		NotifyService.ReceivedCalls()
+			.Where(call => call.GetMethodInfo().Name == nameof(INotifyService.NotifyLocalized))
+			.Where(call => call.GetArguments() is [long h, string, object[], ..] && h == handle)
+			.LastOrDefault(call => (string)call.GetArguments()[1]! is
+				nameof(ErrorMessages.Notifications.WelcomeBackFormat));
+}

--- a/SharpMUSH.Tests/Server/LoginGreetingTests.cs
+++ b/SharpMUSH.Tests/Server/LoginGreetingTests.cs
@@ -5,6 +5,7 @@ using NSubstitute.Core;
 using SharpMUSH.Library.Definitions;
 using SharpMUSH.Library.Extensions;
 using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
 using SharpMUSH.Library.Queries.Database;
 using SharpMUSH.Library.Services;
 using SharpMUSH.Library.Services.Interfaces;
@@ -16,7 +17,8 @@ namespace SharpMUSH.Tests.Server;
 /// <summary>
 /// The first line of every telnet session. It used to be
 /// <c>"Welcome back, #12:1786227218582!"</c> — the <see cref="DBRef"/> was passed straight in as
-/// the format argument, so its <c>ToString()</c> rendered.
+/// the format argument, so its <c>ToString()</c> rendered — and a character created seconds
+/// earlier by <c>make</c> was welcomed "back" to a game it had never seen.
 /// </summary>
 public class LoginGreetingTests
 {
@@ -25,7 +27,9 @@ public class LoginGreetingTests
 
 	private INotifyService NotifyService => WebAppFactoryArg.Services.GetRequiredService<INotifyService>();
 	private IConnectionService ConnectionService => WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
+	private IAccountService AccountService => WebAppFactoryArg.Services.GetRequiredService<IAccountService>();
 	private IMediator Mediator => WebAppFactoryArg.Services.GetRequiredService<IMediator>();
+	private IMUSHCodeParser Parser => WebAppFactoryArg.CommandParser;
 
 	private static readonly LocalizationService Localization = new();
 
@@ -70,6 +74,46 @@ public class LoginGreetingTests
 			.IsEqualTo(nameof(ErrorMessages.Notifications.WelcomeBackFormat));
 	}
 
+	[Test]
+	public async Task AFirstLoginIsNotWelcomedBack()
+	{
+		var playerRef = await TestIsolationHelpers.CreateTestPlayerAsync(
+			WebAppFactoryArg.Services, Mediator, "GreetFirst");
+		var name = await NameOfAsync(playerRef);
+
+		var handle = await RegisterHandleAsync();
+		await ConnectionService.Bind(handle, playerRef, firstLogin: true);
+
+		await Assert.That(GreetingKeyTo(handle))
+			.IsEqualTo(nameof(ErrorMessages.Notifications.WelcomeFirstLoginFormat));
+
+		var greeting = GreetingTo(handle)!;
+		await Assert.That(greeting).Contains(name);
+		await Assert.That(greeting).DoesNotContain("back");
+	}
+
+	/// <summary>
+	/// End to end through the command a player actually types: <c>make</c> creates the character
+	/// and walks it straight into play, which is the one moment a character has genuinely never
+	/// been here before.
+	/// </summary>
+	[Test, NotInParallel([nameof(LoginGreetingTests), "ConfigMutation"])]
+	public async Task MakeGreetsTheBrandNewCharacterAsNew()
+	{
+		var username = TestIsolationHelpers.GenerateUniqueName("greetmake");
+		var characterName = TestIsolationHelpers.GenerateUniqueName("GreetMade");
+
+		var handle = await RegisterHandleAsync();
+		await Parser.CommandParse(handle, ConnectionService, MModule.single($"register {username} some-password-1"));
+		await Assert.That(await AccountService.GetByUsernameAsync(username)).IsNotNull();
+
+		await Parser.CommandParse(handle, ConnectionService, MModule.single($"make {characterName} some-password-1"));
+
+		await Assert.That(GreetingKeyTo(handle))
+			.IsEqualTo(nameof(ErrorMessages.Notifications.WelcomeFirstLoginFormat));
+		await Assert.That(GreetingTo(handle)!).Contains(characterName);
+	}
+
 	private async ValueTask<string> NameOfAsync(DBRef dbref) =>
 		(await Mediator.Send(new GetObjectNodeQuery(dbref))).Known().Object().Name;
 
@@ -90,5 +134,6 @@ public class LoginGreetingTests
 			.Where(call => call.GetMethodInfo().Name == nameof(INotifyService.NotifyLocalized))
 			.Where(call => call.GetArguments() is [long h, string, object[], ..] && h == handle)
 			.LastOrDefault(call => (string)call.GetArguments()[1]! is
-				nameof(ErrorMessages.Notifications.WelcomeBackFormat));
+				nameof(ErrorMessages.Notifications.WelcomeBackFormat)
+				or nameof(ErrorMessages.Notifications.WelcomeFirstLoginFormat));
 }


### PR DESCRIPTION
PR **5 of a 10-PR stack**. Base is its predecessor `fix/audit2-04-exception-surfacing`, **not `main`** — review the last five commits only.

This one is about the first thing a telnet player ever sees, plus one connection-metadata bug in the same layer. Every finding was reproduced on a real socket against a real stack (ArangoDB + NATS, `ASPNETCORE_ENVIRONMENT=Production`, ConnectionServer on :4201, Server on :8080); transcripts below are captured over TCP with IAC negotiation and ANSI stripped.

#757 (the base of this PR) is what made two of these visible at all: `WHO` and `QUIT` were throwing and printing *nothing* before it.

---

## N-04a — the banner advertised a command that does not exist

`SharpMUSH.Server/connect.txt` promised `create <name> <password>`. There is no such command. The pre-login set is `CONNECT`, `LOGIN`, `REGISTER`, `PLAY`, `MAKE`, `QUIT`, `WHO` (`CommandBehavior.SOCKET`, verified against the command library, not the docs).

Worse: the **account flow** — `register` / `login` / `make` / `play`, the telnet mirror of the portal's register + login + create-character, and the only route to a character for a first-time player — was not on the first screen at all.

### The new banner in full

```
          ==         ==          
         ====       ====         
       =======     =======           Welcome to SharpMUSH!
      =========   =========      
     =========== ===========         ACCOUNT - one account, many characters:
    =================== =====            register <name> [email] <password>
  ======-  ===========   ======          login <name-or-email> <password>
 ======     =========     ======         make <character> <password>
======   =   =======   =   ======        play <character>
======   ==   =====   ==   ======
 =====   ===   ===   ===   =====     CHARACTER - classic MUSH login:
 =====   ====   =   ====   =====         connect <character> <password>
  ====   =====     =====   ====          connect guest
   ===    ====     ====    ===   
   ===     ===     ===-    ===       ANY TIME:
    ==     ===     ===     ==            WHO      see who is online
     =      ==     ==      =             QUIT     disconnect
             =     =             
```

ASCII art byte-for-byte unchanged. Longest line 76 columns. A test reads the shipped file and checks every command word it advertises against the live SOCKET command set, so this cannot drift again silently.

`newuser.txt` still said "a wizard will create a character for you shortly" and now points at `make`/`play`. **Flagged, not fixed:** `newuser_file` and `who_file` are configured but read by nothing at runtime.

Other message files (`down`, `full`, `guest`, `motd`, `quit`, `register`, `wizmotd`) were checked and are consistent. There are no locale variants of `connect.txt`, and `connect_html_file` points at a `connect.html` that does not exist in the repo (pre-existing; not touched).

## N-04b — WHO and QUIT threw at the connect screen

`Commands.Who` and `Commands.Quit` both opened with an unconditional `KnownExecutorObject()`, which throws `ArgumentNullException` on the `None` case — and a handle at the connect screen has no executor at all. Both are declared `CommandBehavior.SOCKET` *precisely* so they work there, and the banner advertised WHO.

Executor is now resolved optionally in both. "No executor" means "not a wizard", so WHO returns the mortal layout — the wizard one carries host names and descriptors, exactly what an anonymous viewer must not receive. `CanSee` needs a viewer it does not have; for an unprivileged non-`SEE_ALL` viewer it reduces to the DARK check, so that is what is applied. DOING is read as the listed player reads it on itself (`@doing` is public, and it is the one column the pre-login listing exists to show).

QUIT threw at its *second* statement, before `Disconnect()` and the `DisconnectConnectionMessage`, so the socket also survived the QUIT.

**Rest of the SOCKET set audited:** `CONNECT`, `REGISTER`, `LOGIN`, `MAKE`, `PLAY` already worked off the handle. WHO and QUIT were the only two with this shape.

## N-14 — every login greeted you with a raw dbref

`ConnectionStateChangeHandler` passed `notification.PlayerRef!` as the format argument to `"Welcome back, {0}!"`, so `DBRef.ToString()` rendered. First line of every session. Now resolves and passes the character's name; if the name cannot be resolved the greeting is skipped and a warning logged, because saying nothing beats greeting somebody by database key.

## N-15 — a brand-new character was welcomed "back"

A character created with `make` enters play immediately and got "Welcome back" to a game it had never seen. A `firstLogin` flag now rides from `Bind()` onto `ConnectionStateChangeNotification`, and only `MAKE` sets it — the one path that creates a character and enters play in the same breath.

**The portal's character-creation path does not reach this handler.** `POST /api/account/characters` creates the character and returns its dbref; it binds no connection, so no state change is published. The player enters later via the normal OTT `connect token` login, which is a returning login by then.

New key `WelcomeFirstLoginFormat` in `ErrorMessages.Notifications` and in **both** engine locale files. See the i18n note below.

## N-13 — presence class dropped from persisted connection state

`ConnectionServerService.RegisterAsync` forwarded `presenceClass` correctly on the NATS `ConnectionEstablishedMessage` but omitted it from **both** the in-memory `ConnectionData` and the `Metadata` dictionary written to the state store. `IConnectionService.ConnectionData.PresenceClass` reads that key with a default of `"play"`, so a connection rebuilt by `ReconcileFromStateStoreAsync` silently lost its `"portal"` classification and became visible to mortal WHO.

**Honest scope of the verification:** this was **not** reproduced against live sockets across a ConnectionServer restart. It is reproduced in a test — the real `ConnectionServerService.RegisterAsync` writes into an in-memory `IConnectionStateStore`, a real `ConnectionService` reconciles out of it, and the rebuilt connection is asserted to still be portal-class. With the fix reverted, that test fails with `Expected to be equal to "portal" but received "play"` (verified, output below). The only part not exercised is the process restart itself.

---

# Telnet transcripts

Captured over raw TCP to :4201, IAC and ANSI stripped. `>>>` lines are what was typed.

## BEFORE (base branch `fix/audit2-04-exception-surfacing`)

```
Connected!
          ==         ==          
         ====       ====         
       =======     =======                  Welcome to SharpMUSH!
      =========   =========      
     =========== ===========         
    =================== =====          
  ======-  ===========   ======      The following commands are available:
 ======     =========     ======       
======   =   =======   =   ======    - Connect to a Character
======   ==   =====   ==   ======        connect <name> <password>
 =====   ===   ===   ===   =====     - Create a new Character  
 =====   ====   =   ====   =====         create <name> <password>
  ====   =====     =====   ====      - See who is online
   ===    ====     ====    ===           WHO
   ===     ===     ===-    ===   
    ==     ===     ===     ==        
     =      ==     ==      =     
             =     =             

>>> WHO
#-1 EXCEPTION: {"id":"243aac5bd8a1","command":"WHO","type":"ArgumentNullException"}

>>> create Alice hunter2
No such command available at login.

>>> QUIT
#-1 EXCEPTION: {"id":"ef9bfbaad6cf","command":"QUIT","type":"ArgumentNullException"}
```

Every one of the three things the banner advertises is broken or fictional. Second session, the account flow:

```
>>> register auditfiveB audit-pass-5
Account 'auditfiveB' created successfully.
You have no characters yet.
Use: make <character-name> <password>    to create your first character.

>>> make Cassia char-pass-5
Welcome back, #22:1786241188410!

Welcome to SharpMUSH!
Room Zero(#0R)
You see nothing special.
Contents:
Cassia
```

`Cassia` is three seconds old and is welcomed *back*, by database key.

Third session, returning:

```
>>> login auditfiveB audit-pass-5
Logged in as auditfiveB. Your characters:
  Cassia (#22)
Use: play <name>    to connect as a character
Use: make <name> <password>    to create a new character

>>> play Cassia
Welcome back, #22:1786241188410!
```

## AFTER (this branch)

Brand-new character through the account flow:

```
Connected!
          ==         ==          
         ====       ====         
       =======     =======           Welcome to SharpMUSH!
      =========   =========      
     =========== ===========         ACCOUNT - one account, many characters:
    =================== =====            register <name> [email] <password>
  ======-  ===========   ======          login <name-or-email> <password>
 ======     =========     ======         make <character> <password>
======   =   =======   =   ======        play <character>
======   ==   =====   ==   ======
 =====   ===   ===   ===   =====     CHARACTER - classic MUSH login:
 =====   ====   =   ====   =====         connect <character> <password>
  ====   =====     =====   ====          connect guest
   ===    ====     ====    ===   
   ===     ===     ===-    ===       ANY TIME:
    ==     ===     ===     ==            WHO      see who is online
     =      ==     ==      =             QUIT     disconnect
             =     =             

>>> register auditfiveC audit-pass-5
Account 'auditfiveC' created successfully.
You have no characters yet.
Use: make <character-name> <password>    to create your first character.

>>> make Delphine char-pass-5
Welcome, Delphine! This is your first time connecting.

Welcome to SharpMUSH!
Room Zero(#0R)
You see nothing special.
Contents:
Delphine

>>> QUIT
GOODBYE.

Goodbye from SharpMUSH!
```

Returning to the same character:

```
>>> login auditfiveC audit-pass-5
Logged in as auditfiveC. Your characters:
  Delphine (#23)
Use: play <name>    to connect as a character
Use: make <name> <password>    to create a new character

>>> play Delphine
Welcome back, Delphine!

Welcome to SharpMUSH!
Room Zero(#0R)
You see nothing special.
Contents:
Delphine
```

The connect screen, with another character logged in on a second socket:

```
>>> WHO
Player Name          On For   Idle  Doing
Cassia                  12s    11s  
There is one player connected.

>>> create Alice hunter2
No such command available at login.

>>> QUIT
GOODBYE.

Goodbye from SharpMUSH!

[--- server closed the socket ---]
```

Mortal-shaped listing (no `Loc #`, no `Des`, no `Host`), and QUIT now actually hangs up. `create` still does not exist — the banner simply no longer claims it does.

---

# Verification

**Build** — `dotnet build` with the `VerifyEditorConfigFormatting` gate on: **0 errors, 32 warnings**, all pre-existing (`MSB3277` from the plugin test fixtures, `CS0067`/`TUnit0046` in `SharpMUSH.Tests.BUnit`, `NU1603`/`NU1510`, `ANT01`). No warning references any file this PR touches. No suppressions; `TreatWarningsAsErrors` untouched. `dotnet format whitespace` run to convergence on every touched folder.

**Tests**

| Suite | total | passed | failed | skipped |
|---|---|---|---|---|
| `SharpMUSH.Tests` | 5374 | 5178 | **0** | 196 |
| `SharpMUSH.Tests.Integration` | 298 | 298 | **0** | 0 |
| `SharpMUSH.Tests.BUnit` | 463 | 463 | **0** | 0 |

New tests (13):

- `ConnectScreenTests` (3) — pre-login WHO returns a listing and does not throw; the header is the mortal one and carries no `Host`/`Loc #`/`Des`; pre-login QUIT says GOODBYE and actually drops the connection.
- `ConnectBannerTests` (3) — every command word the shipped banner advertises exists as a SOCKET command; the account flow is documented; a fresh connection really receives that file.
- `LoginGreetingTests` (4) — a returning player is greeted by name with no `#N`/`#N:timestamp` anywhere in the line; returning vs. first login select different messages; `make` end-to-end greets the brand-new character as new.
- `PresenceClassPlumbingTests` (+3) — presence class on the session the ConnectionServer keeps, and a store round-trip in both directions.

`CommandExceptionSurfacingTests.APreLoginCommandWithNoExecutorNotifiesTheConnectionHandle` used pre-login `WHO` to demonstrate the handle-targeted exception report. That was a bug being used as a fixture, so it is re-pointed at a connection bound to a dbref that is not in the database — which still has nowhere to deliver but the socket. Same contract, no dependence on WHO being broken.

**Reverting the N-13 fix and re-running:**

```
failed APortalConnectionSurvivesAStateStoreRoundTripAsPortal (55ms)
  AssertionException: Expected to be equal to "portal" but received "play"
failed RegisterAsync_records_the_presence_class_on_the_session_it_keeps (55ms)
  AssertionException: Expected to be equal to "portal" but received "play"
  total: 9  failed: 2  succeeded: 7
```

**i18n** — `python3 tools/i18n/validate_resx.py`: **all gates passed**, 16 locales at 100% of 1116 neutral keys.

```
en           1116 keys  (neutral)
bg/da/de/es/fr/hr/hu/nb/nl/pl/pt-BR/ro/ru/sv/zh-Hans   1116 keys  100%

all gates passed
```

To be precise about what that covers: the validator checks `SharpMUSH.Client/Resources/SharedResource*.resx`, the **portal's** 16 locales. `WelcomeFirstLoginFormat` is a server notification, so it lives in `SharpMUSH.Library/Resources/Notifications.resx` — and the engine ships exactly **two** locale files there, `en` and `fr`. Both were updated. Adding a server-notification key to the portal's resource set would have been wrong, so this PR does not claim 16 translations it did not write; it claims the engine's two, plus no regression in the portal's sixteen.

---

# Found but out of scope

- **A connection bound to a dbref that is not in the database crashes every command.** `SharpMUSHParserVisitor.EvaluateCommands` calls `WithoutNone()` on the executor and throws `ArgumentException: Cannot convert an None to a non-None value.` This is now *visible* thanks to #757 (it is what the re-pointed surfacing test asserts on), but making the parser degrade gracefully when an executor vanishes mid-session is its own change.
- **`newuser_file` and `who_file` are configured but never read** at runtime. Their text was corrected; wiring them into the login/WHO paths is a separate change.
- **`connect_html_file` defaults to `connect.html`, which does not exist** in the repo.

---

DO NOT MERGE — stacked PR, review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MPRzndB5egy4F2A3q5852
