### PR TITLE
Fix @mail and make channels work over telnet

### DIFF
--- a/SharpMUSH.Database.ArangoDB/ArangoDatabase.Channels.cs
+++ b/SharpMUSH.Database.ArangoDB/ArangoDatabase.Channels.cs
@@ -155,16 +155,22 @@ public partial class ArangoDatabase
 		MString? description, string[]? privs,
 		string? joinLock, string? speakLock, string? seeLock, string? hideLock, string? modLock, string? mogrifier,
 		int? buffer, CancellationToken ct = default)
+		// Vertex.UpdateAsync takes the document KEY, not the full "collection/key" _id that
+		// SharpChannel.Id carries — passing the _id produced a 404 on every channel update.
 		=> await arangoDb.Graph.Vertex.UpdateAsync(handle,
-			DatabaseConstants.GraphChannels, DatabaseConstants.Channels, channel.Id,
+			DatabaseConstants.GraphChannels, DatabaseConstants.Channels, ExtractKey(channel.Id!),
 			new
 			{
+				// Name is the plain-text lookup key (GetChannelAsync filters on it) and MarkedUpName holds
+				// the serialized MString — the same way CreateChannelAsync writes them. These two were
+				// swapped, so any channel update wrote serialized markup into Name and left the channel
+				// unfindable, with @channel/what then failing to deserialize the plain text in MarkedUpName.
 				Name = name is not null
-					? MModule.serialize(name)
-					: MModule.serialize(channel.Name),
-				MarkedUpName = name is not null
 					? name.ToPlainText()
 					: channel.Name.ToPlainText(),
+				MarkedUpName = name is not null
+					? MModule.serialize(name)
+					: MModule.serialize(channel.Name),
 				Description = description is not null
 					? MModule.serialize(description)
 					: MModule.serialize(channel.Description),
@@ -191,7 +197,7 @@ public partial class ArangoDatabase
 
 	public async ValueTask DeleteChannelAsync(SharpChannel channel, CancellationToken ct = default) =>
 		await arangoDb.Graph.Vertex.RemoveAsync(handle, DatabaseConstants.GraphChannels, DatabaseConstants.Channels,
-			channel.Id, cancellationToken: ct);
+			ExtractKey(channel.Id!), cancellationToken: ct);
 
 	public async ValueTask AddUserToChannelAsync(SharpChannel channel, AnySharpObject obj, CancellationToken ct = default)
 		=> await arangoDb.Graph.Edge.CreateAsync(
@@ -236,30 +242,32 @@ public partial class ArangoDatabase
 		var edge = result?.FirstOrDefault(x => x.To == channel.Id);
 		if (edge is null) return;
 
-		var updates = new List<KeyValuePair<string, object>>();
+		// A List<KeyValuePair<..>> serializes as a JSON array, which Arango rejects with
+		// "VPack error: Expecting Object". The patch body has to be an object.
+		var updates = new Dictionary<string, object>();
 		if (status.Combine is { } combine)
 		{
-			updates.Add(new KeyValuePair<string, object>(nameof(status.Combine), combine));
+			updates[nameof(status.Combine)] = combine;
 		}
 
 		if (status.Gagged is { } gagged)
 		{
-			updates.Add(new KeyValuePair<string, object>(nameof(status.Gagged), gagged));
+			updates[nameof(status.Gagged)] = gagged;
 		}
 
 		if (status.Hide is { } hide)
 		{
-			updates.Add(new KeyValuePair<string, object>(nameof(status.Hide), hide));
+			updates[nameof(status.Hide)] = hide;
 		}
 
 		if (status.Mute is { } mute)
 		{
-			updates.Add(new KeyValuePair<string, object>(nameof(status.Mute), mute));
+			updates[nameof(status.Mute)] = mute;
 		}
 
 		if (status.Title is { } title)
 		{
-			updates.Add(new KeyValuePair<string, object>(nameof(status.Title), MModule.serialize(title)));
+			updates[nameof(status.Title)] = MModule.serialize(title);
 		}
 
 		await arangoDb.Graph.Edge.UpdateAsync(handle, DatabaseConstants.GraphChannels, DatabaseConstants.OnChannel,

--- a/SharpMUSH.Database.ArangoDB/ArangoDatabase.Mail.cs
+++ b/SharpMUSH.Database.ArangoDB/ArangoDatabase.Mail.cs
@@ -153,11 +153,11 @@ public partial class ArangoDatabase
 				return;
 			case { IsClearEdit: true }:
 				await arangoDb.Graph.Vertex.UpdateAsync(handle, DatabaseConstants.GraphMail, DatabaseConstants.Mails,
-					key, new { Read = commandMail.AsClearEdit }, cancellationToken: ct);
+					key, new { Cleared = commandMail.AsClearEdit }, cancellationToken: ct);
 				return;
 			case { IsTaggedEdit: true }:
 				await arangoDb.Graph.Vertex.UpdateAsync(handle, DatabaseConstants.GraphMail, DatabaseConstants.Mails,
-					key, new { Urgent = commandMail.AsTaggedEdit }, cancellationToken: ct);
+					key, new { Tagged = commandMail.AsTaggedEdit }, cancellationToken: ct);
 				return;
 			case { IsUrgentEdit: true }:
 				await arangoDb.Graph.Vertex.UpdateAsync(handle, DatabaseConstants.GraphMail, DatabaseConstants.Mails,

--- a/SharpMUSH.Implementation/Commands/BuildingCommands.cs
+++ b/SharpMUSH.Implementation/Commands/BuildingCommands.cs
@@ -33,6 +33,7 @@ public partial class Commands
 	[SharpCommand(Name = "@CREATE", Behavior = CB.Default | CB.EqSplit, MinArgs = 1, MaxArgs = 3, ParameterNames = ["name", "cost", "dbref"])]
 	public static async ValueTask<Option<CallState>> Create(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var args = parser.CurrentState.Arguments;
 		var name = args["0"].Message!;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
@@ -127,6 +128,7 @@ public partial class Commands
 		MinArgs = 2, MaxArgs = 2, ParameterNames = ["object", "name"])]
 	public static async ValueTask<Option<CallState>> Rename(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var target = parser.CurrentState.Arguments["0"].Message!.ToPlainText()!;
 		var name = parser.CurrentState.Arguments["1"].Message!;
@@ -159,6 +161,7 @@ public partial class Commands
 	[SharpCommand(Name = "@SET", Behavior = CB.RSArgs | CB.EqSplit, MinArgs = 2, MaxArgs = 2, ParameterNames = ["object", "attribute", "value"])]
 	public static async ValueTask<Option<CallState>> SetCommand(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var args = parser.CurrentState.Arguments;
 		var split = HelperFunctions.SplitDbRefAndOptionalAttr(MModule.plainText(args["0"].Message!));
 		var enactor = (await parser.CurrentState.EnactorObject(Mediator!)).WithoutNone();
@@ -240,6 +243,7 @@ public partial class Commands
 		MaxArgs = 2, ParameterNames = ["object", "player"])]
 	public static async ValueTask<Option<CallState>> ChangeOwner(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 		var targetName = args["0"].Message!.ToPlainText();
@@ -297,6 +301,7 @@ public partial class Commands
 	[SharpCommand(Name = "@DESTROY", Switches = ["OVERRIDE"], Behavior = CB.Default, MinArgs = 1, MaxArgs = 1, ParameterNames = ["object"])]
 	public static async ValueTask<Option<CallState>> Destroy(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 		var targetName = args["0"].Message!.ToPlainText();
@@ -619,6 +624,7 @@ public partial class Commands
 		MaxArgs = 2, ParameterNames = ["object", "destination"])]
 	public static async ValueTask<Option<CallState>> Link(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 		var exitName = args["0"].Message!.ToPlainText();
@@ -785,6 +791,7 @@ public partial class Commands
 	[SharpCommand(Name = "@NUKE", Switches = [], Behavior = CB.Default | CB.NoGagged, MinArgs = 1, MaxArgs = 1, ParameterNames = ["object"])]
 	public static async ValueTask<Option<CallState>> Nuke(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		// @nuke is @destroy/override: it bypasses the SAFE flag and the "use @nuke" player guard.
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
@@ -799,6 +806,7 @@ public partial class Commands
 	[SharpCommand(Name = "@UNDESTROY", Switches = [], Behavior = CB.Default | CB.NoGagged, MinArgs = 1, MaxArgs = 1, ParameterNames = ["object"])]
 	public static async ValueTask<Option<CallState>> UnDestroy(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 		var targetName = args["0"].Message!.ToPlainText();
@@ -855,6 +863,7 @@ public partial class Commands
 		MinArgs = 2, MaxArgs = 2, ParameterNames = ["object", "zone"])]
 	public static async ValueTask<Option<CallState>> ChangeZone(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 		var targetName = args["0"].Message!.ToPlainText();
@@ -949,6 +958,7 @@ public partial class Commands
 		MinArgs = 1, MaxArgs = 6, ParameterNames = ["name", "exits"])]
 	public static async ValueTask<Option<CallState>> Dig(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		// NOTE: We discard arguments 4-6.
 		var executorBase = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var executor = executorBase.Object();
@@ -1035,6 +1045,7 @@ public partial class Commands
 		MinArgs = 2, MaxArgs = 2, ParameterNames = ["object", "locktype", "key"])]
 	public static async ValueTask<Option<CallState>> Lock(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 		var target = args["0"].Message!.ToPlainText();
@@ -1074,6 +1085,7 @@ public partial class Commands
 		MinArgs = 1, MaxArgs = 1, ParameterNames = ["object", "locktype"])]
 	public static async ValueTask<Option<CallState>> Unlock(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 		var target = args["0"].Message!.ToPlainText();
@@ -1111,6 +1123,7 @@ public partial class Commands
 		MinArgs = 2, MaxArgs = 2, ParameterNames = ["object", "key"])]
 	public static async ValueTask<Option<CallState>> ELock(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		// @ELOCK is an alias for @lock/enter
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
@@ -1141,6 +1154,7 @@ public partial class Commands
 		MinArgs = 1, MaxArgs = 1, ParameterNames = ["object"])]
 	public static async ValueTask<Option<CallState>> EUnlock(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		// @EUNLOCK is an alias for @unlock/enter
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
@@ -1170,6 +1184,7 @@ public partial class Commands
 		MinArgs = 2, MaxArgs = 2, ParameterNames = ["object", "key"])]
 	public static async ValueTask<Option<CallState>> ULock(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		// @ULOCK is an alias for @lock/use
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
@@ -1200,6 +1215,7 @@ public partial class Commands
 		MinArgs = 1, MaxArgs = 1, ParameterNames = ["object"])]
 	public static async ValueTask<Option<CallState>> UUnlock(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		// @UUNLOCK is an alias for @unlock/use
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
@@ -1246,6 +1262,7 @@ public partial class Commands
 		MinArgs = 1, MaxArgs = 5, ParameterNames = ["exit", "destination"])]
 	public static async ValueTask<Option<CallState>> Open(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 		var exitName = args["0"].Message!.ToPlainText();
@@ -1335,6 +1352,7 @@ public partial class Commands
 		MinArgs = 1, MaxArgs = 2, ParameterNames = ["object", "name", "cost"])]
 	public static async ValueTask<Option<CallState>> Clone(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 		var targetName = args["0"].Message!.ToPlainText();
@@ -1448,6 +1466,7 @@ public partial class Commands
 	[SharpCommand(Name = "@MONIKER", Switches = [], Behavior = CB.Default | CB.EqSplit, MinArgs = 1, MaxArgs = 2, ParameterNames = ["object", "moniker"])]
 	public static async ValueTask<Option<CallState>> Moniker(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 		var targetName = args["0"].Message!.ToPlainText();
@@ -1480,9 +1499,10 @@ public partial class Commands
 		);
 	}
 
-	[SharpCommand(Name = "@PARENT", Switches = [], Behavior = CB.Default | CB.EqSplit, MinArgs = 0, MaxArgs = 2, ParameterNames = ["object", "parent"])]
+	[SharpCommand(Name = "@PARENT", Switches = [], Behavior = CB.Default | CB.EqSplit, MinArgs = 1, MaxArgs = 2, ParameterNames = ["object", "parent"])]
 	public static async ValueTask<Option<CallState>> Parent(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 
@@ -1522,6 +1542,7 @@ public partial class Commands
 	[SharpCommand(Name = "@UNLINK", Switches = [], Behavior = CB.Default | CB.NoGagged, MinArgs = 1, MaxArgs = 1, ParameterNames = ["object"])]
 	public static async ValueTask<Option<CallState>> Unlink(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 		var targetName = args["0"].Message!.ToPlainText();

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelAdd.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelAdd.cs
@@ -28,7 +28,9 @@ public static class ChannelAdd
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService, PermissionService, Mediator, NotifyService, channelName, true);
+		// notify: false — a missing channel is the expected case when creating one; the player should
+		// not be told "Channel not found." on their way to "Channel has been created."
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService, PermissionService, Mediator, NotifyService, channelName, false);
 		if (!maybeChannel.IsError)
 		{
 			await NotifyService.Notify(executor, "CHAT: Channel already exists.", executor);

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelBuffer.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelBuffer.cs
@@ -28,8 +28,11 @@ public static class ChannelBuffer
 
 		var channel = maybeChannel.AsChannel;
 
-		if (await PermissionService.ChannelCanModifyAsync(executor, channel))
+		// The sense of this check was inverted: whoever COULD modify the channel was refused,
+		// and whoever could not fell through and made the change.
+		if (!await PermissionService.ChannelCanModifyAsync(executor, channel))
 		{
+			await NotifyService.Notify(executor, "You cannot modify this channel.", executor);
 			return new CallState("You cannot modify this channel.");
 		}
 
@@ -51,6 +54,8 @@ public static class ChannelBuffer
 			null,
 			Buffer: linesInt));
 
