### PR TITLE
Command parity: @version, @pcreate, unknown switches, @wiki/list grammar, @list <type>

### DIFF
--- a/SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpcmd.md
+++ b/SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpcmd.md
@@ -2498,6 +2498,8 @@ Switches include:
 - powers : Alias for @powers/list, shows all powers.
 - allocations : Information about memory allocations. Admin-only.
 
+Each of those may be given as a switch (`@list/commands`) or as an argument (`@list commands`); the two are equivalent, and a switch wins if you give both. As an argument, "commands", "functions", "powers", "locks" and "allocations" may be abbreviated to any prefix, while "motd", "attribs" and "flags" must be spelled in full. Anything else, or nothing at all, answers "I don't understand what you want to @list."
+
 By default, information is shown in upper-case. Add the `/lowercase` switch to show output in lowercase instead.
 
 "commands" and "functions" show built-in and local commands/functions by default. The `/builtin` or `/local` switches can be given to limit this.

--- a/SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpwiki.md
+++ b/SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpwiki.md
@@ -14,6 +14,13 @@ Page targets may carry a namespace prefix: `Help:Markdown Guide` refers to the
 page "Markdown Guide" in the help namespace. Without a prefix, pages live in
 the main namespace. Valid namespaces: main, help, character, system.
 
+Listings (`@wiki/list`, `@wiki/search`, `@wiki/recent`) print every page's
+identifier fully qualified as `<namespace>:<category>:<slug>` — `home` in the
+main namespace lists as `main:general:home`. One column, one grammar, and the
+identifier printed is always one you can paste straight back into `@wiki`.
+Typing a target is unchanged: the short forms still work, so `@wiki home`,
+`@wiki main:home` and `@wiki main:general:home` all reach the same page.
+
 Viewing and discovery:
 * `@wiki <page>` or `@wiki/view <page>` - display a page
 * `@wiki/list [<namespace>]` - list pages

--- a/SharpMUSH.Implementation/Commands/GeneralCommands.cs
+++ b/SharpMUSH.Implementation/Commands/GeneralCommands.cs
@@ -6826,24 +6826,34 @@ public partial class Commands
 		}
 	}
 
+	/// <summary>
+	/// Line-for-line the shape of PennMUSH's <c>do_version</c> (src/version.c): the game's name, the
+	/// address <em>only when one is configured</em>, the restart time, then the version banner — which is
+	/// the very string <c>version()</c> returns, exactly as PennMUSH's <c>fun_version</c> and
+	/// <c>do_version</c> both format from VERSION/PATCHLEVEL/PATCHDATE.
+	/// </summary>
 	[SharpCommand(Name = "@VERSION", Switches = [], Behavior = CB.Default, MinArgs = 0, MaxArgs = 0, ParameterNames = [])]
 	public static async ValueTask<Option<CallState>> Version(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var uptimeData = await ObjectDataService!.GetExpandedServerDataAsync<UptimeData>();
+		var net = Configuration!.CurrentValue.Net;
 
-		var lines = new List<MString>
+		var lines = new List<MString> { MModule.single($"You are connected to {net.MudName}") };
+
+		// PennMUSH: `if (MUDURL && *MUDURL)`. An unset mud_url means the game has no published address,
+		// which is not the same fact as "the address is Unknown" — so the line is omitted, not filled in.
+		if (!string.IsNullOrWhiteSpace(net.MudUrl))
 		{
-			MModule.concat(MModule.single("You are connected to "),
-				MModule.single(Configuration!.CurrentValue.Net.MudName ?? "Unknown")),
-			MModule.concat(MModule.single("Address: "), MModule.single(Configuration.CurrentValue.Net.MudUrl ?? "Unknown")),
-			MModule.single("SharpMUSH version 0")
-		};
+			lines.Add(MModule.single($"Address: {net.MudUrl}"));
+		}
 
 		if (uptimeData != null)
 		{
 			lines.Add(MModule.single($"Last restarted: {uptimeData.LastRebootTime:ddd MMM dd HH:mm:ss yyyy}"));
 		}
+
+		lines.Add(MModule.single(Implementation.Generated.VersionInfo.Version));
 
 		var result = MModule.multipleWithDelimiter(MModule.single("\n"), lines.ToArray());
 

--- a/SharpMUSH.Implementation/Commands/MoreCommands.cs
+++ b/SharpMUSH.Implementation/Commands/MoreCommands.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using OneOf.Types;
 using SharpMUSH.Implementation.Commands.ChannelCommand;
@@ -115,19 +116,87 @@ public partial class Commands
 		return CallState.Empty;
 	}
 