-		return new CallState(string.Format(ErrorMessages.Notifications.ChatResizingBuffer, channel.Name.ToPlainText()));
+		var bufferResult = string.Format(ErrorMessages.Notifications.ChatResizingBuffer, channel.Name.ToPlainText());
+		await NotifyService.Notify(executor, bufferResult, executor);
+		return new CallState(bufferResult);
 	}
 }

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelChown.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelChown.cs
@@ -27,8 +27,11 @@ public static class ChannelChown
 
 		var channel = maybeChannel.AsChannel;
 
-		if (await PermissionService.ChannelCanModifyAsync(executor, channel))
+		// The sense of this check was inverted: whoever COULD modify the channel was refused,
+		// and whoever could not fell through and made the change.
+		if (!await PermissionService.ChannelCanModifyAsync(executor, channel))
 		{
+			await NotifyService.Notify(executor, ErrorMessages.Returns.YouCannotModifyThisChannel, executor);
 			return new CallState(ErrorMessages.Returns.YouCannotModifyThisChannel);
 		}
 

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelDelete.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelDelete.cs
@@ -27,13 +27,17 @@ public static class ChannelDelete
 
 		var channel = maybeChannel.AsChannel;
 
-		if (await PermissionService.ChannelCanModifyAsync(executor, channel))
+		// The sense of this check was inverted: whoever COULD modify the channel was refused, and
+		// whoever could not fell through and deleted it.
+		if (!await PermissionService.ChannelCanModifyAsync(executor, channel))
 		{
+			await NotifyService.Notify(executor, "CHAT: You cannot modify this channel.", executor);
 			return new CallState("You cannot modify this channel.");
 		}
 
 		await Mediator.Send(new DeleteChannelCommand(channel));
 
+		await NotifyService.Notify(executor, "CHAT: Channel has been deleted.", executor);
 		return new CallState("Channel has been deleted.");
 	}
 }

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelDescribe.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelDescribe.cs
@@ -27,8 +27,11 @@ public static class ChannelDescribe
 
 		var channel = maybeChannel.AsChannel;
 
-		if (await PermissionService.ChannelCanModifyAsync(executor, channel))
+		// The sense of this check was inverted: whoever COULD modify the channel was refused,
+		// and whoever could not fell through and made the change.
+		if (!await PermissionService.ChannelCanModifyAsync(executor, channel))
 		{
+			await NotifyService.Notify(executor, "You cannot modify this channel.", executor);
 			return new CallState("You cannot modify this channel.");
 		}
 
@@ -44,6 +47,8 @@ public static class ChannelDescribe
 			null,
 			null));
 
-		return new CallState(string.Format(ErrorMessages.Notifications.ChatChannelDescSet, channel.Name.ToPlainText()));
+		var describeResult = string.Format(ErrorMessages.Notifications.ChatChannelDescSet, channel.Name.ToPlainText());
+		await NotifyService.Notify(executor, describeResult, executor);
+		return new CallState(describeResult);
 	}
 }

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelHelper.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelHelper.cs
@@ -45,6 +45,11 @@ public class PrivilegeOrError : OneOfBase<string[], Error<string[]>>
 
 public static class ChannelHelper
 {
+	/// <summary>
+	/// Channel privilege names and their single-character abbreviations, matching PennMUSH's
+	/// <c>chan_privs</c> table (<c>extchat.c</c>). The characters are case-sensitive: 'O' is Object
+	/// and 'o' is Open.
+	/// </summary>
 	private static readonly ReadOnlyDictionary<string, char> ChannelPrivileges = new(
 		new Dictionary<string, char>(StringComparer.OrdinalIgnoreCase)
 		{
@@ -52,7 +57,6 @@ public static class ChannelHelper
 			{ "Player", 'P' },
 			{ "Admin", 'A' },
 			{ "Wizard", 'W' },
-			{ "Thing", 'T' },
 			{ "Object", 'O' },
 			{ "Quiet", 'Q' },
 			{ "Open", 'o' },
@@ -86,7 +90,7 @@ public static class ChannelHelper
 			.ToArray();
 
 		var badList = list.Where(x => x.Length == 1
-			? !ChannelPrivilegesReverse.ContainsKey(x.ToUpper()[0])
+			? !ChannelPrivilegesReverse.ContainsKey(x[0])
 			: !ChannelPrivileges.ContainsKey(x)).ToArray();
 
 		if (badList.Length != 0)
@@ -95,7 +99,7 @@ public static class ChannelHelper
 		}
 
 		var validatedList = list.Select(x => x.Length == 1
-				? ChannelPrivilegesReverse.GetValueOrDefault(x.ToUpper()[0], null)
+				? ChannelPrivilegesReverse.GetValueOrDefault(x[0], null)
 				: (ChannelPrivileges.ContainsKey(x) ? x : null))
 			.Where(x => x != null).ToArray();
 

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelList.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelList.cs
@@ -30,8 +30,13 @@ public static class ChannelList
 				shouldNotify: true);
 		}
 
+		// sharpchat.md:181 — "If a <prefix> is given, only channels whose names begin with <prefix> are shown."
+		var prefix = arg0.ToPlainText().Trim();
+
 		var channelList = await channels
 			.Where(async (x, _) => await PermissionService.ChannelCanSeeAsync(executor, x))
+			.Where((x, _) => ValueTask.FromResult(prefix.Length == 0
+				|| x.Name.ToPlainText().StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
 			.Where(async (x, ct) => !offSwitch || await x.Members.Value
 				.AllAsync(m => m.Member.Object().Id != executor.Object().Id, ct))
 			.Where(async (x, ct) => !onSwitch || await x.Members.Value
@@ -40,6 +45,12 @@ public static class ChannelList
 				? channel.Name
 				: MModule.concat(MModule.single("Name: "), channel.Name))
 			.ToArrayAsync();
+
+		if (channelList.Length == 0)
+		{
+			await NotifyService.Notify(executor, "CHAT: No channels match that.", executor);
+			return new CallState(MModule.empty());
+		}
 
 		var result = MModule.multipleWithDelimiter(MModule.single("\n"), channelList);
 		await NotifyService.Notify(executor, result, executor);

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelMogrifier.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelMogrifier.cs
@@ -28,8 +28,11 @@ public static class ChannelMogrifier
 
 		var channel = maybeChannel.AsChannel;
 
-		if (await PermissionService.ChannelCanModifyAsync(executor, channel))
+		// The sense of this check was inverted: whoever COULD modify the channel was refused,
+		// and whoever could not fell through and made the change.
+		if (!await PermissionService.ChannelCanModifyAsync(executor, channel))
 		{
+			await NotifyService.Notify(executor, "You cannot modify this channel.", executor);
 			return new CallState("You cannot modify this channel.");
 		}
 

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelOff.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelOff.cs
@@ -40,6 +40,13 @@ public static class ChannelOff
 
 		var channel = maybeChannel.AsChannel;
 
+		if (!await ChannelHelper.IsMemberOfChannel(target, channel))
+		{
+			var notOn = $"CHAT: {target.Object().Name} is not on {channel.Name.ToPlainText()}.";
+			await NotifyService.Notify(executor, notOn, executor);
+			return new CallState(notOn);
+		}
+
 		// Channel join/leave announcements are handled by the channel system
 		await Mediator.Send(new RemoveUserFromChannelCommand(channel, target));
 

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelOn.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelOn.cs
@@ -40,6 +40,13 @@ public static class ChannelOn
 
 		var channel = maybeChannel.AsChannel;
 
+		if (await ChannelHelper.IsMemberOfChannel(target, channel))
+		{
+			var alreadyOn = $"CHAT: {target.Object().Name} is already on {channel.Name.ToPlainText()}.";
+			await NotifyService.Notify(executor, alreadyOn, executor);
+			return new CallState(alreadyOn);
+		}
+
 		// Channel join/leave announcements are handled by the channel system
 		await Mediator.Send(new AddUserToChannelCommand(channel, target));
 

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelPrivs.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelPrivs.cs
@@ -27,8 +27,11 @@ public static class ChannelPrivs
 
 		var channel = maybeChannel.AsChannel;
 
-		if (await PermissionService.ChannelCanModifyAsync(executor, channel))
+		// The sense of this check was inverted: whoever COULD modify the channel was refused,
+		// and whoever could not fell through and made the change.
+		if (!await PermissionService.ChannelCanModifyAsync(executor, channel))
 		{
+			await NotifyService.Notify(executor, "You are not the owner of the channel.", executor);
 			return new CallState("You are not the owner of the channel.");
 		}
 
@@ -51,6 +54,7 @@ public static class ChannelPrivs
 			null,
 			null));
 
+		await NotifyService.Notify(executor, "CHAT: Channel privileges have been updated.", executor);
 		return new CallState("CHAT: Channel privileges have been updated.");
 	}
 }

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelRecall.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelRecall.cs
@@ -40,7 +40,7 @@ public static class ChannelRecall
 			.Select(x => x.Message)
 			.ToListAsync();
 
-		var message = MModule.multiple(messages);
+		var message = MModule.multipleWithDelimiter(MModule.single("\n"), messages);
 
 		if (switches.Contains("QUIET"))
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelRename.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelRename.cs
@@ -36,8 +36,11 @@ public static class ChannelRename
 
 		var channel = maybeChannel.AsChannel;
 
-		if (await PermissionService.ChannelCanModifyAsync(executor, channel))
+		// The sense of this check was inverted: whoever COULD modify the channel was refused,
+		// and whoever could not fell through and made the change.
+		if (!await PermissionService.ChannelCanModifyAsync(executor, channel))
 		{
+			await NotifyService.Notify(executor, "You are not the owner of the channel.", executor);
 			return new CallState("You are not the owner of the channel.");
 		}
 

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelTitle.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelTitle.cs
@@ -1,5 +1,7 @@
 using Mediator;
 using SharpMUSH.Library;
+using SharpMUSH.Library.Commands.Database;
+using SharpMUSH.Library.Models;
 using SharpMUSH.Library.ParserInterfaces;
 using SharpMUSH.Library.Services.Interfaces;
 using SharpMUSH.Library.Definitions;
@@ -8,6 +10,12 @@ namespace SharpMUSH.Implementation.Commands.ChannelCommand;
 
 public static class ChannelTitle
 {
+	/// <summary>
+	/// <c>@channel/title &lt;channel&gt;=&lt;title&gt;</c> — sharpchat.md:236: "sets your title on
+	/// &lt;channel&gt;. Your title appears in front of your name when you speak on the channel...
+	/// If &lt;title&gt; is not given, your title is cleared." It is the speaker's own title, so it
+	/// requires channel membership rather than channel ownership.
+	/// </summary>
 	public static async ValueTask<CallState> Handle(IMUSHCodeParser parser, ILocateService LocateService, IPermissionService PermissionService, IMediator Mediator, INotifyService NotifyService, MString channelName, MString title)
 	{
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator);
@@ -26,11 +34,24 @@ public static class ChannelTitle
 
 		var channel = maybeChannel.AsChannel;
 
-		if (!await PermissionService.ChannelCanModifyAsync(executor, channel))
+		var memberStatus = await ChannelHelper.ChannelMemberStatus(executor, channel);
+		if (memberStatus is null)
 		{
-			return new CallState("You are not the owner of the channel.");
+			var notOn = string.Format(ErrorMessages.Notifications.ChatNotOnChannel, channel.Name.ToPlainText());
+			await NotifyService.Notify(executor, notOn, executor);
+			return new CallState(notOn);
 		}
 
-		return new CallState("Channel title has been updated.");
+		var (_, status) = memberStatus;
+		var cleared = MModule.getLength(title) == 0;
+
+		await Mediator.Send(new UpdateChannelUserStatusCommand(channel, executor,
+			status with { Title = cleared ? MModule.empty() : title }));
+
+		var response = cleared
+			? $"CHAT: Title cleared on {channel.Name.ToPlainText()}."
+			: $"CHAT: Title set on {channel.Name.ToPlainText()}.";
+		await NotifyService.Notify(executor, response, executor);
+		return new CallState(response);
 	}
 }

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelWhat.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelWhat.cs
@@ -1,6 +1,7 @@
 using Mediator;
 using SharpMUSH.Library;
 using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Queries.Database;
 using SharpMUSH.Library.Services.Interfaces;
 using SharpMUSH.Library.Definitions;
 
@@ -8,7 +9,13 @@ namespace SharpMUSH.Implementation.Commands.ChannelCommand;
 
 public static class ChannelWhat
 {
-	public static async ValueTask<CallState> Handle(IMUSHCodeParser parser, ILocateService locateService, IPermissionService permissionService, IMediator mediator, INotifyService notifyService, MString channelName)
+	/// <summary>
+	/// <c>@channel/what [&lt;prefix&gt;]</c> — sharpchat.md:187: "shows the name, description, owner,
+	/// priv flags, mogrifier and buffer size for all channels, or all channels whose names begin with
+	/// &lt;prefix&gt; if one is given."
+	/// </summary>
+	public static async ValueTask<CallState> Handle(IMUSHCodeParser parser, ILocateService locateService,
+		IPermissionService permissionService, IMediator mediator, INotifyService notifyService, MString prefixArgument)
 	{
 		var executor = await parser.CurrentState.KnownExecutorObject(mediator);
 		if (await executor.IsGuest())
@@ -17,19 +24,34 @@ public static class ChannelWhat
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, locateService, permissionService, mediator, notifyService, channelName, true);
+		var prefix = prefixArgument.ToPlainText().Trim();
 
-		if (maybeChannel.IsError)
+		var channels = await mediator.CreateStream(new GetChannelListQuery())
+			.Where(async (channel, _) => await permissionService.ChannelCanSeeAsync(executor, channel))
+			.Where((channel, _) => ValueTask.FromResult(prefix.Length == 0
+				|| channel.Name.ToPlainText().StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
+			.ToArrayAsync();
+
+		if (channels.Length == 0)
 		{
-			return maybeChannel.AsError.Value;
+			await notifyService.Notify(executor, "CHAT: No channels match that.", executor);
+			return new CallState(MModule.empty());
 		}
 
-		var channel = maybeChannel.AsChannel;
+		List<MString> lines = [];
+		foreach (var channel in channels)
+		{
+			var owner = await channel.Owner.WithCancellation(CancellationToken.None);
+			lines.Add(MModule.concat(MModule.single("Channel: "), channel.Name));
+			lines.Add(MModule.concat(MModule.single("Description: "), channel.Description));
+			lines.Add(MModule.single($"Owner: {owner.Object.Name}(#{owner.Object.DBRef.Number})"));
+			lines.Add(MModule.single($"Flags: {string.Join(" ", channel.Privs)}"));
+			lines.Add(MModule.single($"Mogrifier: {(string.IsNullOrEmpty(channel.Mogrifier) ? "none" : channel.Mogrifier)}"));
+			lines.Add(MModule.single($"Buffer: {channel.Buffer}"));
+		}
 
-		var members = channel.Members.Value;
-		var memberList = members.Select(x => x.Member).ToArrayAsync();
-		var memberString = string.Join(", ", memberList);
-
-		return new CallState(MModule.single(memberString));
+		var output = MModule.multipleWithDelimiter(MModule.single("\n"), lines);
+		await notifyService.Notify(executor, output, executor);
+		return new CallState(output);
 	}
 }

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelWipe.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelWipe.cs
@@ -26,8 +26,11 @@ public static class ChannelWipe
 
 		var channel = maybeChannel.AsChannel;
 
-		if (await PermissionService.ChannelCanModifyAsync(executor, channel))
+		// The sense of this check was inverted: whoever COULD modify the channel was refused,
+		// and whoever could not fell through and made the change.
+		if (!await PermissionService.ChannelCanModifyAsync(executor, channel))
 		{
+			await NotifyService.Notify(executor, "You are not the owner of the channel.", executor);
 			return new CallState("You are not the owner of the channel.");
 		}
 

--- a/SharpMUSH.Implementation/Commands/ChannelCommands.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommands.cs
@@ -101,12 +101,16 @@ public partial class Commands
 
 		var (_, status) = maybeMemberStatus;
 
-		// Notification type is determined from message prefix in ChannelMessageRequestHandler
+		// sharpchat.md:33 — "If <message> begins with a ':' or ';' it will be posed (or semiposed)
+		// instead of spoken." Anything else is speech, which is what produces the documented
+		// `<Public> Mike says, "Hello"` rendering.
+		var (chatType, chatMessage) = ClassifyChannelSpeech(message);
+
 		await Mediator!.Publish(new ChannelMessageNotification(
 			channel,
 			executor.WithNoneOption(),
-			INotifyService.NotificationType.Emit,
-			message,
+			chatType,
+			chatMessage,
 			status.Title ?? MModule.empty(),
 			MModule.single(executor.Object().Name),
 			MModule.single("says"),
@@ -114,6 +118,19 @@ public partial class Commands
 		));
 
 		return new CallState(string.Empty);
+	}
+
+	private static (INotifyService.NotificationType Type, MString Message) ClassifyChannelSpeech(MString message)
+	{
+		var plain = message.ToPlainText();
+		var rest = MModule.substring(1, MModule.getLength(message) - 1, message);
+
+		return plain switch
+		{
+			[':', ..] => (INotifyService.NotificationType.Pose, rest),
+			[';', ..] => (INotifyService.NotificationType.SemiPose, rest),
+			_ => (INotifyService.NotificationType.Say, message)
+		};
 	}
 
 	[SharpCommand(Name = "@NSCEMIT", Switches = ["NOEVAL", "NOISY", "SILENT"],

--- a/SharpMUSH.Implementation/Commands/Commands.cs
+++ b/SharpMUSH.Implementation/Commands/Commands.cs
@@ -6,6 +6,10 @@ using SharpMUSH.Library.Definitions;
 using SharpMUSH.Library.Services;
 using SharpMUSH.Library.Services.Interfaces;
 using SharpMUSH.Messaging.Abstractions;
+using SharpMUSH.Library.Attributes;
+using SharpMUSH.Library.DiscriminatedUnions;
+using SharpMUSH.Library.Extensions;
+using SharpMUSH.Library.ParserInterfaces;
 
 namespace SharpMUSH.Implementation.Commands;
 
@@ -147,5 +151,33 @@ public partial class Commands : ILibraryProvider<CommandDefinition>
 
 		// Store reference to this command library for @command introspection
 		CommandLibrary = _commandLibrary;
+	}
+
+	/// <summary>
+	/// Rejects an invocation carrying fewer arguments than the command declares in
+	/// <see cref="SharpCommandAttribute.MinArgs"/>, reporting the arity the way functions already do.
+	/// <para>Commands declare MinArgs but the engine never enforced it, so a handler that indexed
+	/// <c>Arguments["0"]</c> without checking threw <see cref="KeyNotFoundException"/> on a bare
+	/// invocation. Enforcing it centrally in the dispatcher was measured and rejected: it pre-empts
+	/// the specific usage messages that ~40 commands (@enable, @disable, @verb, @command, @respond,
+	/// @atrchown, @include and others) already render for themselves, which is strictly worse for the
+	/// player. This is the per-command opt-in instead — call it from handlers that would otherwise
+	/// index an argument they never checked for.</para>
+	/// </summary>
+	/// <returns>The rejection to return, or <c>null</c> when the arity is satisfied.</returns>
+	private static async ValueTask<CallState?> RejectIfTooFewArguments(IMUSHCodeParser parser,
+		SharpCommandAttribute attribute)
+	{
+		var count = parser.CurrentState.Arguments.Count;
+		if (count >= attribute.MinArgs)
+		{
+			return null;
+		}
+
+		var message = string.Format(ErrorMessages.Returns.TooFewCommandArguments,
+			attribute.Name, attribute.MinArgs, count);
+		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
+		await NotifyService!.Notify(executor, message, executor);
+		return new CallState(message);
 	}
 }

--- a/SharpMUSH.Implementation/Commands/GeneralCommands.cs
+++ b/SharpMUSH.Implementation/Commands/GeneralCommands.cs
@@ -6334,7 +6334,7 @@ public partial class Commands
 	[SharpCommand(Name = "@MAIL",
 		Switches =
 		[
-			"NOEVAL", "NOSIG", "STATS", "CSTATS", "DSTATS", "FSTATS", "DEBUG", "NUKE", "FOLDERS", "UNFOLDER", "LIST", "READ",
+			"NOEVAL", "NOSIG", "STATS", "CSTATS", "DSTATS", "FSTATS", "DEBUG", "NUKE", "FOLDER", "UNFOLDER", "LIST", "READ",
 			"UNREAD", "CLEAR", "UNCLEAR", "STATUS", "PURGE", "FILE", "TAG", "UNTAG", "FWD", "FORWARD", "SEND", "SILENT",
 			"URGENT", "REVIEW", "RETRACT"
 		], Behavior = CB.Default | CB.EqSplit | CB.NoParse, MinArgs = 0, MaxArgs = 2, ParameterNames = ["player", "subject"])]
@@ -6406,7 +6406,7 @@ public partial class Commands
 				=> await ForwardMail.Handle(parser, ObjectDataService!, LocateService!, PermissionService!, Mediator!, number,
 					arg1!.ToPlainText()),
 			[.., "SEND"] or [.., "URGENT"] or [.., "SILENT"] or [.., "NOSIG"] or []
-				when arg0?.Length != 0 && arg1?.Length != 0
+				when (arg0?.Length ?? 0) != 0 && (arg1?.Length ?? 0) != 0
 				=> await SendMail.Handle(parser, PermissionService!, ObjectDataService!, Mediator!, NotifyService!, AttributeService!, Configuration!, arg0!,
 					arg1!, switches),
 			[.., "READ"] or [] when executor.IsPlayer && (arg1?.Length ?? 0) == 0 &&
@@ -6415,10 +6415,16 @@ public partial class Commands
 					switches),
 			[.., "LIST"] or [] when executor.IsPlayer && (arg1?.Length ?? 0) == 0
 				=> await ListMail.Handle(parser, ObjectDataService!, Mediator!, NotifyService!, arg0, arg1, switches),
-			_ => MModule.single(ErrorMessages.Returns.BadArgumentsToMailCommand)
+			_ => await NotifyAndReturnBadMailArguments(executor)
 		};
 
 		return new CallState(response);
+	}
+
+	private static async ValueTask<MString> NotifyAndReturnBadMailArguments(AnySharpObject executor)
+	{
+		await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.MailBadArguments), executor);
+		return MModule.single(ErrorMessages.Returns.BadArgumentsToMailCommand);
 	}
 
 	[SharpCommand(Name = "@NSPEMIT", Switches = ["LIST", "SILENT", "NOISY", "NOEVAL"], Behavior = CB.Default | CB.EqSplit,

--- a/SharpMUSH.Implementation/Commands/GeneralCommands.cs
+++ b/SharpMUSH.Implementation/Commands/GeneralCommands.cs
@@ -1531,6 +1531,7 @@ public partial class Commands
 		Switches = ["LIST", "INSIDE", "QUIET"], ParameterNames = ["object", "destination"])]
 	public static async ValueTask<Option<CallState>> Teleport(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var args = parser.CurrentState.Arguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 
@@ -2089,6 +2090,7 @@ public partial class Commands
 		MinArgs = 2, MaxArgs = 2, ParameterNames = ["target", "message"])]
 	public static async ValueTask<Option<CallState>> NoSpoofPrompt(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var switches = parser.CurrentState.Switches;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var target = parser.CurrentState.Arguments["0"].Message!.ToPlainText();
@@ -2122,9 +2124,10 @@ public partial class Commands
 	}
 
 	[SharpCommand(Name = "@SCAN", Switches = ["ROOM", "SELF", "ZONE", "GLOBALS"], Behavior = CB.Default | CB.NoGagged,
-		MinArgs = 0, MaxArgs = 0, ParameterNames = ["object", "code"])]
+		MinArgs = 1, MaxArgs = 0, ParameterNames = ["object", "code"])]
 	public static async ValueTask<Option<CallState>> Scan(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var arg0 = parser.CurrentState.Arguments["0"].Message!;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var switches = parser.CurrentState.Switches.Any()
@@ -2254,6 +2257,7 @@ public partial class Commands
 		Behavior = CB.Default | CB.EqSplit | CB.RSArgs | CB.RSNoParse | CB.NoGagged, MinArgs = 3, MaxArgs = int.MaxValue, ParameterNames = ["expression", "cases..."])]
 	public static async ValueTask<Option<CallState>> Switch(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var args = parser.CurrentState.ArgumentsOrdered;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var switches = parser.CurrentState.Switches.ToArray();
@@ -2846,6 +2850,7 @@ public partial class Commands
 		MaxArgs = 2, ParameterNames = ["object", "attribute"])]
 	public static async ValueTask<Option<CallState>> Drain(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var arg0 = parser.CurrentState.Arguments["0"].Message!.ToPlainText();
 		var arg1 = parser.CurrentState.Arguments.GetValueOrDefault("1")?.Message?.ToPlainText();
 		var switches = parser.CurrentState.Switches.ToArray();
@@ -3071,6 +3076,7 @@ public partial class Commands
 		MinArgs = 2, MaxArgs = 3, ParameterNames = ["condition", "true-command", "false-command"])]
 	public static async ValueTask<Option<CallState>> IfElse(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var parsedIfElse = await parser.CurrentState.Arguments["0"].ParsedMessage();
 		var truthy = Predicates.Truthy(parsedIfElse!);
 
@@ -4562,6 +4568,7 @@ public partial class Commands
 		Behavior = CB.Default | CB.EqSplit | CB.RSArgs | CB.RSNoParse, MinArgs = 1, MaxArgs = int.MaxValue, ParameterNames = ["expression", "cases..."])]
 	public static async ValueTask<Option<CallState>> Select(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 		var switches = parser.CurrentState.Switches.ToArray();
@@ -4750,6 +4757,7 @@ public partial class Commands
 		Behavior = CB.Default | CB.EqSplit | CB.RSArgs | CB.NoGagged, MinArgs = 1, MaxArgs = int.MaxValue, ParameterNames = ["object/attribute", "arguments..."])]
 	public static async ValueTask<Option<CallState>> Trigger(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var enactor = (await parser.CurrentState.EnactorObject(Mediator!)).WithoutNone();
 		var args = parser.CurrentState.Arguments;
@@ -5674,7 +5682,7 @@ public partial class Commands
 		return CallState.Empty;
 	}
 