+	/// <summary>
+	/// The eight things <c>@list</c> can list. PennMUSH spells each of them both ways — as a switch
+	/// (<c>cmd_list</c>) and as an argument (<c>do_list</c>), both in src/cmds.c — so SharpMUSH does too.
+	/// </summary>
+	private enum ListKind
+	{
+		Motd,
+		Functions,
+		Commands,
+		Attribs,
+		Locks,
+		Flags,
+		Powers,
+		Allocations
+	}
+
+	/// <summary>
+	/// Resolves <c>@list &lt;type&gt;</c>'s argument the way PennMUSH's <c>do_list</c> (src/cmds.c) does:
+	/// in that order, and with that mix of prefix and exact matching. "commands", "functions", "powers",
+	/// "locks" and "allocations" accept any non-empty prefix (<c>string_prefixe</c>); "motd", "attribs"
+	/// and "flags" must be spelled in full (<c>strcasecmp</c>).
+	/// </summary>
+	/// <remarks>
+	/// The order is load-bearing, not incidental: "f" reaches <c>functions</c> by prefix before it can
+	/// reach the exact-match-only <c>flags</c>, exactly as it does in PennMUSH.
+	/// </remarks>
+	private static ListKind? ResolveListKind(string argument)
+	{
+		var arg = argument.Trim();
+		if (arg.Length == 0) return null;
+
+		bool Prefix(string full) => full.StartsWith(arg, StringComparison.OrdinalIgnoreCase);
+		bool Exact(string full) => full.Equals(arg, StringComparison.OrdinalIgnoreCase);
+
+		if (Prefix("commands")) return ListKind.Commands;
+		if (Prefix("functions")) return ListKind.Functions;
+		if (Exact("motd")) return ListKind.Motd;
+		if (Exact("attribs")) return ListKind.Attribs;
+		if (Exact("flags")) return ListKind.Flags;
+		if (Prefix("powers")) return ListKind.Powers;
+		if (Prefix("locks")) return ListKind.Locks;
+		if (Prefix("allocations")) return ListKind.Allocations;
+
+		return null;
+	}
+
 	[SharpCommand(Name = "@LIST",
 		Switches =
 		[
 			"LOWERCASE", "MOTD", "LOCKS", "FLAGS", "FUNCTIONS", "POWERS", "COMMANDS", "ATTRIBS", "ALLOCATIONS", "ALL",
 			"BUILTIN", "LOCAL"
-		], Behavior = CB.Default, MinArgs = 0, MaxArgs = 0, ParameterNames = ["type"])]
+		], Behavior = CB.Default, MinArgs = 0, MaxArgs = 1, ParameterNames = ["type"])]
 	public static async ValueTask<Option<CallState>> List(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 		var switches = parser.CurrentState.Switches;
 		var useLowercase = switches.Contains("LOWERCASE");
 
-		if (switches.Contains("MOTD"))
+		// PennMUSH's cmd_list consults the switches first and only falls through to do_list — which reads
+		// the same eight names off the argument — when none of them is set. A switch therefore still wins
+		// over a contradicting argument, and `@list/lowercase commands` keeps working.
+		var kind =
+			switches.Contains("MOTD") ? ListKind.Motd
+			: switches.Contains("FUNCTIONS") ? ListKind.Functions
+			: switches.Contains("COMMANDS") ? ListKind.Commands
+			: switches.Contains("ATTRIBS") ? ListKind.Attribs
+			: switches.Contains("LOCKS") ? ListKind.Locks
+			: switches.Contains("FLAGS") ? ListKind.Flags
+			: switches.Contains("POWERS") ? ListKind.Powers
+			: switches.Contains("ALLOCATIONS") ? ListKind.Allocations
+			: ResolveListKind(parser.CurrentState.Arguments.TryGetValue("0", out var typeArg)
+				? typeArg.Message?.ToPlainText() ?? string.Empty
+				: string.Empty);
+
+		if (kind is null)
+		{
+			await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.ListNotUnderstood), executor);
+			return CallState.Empty;
+		}
+
+		if (kind == ListKind.Motd)
 		{
 			var isWizard = await executor.IsWizard();
 
@@ -150,7 +219,7 @@ public partial class Commands
 			return CallState.Empty;
 		}
 
-		if (switches.Contains("FLAGS"))
+		if (kind == ListKind.Flags)
 		{
 			var output = new System.Text.StringBuilder();
 			var header = useLowercase ? "Object Flags:" : "OBJECT FLAGS:";
@@ -175,7 +244,7 @@ public partial class Commands
 			return CallState.Empty;
 		}
 
-		if (switches.Contains("POWERS"))
+		if (kind == ListKind.Powers)
 		{
 			var output = new System.Text.StringBuilder();
 			var header = useLowercase ? "Object Powers:" : "OBJECT POWERS:";
@@ -200,7 +269,7 @@ public partial class Commands
 			return CallState.Empty;
 		}
 
-		if (switches.Contains("LOCKS"))
+		if (kind == ListKind.Locks)
 		{
 			var output = new System.Text.StringBuilder();
 			var header = useLowercase ? "Lock Types:" : "LOCK TYPES:";
@@ -217,7 +286,7 @@ public partial class Commands
 			return CallState.Empty;
 		}
 
-		if (switches.Contains("ATTRIBS"))
+		if (kind == ListKind.Attribs)
 		{
 			var output = new System.Text.StringBuilder();
 			var header = useLowercase ? "Standard Attributes:" : "STANDARD ATTRIBUTES:";
@@ -234,7 +303,7 @@ public partial class Commands
 			return CallState.Empty;
 		}
 
-		if (switches.Contains("COMMANDS"))
+		if (kind == ListKind.Commands)
 		{
 			var output = new System.Text.StringBuilder();
 			var header = useLowercase ? "Commands:" : "COMMANDS:";
@@ -268,7 +337,7 @@ public partial class Commands
 			return CallState.Empty;
 		}
 
-		if (switches.Contains("FUNCTIONS"))
+		if (kind == ListKind.Functions)
 		{
 			var output = new System.Text.StringBuilder();
 			var header = useLowercase ? "Functions:" : "FUNCTIONS:";
@@ -302,7 +371,7 @@ public partial class Commands
 			return CallState.Empty;
 		}
 
-		if (switches.Contains("ALLOCATIONS"))
+		if (kind == ListKind.Allocations)
 		{
 			var isWizard = await executor.IsWizard();
 			if (!isWizard)
@@ -322,8 +391,8 @@ public partial class Commands
 			return CallState.Empty;
 		}
 