-	[SharpCommand(Name = "@VERB", Switches = [], Behavior = CB.Default | CB.EqSplit | CB.RSArgs, MinArgs = 0,
+	[SharpCommand(Name = "@VERB", Switches = [], Behavior = CB.Default | CB.EqSplit | CB.RSArgs, MinArgs = 2,
 		MaxArgs = 0, ParameterNames = ["object", "verb", "target"])]
 	public static async ValueTask<Option<CallState>> Verb(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
@@ -5689,13 +5697,17 @@ public partial class Commands
 			return new CallState(ErrorMessages.Returns.CantSeeThat);
 		}
 
-		var victimName = args.ElementAtOrDefault(0).Value.Message!.ToPlainText();
-		var actorName = args.ElementAtOrDefault(1).Value.Message!.ToPlainText();
-		var what = args.ElementAtOrDefault(2).Value.Message!.ToPlainText();
-		var whatd = args.ElementAtOrDefault(3).Value.Message!.ToPlainText();
-		var owhat = args.ElementAtOrDefault(4).Value.Message!.ToPlainText();
-		var owhatd = args.ElementAtOrDefault(5).Value.Message!.ToPlainText();
-		var awhat = args.ElementAtOrDefault(6).Value.Message!.ToPlainText();
+		// ElementAtOrDefault past the end yields a default KeyValuePair whose Value is a null CallState,
+		// so every optional slot has to be read through a null-safe accessor.
+		string ArgAt(int index) => args.ElementAtOrDefault(index).Value?.Message?.ToPlainText() ?? string.Empty;
+
+		var victimName = ArgAt(0);
+		var actorName = ArgAt(1);
+		var what = ArgAt(2);
+		var whatd = ArgAt(3);
+		var owhat = ArgAt(4);
+		var owhatd = ArgAt(5);
+		var awhat = ArgAt(6);
 
 		const int RequiredArgsBeforeStack = 7;
 		var stackArgs = args.Skip(RequiredArgsBeforeStack)
@@ -6507,12 +6519,13 @@ public partial class Commands
 	}
 
 	[SharpCommand(Name = "@PASSWORD", Switches = [],
-		Behavior = CB.Player | CB.EqSplit | CB.NoParse | CB.RSNoParse | CB.NoGuest, MinArgs = 0, MaxArgs = 0, ParameterNames = ["old", "new"])]
+		Behavior = CB.Player | CB.EqSplit | CB.NoParse | CB.RSNoParse | CB.NoGuest, MinArgs = 2, MaxArgs = 0, ParameterNames = ["old", "new"])]
 	public static async ValueTask<Option<CallState>> Password(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var oldPassword = parser.CurrentState.Arguments["0"].Message!.ToPlainText();
-		var newPassword = parser.CurrentState.Arguments["0"].Message!.ToPlainText();
+		var newPassword = parser.CurrentState.Arguments["1"].Message!.ToPlainText();
 
 		if (!executor.IsPlayer)
 		{
@@ -7236,9 +7249,10 @@ public partial class Commands
 	}
 
 	[SharpCommand(Name = "@SKIP", Switches = ["IFELSE"], Behavior = CB.Default | CB.EqSplit | CB.RSArgs | CB.RSNoParse,
-		MinArgs = 0, MaxArgs = 0, ParameterNames = [])]
+		MinArgs = 1, MaxArgs = 0, ParameterNames = [])]
 	public static async ValueTask<Option<CallState>> Skip(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var parsedIfElse = await parser.CurrentState.Arguments["0"].ParsedMessage();
 		var falsey = Predicates.Falsy(parsedIfElse!);
 
@@ -7254,6 +7268,7 @@ public partial class Commands
 		Behavior = CB.Default | CB.EqSplit | CB.RSArgs | CB.NoGagged, MinArgs = 3, MaxArgs = 0, ParameterNames = ["object", "type", "message"])]
 	public static async ValueTask<Option<CallState>> Message(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var switches = parser.CurrentState.Switches;
 		var args = parser.CurrentState.ArgumentsOrdered;

--- a/SharpMUSH.Implementation/Commands/GeneralCommands.cs
+++ b/SharpMUSH.Implementation/Commands/GeneralCommands.cs
@@ -4996,63 +4996,84 @@ public partial class Commands
 	{
 		var args = parser.CurrentState.Arguments;
 		var switches = parser.CurrentState.Switches.ToArray();
+		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 
-		if (switches.Contains("QUIET") && (!switches.Contains("LIST") || !switches.Contains("RECALL")))
+		// /quiet only pairs with /list or /recall — it is invalid alongside anything else.
+		if (switches.Contains("QUIET") && !switches.Contains("LIST") && !switches.Contains("RECALL"))
 		{
+			await NotifyService!.Notify(executor, "CHAT: Incorrect combination of switches.", executor);
 			return new CallState("CHAT: INCORRECT COMBINATION OF SWITCHES");
 		}
+
+		// sharpchat.md:179-181 documents `@channel/list[/on|/off][/quiet] [<prefix>]` and
+		// `@channel/what [<prefix>]` — the argument is OPTIONAL there and required everywhere else.
+		// Reading Arguments["0"] unconditionally turned every argument-less switched form into a
+		// KeyNotFoundException, so read through the dictionary and let the arms state their own arity.
+		var arg0 = args.GetValueOrDefault("0")?.Message;
+		var arg1 = args.GetValueOrDefault("1")?.Message;
+		var emptyIfMissing0 = arg0 ?? MModule.empty();
+		var emptyIfMissing1 = arg1 ?? MModule.empty();
 
 		// Note: Channel visibility checking is handled by PermissionService.ChannelCanSeeAsync in each handler
 		return switches switch
 		{
-			[.., "LIST"] => await ChannelCommand.ChannelList.Handle(parser, LocateService!, PermissionService!, Mediator!,
-				NotifyService!, args["0"].Message!, args["1"].Message!, switches),
+			// /list, /recall and /decompile combine with other switches (`@channel/list/on/quiet`), so they
+			// match on membership rather than on a positional list pattern that only fires when they are last.
+			_ when switches.Contains("LIST") => await ChannelCommand.ChannelList.Handle(parser, LocateService!,
+				PermissionService!, Mediator!, NotifyService!, emptyIfMissing0, emptyIfMissing1, switches),
+			_ when switches.Contains("RECALL") && arg0 is not null => await ChannelRecall.Handle(parser, LocateService!,
+				PermissionService!, Mediator!, NotifyService!, arg0, emptyIfMissing1, switches),
+			_ when switches.Contains("DECOMPILE") && arg0 is not null => await ChannelDecompile.Handle(parser,
+				LocateService!, PermissionService!, Mediator!, NotifyService!, arg0, emptyIfMissing1, switches),
 			["WHAT"] => await ChannelWhat.Handle(parser, LocateService!, PermissionService!, Mediator!, NotifyService!,
-				args["0"].Message!),
-			["WHO"] => await ChannelWho.Handle(parser, LocateService!, PermissionService!, Mediator!, NotifyService!,
-				args["0"].Message!),
-			["ON"] or ["JOIN"] => await ChannelOn.Handle(parser, LocateService!, PermissionService!, Mediator!,
-				NotifyService!, args["0"].Message!, args["1"].Message),
-			["OFF"] or ["LEAVE"] => await ChannelOff.Handle(parser, LocateService!, PermissionService!, Mediator!,
-				NotifyService!, args["0"].Message!, args["1"].Message),
-			["GAG"] => await ChannelGag.Handle(parser, LocateService!, PermissionService!, Mediator!, NotifyService!,
-				args["0"].Message!, args["1"].Message!, switches),
-			["MUTE"] => await ChannelMute.Handle(parser, LocateService!, PermissionService!, Mediator!, NotifyService!,
-				args["0"].Message!, args["1"].Message!),
-			["HIDE"] => await ChannelHide.Handle(parser, LocateService!, PermissionService!, Mediator!, NotifyService!,
-				args["0"].Message!, args["1"].Message!),
-			["COMBINE"] => await ChannelCombine.Handle(parser, LocateService!, PermissionService!, Mediator!, NotifyService!,
-				args["0"].Message!, args["1"].Message!),
-			["TITLE"] => await ChannelTitle.Handle(parser, LocateService!, PermissionService!, Mediator!, NotifyService!,
-				args["0"].Message!, args["1"].Message!),
-			[.., "RECALL"] => await ChannelRecall.Handle(parser, LocateService!, PermissionService!, Mediator!,
-				NotifyService!, args["0"].Message!, args["1"].Message!, switches),
-			["ADD"] when args.ContainsKey("0") && args.ContainsKey("1")
+				emptyIfMissing0),
+			["WHO"] when arg0 is not null => await ChannelWho.Handle(parser, LocateService!, PermissionService!, Mediator!,
+				NotifyService!, arg0),
+			(["ON"] or ["JOIN"]) when arg0 is not null => await ChannelOn.Handle(parser, LocateService!, PermissionService!,
+				Mediator!, NotifyService!, arg0, arg1),
+			(["OFF"] or ["LEAVE"]) when arg0 is not null => await ChannelOff.Handle(parser, LocateService!,
+				PermissionService!, Mediator!, NotifyService!, arg0, arg1),
+			["GAG"] when arg0 is not null => await ChannelGag.Handle(parser, LocateService!, PermissionService!, Mediator!,
+				NotifyService!, arg0, arg1, switches),
+			["MUTE"] when arg0 is not null => await ChannelMute.Handle(parser, LocateService!, PermissionService!, Mediator!,
+				NotifyService!, arg0, emptyIfMissing1),
+			["HIDE"] when arg0 is not null => await ChannelHide.Handle(parser, LocateService!, PermissionService!, Mediator!,
+				NotifyService!, arg0, arg1),
+			["COMBINE"] when arg0 is not null => await ChannelCombine.Handle(parser, LocateService!, PermissionService!,
+				Mediator!, NotifyService!, arg0, arg1),
+			["TITLE"] when arg0 is not null => await ChannelTitle.Handle(parser, LocateService!, PermissionService!,
+				Mediator!, NotifyService!, arg0, emptyIfMissing1),
+			["ADD"] when arg0 is not null && arg1 is not null
 				=> await ChannelAdd.Handle(parser, LocateService!, PermissionService!, Mediator!, NotifyService!,
-					Configuration!, args["0"].Message!, args["1"].Message!),
-			["PRIVS"] when args.ContainsKey("0") && args.ContainsKey("1")
+					Configuration!, arg0, arg1),
+			["PRIVS"] when arg0 is not null && arg1 is not null
 				=> await ChannelPrivs.Handle(parser, LocateService!, PermissionService!, Mediator!, NotifyService!,
-					args["0"].Message!, args["1"].Message!),
-			["DESCRIBE"] when args.ContainsKey("0") && args.ContainsKey("1")
+					arg0, arg1),
+			["DESCRIBE"] when arg0 is not null && arg1 is not null
 				=> await ChannelDescribe.Handle(parser, LocateService!, PermissionService!, Mediator!, NotifyService!,
-					args["0"].Message!, args["1"].Message!),
-			["BUFFER"] when args.ContainsKey("0") && args.ContainsKey("1")
+					arg0, arg1),
+			["BUFFER"] when arg0 is not null && arg1 is not null
 				=> await ChannelBuffer.Handle(parser, LocateService!, PermissionService!, Mediator!, NotifyService!,
-					Configuration!, args["0"].Message!, args["1"].Message!),
-			[.., "DECOMPILE"] => await ChannelDecompile.Handle(parser, LocateService!, PermissionService!, Mediator!,
-				NotifyService!, args["0"].Message!, args["1"].Message!, switches),
-			["CHOWN"] => await ChannelChown.Handle(parser, LocateService!, PermissionService!, Mediator!, NotifyService!,
-				args["0"].Message!, args["1"].Message!),
-			["RENAME"] => await ChannelRename.Handle(parser, LocateService!, PermissionService!, Mediator!, NotifyService!,
-				Configuration!, args["0"].Message!, args["1"].Message!),
-			["WIPE"] => await ChannelWipe.Handle(parser, LocateService!, PermissionService!, Mediator!, NotifyService!,
-				args["0"].Message!, args["1"].Message!),
-			["DELETE"] => await ChannelDelete.Handle(parser, LocateService!, PermissionService!, Mediator!, NotifyService!,
-				args["0"].Message!, args["1"].Message!),
-			["MOGRIFIER"] => await ChannelMogrifier.Handle(parser, LocateService!, PermissionService!, Mediator!,
-				NotifyService!, args["0"].Message!, args.GetValueOrDefault("1")?.Message),
-			_ => new CallState("What do you want to do with the channel?")
+					Configuration!, arg0, arg1),
+			["CHOWN"] when arg0 is not null => await ChannelChown.Handle(parser, LocateService!, PermissionService!,
+				Mediator!, NotifyService!, arg0, emptyIfMissing1),
+			["RENAME"] when arg0 is not null && arg1 is not null
+				=> await ChannelRename.Handle(parser, LocateService!, PermissionService!, Mediator!, NotifyService!,
+					Configuration!, arg0, arg1),
+			["WIPE"] when arg0 is not null => await ChannelWipe.Handle(parser, LocateService!, PermissionService!, Mediator!,
+				NotifyService!, arg0, emptyIfMissing1),
+			["DELETE"] when arg0 is not null => await ChannelDelete.Handle(parser, LocateService!, PermissionService!,
+				Mediator!, NotifyService!, arg0, emptyIfMissing1),
+			["MOGRIFIER"] when arg0 is not null => await ChannelMogrifier.Handle(parser, LocateService!, PermissionService!,
+				Mediator!, NotifyService!, arg0, arg1),
+			_ => await NotifyAndReturnChannelUsage(executor)
 		};