-		await NotifyService!.Notify(executor, "You must specify what to list. Use one of: /MOTD /FUNCTIONS /COMMANDS /ATTRIBS /LOCKS /FLAGS /POWERS /ALLOCATIONS", executor);
-		return CallState.Empty;
+		// Unreachable: every ListKind has a branch above, and a null kind returned early.
+		throw new UnreachableException($"@list has no branch for {kind}.");
 	}
 
 	[SharpCommand(Name = "@LOGWIPE", Switches = ["CHECK", "CMD", "CONN", "ERR", "TRACE", "WIZ", "ROTATE", "TRIM", "WIPE"],

--- a/SharpMUSH.Implementation/Commands/WikiCommand/WikiCommandHelper.cs
+++ b/SharpMUSH.Implementation/Commands/WikiCommand/WikiCommandHelper.cs
@@ -88,17 +88,18 @@ public static class WikiCommandHelper
 	}
 
 	/// <summary>
-	/// The display form of a page reference: "slug" for a Main/general page, "ns:category:slug"
-	/// otherwise. This round-trips through <see cref="ResolveTarget"/>.
+	/// The display form of a page reference, always fully qualified as "ns:category:slug". Round-trips
+	/// through <see cref="ResolveTarget"/>, so every identifier a listing prints can be pasted straight
+	/// back into <c>@wiki</c>.
 	/// </summary>
-	public static string DisplayReference(WikiPage page)
-	{
-		var cat = page.Category ?? WikiHelpers.DefaultCategory;
-		return page.Namespace.Equals("main", StringComparison.OrdinalIgnoreCase)
-			&& cat.Equals(WikiHelpers.DefaultCategory, StringComparison.OrdinalIgnoreCase)
-				? page.Slug
-				: $"{page.Namespace}:{cat}:{page.Slug}";
-	}
+	/// <remarks>
+	/// Main-namespace pages used to print bare ("home") while everything else printed qualified
+	/// ("help:general:markdown_guide"), which put two identifier grammars in one column of one listing
+	/// and left the reader to work out which spelling a given row was in. One grammar for every row is
+	/// the cost of one prefix on the common case.
+	/// </remarks>
+	public static string DisplayReference(WikiPage page) =>
+		$"{page.Namespace}:{page.Category ?? WikiHelpers.DefaultCategory}:{page.Slug}";
 
 	/// <summary>
 	/// Edit permission mirrors the web rule: protected pages are Wizard-only;

--- a/SharpMUSH.Implementation/Commands/WizardCommands.cs
+++ b/SharpMUSH.Implementation/Commands/WizardCommands.cs
@@ -1971,6 +1971,11 @@ public partial class Commands
 
 		var player = await Mediator!.Send(new CreatePlayerCommand(name, password, defaultHomeDbref, defaultHomeDbref, startingQuota));
 
+		// PennMUSH src/wiz.c do_pcreate ends with exactly this notify — including the password, which the
+		// wizard has to be able to pass on to the new player and just typed anyway.
+		await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.PlayerCreatedFormat), executor,
+			name, player.Number, password);
+
 		// PennMUSH spec: player`create (objid, name, how, descriptor, email)
 		await EventService!.TriggerEventAsync(
 			parser,

--- a/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
+++ b/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
@@ -1892,7 +1892,23 @@ public class SharpMUSHParserVisitor(
 						}
 					}
 
-					// No extend hook or it didn't match - return error for invalid switches
+					// No extend hook or it didn't match - return error for invalid switches.
+					// PennMUSH (src/command.c) *notifies* here — `notify(executor, switch_err)` with
+					// "%s doesn't know switch %s." — instead of running the command. Returning the error
+					// only as a CallState made a mistyped switch silently do nothing at a prompt, which is
+					// how `@shutdown/what` and `@wiki/get home` both came to complete with no output at all.
+					// PennMUSH names only the first unknown switch, and names it upper-cased — the switch
+					// text it formats has already been through the command line's canonicalisation
+					// (oracle: `@shutdown/what` → "@SHUTDOWN doesn't know switch WHAT."). The return value
+					// still lists every offender as typed, because that string is a machine-readable
+					// result callers already match on.
+					if (!executor.IsNone)
+					{
+						await NotifyService.NotifyLocalized(executor.Known(),
+							nameof(ErrorMessages.Notifications.CommandUnknownSwitchFormat),
+							libraryCommandDefinition.Attribute.Name, invalidSwitches[0].ToUpperInvariant());
+					}
+
 					var invalidSwitchList = string.Join(", ", invalidSwitches);
 					return new CallState($"#-1 INVALID SWITCH: {invalidSwitchList}");
 				}

--- a/SharpMUSH.Library/Definitions/ErrorMessages.cs
+++ b/SharpMUSH.Library/Definitions/ErrorMessages.cs
@@ -1464,6 +1464,13 @@ public static class ErrorMessages
 		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
 		public const string ChownAllCompleteFormat = "Changed ownership of {0} object(s) from {1} to {2}.";
 
+		/// <summary>
+		/// PennMUSH src/command.c: <c>"%s doesn't know switch %s."</c>, notified in place of running the
+		/// command. Only the first unknown switch is named, as PennMUSH names only the first.
+		/// </summary>
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string CommandUnknownSwitchFormat = "{0} doesn't know switch {1}.";
+
 		public const string DumpDoesNothing = "Dump command does nothing for SharpMUSH. Consider using @backup.";
 
 		public const string PlayerCreateInvalidName = "That is not a valid player name.";

--- a/SharpMUSH.Library/Definitions/ErrorMessages.cs
+++ b/SharpMUSH.Library/Definitions/ErrorMessages.cs
@@ -1469,6 +1469,9 @@ public static class ErrorMessages
 		public const string PlayerCreateInvalidName = "That is not a valid player name.";
 		public const string PlayerNameAlreadyExists = "That player name already exists.";
 		public const string PlayerCreateInvalidPassword = "That is not a valid password.";
+		/// <summary>PennMUSH src/wiz.c do_pcreate: "New player '%s' (#%d) created with password '%s'".</summary>
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string PlayerCreatedFormat = "New player '{0}' (#{1}) created with password '{2}'";
 
 		public const string QuotaSetUsage = "Usage: @quota/set <player>=<amount>";
 		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]

--- a/SharpMUSH.Library/Definitions/ErrorMessages.cs
+++ b/SharpMUSH.Library/Definitions/ErrorMessages.cs
@@ -1471,6 +1471,9 @@ public static class ErrorMessages
 		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
 		public const string CommandUnknownSwitchFormat = "{0} doesn't know switch {1}.";
 
+		/// <summary>PennMUSH src/cmds.c do_list, for a missing or unrecognised <c>@list</c> type.</summary>
+		public const string ListNotUnderstood = "I don't understand what you want to @list.";
+
 		public const string DumpDoesNothing = "Dump command does nothing for SharpMUSH. Consider using @backup.";
 
 		public const string PlayerCreateInvalidName = "That is not a valid player name.";

--- a/SharpMUSH.Library/Resources/Notifications.resx
+++ b/SharpMUSH.Library/Resources/Notifications.resx
@@ -2266,6 +2266,9 @@
   <data name="CommandUnknownSwitchFormat" xml:space="preserve">
     <value>{0} doesn't know switch {1}.</value>
   </data>
+  <data name="ListNotUnderstood" xml:space="preserve">
+    <value>I don't understand what you want to @list.</value>
+  </data>
 
   <!-- @dump -->
   <data name="DumpDoesNothing" xml:space="preserve">

--- a/SharpMUSH.Library/Resources/Notifications.resx
+++ b/SharpMUSH.Library/Resources/Notifications.resx
@@ -2263,6 +2263,9 @@
     <value>Changed ownership of {0} object(s) from {1} to {2}.</value>
   </data>
 
+  <data name="CommandUnknownSwitchFormat" xml:space="preserve">
+    <value>{0} doesn't know switch {1}.</value>
+  </data>
 
   <!-- @dump -->
   <data name="DumpDoesNothing" xml:space="preserve">

--- a/SharpMUSH.Library/Resources/Notifications.resx
+++ b/SharpMUSH.Library/Resources/Notifications.resx
@@ -2263,6 +2263,7 @@
     <value>Changed ownership of {0} object(s) from {1} to {2}.</value>
   </data>
 
+
   <!-- @dump -->
   <data name="DumpDoesNothing" xml:space="preserve">
     <value>Dump command does nothing for SharpMUSH. Consider using @backup.</value>
@@ -2277,6 +2278,9 @@
   </data>
   <data name="PlayerCreateInvalidPassword" xml:space="preserve">
     <value>That is not a valid password.</value>
+  </data>
+  <data name="PlayerCreatedFormat" xml:space="preserve">
+    <value>New player '{0}' (#{1}) created with password '{2}'</value>
   </data>
 
   <!-- @quota -->

--- a/SharpMUSH.Tests/Commands/AdminCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/AdminCommandTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using OneOf;
+using SharpMUSH.Library.Definitions;
 using SharpMUSH.Library.DiscriminatedUnions;
 using SharpMUSH.Library.ParserInterfaces;
 using SharpMUSH.Library.Services.Interfaces;
@@ -16,18 +17,28 @@ public class AdminCommandTests
 	private IConnectionService ConnectionService => WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
 	private IMUSHCodeParser Parser => WebAppFactoryArg.CommandParser;
 
+	/// <summary>
+	/// PennMUSH src/wiz.c <c>do_pcreate</c> ends with
+	/// <c>notify_format(creator, T("New player '%s' (#%d) created with password '%s'"), ...)</c>.
+	/// SharpMUSH created the player and told the wizard nothing at all — no confirmation, no dbref.
+	/// </summary>
+	/// <remarks>
+	/// Was skipped for "state pollution from other tests": it asserted on a <c>Notify</c> that the
+	/// command never made, and used a fixed player name that a second run in a shared session would
+	/// collide with. The name is now unique per run and the assertion names the message key.
+	/// </remarks>
 	[Test]
-	[Category("TestInfrastructure")]
-	[Skip("Test infrastructure issue - state pollution from other tests")]
 	public async ValueTask PcreateCommand()
 	{
-		var executor = WebAppFactoryArg.ExecutorDBRef;
-		await Parser.CommandParse(1, ConnectionService, MModule.single("@pcreate TestPlayerPcreate=passwordPcreate"));
+		var name = $"PcreateTarget{Guid.NewGuid():N}"[..24];
+		var result = await Parser.CommandParse(1, ConnectionService, MModule.single($"@pcreate {name}=passwordPcreate"));
 
-		await NotifyService
-			.Received(1)
-			.Notify(TestHelpers.MatchingObject(executor), Arg.Is<OneOf<MString, string>>(msg =>
-				TestHelpers.MessagePlainTextStartsWith(msg, "#")), TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
+		var created = result.Message!.ToPlainText();
+		var dbrefNumber = created.TrimStart('#').Split(':')[0];
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedRendering(
+			NotifyService, nameof(ErrorMessages.Notifications.PlayerCreatedFormat),
+			$"New player '{name}' (#{dbrefNumber}) created with password 'passwordPcreate'")).IsTrue();
 	}
 
 	[Test]

--- a/SharpMUSH.Tests/Commands/AtListCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/AtListCommandTests.cs
@@ -2,6 +2,7 @@ using Mediator;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using OneOf;
+using SharpMUSH.Library.Definitions;
 using SharpMUSH.Library.DiscriminatedUnions;
 using SharpMUSH.Library.Models;
 using SharpMUSH.Library.ParserInterfaces;
@@ -9,6 +10,9 @@ using SharpMUSH.Library.Services.Interfaces;
 
 namespace SharpMUSH.Tests.Commands;
 
+// ClearReceivedCalls below wipes the session-shared Notify substitute, so this class may not run
+// alongside another that reads it.
+[NotInParallel]
 public class AtListCommandTests
 {
 	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
@@ -19,16 +23,96 @@ public class AtListCommandTests
 	private IMUSHCodeParser Parser => WebAppFactoryArg.CommandParser;
 	private IMediator Mediator => WebAppFactoryArg.Services.GetRequiredService<IMediator>();
 
+	// Several tests in this class produce byte-identical output ("COMMANDS:", "FUNCTIONS:",
+	// "Object Flags:") through the switch spelling and the argument spelling, so a session-shared
+	// Notify substitute would make every Received(1) count the other tests' calls too.
+	[Before(Test)]
+	public void ResetNotifications() => NotifyService.ClearReceivedCalls();
+
+	// PennMUSH src/cmds.c do_list: a bare @list falls through to `notify(player,
+	// T("I don't understand what you want to @list."))`, the same answer an unrecognised type gets.
 	[Test]
 	public async ValueTask List_NoSwitch_DisplaysHelpMessage()
 	{
-		var executor = WebAppFactoryArg.ExecutorDBRef;
 		await Parser.CommandParse(1, ConnectionService, MModule.single("@list"));
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.ListNotUnderstood))).IsTrue();
+	}
+
+	// PennMUSH src/cmds.c do_list: an unrecognised type gets the same message as no type at all.
+	[Test]
+	public async ValueTask List_UnknownArgument_DisplaysHelpMessage()
+	{
+		await Parser.CommandParse(1, ConnectionService, MModule.single("@list zorblatt"));
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.ListNotUnderstood))).IsTrue();
+	}
+
+	// PennMUSH src/cmds.c cmd_list falls through to do_list(executor, arg_left, ...) when no
+	// content switch is set, so `@list commands` is the documented spelling (game/txt/hlp/penncmd.hlp:
+	// "@list[/lowercase] <switch>") and must produce the same listing as `@list/commands`.
+	[Test]
+	public async ValueTask List_CommandsArgument_DisplaysCommandList()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		await Parser.CommandParse(1, ConnectionService, MModule.single("@list commands"));
 
 		await NotifyService
 			.Received(1)
 			.Notify(TestHelpers.MatchingObject(executor),
-				Arg.Is<OneOf.OneOf<MString, string>>(s => TestHelpers.MessagePlainTextEquals(s, "You must specify what to list. Use one of: /MOTD /FUNCTIONS /COMMANDS /ATTRIBS /LOCKS /FLAGS /POWERS /ALLOCATIONS")), TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
+				Arg.Is<OneOf.OneOf<MString, string>>(s => TestHelpers.MessagePlainTextStartsWith(s, "COMMANDS:")), TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
+	}
+
+	// do_list uses string_prefixe("commands", arg) — any non-empty prefix matches.
+	[Test]
+	public async ValueTask List_AbbreviatedArgument_DisplaysCommandList()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		await Parser.CommandParse(1, ConnectionService, MModule.single("@list comm"));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf.OneOf<MString, string>>(s => TestHelpers.MessagePlainTextStartsWith(s, "COMMANDS:")), TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
+	}
+
+	// do_list tests "commands" then "functions" by prefix before it reaches the exact-match-only
+	// "flags", so a bare "f" is functions in PennMUSH, not flags.
+	[Test]
+	public async ValueTask List_SingleLetterF_ResolvesToFunctionsNotFlags()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		await Parser.CommandParse(1, ConnectionService, MModule.single("@list f"));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf.OneOf<MString, string>>(s => TestHelpers.MessagePlainTextStartsWith(s, "FUNCTIONS:")), TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
+	}
+
+	// do_list matches "flags" with strcasecmp, not string_prefixe: an abbreviation is not a flag list.
+	[Test]
+	public async ValueTask List_AbbreviatedFlags_IsNotAccepted()
+	{
+		await Parser.CommandParse(1, ConnectionService, MModule.single("@list flag"));
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(
+			NotifyService, nameof(ErrorMessages.Notifications.ListNotUnderstood))).IsTrue();
+	}
+
+	// The /lowercase modifier is orthogonal to how the type was spelled.
+	[Test]
+	public async ValueTask List_LowercaseSwitchWithArgument_DisplaysLowercaseList()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		await Parser.CommandParse(1, ConnectionService, MModule.single("@list/lowercase flags"));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf.OneOf<MString, string>>(s => TestHelpers.MessagePlainTextStartsWith(s, "Object Flags:")), TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
 	}
 
 	[Test]