+	}
+
+	private static async ValueTask<CallState> NotifyAndReturnChannelUsage(AnySharpObject executor)
+	{
+		await NotifyService!.Notify(executor, "What do you want to do with the channel?", executor);
+		return new CallState("What do you want to do with the channel?");
 	}
 
 	[SharpCommand(Name = "@DECOMPILE", Switches = ["DB", "NAME", "PREFIX", "TF", "FLAGS", "ATTRIBS", "SKIPDEFAULTS"],

--- a/SharpMUSH.Implementation/Commands/MailCommand/MessageListHelper.cs
+++ b/SharpMUSH.Implementation/Commands/MailCommand/MessageListHelper.cs
@@ -102,7 +102,7 @@ public static class MessageListHelper
 						 && !int.TryParse(rangeSplit[0], out _) && int.TryParse(rangeSplit[1], out var right)
 				=> ErrorOrMailList.FromAsyncEnumerable(mailList.Take(right)),
 			_ when int.TryParse(msgList, out var specificMessage)
-				=> ErrorOrMailList.FromAsyncEnumerable(mailList.Skip(specificMessage).Take(1)),
+				=> ErrorOrMailList.FromAsyncEnumerable(mailList.Skip(Math.Max(0, specificMessage - 1)).Take(1)),
 			[] when msgList.Length == 0
 				=> ErrorOrMailList.FromAsyncEnumerable(mailList),
 			_ => new Error<string>("MAIL: Invalid message specification")
@@ -164,7 +164,7 @@ public static class MessageListHelper
 						 && !int.TryParse(rangeSplit[0], out _) && int.TryParse(rangeSplit[1], out var right)
 				=> ErrorOrMailList.FromAsyncEnumerable(mailList.Take(right)),
 			_ when int.TryParse(msgList, out var specificMessage)
-				=> ErrorOrMailList.FromAsyncEnumerable(mailList.Skip(specificMessage).Take(1)),
+				=> ErrorOrMailList.FromAsyncEnumerable(mailList.Skip(Math.Max(0, specificMessage - 1)).Take(1)),
 			[] when msgList.Length == 0
 				=> ErrorOrMailList.FromAsyncEnumerable(mailList),
 			_ => new Error<string>("MAIL: Invalid message specification")

--- a/SharpMUSH.Implementation/Commands/MailCommand/StatusMail.cs
+++ b/SharpMUSH.Implementation/Commands/MailCommand/StatusMail.cs
@@ -17,7 +17,6 @@ public static class StatusMail
 		var executor = await parser.CurrentState.KnownExecutorObject(mediator);
 		var filteredList = await MessageListHelper.Handle(parser, objectDataService, mediator, notifyService, arg0, executor);
 		var statusString = arg1?.ToPlainText().ToUpper();
-		var id = arg0!.ToPlainText();
 
 		if (filteredList.IsError)
 		{
@@ -29,14 +28,24 @@ public static class StatusMail
 
 		switch (sw)
 		{
-			case "UPDATE" when string.IsNullOrEmpty(statusString):
+			// @mail/status [<msg-list>|all]=<status> — the target status arrives as arg1, so the
+			// STATUS switch has to resolve to one of the concrete status verbs before dispatch.
+			case "STATUS" when string.IsNullOrEmpty(statusString):
 				await notifyService.Notify(executor, "Update to what?", executor);
 				return MModule.single(ErrorMessages.Returns.UpdateToWhat);
-			case "UPDATE"
-				when statusString is "CLEAR" or "UNCLEAR" or "TAG" or "UNTAG" or "UNREAD" or "READ" or "URGENT" or "UNURGENT":
-				sw = statusString;
+			case "STATUS"
+				when statusString is "CLEARED" or "UNCLEARED" or "TAGGED" or "UNTAGGED" or "UNREAD" or "READ" or "URGENT"
+					or "UNURGENT":
+				sw = statusString switch
+				{
+					"CLEARED" => "CLEAR",
+					"UNCLEARED" => "UNCLEAR",
+					"TAGGED" => "TAG",
+					"UNTAGGED" => "UNTAG",
+					_ => statusString
+				};
 				break;
-			case "UPDATE":
+			case "STATUS":
 				await notifyService.Notify(executor, $"{statusString} is not a valid status.", executor);
 				return MModule.single($"{statusString} is not a valid status.");
 		}

--- a/SharpMUSH.Implementation/Commands/MoreCommands.cs
+++ b/SharpMUSH.Implementation/Commands/MoreCommands.cs
@@ -53,6 +53,7 @@ public partial class Commands
 		MinArgs = 1, MaxArgs = 2, ParameterNames = [])]
 	public static async ValueTask<Option<CallState>> ChannelLock(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 		var switches = parser.CurrentState.Switches;
@@ -371,6 +372,7 @@ public partial class Commands
 		MaxArgs = 2, ParameterNames = ["list", "position", "value"])]
 	public static async ValueTask<Option<CallState>> LockSet(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 
@@ -635,6 +637,7 @@ public partial class Commands
 	[SharpCommand(Name = "BUY", Switches = [], Behavior = CB.Default | CB.NoGagged, MinArgs = 1, MaxArgs = 3, ParameterNames = ["object"])]
 	public static async ValueTask<Option<CallState>> Buy(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 
@@ -957,6 +960,7 @@ public partial class Commands
 	[SharpCommand(Name = "DROP", Switches = [], Behavior = CB.Player | CB.Thing, MinArgs = 1, MaxArgs = 1, ParameterNames = ["object"])]
 	public static async ValueTask<Option<CallState>> Drop(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 		var objectName = args["0"].Message!.ToPlainText();
@@ -1091,6 +1095,7 @@ public partial class Commands
 		Behavior = CB.Player | CB.Thing | CB.NoGagged, MinArgs = 1, MaxArgs = 1, ParameterNames = ["object"])]
 	public static async ValueTask<Option<CallState>> Empty(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 		var objectName = args["0"].Message!.ToPlainText();
@@ -1312,6 +1317,7 @@ public partial class Commands
 	[SharpCommand(Name = "ENTER", Switches = [], Behavior = CB.Default, MinArgs = 1, MaxArgs = 1, ParameterNames = ["object"])]
 	public static async ValueTask<Option<CallState>> Enter(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 		var objectName = args["0"].Message!.ToPlainText();
@@ -1518,9 +1524,10 @@ public partial class Commands
 		return CallState.Empty;
 	}
 
-	[SharpCommand(Name = "GET", Switches = [], Behavior = CB.Player | CB.Thing | CB.NoGagged, MinArgs = 0, MaxArgs = 0, ParameterNames = ["object"])]
+	[SharpCommand(Name = "GET", Switches = [], Behavior = CB.Player | CB.Thing | CB.NoGagged, MinArgs = 1, MaxArgs = 0, ParameterNames = ["object"])]
 	public static async ValueTask<Option<CallState>> Get(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 
@@ -1670,10 +1677,11 @@ public partial class Commands
 		return CallState.Empty;
 	}
 
-	[SharpCommand(Name = "GIVE", Switches = ["SILENT"], Behavior = CB.Default | CB.EqSplit | CB.NoGagged, MinArgs = 0,
+	[SharpCommand(Name = "GIVE", Switches = ["SILENT"], Behavior = CB.Default | CB.EqSplit | CB.NoGagged, MinArgs = 2,
 		MaxArgs = 0, ParameterNames = ["player", "amount"])]
 	public static async ValueTask<Option<CallState>> Give(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 		var isSilent = parser.CurrentState.Switches.Contains("SILENT");

--- a/SharpMUSH.Implementation/Commands/SingleTokenCommands.cs
+++ b/SharpMUSH.Implementation/Commands/SingleTokenCommands.cs
@@ -15,11 +15,11 @@ public partial class Commands
 		// Re-parse the command with NoEval mode. This is necessary because the command
 		// was already tokenized in Default mode by the time we reach this handler.
 		// The "]" prefix changes evaluation semantics for the entire command.
-		var oldCommand = MModule.multipleWithDelimiter(MModule.single(" "),
-		[
-			parser.CurrentState.Arguments["0"].Message!,
-			parser.CurrentState.Arguments["1"].Message!
-		]);
+		var oldCommand = RebuildTokenlessCommand(parser);
+		if (MModule.getLength(oldCommand) == 0)
+		{
+			return CallState.Empty;
+		}
 
 		await parser.With(s => s with { ParseMode = ParseMode.NoEval },
 			async np => await np.CommandParse(oldCommand));
@@ -38,17 +38,34 @@ public partial class Commands
 	[SharpCommand(Name = "~", Behavior = CommandBehavior.SingleToken | CommandBehavior.NoParse, MinArgs = 1, MaxArgs = 1, ParameterNames = [])]
 	public static async ValueTask<Option<CallState>> StrictParse(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
-		var oldCommand = MModule.multipleWithDelimiter(MModule.single(" "),
-		[
-			parser.CurrentState.Arguments["0"].Message!,
-			parser.CurrentState.Arguments["1"].Message!
-		]);
+		var oldCommand = RebuildTokenlessCommand(parser);
+		if (MModule.getLength(oldCommand) == 0)
+		{
+			return CallState.Empty;
+		}
 
 		await parser.With(
 			s => s with { Flags = s.Flags | ParserStateFlags.StrictParse },
 			async sp => await sp.CommandParse(oldCommand));
 
 		return new CallState(string.Empty);
+	}
+
+	/// <summary>
+	/// Reassembles the command line that a prefix token such as <c>]</c> or <c>~</c> modifies, with the
+	/// token itself removed, so it can be re-dispatched. An empty result means the player typed the bare
+	/// token and there is nothing to re-dispatch — re-parsing then would re-enter this same command.
+	/// </summary>
+	private static MString RebuildTokenlessCommand(IMUSHCodeParser parser)
+	{
+		var parts = parser.CurrentState.ArgumentsOrdered.Values
+			.Select(x => x.Message ?? MModule.empty())
+			.Where(x => MModule.getLength(x) > 0)
+			.ToArray();
+
+		return parts.Length == 0
+			? MModule.empty()
+			: MModule.multipleWithDelimiter(MModule.single(" "), parts);
 	}
 
 	// RSNoParse: only the RHS value is kept unevaluated (deferred/literal).

--- a/SharpMUSH.Implementation/Commands/WizardCommands.cs
+++ b/SharpMUSH.Implementation/Commands/WizardCommands.cs
@@ -652,9 +652,10 @@ public partial class Commands
 
 
 	[SharpCommand(Name = "@RWALL", Switches = ["NOEVAL", "EMIT"], Behavior = CB.Default,
-		CommandLock = "FLAG^WIZARD|FLAG^ROYALTY", MinArgs = 0, ParameterNames = ["message"])]
+		CommandLock = "FLAG^WIZARD|FLAG^ROYALTY", MinArgs = 1, ParameterNames = ["message"])]
 	public static async ValueTask<Option<CallState>> RoyaltyWall(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var shout = parser.CurrentState.Arguments["0"].Message!;
 		var handles = ConnectionService!.GetAll().Select(x => x.Handle);
@@ -676,6 +677,7 @@ public partial class Commands
 		MinArgs = 1, MaxArgs = 1, ParameterNames = ["message"])]
 	public static async ValueTask<Option<CallState>> WizardWall(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var shout = parser.CurrentState.Arguments["0"].Message!;
 		var handles = ConnectionService!.GetAll().Select(x => x.Handle);
@@ -1631,9 +1633,10 @@ public partial class Commands
 	}
 
 	[SharpCommand(Name = "@NEWPASSWORD", Switches = ["GENERATE"], Behavior = CB.Default | CB.EqSplit | CB.RSNoParse,
-		CommandLock = "FLAG^WIZARD", MinArgs = 0, ParameterNames = ["player", "password"])]
+		CommandLock = "FLAG^WIZARD", MinArgs = 1, ParameterNames = ["player", "password"])]
 	public static async ValueTask<Option<CallState>> NewPassword(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 		var arg0 = args["0"].Message!.ToPlainText();
@@ -1667,7 +1670,13 @@ public partial class Commands
 			return new CallState(generatedPassword);
 		}
 