--- a/SharpMUSH.Tests/Commands/SystemCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/SystemCommandTests.cs
@@ -88,6 +88,37 @@ public class SystemCommandTests
 		await Assert.That(result.Message!.ToPlainText()).IsEqualTo("#-1 INVALID SWITCH: list");
 	}
 
+	// PennMUSH src/command.c: an unknown switch is formatted as "%s doesn't know switch %s." into
+	// switch_err and then `notify(executor, switch_err)`ed *instead of* running the command. SharpMUSH
+	// only ever produced the CallState, so an unknown switch typed at a prompt did nothing visible at
+	// all — which is what made `@shutdown/what` and `@wiki/get home` look like commands that succeed
+	// silently. Oracle (PennMUSH 1.8.8, minimal db): `@shutdown/what` -> "@SHUTDOWN doesn't know
+	// switch WHAT." — canonical command name, upper-cased switch.
+	[Test]
+	public async ValueTask UnknownSwitchIsAnnounced()
+	{
+		var result = await Parser.CommandParse(1, ConnectionService, MModule.single("@shutdown/what"));
+
+		await Assert.That(result.Message!.ToPlainText()).IsEqualTo("#-1 INVALID SWITCH: what");
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedRendering(
+			NotifyService, nameof(ErrorMessages.Notifications.CommandUnknownSwitchFormat),
+			"@SHUTDOWN doesn't know switch WHAT.")).IsTrue();
+	}
+
+	// The same root cause seen from @wiki, which has no /get switch: its documented reader is
+	// `@wiki/view <page>` (SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpwiki.md). No PennMUSH
+	// equivalent exists; the helpfile is the contract, and "not a switch" must say so.
+	[Test]
+	public async ValueTask UnknownWikiSwitchIsAnnounced()
+	{
+		var result = await Parser.CommandParse(1, ConnectionService, MModule.single("@wiki/get home"));
+
+		await Assert.That(result.Message!.ToPlainText()).IsEqualTo("#-1 INVALID SWITCH: get");
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedRendering(
+			NotifyService, nameof(ErrorMessages.Notifications.CommandUnknownSwitchFormat),
+			"@WIKI doesn't know switch GET.")).IsTrue();
+	}
+
 	// PennMUSH reference: cmd_hide calls hide_player(executor, status, arg_left).
 	// @HIDE acts on the executor. Use an isolated player to avoid modifying shared God (#1).
 	// Expected: "You are now hidden from the WHO list."

--- a/SharpMUSH.Tests/Commands/UtilityCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/UtilityCommandTests.cs
@@ -396,6 +396,11 @@ public class UtilityCommandTests
 			.Notify(TestHelpers.MatchingObject(executor), "Database Statistics:", TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
 	}
 
+	// PennMUSH src/version.c do_version prints, in order: "You are connected to <MUDNAME>", "Address:
+	// <MUDURL>" *only when MUDURL is set*, "Last restarted: ...", then the version banner formatted from
+	// VERSION/PATCHLEVEL/PATCHDATE — byte-identical to what src/funmisc.c fun_version returns. So
+	// @version's version line and version() are one string from one source, and mud_url being unset
+	// omits the Address line rather than printing a placeholder.
 	[Test]
 	public async ValueTask VersionCommand()
 	{
@@ -406,7 +411,25 @@ public class UtilityCommandTests
 		await NotifyService
 			.Received(1)
 			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
-				Arg.Is<OneOf<MString, string>>(s => TestHelpers.MessageContains(s, "SharpMUSH version")), TestHelpers.MatchingObject(testPlayer.DbRef), INotifyService.NotificationType.Announce);
+				Arg.Is<OneOf<MString, string>>(s => TestHelpers.MessageContains(s, SharpMUSH.Implementation.Generated.VersionInfo.Version)), TestHelpers.MatchingObject(testPlayer.DbRef), INotifyService.NotificationType.Announce);
+	}
+
+	[Test]
+	public async ValueTask VersionCommandAgreesWithVersionFunction()
+	{
+		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "VersionAgree");
+		var command = await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("@version"));
+		var function = await Parser.FunctionParse(MModule.single("version()"));
+
+		var banner = function!.Message!.ToPlainText();
+		var lines = command.Message!.ToPlainText().Split('\n');
+
+		await Assert.That(banner).IsNotEmpty();
+		await Assert.That(lines).Contains(banner);
+		// The placeholders the two answers used to disagree over are gone for good.
+		await Assert.That(command.Message!.ToPlainText()).DoesNotContain("SharpMUSH version 0");
+		await Assert.That(command.Message!.ToPlainText()).DoesNotContain("Address: Unknown");
 	}
 
 	[Test]

--- a/SharpMUSH.Tests/Commands/WikiCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/WikiCommandTests.cs
@@ -83,6 +83,60 @@ public class WikiCommandTests
 		await ExpectNotify(player.DbRef, "help:general:markdown_guide");
 	}
 
+	/// <summary>
+	/// One column, one grammar. Main-namespace pages listed bare ("home") while every other namespace
+	/// listed qualified ("help:general:markdown_guide"), so a reader could not tell from the column which
+	/// spelling any given row was in. Every row is now fully qualified.
+	/// </summary>
+	[Test]
+	public async ValueTask WikiList_QualifiesMainNamespaceRowsToo()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "WikiMainLister");
+
+		await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single("@wiki/create Qualified Row Page=Body of the qualified row page."));
+		var listing = await Parser.CommandParse(player.Handle, ConnectionService, MModule.single("@wiki/list"));
+
+		var rows = listing.Message!.ToPlainText()
+			.Split('\n')
+			.Skip(1) // the "WIKI: N page(s):" header
+			.Select(r => r.Trim())
+			.Where(r => r.Length > 0 && !r.StartsWith('…'))
+			.ToArray();
+
+		await Assert.That(rows).IsNotEmpty();
+		foreach (var row in rows)
+		{
+			var identifier = row.Split(' ')[0];
+			await Assert.That(identifier.Split(':').Length).IsEqualTo(3);
+		}
+
+		await Assert.That(rows.Any(r => r.StartsWith("main:general:qualified_row_page"))).IsTrue();
+	}
+
+	/// <summary>
+	/// The claim the qualification is worth anything: an identifier a listing prints has to be one
+	/// <c>@wiki</c> accepts back. A listing printing unusable identifiers is the same bug in a new place.
+	/// </summary>
+	[Test]
+	public async ValueTask WikiList_PrintedIdentifierIsAcceptedBackByView()
+	{
+		var player = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "WikiRoundTrip");
+
+		await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single("@wiki/create Round Trip Page=Body of the round trip page."));
+
+		await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single("@wiki/view main:general:round_trip_page"));
+		await ExpectNotify(player.DbRef, "Body of the round trip page");
+
+		await Parser.CommandParse(player.Handle, ConnectionService,
+			MModule.single("@wiki/view help:general:markdown_guide"));
+		await ExpectNoNotify(player.DbRef, "WIKI: No such page: help:general:markdown_guide");
+	}
+
 	[Test]
 	public async ValueTask WikiSearch_FindsPageByContent()
 	{

--- a/SharpMUSH.Tests/Functions/WikiFunctionUnitTests.cs
+++ b/SharpMUSH.Tests/Functions/WikiFunctionUnitTests.cs
@@ -161,8 +161,10 @@ public class WikiFunctionUnitTests
 
 		var result = await Eval("wikisearch(vertugadin)");
 
+		// A reference is fully qualified in every listing surface, main namespace included, so the
+		// expected answer here is "main:general:<slug>" rather than the bare slug.
 		await Assert.That(result)
-			.IsEqualTo(page.Slug)
+			.IsEqualTo($"main:general:{page.Slug}")
 			.Because("wikisearch() returns references, never titles — a locale-aware search must widen what "
 				+ "is found without changing the shape of the answer");
 	}


### PR DESCRIPTION
**PR 7 of a 10-PR stack. Base is `fix/audit2-06-mail-and-channels`, not `main`** — review the top commit range only; the first eight commits shown belong to PRs 1–6.

Five audit findings, each reproduced live over a raw telnet socket before and after. One commit per finding.

Every "PennMUSH does X" below says how it was established. Where it says **oracle**, it means a live PennMUSH 1.8.8 (git 80a1d5b) started from `tools/oracle/run-pennmush.sh` against a minimal db, driven over telnet. Per `tools/oracle/README.md` the oracle stays out of CI; what landed in CI is the observed behaviour baked into deterministic TUnit tests.

## Verification setup