-		var arg1 = args["1"].Message!.ToPlainText();
+		if (!args.TryGetValue("1", out var arg1CallState))
+		{
+			await NotifyService!.Notify(executor, "Usage: @newpassword <player>=<password>", executor);
+			return new CallState(string.Format(ErrorMessages.Returns.TooFewCommandArguments, "@NEWPASSWORD", 2, 1));
+		}
+
+		var arg1 = arg1CallState.Message!.ToPlainText();
 		var newHashedPassword = PasswordService!.HashPassword(asPlayer.Object.DBRef.ToString(), arg1);
 
 		await Mediator!.Send(new SetPlayerPasswordCommand(asPlayer, newHashedPassword));
@@ -1930,6 +1939,7 @@ public partial class Commands
 		MinArgs = 2, MaxArgs = 3, ParameterNames = ["name", "password"])]
 	public static async ValueTask<Option<CallState>> PlayerCreate(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var defaultHome = Configuration!.CurrentValue.Database.DefaultHome;
 		var defaultHomeDbref = new DBRef((int)defaultHome);
 		var startingQuota = (int)Configuration!.CurrentValue.Limit.StartingQuota;
@@ -2308,9 +2318,10 @@ public partial class Commands
 	}
 
 	[SharpCommand(Name = "@WALL", Switches = ["NOEVAL", "EMIT"], Behavior = CB.Default,
-		CommandLock = "FLAG^WIZARD|FLAG^ROYALTY|POWER^ANNOUNCE", MinArgs = 0, ParameterNames = ["message"])]
+		CommandLock = "FLAG^WIZARD|FLAG^ROYALTY|POWER^ANNOUNCE", MinArgs = 1, ParameterNames = ["message"])]
 	public static async ValueTask<Option<CallState>> Wall(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var shout = parser.CurrentState.Arguments["0"].Message!;
 		var handles = ConnectionService!.GetAll().Select(x => x.Handle);
@@ -2332,6 +2343,7 @@ public partial class Commands
 		MinArgs = 2, MaxArgs = 2, ParameterNames = ["old-zone", "new-zone"])]
 	public static async ValueTask<Option<CallState>> ChangeZoneAll(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
+		if (await RejectIfTooFewArguments(parser, _2) is { } tooFewArguments) return tooFewArguments;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var args = parser.CurrentState.Arguments;
 		var playerName = args["0"].Message!.ToPlainText();

--- a/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
+++ b/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
@@ -1444,10 +1444,17 @@ public class SharpMUSHParserVisitor(
 	private async Task<Option<CallState>> HandleChannelCommand(IMUSHCodeParser prs, SharpChannel channel,
 		CommandContext context, MString src)
 	{
-		var rest = MModule.substring(
+		var full = MModule.substring(
 			context.evaluationString().Start.StartIndex,
 			context.evaluationString().Stop.StopIndex - context.evaluationString().Start.StartIndex + 1,
 			src);
+
+		// The evaluation string still carries the `+<channel>` token itself; only what follows the first
+		// space is the message. Without this, `+Public Hi` was chatted as the literal "+Public Hi".
+		var firstSpace = MModule.indexOf(full, " ");
+		var rest = firstSpace == -1
+			? MModule.empty()
+			: MModule.substring(firstSpace + 1, MModule.getLength(full) - firstSpace - 1, full);
 
 		var chatParser = prs.Push(prs.CurrentState with
 		{

--- a/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
+++ b/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
@@ -2119,7 +2119,11 @@ public class SharpMUSHParserVisitor(
 
 		// TODO: Investigate if single-token commands should support argument splitting.
 		// Currently causing errors, may require special handling for single-character commands.
-		var splitResult = await ArgumentSplit(prs, src, context, singleLibraryCommandDefinition.LibraryInformation);
+		// The root command must be passed so the no-space branch strips the token: without it, a bare
+		// "]" split to a single argument equal to "]" itself, and the re-dispatch in NoParse/StrictParse
+		// re-entered this same path forever — a stack overflow that takes the whole process down.
+		var splitResult = await ArgumentSplit(prs, src, context, singleLibraryCommandDefinition.LibraryInformation,
+			singleRootCommand);
 		if (splitResult.TryPickT1(out var splitError, out var arguments))
 		{
 			if (prs.CurrentState.Handle.HasValue)

--- a/SharpMUSH.Library/Definitions/ErrorMessages.cs
+++ b/SharpMUSH.Library/Definitions/ErrorMessages.cs
@@ -1195,6 +1195,7 @@ public static class ErrorMessages
 		public const string IncludeErrorExecutingFormat = "Error executing included attribute: {0}";
 
 		public const string MailTooManySwitches = "Error: Too many switches passed to @mail.";
+		public const string MailBadArguments = "MAIL: Bad arguments to @mail. See 'help @mail' for usage.";
 
 		public const string PasswordOnlyPlayersHavePasswords = "Only players have passwords.";
 		public const string PasswordInvalid = "Invalid password.";

--- a/SharpMUSH.Library/Definitions/ErrorMessages.cs
+++ b/SharpMUSH.Library/Definitions/ErrorMessages.cs
@@ -104,6 +104,8 @@ public static class ErrorMessages
 		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
 		public const string TooManyArguments = "#-1 FUNCTION ({0}) EXPECTS AT MOST {1} ARGUMENTS BUT GOT {2}";
 		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string TooFewCommandArguments = "#-1 COMMAND ({0}) EXPECTS AT LEAST {1} ARGUMENTS BUT GOT {2}";
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
 		public const string GotEvenArgs = "#-1 FUNCTION ({0}) EXPECTS AN ODD NUMBER OF ARGUMENTS";
 		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
 		public const string GotUnEvenArgs = "#-1 FUNCTION ({0}) EXPECTS AN EVEN NUMBER OF ARGUMENTS";

--- a/SharpMUSH.Library/Resources/Notifications.resx
+++ b/SharpMUSH.Library/Resources/Notifications.resx
@@ -1740,6 +1740,9 @@
   <data name="MailTooManySwitches" xml:space="preserve">
     <value>Error: Too many switches passed to @mail.</value>
   </data>
+  <data name="MailBadArguments" xml:space="preserve">
+    <value>MAIL: Bad arguments to @mail. See 'help @mail' for usage.</value>
+  </data>
 
   <!-- @password command -->
   <data name="PasswordOnlyPlayersHavePasswords" xml:space="preserve">

--- a/SharpMUSH.Tests/Commands/ChannelCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/ChannelCommandTests.cs
@@ -57,22 +57,22 @@ public class ChannelCommandTests
 	}
 
 	[Test]
-	[Category("NotImplemented")]
-	[Skip("Not Yet Implemented")]
 	public async ValueTask ChatCommand()
 	{
 		var executor = WebAppFactoryArg.ExecutorDBRef;
 		await Parser.CommandParse(1, ConnectionService, MModule.single($"@chat {TestChannelName}=ChatCommand: Test message"));
 
+		// sharpchat.md:39 — `@chat pub=Hello` renders as `<Public> Mike says, "Hello"`. This test used to
+		// assert the un-attributed emit form, which is what @chat produced when it published every
+		// message as NotificationType.Emit regardless of the message's leading character.
 		await NotifyService
 			.Received()
 			.Notify(TestHelpers.MatchingObject(executor), Arg.Is<OneOf.OneOf<MString, string>>(msg =>
-				TestHelpers.MessageEquals(msg, "<TestCommandChannel> ChatCommand: Test message")), Arg.Any<AnySharpObject>());
+					TestHelpers.MessageEquals(msg, "<TestCommandChannel> God says, \"ChatCommand: Test message\"")),
+				Arg.Any<AnySharpObject>(), INotifyService.NotificationType.Say);
 	}
 
 	[Test]
-	[Category("NotImplemented")]
-	[Skip("Not Yet Implemented")]
 	public async ValueTask ChannelCommand()
 	{
 		var executor = WebAppFactoryArg.ExecutorDBRef;

--- a/SharpMUSH.Tests/Commands/CommandArityTests.cs
+++ b/SharpMUSH.Tests/Commands/CommandArityTests.cs
@@ -1,0 +1,114 @@
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NSubstitute.Core;
+using OneOf;
+using SharpMUSH.Library.DiscriminatedUnions;
+using SharpMUSH.Library.Extensions;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Services.Interfaces;
+
+namespace SharpMUSH.Tests.Commands;
+
+/// <summary>
+/// Commands declare <c>MinArgs</c> exactly as functions do, but only functions ever enforced it.
+/// Every handler that indexed <c>Arguments["0"]</c> without a guard therefore threw
+/// <see cref="KeyNotFoundException"/> when invoked bare — invisible until PR 5 started surfacing
+/// swallowed command exceptions. These tests pin the enforcement: a bare invocation of a command
+/// that requires arguments answers with an arity error rather than a crash.
+/// </summary>
+public class CommandArityTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactoryArg { get; init; }
+
+	private INotifyService NotifyService => WebAppFactoryArg.Services.GetRequiredService<INotifyService>();
+	private IConnectionService ConnectionService => WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
+	private IMediator Mediator => WebAppFactoryArg.Services.GetRequiredService<IMediator>();
+
+	[Test]
+	[Arguments("@switch", "@SWITCH", 3)]
+	[Arguments("@parent", "@PARENT", 1)]
+	[Arguments("@scan", "@SCAN", 1)]
+	[Arguments("get", "GET", 1)]
+	[Arguments("give", "GIVE", 2)]
+	[Arguments("@password", "@PASSWORD", 2)]
+	public async Task ABareCommandThatRequiresArgumentsReportsItsArityInsteadOfThrowing(
+		string command, string reportedName, int minArgs)
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, $"Arity{reportedName.TrimStart('@')}");
+		var parser = WebAppFactoryArg.CommandParserFor(player.DbRef, player.Handle);
+
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single(command));
+
+		var messages = NotificationsTo(player.DbRef);
+
+		await Assert.That(messages).DoesNotContain(m => m.StartsWith("#-1 EXCEPTION: "));
+		await Assert.That(messages).Contains(
+			$"#-1 COMMAND ({reportedName}) EXPECTS AT LEAST {minArgs} ARGUMENTS BUT GOT 0");
+	}
+
+	/// <summary>
+	/// The counterpart: a command that legitimately takes zero arguments must not be caught by the
+	/// same gate. <c>@channel/list</c> takes an OPTIONAL prefix (sharpchat.md:179), so a bare
+	/// invocation is a legal listing request.
+	/// </summary>
+	[Test]
+	[Arguments("@channel/list")]
+	[Arguments("@channel/what")]
+	[Arguments("@channel")]
+	public async Task AnArgumentlessSwitchedChannelFormDoesNotThrow(string command)
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService,
+			$"ChanArity{command.Replace("@", "").Replace("/", "")}");
+		var parser = WebAppFactoryArg.CommandParserFor(player.DbRef, player.Handle);
+
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single(command));
+
+		var messages = NotificationsTo(player.DbRef);
+
+		await Assert.That(messages).DoesNotContain(m => m.StartsWith("#-1 EXCEPTION: "));
+		await Assert.That(messages).DoesNotContain(m => m.StartsWith("#-1 COMMAND ("));
+	}
+
+	/// <summary>
+	/// A switched form whose channel argument is genuinely required answers with the usage line
+	/// rather than crashing on the missing <c>Arguments["0"]</c>.
+	/// </summary>
+	[Test]
+	[Arguments("@channel/who")]
+	[Arguments("@channel/on")]
+	[Arguments("@channel/off")]
+	[Arguments("@channel/recall")]
+	public async Task ASwitchedChannelFormMissingItsChannelAnswersWithUsage(string command)
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService,
+			$"ChanUsage{command.Replace("@", "").Replace("/", "")}");
+		var parser = WebAppFactoryArg.CommandParserFor(player.DbRef, player.Handle);
+
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single(command));
+
+		var messages = NotificationsTo(player.DbRef);
+
+		await Assert.That(messages).DoesNotContain(m => m.StartsWith("#-1 EXCEPTION: "));
+		await Assert.That(messages).Contains("What do you want to do with the channel?");
+	}
+
+	private string[] NotificationsTo(DBRef target) =>
+		NotifyService.ReceivedCalls()
+			.Where(call => call.GetMethodInfo().Name == nameof(INotifyService.Notify))
+			.Where(call => call.GetArguments() is [AnySharpObject obj, ..] && obj.Object().DBRef == target)
+			.Select(TextOf)
+			.Where(text => text is not null)
+			.Select(text => text!)
+			.ToArray();
+
+	private static string? TextOf(ICall call) =>
+		call.GetArguments() is [_, OneOf<MString, string> msg, ..]
+			? msg.Match(ms => ms.ToPlainText(), s => s)
+			: null;
+}

--- a/SharpMUSH.Tests/Commands/CommandExceptionSurfacingTests.cs
+++ b/SharpMUSH.Tests/Commands/CommandExceptionSurfacingTests.cs
@@ -4,10 +4,13 @@ using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.Core;
 using OneOf;
+using SharpMUSH.Library.Attributes;
+using SharpMUSH.Library.Definitions;
 using SharpMUSH.Library.DiscriminatedUnions;
 using SharpMUSH.Library.Extensions;
 using SharpMUSH.Library.Models;
 using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Services;
 using SharpMUSH.Library.Services.Interfaces;
 using System.Collections.Concurrent;
 using System.Text;
@@ -23,11 +26,12 @@ namespace SharpMUSH.Tests.Commands;
 /// payload is valid JSON, a mortal's copy leaks no internals, and the server log still gets
 /// everything.
 ///
-/// <para>The crashing command used here is bare <c>@switch</c>, which indexes <c>args["0"]</c>
-/// despite declaring <c>MinArgs = 3</c> and throws <c>KeyNotFoundException</c>. That underlying bug
-/// belongs to a later PR in this stack; when it is fixed, these tests must be re-pointed at another
-/// throwing command (or a deliberate one), NOT deleted — what they assert is the surfacing
-/// behaviour, not the bug.</para>
+/// <para>These originally rode on bare <c>@switch</c>, which indexed <c>args["0"]</c> despite
+/// declaring <c>MinArgs = 3</c>. Command <c>MinArgs</c> is now enforced, so that command no longer
+/// throws; per the standing note, the tests are re-pointed rather than deleted — what they assert
+/// is the surfacing behaviour, not the bug. The crash is now produced deliberately by a
+/// test-registered command that throws <see cref="KeyNotFoundException"/>, so no future fix can
+/// silently disarm this class again.</para>
 /// </summary>
 [NotInParallel]
 public class CommandExceptionSurfacingTests
@@ -41,8 +45,32 @@ public class CommandExceptionSurfacingTests
 
 	private IMediator Mediator => WebAppFactoryArg.Services.GetRequiredService<IMediator>();
 
-	/// <summary>Bare, so no <c>"0"</c> argument is ever put in the argument dictionary.</summary>
-	private const string CrashingCommand = "@switch";
+	/// <summary>Registered by <see cref="RegisterCrashingCommand"/>; throws unconditionally.</summary>
+	private const string CrashingCommand = "@zzcrash";
+
+	[Before(Test)]
+	public void RegisterCrashingCommand()
+	{
+		var library = WebAppFactoryArg.Services.GetRequiredService<LibraryService<string, CommandDefinition>>();
+		if (library.ContainsKey(CrashingCommand))
+		{
+			return;
+		}
+
+		var attribute = new SharpCommandAttribute
+		{
+			Name = CrashingCommand.ToUpperInvariant(),
+			Switches = [],
+			Behavior = CommandBehavior.Default,
+			MinArgs = 0,
+			MaxArgs = 0,
+			ParameterNames = []
+		};
+
+		library.Add(CrashingCommand,
+			(new CommandDefinition(attribute,
+				_ => throw new KeyNotFoundException("Deliberate crash for exception-surfacing tests.")), true));
+	}
 
 	[Test]
 	public async Task ACommandThatThrowsIsSurfacedInsteadOfSwallowed()

--- a/SharpMUSH.Tests/Commands/MailCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/MailCommandTests.cs
@@ -1,6 +1,10 @@
+using Mediator;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
+using NSubstitute.Core;
 using SharpMUSH.Library.DiscriminatedUnions;
+using SharpMUSH.Library.Extensions;
+using SharpMUSH.Library.Models;
 using SharpMUSH.Library.ParserInterfaces;
 using SharpMUSH.Library.Services.Interfaces;
 using OneOf;
@@ -14,20 +18,92 @@ public class MailCommandTests
 
 	private INotifyService NotifyService => WebAppFactoryArg.Services.GetRequiredService<INotifyService>();
 	private IConnectionService ConnectionService => WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
+	private IMediator Mediator => WebAppFactoryArg.Services.GetRequiredService<IMediator>();
 	private IMUSHCodeParser Parser => WebAppFactoryArg.CommandParser;
 
+	/// <summary>
+	/// sharpmail.md:47 lists bare <c>@mail</c> under @MAIL/LIST: "a brief list of all mail in the
+	/// current folder". It used to reach the SEND arm instead — <c>arg0?.Length != 0</c> is
+	/// <c>int?</c> compared to <c>int</c>, and a null lifts to <c>true</c> — and then throw
+	/// <see cref="NullReferenceException"/> inside SendMail on the two null arguments.
+	/// A message is sent first so an empty mailbox cannot pass this by accident.
+	/// </summary>
 	[Test]