Podman + NATS (`sharpmush-nats`), `SharpMUSH.Server` on :8080 with `SHARPMUSH_DATABASE_PROVIDER=surrealdb`, `SharpMUSH.ConnectionServer` on :4201 telnet, both `ASPNETCORE_ENVIRONMENT=Production` sharing `NATS_URL=nats://localhost:4222`. Transcripts are from a raw socket with IAC negotiation and ANSI stripped, connected as God (#1) via a one-time token.

---

## N-16 — `@version` and `version()` gave two different answers

**Before**

```
>>> @version
You are connected to SharpMUSH
Address: Unknown
SharpMUSH version 0
Last restarted: Sat Aug 08 22:49:14 2026

>>> think version()
PennMUSH emulated in SharpMUSH 1.0.0.0
```

**What PennMUSH does, and how that was established.** `src/version.c` `do_version` prints the game name, then `Address:` **guarded by `if (MUDURL && *MUDURL)`**, then `Last restarted:`, then a version line formatted from `VERSION`/`PATCHLEVEL`/`PATCHDATE`. `src/funmisc.c` `fun_version` formats the *same* string from the *same* three constants. Confirmed on the **oracle**, both with `mud_url` unset and with it set:

```
>>> @version                                  >>> @config/set mud_url=http://example.test/
You are connected to PennMUSH                 Option set.
Last restarted: Sat Aug 08 23:08:37 2026
PennMUSH version 1.8.8 patchlevel 0 [04/20/2020]     >>> @version
Git revision: 80a1d5b                                You are connected to PennMUSH
                                                     Address: http://example.test/
>>> think version()                                  Last restarted: Sat Aug 08 23:08:37 2026
PennMUSH version 1.8.8 patchlevel 0 [04/20/2020] (rev 80a1d5b)
```

**After.** The version line is now literally `VersionInfo.Version` — the string `version()` returns, from the one source generator that produces it. The `Address:` line is emitted only when `mud_url` is configured, matching `do_version`'s guard: an unset `mud_url` means the game publishes no address, which is a different fact from "the address is Unknown". Field order now matches `do_version`. The dead `?? "Unknown"` on `MudName` (a non-nullable string defaulting to `"SharpMUSH"`) went with it.

```
>>> @version                                  # after PATCH Net.MudUrl=http://example.test/
You are connected to SharpMUSH                >>> @version
Last restarted: Sat Aug 08 23:31:13 2026      You are connected to SharpMUSH
PennMUSH emulated in SharpMUSH 1.0.0.0        Address: http://example.test/
                                              Last restarted: Sat Aug 08 23:31:13 2026
>>> think version()                           PennMUSH emulated in SharpMUSH 1.0.0.0
PennMUSH emulated in SharpMUSH 1.0.0.0
```

---

## N-17a — `@pcreate` created a player and said nothing

**Before**

```
>>> @pcreate Testee=pw123456
(no output)
```

It really did create the player — `pmatch(Testee)` returned a dbref — the wizard was just never told.

**What PennMUSH does, and how that was established.** `src/wiz.c` `do_pcreate` ends with `notify_format(creator, T("New player '%s' (#%d) created with password '%s'"), player_name, player, player_password)`. Confirmed on the **oracle**:

```
>>> @pcreate Testee=pw123456
New player 'Testee' (#3) created with password 'pw123456'
```

**After**

```
>>> @pcreate Testee=pw123456
New player 'Testee' (#12) created with password 'pw123456'
```

Including the password, as PennMUSH does: the wizard has to hand it to the new player and just typed it anyway.

`AdminCommandTests.PcreateCommand` is **un-skipped** rather than left behind. Its `[Skip("state pollution from other tests")]` was a misdiagnosis — it asserted on a `Notify` the command never made, and used a fixed player name a second run in the shared session would collide with. The name is now unique per run and the assertion renders the message and compares it in full.

---

## N-17b + N-18 — `@shutdown/what` and `@wiki/get home` completed with no output

Two findings, one cause. The dispatcher validated switches and returned `#-1 INVALID SWITCH: <sw>` **as a CallState without notifying anybody**, so at a prompt — where the return value goes nowhere — a mistyped switch was indistinguishable from a command that succeeds silently. #757 could not surface it either: nothing throws.

**Before**

```
>>> @shutdown/what
(no output)

>>> @wiki/get home
(no output)
```

**What PennMUSH does, and how that was established.** `src/command.c:1389` formats `"%s doesn't know switch %s."` into `switch_err` during switch parsing, and `src/command.c:1645` `notify(executor, switch_err)`s it *instead of* running the command. Only the first offending switch is named (`if (se == switch_err)`). Confirmed on the **oracle** — note the switch comes out **upper-cased**, because the text has already been through the command line's canonicalisation by the time it is formatted:

```
>>> @shutdown/what
@SHUTDOWN doesn't know switch WHAT.
```

**After**

```
>>> @shutdown/what
@SHUTDOWN doesn't know switch WHAT.

>>> @wiki/get home
@WIKI doesn't know switch GET.
```

The `CallState` still lists every invalid switch as typed — that string is a machine-readable result callers already match on, and `SystemCommandTests` encodes it.

On N-18 specifically: PennMUSH has no `@wiki` (**oracle**: `@wiki/get home` → `Huh?  (Type "help" for help.)`), so `SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpwiki.md` is the contract, and it documents `@wiki <page>` / `@wiki/view <page>` and no `/get`. "That is not a switch" is therefore the correct answer — it just has to be said out loud.

---

## N-19 — `@wiki/list` printed two identifier grammars in one column

**Before**

```
>>> @wiki/list
WIKI: 3 page(s):
  help:general:application_schema_guide Application Schema Guide (rev 1, 2026-08-09)
  help:general:markdown_guide    Markdown Guide (rev 1, 2026-08-09)
  home                           Home (rev 1, 2026-08-09)
```

### Choice: qualify every row. Not a separate namespace column.

**I implemented the recommended option — every row fully qualified as `<ns>:<category>:<slug>`, main included.** The alternative on the table was a separate namespace column; I did not take it, for one reason: the column's job is to give the reader something they can type back, and a reference split across two columns has to be reassembled by hand before it can be typed. That reintroduces exactly the work qualifying was supposed to remove. The cost is one 13-character prefix on the common case, which reads fine at the column width the listing already uses.

**After**

```
>>> @wiki/list
WIKI: 3 page(s):
  help:general:application_schema_guide Application Schema Guide (rev 1, 2026-08-09)
  help:general:markdown_guide    Markdown Guide (rev 1, 2026-08-09)
  main:general:home              Home (rev 1, 2026-08-09)
```

**The round-trip claim is verified, not assumed** — a listing that prints unusable identifiers would be the same bug in a new place. `WikiCommandHelper.ResolveTarget` already accepted the three-part form; there is now a test that pastes a printed identifier straight back into `@wiki/view`, plus this over the socket:

```
>>> @wiki main:general:home
------------------------------------------------------------------------------
Wiki: Home [main]
Category: general   Tags: -   Rev 1 — 2026-08-09 04:31
------------------------------------------------------------------------------
[image: SharpMUSH logo]

This is your MUSH's home page. It's stored as a wiki article and can be edited by any authorised user.
...
```

Short forms are untouched: `@wiki home`, `@wiki main:home` and `@wiki main:general:home` all reach the same page. `wiki()`/`wikilist()`/`wikisearch()` share `DisplayReference` and change with it — deliberately, so the command and the functions spell a page reference one way. `sharpwiki.md` documents the listing grammar.

---

## N-20 — `@list commands` was refused

**Before**

```
>>> @list commands
You must specify what to list. Use one of: /MOTD /FUNCTIONS /COMMANDS /ATTRIBS /LOCKS /FLAGS /POWERS /ALLOCATIONS
```

**What PennMUSH does, and how that was established.** `game/txt/hlp/penncmd.hlp:1819` documents both spellings: `@list/<switch>` and `@list[/lowercase] <switch>`. `src/cmds.c` `cmd_list` consults the switches and, when none is set, falls through to `do_list(executor, arg_left, lc, which)`, which reads the same eight names off the argument. `do_list`'s matching is deliberately not uniform: `commands`, `functions`, `powers`, `locks`, `allocations` match on any non-empty prefix (`string_prefixe`), while `motd`, `attribs`, `flags` must be spelled in full (`strcasecmp`). The **order** is load-bearing — `f` reaches `functions` by prefix before it can reach the exact-match-only `flags`. Anything else, or nothing, gets `"I don't understand what you want to @list."`

Confirmed on the **oracle**:

```
>>> @list          -> I don't understand what you want to @list.
>>> @list zorblatt -> I don't understand what you want to @list.
>>> @list flag     -> I don't understand what you want to @list.
>>> @list f        -> Functions: @@ ABS ACCENT ACCNAME ACOS ADD ...
>>> @list commands -> Commands: @@ ADDCOM AHELP @ALLHALT ...
```

**After** — same rules, same order, same messages:

```
>>> @list commands
COMMANDS:
  ]
  @@
  @ACCOUNT
  @ALLHALT
  ...

>>> @list          -> I don't understand what you want to @list.
>>> @list zorblatt -> I don't understand what you want to @list.
>>> @list flag     -> I don't understand what you want to @list.
>>> @list f        -> FUNCTIONS: (abs, accent, accname, acos, add, ...)
>>> @list/lowercase flags -> Object Flags: ...
```

The switch form still works and still wins if both are given. The eight branches are now keyed off a `ListKind` resolved once, up front, rather than eight independent `switches.Contains` checks, so the switch and argument paths cannot drift apart.

**Consistency with PR 6's `RejectIfTooFewArguments`:** `MaxArgs` goes `0 → 1` to admit the argument; `MinArgs` stays `0`, so `RejectIfTooFewArguments` correctly does not apply — a bare `@list` is a legal invocation with its own PennMUSH answer, not an arity error.

---

## Test and build numbers

| | total | passed | failed | skipped |
|---|---|---|---|---|
| `SharpMUSH.Tests` | 5400 | 5208 | **0** | 192 |
| `SharpMUSH.Tests.Integration` | 298 | 298 | **0** | 0 |

`dotnet build`: **0 errors**, no new warnings (the 32 remaining are the pre-existing `MSB3277` assembly-unification warnings in the `SharpMUSH.Tests/Fixtures/*Plugin` projects, unchanged from the base commit). No suppressions added; `TreatWarningsAsErrors` untouched. `dotnet format whitespace` run to convergence on `SharpMUSH.Implementation`, `SharpMUSH.Library` and `SharpMUSH.Tests`; the `VerifyEditorConfigFormatting` gate passes on a full `dotnet build`.

New deterministic tests, all baked from observed PennMUSH behaviour, no live PennMUSH in CI:

- `UtilityCommandTests.VersionCommand` (now asserts the shared banner) and `VersionCommandAgreesWithVersionFunction`
- `AdminCommandTests.PcreateCommand` (un-skipped, exact rendered message)
- `SystemCommandTests.UnknownSwitchIsAnnounced`, `UnknownWikiSwitchIsAnnounced`
- `WikiCommandTests.WikiList_QualifiesMainNamespaceRowsToo`, `WikiList_PrintedIdentifierIsAcceptedBackByView`
- `AtListCommandTests`: `List_UnknownArgument_*`, `List_CommandsArgument_*`, `List_AbbreviatedArgument_*`, `List_SingleLetterF_ResolvesToFunctionsNotFlags`, `List_AbbreviatedFlags_IsNotAccepted`, `List_LowercaseSwitchWithArgument_*`

One pre-existing test moved with the N-19 behaviour: `WikiFunctionUnitTests.WikiSearch_MatchesTranslationBodiesAndStillReturnsReferences` asserted the bare slug; its own stated intent ("returns references, never titles") is unchanged, it now expects the qualified reference.

## Found, deliberately left out of scope

- **`SharpMUSH.Tests/TestHelpers.cs` is dead code.** `SharpMUSH.Tests.csproj:164` has `<Compile Remove="TestHelpers.cs" />`; the class that actually compiles is the same-named, same-namespace one in `SharpMUSH.Tests.Infrastructure`. The excluded copy is a 176-line stale duplicate that silently diverges — editing it appears to work and changes nothing. Deleting it is a one-line change but belongs in its own commit, not in a parity PR.
- **`@list/commands` output shape still differs from PennMUSH.** PennMUSH prints one wrapped line (`Commands: @@ ADDCOM AHELP ...`); SharpMUSH prints a header and one name per line. That is pre-existing behaviour of the switch form, identical before and after this PR, and the finding was about the command being *refused*, not about its formatting. Reformatting all eight listings is a separate change.
- **`@config/set` is unimplemented** (`"@config/set and @config/save are not yet implemented."`), so the `mud_url` half of N-16 had to be verified through the portal's `PATCH /api/configuration` instead of in-game. Unrelated to this PR's findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MPRzndB5egy4F2A3q5852