-	[Category("NotImplemented")]
-	[Skip("Not Yet Implemented")]
+	public async ValueTask BareMailListsTheMailboxRatherThanTryingToSend()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "MailBareList");
+		var parser = WebAppFactoryArg.CommandParserFor(player.DbRef, player.Handle);
+
+		await parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"@mail #{player.DbRef.Number}=Bare List Subject/Bare list body."));
+
+		var beforeBare = NotificationsTo(player.DbRef).Length;
+
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single("@mail"));
+
+		var afterBare = NotificationsTo(player.DbRef).Skip(beforeBare).ToArray();
+
+		await Assert.That(afterBare).DoesNotContain(m => m.StartsWith("#-1 EXCEPTION: "));
+		await Assert.That(afterBare).Contains(m => m.Contains("MAIL (folder INBOX)"));
+		await Assert.That(afterBare).Contains(m => m.Contains("Bare List Subject"));
+	}
+
+	/// <summary>
+	/// <c>@mail/clear</c> with no msg-list clears the whole current folder (sharpmail.md:91).
+	/// It used to dereference a null <c>arg0</c> in StatusMail.
+	/// </summary>
+	[Test]
+	public async ValueTask ClearWithNoMessageListDoesNotThrow()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "MailBareClear");
+		var parser = WebAppFactoryArg.CommandParserFor(player.DbRef, player.Handle);
+
+		await parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single($"@mail #{player.DbRef.Number}=Clear Subject/Clear body."));
+
+		var beforeClear = NotificationsTo(player.DbRef).Length;
+
+		await parser.CommandParse(player.Handle, ConnectionService, MModule.single("@mail/clear"));
+
+		var afterClear = NotificationsTo(player.DbRef).Skip(beforeClear).ToArray();
+
+		await Assert.That(afterClear).DoesNotContain(m => m.StartsWith("#-1 EXCEPTION: "));
+		await Assert.That(afterClear).Contains(m => m.Contains("updated"));
+	}
+
+	private string[] NotificationsTo(DBRef target) =>
+		NotifyService.ReceivedCalls()
+			.Where(call => call.GetMethodInfo().Name == nameof(INotifyService.Notify))
+			.Where(call => call.GetArguments() is [AnySharpObject obj, ..] && obj.Object().DBRef == target)
+			.Select(TextOf)
+			.Where(text => text is not null)
+			.Select(text => text!)
+			.ToArray();
+
+	private static string? TextOf(ICall call) =>
+		call.GetArguments() is [_, OneOf<MString, string> msg, ..]
+			? msg.Match(ms => ms.ToPlainText(), s => s)
+			: null;
+
+	[Test]
 	public async ValueTask MailCommand()
 	{
 		var executor = WebAppFactoryArg.ExecutorDBRef;
 		await Parser.CommandParse(1, ConnectionService, MModule.single("@mail #1=Test subject/Test message"));
 
+		// Mailing yourself produces both halves of the exchange: the send confirmation and the
+		// delivery notice. The original expectation of exactly one is what kept this skipped.
 		await NotifyService
-			.Received(1)
+			.Received()
 			.Notify(TestHelpers.MatchingObject(executor), Arg.Is<OneOf<MString, string>>(msg =>
-				TestHelpers.MessagePlainTextStartsWith(msg, "MAIL:")), TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
+				TestHelpers.MessagePlainTextStartsWith(msg, "MAIL: You sent a message")), TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
+
+		await NotifyService
+			.Received()
+			.Notify(TestHelpers.MatchingObject(executor), Arg.Is<OneOf<MString, string>>(msg =>
+				TestHelpers.MessagePlainTextStartsWith(msg, "MAIL: You have received a message")), TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
 	}
 
 	[Test]


### PR DESCRIPTION
PR 6 of a 10-PR stack. **Targets `fix/audit2-05-telnet-first-contact`, not `main`.**

Every bug below was invisible before #757 made swallowed command exceptions visible as `#-1 EXCEPTION: {json}`. That is where the before-evidence comes from.

---

## N-06 — bare `@mail` tried to send a message to nobody

`GeneralCommands.cs`, the `@MAIL` send arm:

```csharp
[.., "SEND"] or [.., "URGENT"] or [.., "SILENT"] or [.., "NOSIG"] or []
    when arg0?.Length != 0 && arg1?.Length != 0
```

`arg0` is `MString?`, so `arg0?.Length` is `int?`. Comparing `int?` to `int` lifts the comparison: with no argument, `null != 0` is **true**, not false. So bare `@mail` passed the *send* guard, called `SendMail.Handle(arg0!, arg1!)` with two nulls, and threw `NullReferenceException`. The LIST arm below it never ran.

That is not what bare `@mail` means. `SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpmail.md:47` lists it under the @MAIL/LIST topic:

> `@mail` — This gives a brief list of all mail in the current folder, with sender name, time sent, and message status.

PennMUSH agrees (`game/txt/hlp/pennmail.hlp`). Sibling arms in the same switch already use `(arg?.Length ?? 0) != 0`; this matches them.

**Before / after, real telnet socket, with an unread message present:**

```
>>> @mail/list
---------------------------  MAIL (folder INBOX)  ----------------------------
[N----]  1     God             Test Subject                   Sun Aug 09 02:34
------------------------------------------------------------------------------

>>> @mail                                          # BEFORE
#-1 EXCEPTION: {"id":"4056b27c586e","command":"@mail","type":"NullReferenceException","message":"Object reference not set to an instance of an object."}

>>> @mail                                          # AFTER
---------------------------  MAIL (folder INBOX)  ----------------------------
[N----]  1     God             Test Subject                   Sun Aug 09 02:34
------------------------------------------------------------------------------
```

Auditing **every** arm of that switch, as asked, turned up three more:

| Form | Before | Cause |
|---|---|---|
| `@mail/folder` | silent | switch list declared `FOLDERS`, arm matched `FOLDER` — the documented spelling (sharpmail.md:125) was rejected as an invalid switch and the accepted one matched nothing |
| `@mail/clear`, `/tag`, `/untag`, `/unread` | `#-1 EXCEPTION: NullReferenceException` | `StatusMail` dereferenced `arg0!` for a variable it never used; sharpmail.md:91 documents the no-msg-list form as clearing the whole folder |
| `@mail/status 1=urgent` | `#-1 EXCEPTION` / no-op | dispatched a `"UPDATE"` case that nothing passes, so the status verb in arg1 was never resolved and it fell to a throwing default |
| `@mail/fwd` (bad args) | silent | the default arm returned its error as a command value, which never reaches the player |

Two more found on that path and fixed:

- **ArangoDB wrote the wrong field.** `UpdateMailAsync` wrote `Read` for a *clear* edit and `Urgent` for a *tag* edit, so `@mail/clear` silently toggled the read flag and `@mail/tag` toggled urgency. Memgraph and SurrealDB were already correct — this is the default provider only.
- **Off-by-one in the message list.** `msgList == "1"` selected `Skip(1)`, i.e. message 2.

```
>>> @mail/clear      # AFTER
Mail 1 updated.
>>> @mail/folder     # AFTER
MAIL: 1 messages in folder INBOX (1 unread, 0 cleared).
MAIL: Current folder is INBOX.
>>> @mail/fwd        # AFTER
MAIL: Bad arguments to @mail. See 'help @mail' for usage.
```

---

## N-07 — commands indexed arguments that may not exist

Confirmed the real set myself. Bare `@channel` did **not** throw, as PR 4's author said — but it printed nothing either, because the discard arm returned "What do you want to do with the channel?" as a command value rather than notifying. The crashing forms were the switched ones without their argument:

```
>>> @channel/list     BEFORE  #-1 EXCEPTION: {... "type":"KeyNotFoundException","message":"The given key '0' was not present in the dictionary."}
>>> @channel/what     BEFORE  #-1 EXCEPTION: KeyNotFoundException '0'
>>> @channel/who      BEFORE  #-1 EXCEPTION: KeyNotFoundException '0'
>>> @channel/on       BEFORE  #-1 EXCEPTION: KeyNotFoundException '0'
>>> @channel/off      BEFORE  #-1 EXCEPTION: KeyNotFoundException '0'
>>> @channel/recall   BEFORE  #-1 EXCEPTION: KeyNotFoundException '0'
>>> @switch           BEFORE  #-1 EXCEPTION: KeyNotFoundException '0'
```

`sharpchat.md:179` documents `@channel/list[/on|/off][/quiet] [<prefix>]` and `@channel/what [<prefix>]` — the prefix is **optional**, so those are legal argument-less invocations that must list channels. Everything else needs a channel name.

```
>>> @channel/list     AFTER  CHAT: No channels match that.      (and the listing, once a channel exists)
>>> @channel/what     AFTER  CHAT: No channels match that.
>>> @channel/who      AFTER  What do you want to do with the channel?
>>> @channel/on       AFTER  What do you want to do with the channel?
>>> @channel/off      AFTER  What do you want to do with the channel?
>>> @channel/recall   AFTER  What do you want to do with the channel?
>>> @switch           AFTER  #-1 COMMAND (@SWITCH) EXPECTS AT LEAST 3 ARGUMENTS BUT GOT 0
```

### The root cause: I tried the general fix, measured it, and backed it out

PR 4's author is right that command `MinArgs` is never enforced — 70 of 191 commands declare a non-zero minimum the engine ignores, while `SharpMUSHParserVisitor.cs:743` enforces it for functions.

I implemented central enforcement in `HandleInternalCommandPattern` first, because removing the class beats patching instances. **It is not the right fix, and here is the evidence.** With the gate in place the full suite went from 0 failures to 7:

```
failed Test_AtrChown_InvalidArguments      expected NeedObjectAttributePair usage
failed Disable_NoArguments_ShowsUsage      expected EnableDisableUsageSyntaxFormat
failed Enable_NoArguments_ShowsUsage       expected EnableDisableUsageSyntaxFormat
failed Test_Respond_Type_Empty             expected "Content-Type cannot be empty."
failed CommandCommand                      expected "#-1 INVALID SWITCH: list", got "#-1 COMMAND (@COMMAND) EXPECTS AT LEAST 1 ARGUMENTS BUT GOT 0"
failed VerbInsufficientArgs                expected "Usage: @verb <victim>=<actor>,..."
failed RecursionLimit_IncludeCommand_TracksRecursion
```

Those seven are not the whole cost, only the tested part: roughly 40 commands already guard on `args.Count` and render a specific usage message, and a blanket gate replaces every one of them with `#-1 COMMAND (X) EXPECTS AT LEAST N ARGUMENTS BUT GOT 0`. Removing ~30 crashes by degrading ~40 usage messages is a bad trade, and PennMUSH has no command-level arity check to imitate.

What landed instead keeps the root-cause shape without the collateral: `Commands.RejectIfTooFewArguments(parser, _2)` reads the same declared `MinArgs` off the command's own attribute and is called from the ~46 handlers that would otherwise index an argument they never checked for. Commands that already guard themselves are untouched and keep their messages:

```
>>> @parent      #-1 COMMAND (@PARENT) EXPECTS AT LEAST 1 ARGUMENTS BUT GOT 0
>>> give         #-1 COMMAND (GIVE) EXPECTS AT LEAST 2 ARGUMENTS BUT GOT 0
>>> @enable      Usage: @enable <option>
>>> @disable     Usage: @disable <option>
```

Ten commands declared `MinArgs = 0` while indexing `Arguments["0"]` unconditionally; their declarations now state what they require (`@parent`, `@scan`, `@skip`, `@password`, `@verb`, `get`, `give`, `@wall`, `@rwall`, `@newpassword`).

### Sweeping for the same shape turned up four more

- **`@password` compared the old password against itself** — it read `Arguments["0"]` for both the old and the new password.
- **`@verb` threw for any invocation with 2 to 6 arguments** — it read indices 0 through 6 through `ElementAtOrDefault`, whose out-of-range result is a `KeyValuePair` with a **null** `CallState`, so `.Value.Message!` was an NRE. Its own `args.Count < 2` usage guard is kept; only the null-unsafe reads changed.
- **`@newpassword <player>` without `/generate`** read `Arguments["1"]` with no check.
- **Bare `]` and `~` stack-overflowed the entire process.** Not a caught exception — a hard `Stack overflow.` that kills the server, which is how I found it: with no root command passed to the split, the single argument came back equal to the token itself, and the re-dispatch in `NoParse`/`StrictParse` re-entered the same command forever. Both the split and the two handlers are fixed; bare `]` and `~` are now no-ops and `]think 1+1` still prints `1+1`.

---

## Channels must actually work — the lifecycle walk

The audit world had no channels, so nothing past the crash had ever been exercised. It turns out **channels could not be created at all**, and most of what lies beyond that was inert or actively wrong.

`@channel/add` threw `TypeInitializationException`: `ChannelHelper`'s privilege table mapped both `"Thing"` and `"NoTitles"` to `'T'`, so building the reverse lookup threw `An item with the same key has already been added. Key: T` at static-initialisation time. PennMUSH's `chan_privs` (`extchat.c`) has no "Thing" — the object priv is `'O'`. Single-character lookups are also no longer upper-cased, so `'o'` is Open and `'O'` is Object, as PennMUSH intends.

```
>>> @channel/add Public=Player Open    # BEFORE
Channel not found.
#-1 EXCEPTION: {"id":"f251dab600a3","command":"@channel/add","type":"TypeInitializationException",
  "message":"The type initializer for 'SharpMUSH.Implementation.Commands.ChannelCommand.ChannelHelper' threw an exception.",
  "inner":[{"type":"ArgumentException","message":"An item with the same key has already been added. Key: T"}]}
```

(The stray "Channel not found." is `@channel/add` calling its existence check with `notify: true` — also fixed.)

**The whole walk, after, over a real telnet socket:**

```
>>> @channel/add Public=Player Open
Channel has been created.
>>> @channel/list
Name: Public
>>> @channel/list/quiet
Public
>>> @channel/list Pub
Name: Public
>>> @channel/list Zzz
CHAT: No channels match that.
>>> @channel/list/on
Name: Public
>>> @channel/list/off
CHAT: No channels match that.
>>> @channel/what
Channel: Public
Description: 
Owner: God(#1)
Flags: Player Open
Mogrifier: none
Buffer: 0
>>> @channel/who Public
Members of channel <Public> are:
God
>>> @chat Public=Hello world
<Public> God says, "Hello world"
>>> @chat Public=:waves
<Public> God waves
>>> +Public Hi there
<Public> God says, "Hi there"
>>> +Public :grins
<Public> God grins
>>> @cemit Public=Something happens
<Public> Something happens
>>> @channel/title Public=Chief
CHAT: Title set on Public.
>>> @chat Public=With a title
<Public> Chief God says, "With a title"
>>> @channel/title Public
CHAT: Title cleared on Public.
>>> @channel/describe Public=The public channel
CHAT: Channel <Public> description set.
>>> @channel/buffer Public=50
CHAT: Resizing buffer of channel <Public>
>>> @channel/what
Channel: Public
Description: The public channel
Owner: God(#1)
Flags: Player Open
Mogrifier: none
Buffer: 50
>>> @channel/recall Public
<Public> Chief God says, "With a title"
<Public> Something happens
<Public> God grins
<Public> God says, "Hi there"
<Public> God waves
<Public> God says, "Hello world"
>>> @channel/off Public
CHAT: God has been removed from Public.
>>> @channel/off Public
CHAT: God is not on Public.
>>> @channel/who Public
Members of channel <Public> are:
>>> @channel/delete Public
CHAT: Channel has been deleted.
>>> @channel/list
CHAT: No channels match that.
```

Every line above was broken. What each one needed:

**`+<channel> <message>` is implemented after all.** The audit's `Huh?  (Type "help" for help.)` was only the no-such-channel case. With a channel that exists it dispatched — but chatted the *whole line* including the token: `+Public Hi there` came out as `<Public> +Public Hi there`. `HandleChannelCommand` took the entire evaluation string instead of the part after the first space.

**Speech had no speaker.** `@chat` published every message as `NotificationType.Emit`, so `<Public> Hello world` instead of the `<Public> Mike says, "Hello"` that sharpchat.md:39 documents. The handler's full say/pose/semipose formatting existed and was simply never selected. A leading `:` or `;` now selects pose and semipose (sharpchat.md:33).

**Messages arrived twice.** `@channel/on` never checked membership, so joining a channel you were already on created a second edge and every message was delivered once per edge. `/off` had the mirror gap.

**Eight channel-admin commands had their permission test inverted.** `@channel/delete`, `/buffer`, `/chown`, `/wipe`, `/rename`, `/describe`, `/privs` and `/mogrifier` all read `if (await ChannelCanModifyAsync(...)) return "You cannot modify this channel."` — whoever *could* modify the channel was refused, and whoever could not fell through and made the change. `@channel/delete` returning "Channel has been deleted." while the channel stayed in the list is what exposed it.

**Then three ArangoDB defects, all previously unreachable behind that inverted test:**

- `UpdateChannelAsync` and `DeleteChannelAsync` passed `channel.Id` — the full `"collection/key"` `_id` — where the API takes the key, so every update 404'd (`{"code":404,"errorMessage":"not found"}`).
- The member-status patch was built as a `List<KeyValuePair<string, object>>`, which serializes as a JSON *array*: `VPack error: Expecting Object`.
- `UpdateChannelAsync` wrote the serialized markup into `Name` and the plain text into `MarkedUpName` — the opposite of what `CreateChannelAsync` writes and what the read path expects. One `@channel/describe` left the channel unfindable and poisoned `@channel/list` for every channel: `JsonException: 'P' is an invalid start of a value`.

**Smaller ones on the same walk:** `/list` ignored the documented prefix argument; `/list`, `/recall` and `/decompile` matched only as the *last* switch, so `@channel/list/quiet` fell through to the discard arm; the `/quiet` combination check read `!LIST || !RECALL`, true for every input; `@channel/what` returned the result of an un-awaited `ToArrayAsync` and notified nobody (it now shows name, description, owner, privs, mogrifier and buffer per sharpchat.md:187); `@channel/title` stored nothing at all and demanded channel ownership though sharpchat.md:236 defines it as the speaker's own title; `/recall` concatenated the buffer with no line breaks; and the discard arm, `/describe`, `/buffer` and `/privs` returned their messages as command values that never reach the player.

---

## Unskipped tests

| Test | Why it was failing |
|---|---|
| `MailCommandTests.MailCommand` | `Received(1)`, but mailing yourself notifies twice — once for the send, once for the delivery |
| `ChannelCommandTests.ChannelCommand` | `@channel/list` threw `KeyNotFoundException` |
| `ChannelCommandTests.ChatCommand` | asserted the un-attributed emit rendering `@chat` produced while every message was an emit; now asserts the documented speech form |

`CommandExceptionSurfacingTests` rode on bare `@switch` throwing. Per the standing note in that file it is re-pointed rather than deleted — at a deliberately throwing command the test registers itself, so no future fix can silently disarm it again.

## New tests

- `MailCommandTests.BareMailListsTheMailboxRatherThanTryingToSend` — sends a message first, then asserts bare `@mail` prints the folder header **and the subject**, so an empty mailbox cannot pass it by accident.
- `MailCommandTests.ClearWithNoMessageListDoesNotThrow`
- `CommandArityTests` — 13 cases: six bare commands that must report their arity (`@switch`, `@parent`, `@scan`, `get`, `give`, `@password`), three argument-less channel forms that must **not** be caught by the gate (`@channel/list`, `@channel/what`, `@channel`), and four switched forms whose channel argument is required (`/who`, `/on`, `/off`, `/recall`).

## Numbers

- `dotnet build`: **0 errors**, 24–32 warnings, all pre-existing `MSB3277` from the `CommandOnlyPlugin` test fixture. No suppressions. `TreatWarningsAsErrors` untouched. `dotnet format whitespace` clean, run to convergence.
- Full suite: **5389 total, 0 failed, 5196 succeeded, 193 skipped.**
- Live verification ran the real stack: ConnectionServer on :4201 telnet, Server on :8080, one shared NATS, ArangoDB via Podman, `ASPNETCORE_ENVIRONMENT=Production`. Transcripts above are from a raw socket with IAC negotiation and ANSI stripped.

## Found but left out of scope

- **Channel names are not unique.** `CreateChannelCommand` does not reject a duplicate, and `ChannelCommandTests` creates its fixture channel per test — `@channel/list` in that run prints `Name: TestCommandChannel` four times. `@channel/add` guards it at the command layer; the database does not.
- **The MUX comsys aliases are stubs.** `addcom` writes `CHANALIAS\`<alias>` attributes and nothing ever reads them for dispatch, so `<alias> <message>` is not wired up. `ADDCOM`, `DELCOM`, `COMLIST`, `COMTITLE` and `@CLIST` remain `[Skip("Not Yet Implemented")]`. That is a feature, not a bug, and belongs in its own PR.
- **`ChannelHelper`'s privilege names do not match the helpfile.** The table carries PennMUSH's set (Player/Object/Admin/Wizard/Quiet/Open/Hide_Ok/NoTitles/NoNames/NoCemit/Interact/Disabled) while `sharpchat.md:319` documents join/speak/hide/open/quiet/hide_ok/loud/disabled. Reconciling the two is a design decision for the repo owner, not a bug fix — this PR only removed the duplicate that made the table throw.
- **Generic `MinArgs` enforcement** stays unimplemented, deliberately, for the measured reason above. If it is ever wanted, it needs a per-command opt-out so the ~40 commands with their own usage messages keep them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MPRzndB5egy4F2A3q5852
