### PR TITLE
Stop the layout API 404ing on every page view, and ship a profile schema characters actually fill

### DIFF
--- a/SharpMUSH.Client/Components/WikiDisplay.razor
+++ b/SharpMUSH.Client/Components/WikiDisplay.razor
@@ -10,7 +10,23 @@
 @inject IStringLocalizer<SharedResource> Loc
 @inject IJSRuntime JS
 
-@if (Article is null)
+@if (Article is null && IsCharacterBiography)
+{
+    @* A character with no biography is the normal state of a new character, not a missing page.
+       No alert, no "does not exist" wording, no back-link to a wiki the reader never navigated
+       from — just the fact and, for anyone who may write one, the offer. *@
+    <div class="wiki-article wiki-article--no-bio">
+        <MudText Typo="Typo.body2" Class="mud-text-secondary">@Loc["WikiCharacterNoBio", Slug]</MudText>
+        <AuthorizeView Policy="wiki.create">
+            <Authorized>
+                <MudButton EndIcon="@Icons.Material.Filled.Create" Color="Color.Primary" Ripple="true"
+                           Class="mt-2" Style="text-transform:none;"
+                           OnClick="@ActivateEditMode">@Loc["WikiCharacterWriteBio"]</MudButton>
+            </Authorized>
+        </AuthorizeView>
+    </div>
+}
+else if (Article is null)
 {
     <div class="wiki-article">
         <a class="wiki-back" href="/wiki"><MudIcon Icon="@Icons.Material.Filled.ChevronLeft" Style="font-size:0.875rem;" /> @Loc["Wiki"]</a>
@@ -149,6 +165,12 @@ else
 
     private List<BodySegment> _segments = [];
     private List<TocEntry> _toc = [];
+
+    /// <summary>
+    /// True when this page is a character biography — served from /character/{slug}, where the wiki
+    /// framing (and the "this page does not exist" wording) would misread as something broken.
+    /// </summary>
+    private bool IsCharacterBiography => WikiRoutes.IsCharacterProfile(Namespace, Category);
 
     private string CategoryLabel =>
         string.IsNullOrWhiteSpace(Category) ? Loc["ResCategoryGeneral"] : char.ToUpper(Category[0]) + Category[1..];

--- a/SharpMUSH.Client/Resources/SharedResource.bg.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.bg.resx
@@ -3952,6 +3952,14 @@
     <value>Категория</value>
     <comment>MT</comment>
   </data>
+  <data name="WikiCharacterNoBio" xml:space="preserve">
+    <value>{0} все още няма биография.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="WikiCharacterWriteBio" xml:space="preserve">
+    <value>Напишете биография</value>
+    <comment>MT</comment>
+  </data>
   <data name="WikiDelete" xml:space="preserve">
     <value>Изтрий</value>
     <comment>MT — plain imperative, button</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.da.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.da.resx
@@ -3952,6 +3952,14 @@
     <value>Kategori</value>
     <comment>MT</comment>
   </data>
+  <data name="WikiCharacterNoBio" xml:space="preserve">
+    <value>{0} har endnu ingen biografi.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="WikiCharacterWriteBio" xml:space="preserve">
+    <value>Skriv en biografi</value>
+    <comment>MT</comment>
+  </data>
   <data name="WikiDelete" xml:space="preserve">
     <value>Slet</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.de.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.de.resx
@@ -3952,6 +3952,14 @@
     <value>Kategorie</value>
     <comment>MT</comment>
   </data>
+  <data name="WikiCharacterNoBio" xml:space="preserve">
+    <value>{0} hat noch keine Biografie.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="WikiCharacterWriteBio" xml:space="preserve">
+    <value>Biografie schreiben</value>
+    <comment>MT</comment>
+  </data>
   <data name="WikiDelete" xml:space="preserve">
     <value>Löschen</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.es.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.es.resx
@@ -3952,6 +3952,14 @@
     <value>Categoría</value>
     <comment>MT</comment>
   </data>
+  <data name="WikiCharacterNoBio" xml:space="preserve">
+    <value>{0} aún no tiene biografía.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="WikiCharacterWriteBio" xml:space="preserve">
+    <value>Escribir una biografía</value>
+    <comment>MT</comment>
+  </data>
   <data name="WikiDelete" xml:space="preserve">
     <value>Eliminar</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.fr.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.fr.resx
@@ -1600,6 +1600,14 @@
   <data name="AdmHelpSubtitle" xml:space="preserve">
     <value>Parcourez les rubriques, recherchez des références et lisez le manuel.</value>
   </data>
+  <data name="WikiCharacterNoBio" xml:space="preserve">
+    <value>{0} n'a pas encore de biographie.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="WikiCharacterWriteBio" xml:space="preserve">
+    <value>Rédiger une biographie</value>
+    <comment>MT</comment>
+  </data>
   <data name="WkEditLivePreview" xml:space="preserve">
     <value>modification · aperçu en direct</value>
   </data>

--- a/SharpMUSH.Client/Resources/SharedResource.hr.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.hr.resx
@@ -3952,6 +3952,14 @@
     <value>Kategorija</value>
     <comment>MT</comment>
   </data>
+  <data name="WikiCharacterNoBio" xml:space="preserve">
+    <value>{0} još nema biografiju.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="WikiCharacterWriteBio" xml:space="preserve">
+    <value>Napiši biografiju</value>
+    <comment>MT</comment>
+  </data>
   <data name="WikiDelete" xml:space="preserve">
     <value>Obriši</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.hu.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.hu.resx
@@ -3952,6 +3952,14 @@
     <value>Kategória</value>
     <comment>MT</comment>
   </data>
+  <data name="WikiCharacterNoBio" xml:space="preserve">
+    <value>{0} még nem rendelkezik életrajzzal.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="WikiCharacterWriteBio" xml:space="preserve">
+    <value>Életrajz írása</value>
+    <comment>MT</comment>
+  </data>
   <data name="WikiDelete" xml:space="preserve">
     <value>Törlés</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.nb.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.nb.resx
@@ -3952,6 +3952,14 @@
     <value>Kategori</value>
     <comment>MT</comment>
   </data>
+  <data name="WikiCharacterNoBio" xml:space="preserve">
+    <value>{0} har ingen biografi ennå.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="WikiCharacterWriteBio" xml:space="preserve">
+    <value>Skriv en biografi</value>
+    <comment>MT</comment>
+  </data>
   <data name="WikiDelete" xml:space="preserve">
     <value>Slett</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.nl.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.nl.resx
@@ -3952,6 +3952,14 @@
     <value>Categorie</value>
     <comment>MT</comment>
   </data>
+  <data name="WikiCharacterNoBio" xml:space="preserve">
+    <value>{0} heeft nog geen biografie.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="WikiCharacterWriteBio" xml:space="preserve">
+    <value>Een biografie schrijven</value>
+    <comment>MT</comment>
+  </data>
   <data name="WikiDelete" xml:space="preserve">
     <value>Verwijderen</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.pl.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.pl.resx
@@ -3952,6 +3952,14 @@
     <value>Kategoria</value>
     <comment>MT</comment>
   </data>
+  <data name="WikiCharacterNoBio" xml:space="preserve">
+    <value>{0} nie ma jeszcze biografii.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="WikiCharacterWriteBio" xml:space="preserve">
+    <value>Napisz biografię</value>
+    <comment>MT</comment>
+  </data>
   <data name="WikiDelete" xml:space="preserve">
     <value>Usuń</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.pt-BR.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.pt-BR.resx
@@ -3952,6 +3952,14 @@
     <value>Categoria</value>
     <comment>MT</comment>
   </data>
+  <data name="WikiCharacterNoBio" xml:space="preserve">
+    <value>{0} ainda não tem biografia.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="WikiCharacterWriteBio" xml:space="preserve">
+    <value>Escrever uma biografia</value>
+    <comment>MT</comment>
+  </data>
   <data name="WikiDelete" xml:space="preserve">
     <value>Excluir</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.resx
@@ -204,6 +204,12 @@
   <data name="CreateThisPage" xml:space="preserve">
     <value>Create this Page!</value>
   </data>
+  <data name="WikiCharacterNoBio" xml:space="preserve">
+    <value>{0} has no biography yet.</value>
+  </data>
+  <data name="WikiCharacterWriteBio" xml:space="preserve">
+    <value>Write a biography</value>
+  </data>
   <data name="NothingToSeeHere" xml:space="preserve">
     <value>Nothing to see here.</value>
   </data>

--- a/SharpMUSH.Client/Resources/SharedResource.ro.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.ro.resx
@@ -3952,6 +3952,14 @@
     <value>Categorie</value>
     <comment>MT</comment>
   </data>
+  <data name="WikiCharacterNoBio" xml:space="preserve">
+    <value>{0} nu are încă o biografie.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="WikiCharacterWriteBio" xml:space="preserve">
+    <value>Scrie o biografie</value>
+    <comment>MT</comment>
+  </data>
   <data name="WikiDelete" xml:space="preserve">
     <value>Ștergere</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.ru.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.ru.resx
@@ -3952,6 +3952,14 @@
     <value>Категория</value>
     <comment>MT</comment>
   </data>
+  <data name="WikiCharacterNoBio" xml:space="preserve">
+    <value>У {0} пока нет биографии.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="WikiCharacterWriteBio" xml:space="preserve">
+    <value>Написать биографию</value>
+    <comment>MT</comment>
+  </data>
   <data name="WikiDelete" xml:space="preserve">
     <value>Удалить</value>
     <comment>MT — imperative button label.</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.sv.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.sv.resx
@@ -3952,6 +3952,14 @@
     <value>Kategori</value>
     <comment>MT</comment>
   </data>
+  <data name="WikiCharacterNoBio" xml:space="preserve">
+    <value>{0} har ingen biografi ännu.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="WikiCharacterWriteBio" xml:space="preserve">
+    <value>Skriv en biografi</value>
+    <comment>MT</comment>
+  </data>
   <data name="WikiDelete" xml:space="preserve">
     <value>Ta bort</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.zh-Hans.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.zh-Hans.resx
@@ -3952,6 +3952,14 @@
     <value>分类</value>
     <comment>MT</comment>
   </data>
+  <data name="WikiCharacterNoBio" xml:space="preserve">
+    <value>{0} 还没有传记。</value>
+    <comment>MT</comment>
+  </data>
+  <data name="WikiCharacterWriteBio" xml:space="preserve">
+    <value>撰写传记</value>
+    <comment>MT</comment>
+  </data>
   <data name="WikiDelete" xml:space="preserve">
     <value>删除</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Services/LayoutService.cs
+++ b/SharpMUSH.Client/Services/LayoutService.cs
@@ -8,7 +8,7 @@ namespace SharpMUSH.Client.Services;
 /// <summary>
 /// DB-backed, scope-aware layout service. Reads layouts from <c>/api/layouts/{scope}</c> (anonymous-
 /// friendly) and writes them back with <c>layout.admin</c>. A scope that has never been customized
-/// (HTTP 404) or that fails to load resolves to <see cref="GetDefaultLayout"/>.
+/// (HTTP 204) or that fails to load resolves to <see cref="GetDefaultLayout"/>.
 /// </summary>
 public sealed class LayoutService(IHttpClientFactory httpClientFactory, ILogger<LayoutService> logger) : ILayoutService
 {
@@ -99,7 +99,11 @@ public sealed class LayoutService(IHttpClientFactory httpClientFactory, ILogger<
 		{
 			var http = httpClientFactory.CreateClient("api");
 			var response = await http.GetAsync($"api/layouts/{Uri.EscapeDataString(scope)}");
-			if (response.StatusCode == HttpStatusCode.NotFound)
+
+			// 204 is the server saying "nothing stored for this scope" — the ordinary state of an
+			// uncustomized game, and not a failure. 404 is still accepted so a client served from a
+			// cached build keeps working against an older server (and vice versa) during a rollout.
+			if (response.StatusCode is HttpStatusCode.NoContent or HttpStatusCode.NotFound)
 			{
 				return null;
 			}

--- a/SharpMUSH.Server/Controllers/LayoutsController.cs
+++ b/SharpMUSH.Server/Controllers/LayoutsController.cs
@@ -14,13 +14,19 @@ namespace SharpMUSH.Server.Controllers;
 ///
 /// Routes:
 ///   GET    /api/layouts            — list scopes that have a stored (customized) layout
-///   GET    /api/layouts/{scope}    — fetch one scope's layout (404 when never customized → client uses its default)
+///   GET    /api/layouts/{scope}    — fetch one scope's layout (204 when never customized → client uses its default)
 ///   PUT    /api/layouts/{scope}    — create or replace one scope's layout (layout.admin)
 ///   DELETE /api/layouts/{scope}    — reset one scope to its code default (layout.admin)
 ///
 /// Reads are anonymous: a layout is presentation metadata, rendered for guests on public pages
 /// (the front page, the wiki). The widgets placed in it authorize their own data. Writes are gated on
 /// <see cref="PortalPermission.LayoutAdmin"/>, matching application/theme editing.
+///
+/// "No stored layout" is 204, not 404. A game nobody has customized is the ordinary state of every
+/// scope, and it stays the ordinary state after DELETE resets one — so answering 404 made the read
+/// path emit a failed request on literally every page view, and buried real failures in a console
+/// that was permanently red. 204 says what is true: the request succeeded and there is no override
+/// to send, so use the code default.
 /// </summary>
 [ApiController]
 [Route("api/layouts")]
@@ -40,7 +46,7 @@ public class LayoutsController(
 		var result = await layouts.GetLayoutAsync(scope);
 		return result.Match<ActionResult<LayoutConfiguration>>(
 			layout => Ok(layout),
-			_ => NotFound());
+			_ => NoContent());
 	}
 
 	[HttpPut("{scope}")]

--- a/SharpMUSH.Tests.BUnit/Pages/WikiRoutePageTests.cs
+++ b/SharpMUSH.Tests.BUnit/Pages/WikiRoutePageTests.cs
@@ -1,4 +1,5 @@
 using Bunit;
+using Bunit.TestDoubles;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -117,9 +118,10 @@ file sealed class InMemoryWikiHandler(IWikiService wikiService) : HttpMessageHan
 /// <summary>Helper to register the full wiki service stack needed for client component tests.</summary>
 file static class WikiServiceSetup
 {
-	public static void AddWikiTestServices(this BunitContext ctx)
+	/// <summary>Returns the authorization context so a test can grant itself policies.</summary>
+	public static BunitAuthorizationContext AddWikiTestServices(this BunitContext ctx)
 	{
-		ctx.AddAuthorization();
+		var auth = ctx.AddAuthorization();
 
 		// One InMemoryWikiService instance shared between the handler and the test
 		// so tests can seed pages directly via IWikiService and have WikiService
@@ -178,6 +180,7 @@ file static class WikiServiceSetup
 						NullLogger<LayoutService>.Instance));
 
 		ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+		return auth;
 	}
 }
 
@@ -282,9 +285,81 @@ public class WikiRedlinkRenderingTests : BunitContext
 
 public class CharacterRouteTests : BunitContext
 {
+	private readonly BunitAuthorizationContext _auth;
+
 	public CharacterRouteTests()
 	{
-		this.AddWikiTestServices();
+		_auth = this.AddWikiTestServices();
+	}
+
+	/// <summary>
+	/// Renders the real page and waits until the profile layout has resolved and the wiki body has
+	/// settled into its empty state (the widget renders before its fetch completes).
+	/// </summary>
+	private IRenderedComponent<SharpMUSH.Client.Pages.CharacterProfile> RenderProfile(string name)
+	{
+		var cut = Render<SharpMUSH.Client.Pages.CharacterProfile>(p => p.Add(c => c.Name, name));
+		cut.WaitForAssertion(() =>
+		{
+			if (!cut.Markup.Contains("WikiCharacterNoBio", StringComparison.Ordinal))
+				throw new InvalidOperationException("character wiki body not settled yet");
+		}, TimeSpan.FromSeconds(5));
+		return cut;
+	}
+
+	/// <summary>
+	/// A character with no wiki page is the normal case. The profile used to borrow the wiki's
+	/// "This page does not exist yet" alert, which read as breakage on a character's own profile.
+	/// [Authorize] does nothing in bUnit (pages render below AuthorizeRouteView), so this asserts
+	/// the rendered wording directly rather than any redirect.
+	/// </summary>
+	[TUnit.Core.Test]
+	public async Task CharacterProfile_WithoutBiography_StatesTheFactAndOffersToWriteOne()
+	{
+		_auth.SetAuthorized("Scribe");
+		_auth.SetPolicies("wiki.create");
+
+		var markup = RenderProfile("Aurelia").Markup;
+
+		// EchoLocalizer renders the indexed form as "Key(arg)", so this also pins the name argument.
+		await Assert.That(markup).Contains("WikiCharacterNoBio(Aurelia)");
+		await Assert.That(markup).Contains("WikiCharacterWriteBio");
+		await Assert.That(markup).DoesNotContain("WikiPageNotExist");
+		await Assert.That(markup).DoesNotContain("CreateThisPage");
+	}
+
+	/// <summary>
+	/// A reader who cannot create pages gets the same plain statement — not "Nothing to see here",
+	/// which reads as a dead end on a character that plainly exists.
+	/// </summary>
+	[TUnit.Core.Test]
+	public async Task CharacterProfile_WithoutBiography_UnprivilegedReaderSeesNoCreateOffer()
+	{
+		var markup = RenderProfile("Aurelia").Markup;
+
+		await Assert.That(markup).Contains("WikiCharacterNoBio(Aurelia)");
+		await Assert.That(markup).DoesNotContain("WikiCharacterWriteBio");
+		await Assert.That(markup).DoesNotContain("NothingToSeeHere");
+	}
+
+	/// <summary>The ordinary wiki empty state is untouched — it is honest wording for a wiki page.</summary>
+	[TUnit.Core.Test]
+	public async Task WikiPage_WithoutArticle_KeepsTheWikiEmptyState()
+	{
+		_auth.SetAuthorized("Scribe");
+		_auth.SetPolicies("wiki.create");
+
+		var cut = Render<WikiView>(p => p
+				.Add(v => v.Slug, "ghost_page")
+				.Add(v => v.Mode, WikiView.WikiMode.View));
+
+		cut.WaitForAssertion(() =>
+		{
+			if (!cut.Markup.Contains("WikiPageNotExist", StringComparison.Ordinal))
+				throw new InvalidOperationException("wiki body not settled yet");
+		}, TimeSpan.FromSeconds(5));
+
+		await Assert.That(cut.Markup).DoesNotContain("WikiCharacterNoBio");
 	}
 
 	[TUnit.Core.Test]

--- a/SharpMUSH.Tests.Integration/Portal/LayoutsApiTests.cs
+++ b/SharpMUSH.Tests.Integration/Portal/LayoutsApiTests.cs
@@ -1,0 +1,32 @@
+using System.Net;
+using SharpMUSH.Tests.Infrastructure;
+
+namespace SharpMUSH.Tests.Integration.Portal;
+
+/// <summary>
+/// The layout read path on a clean install, over real HTTP and unauthenticated (reads are anonymous —
+/// a guest browsing the front page must not be asked to log in).
+///
+/// Every page view asks for its scope's layout, so an uncustomized game must not answer with an
+/// error: a 4xx here put one failed request on the wire for every route in the portal and made the
+/// browser console permanently noisy, which is what hid genuine failures. 204 is the contract —
+/// request succeeded, no stored override, use the code default.
+/// </summary>
+[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+public class LayoutsApiTests(ServerWebAppFactory factory)
+{
+	[Test]
+	[Arguments("global")]
+	[Arguments("home")]
+	[Arguments("wiki-index")]
+	[Arguments("profile")]
+	[Arguments("a-scope-nobody-has-ever-heard-of")]
+	public async Task Get_UncustomizedScope_Returns204AndNoBody(string scope)
+	{
+		var http = factory.CreateHttpClient();
+		var response = await http.GetAsync($"api/layouts/{scope}");
+
+		await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NoContent);
+		await Assert.That((await response.Content.ReadAsStringAsync()).Length).IsEqualTo(0);
+	}
+}

--- a/SharpMUSH.Tests.Integration/Profile/ProfileApiTests.cs
+++ b/SharpMUSH.Tests.Integration/Profile/ProfileApiTests.cs
@@ -255,8 +255,53 @@ public class ProfileApiTests(ServerWebAppFactory factory)
 		await Assert.That(doc.RootElement.TryGetProperty("pages", out var pages)).IsTrue();
 		await Assert.That(pages.GetArrayLength()).IsEqualTo(1);
 		await Assert.That(pages[0].TryGetProperty("sections", out var sections)).IsTrue();
-		// Public read-only schema: Demographics + Status + Description.
-		await Assert.That(sections.GetArrayLength()).IsEqualTo(3);
+		// Public read-only schema: one Identity section. Every element it declares must be one the
+		// data route always fills — a declared-but-unfilled field renders as a blank row, which is
+		// how a fresh character's profile came to be a table of empty labels.
+		await Assert.That(sections.GetArrayLength()).IsEqualTo(1);
+		await Assert.That(sections[0].GetProperty("name").GetString()).IsEqualTo("Identity");
+		var keys = sections[0].GetProperty("elements").EnumerateArray()
+			.Select(e => e.GetProperty("key").GetString()!).ToArray();
+		await Assert.That(keys).IsEquivalentTo(new[] { "created", "objid" });
+	}
+
+	/// <summary>
+	/// The schema and the data route have to agree: every key the schema declares must arrive with a
+	/// non-empty value for a character that has done nothing but exist. This is the regression — the
+	/// profile page rendered Full Name / Alias / Age / Concept / Status / Faction all blank because
+	/// none of those attributes is set on a newly created character.
+	/// </summary>
+	[Test]
+	public async Task ProfileSchemaAndData_Agree_EveryDeclaredFieldHasAValue()
+	{
+		var mediator = factory.Services.GetRequiredService<IMediator>();
+		var home = new DBRef(0, null);
+		await mediator.Send(new CreatePlayerCommand("SchemaFresh", "testpass", home, home, 1));
+		var fresh = await mediator.CreateStream(new GetPlayerQuery("SchemaFresh")).FirstAsync();
+		var objid = $"#{fresh.Object.Key}:{fresh.Object.CreationTime}";
+
+		var http = factory.CreateHttpClient();
+		using var schemaDoc = JsonDocument.Parse(
+			await (await http.GetAsync("http/profile/schema")).Content.ReadAsStringAsync());
+		using var dataDoc = JsonDocument.Parse(
+			await (await http.GetAsync($"http/profile?objid={Uri.EscapeDataString(objid)}")).Content.ReadAsStringAsync());
+
+		var declared = schemaDoc.RootElement.GetProperty("pages").EnumerateArray()
+			.SelectMany(p => p.GetProperty("sections").EnumerateArray())
+			.SelectMany(s => s.GetProperty("elements").EnumerateArray())
+			.Where(e => e.GetProperty("kind").GetString() == "field")
+			.Select(e => e.GetProperty("key").GetString()!)
+			.ToList();
+
+		await Assert.That(declared).IsNotEmpty();
+
+		var fields = dataDoc.RootElement.GetProperty("fields");
+		foreach (var key in declared)
+		{
+			await Assert.That(fields.TryGetProperty(key, out var field)).IsTrue();
+			await Assert.That(field.GetProperty("visible").GetBoolean()).IsTrue();
+			await Assert.That(field.GetProperty("value").GetString()).IsNotNullOrEmpty();
+		}
 	}
 
 	[Test]
@@ -272,10 +317,12 @@ public class ProfileApiTests(ServerWebAppFactory factory)
 		using var doc = JsonDocument.Parse(body);
 		await Assert.That(doc.RootElement.GetProperty("character").GetString()).IsEqualTo(name);
 		await Assert.That(doc.RootElement.GetProperty("objid").GetString()).IsEqualTo(objid);
-		// All public fields are present as {value, visible} even when unset.
+		// Public fields arrive as {value, visible}. objid is repeated inside `fields` deliberately:
+		// the schema renderer resolves element keys only against `fields`, not the envelope.
 		var fields = doc.RootElement.GetProperty("fields");
-		await Assert.That(fields.TryGetProperty("fullname", out var fullname)).IsTrue();
-		await Assert.That(fullname.GetProperty("visible").GetBoolean()).IsTrue();
+		await Assert.That(fields.GetProperty("objid").GetProperty("value").GetString()).IsEqualTo(objid);
+		await Assert.That(fields.GetProperty("objid").GetProperty("visible").GetBoolean()).IsTrue();
+		await Assert.That(fields.GetProperty("created").GetProperty("value").GetString()).IsNotNullOrEmpty();
 	}
 
 	[Test]

--- a/SharpMUSH.Tests/Client/Services/LayoutServiceTests.cs
+++ b/SharpMUSH.Tests/Client/Services/LayoutServiceTests.cs
@@ -10,8 +10,8 @@ namespace SharpMUSH.Tests.Client.Services;
 
 /// <summary>
 /// Unit tests for the DB-backed, scope-aware <see cref="LayoutService"/>. A scriptable handler stands
-/// in for <c>/api/layouts/{scope}</c> so we can assert default fallback (HTTP 404), caching, stored-
-/// layout reads, and the save/reset round-trip.
+/// in for <c>/api/layouts/{scope}</c> so we can assert default fallback (HTTP 204, and 404 from an
+/// older server), caching, stored-layout reads, and the save/reset round-trip.
 /// </summary>
 public class LayoutServiceTests
 {
@@ -38,6 +38,9 @@ public class LayoutServiceTests
 	}
 
 	private static HttpResponseMessage NotFound() => new(HttpStatusCode.NotFound);
+
+	/// <summary>What the server actually answers for an uncustomized scope.</summary>
+	private static HttpResponseMessage NoContent() => new(HttpStatusCode.NoContent);
 
 	private static HttpResponseMessage Ok(LayoutConfiguration layout)
 		=> new(HttpStatusCode.OK) { Content = JsonContent.Create(layout, options: LayoutSerialization.Options) };
@@ -76,6 +79,20 @@ public class LayoutServiceTests
 		await Assert.That(layout.Zones[WidgetZone.RightSidebar][0].WidgetName).IsEqualTo("CharacterGallery");
 	}
 
+	/// <summary>
+	/// The live shape: an uncustomized scope answers 204 No Content, which resolves to the code
+	/// default without the request ever counting as a failure.
+	/// </summary>
+	[Test]
+	public async Task GetLayoutAsync_WhenNoContent_ReturnsScopeDefault()
+	{
+		var svc = Build(new ScriptedHandler(_ => NoContent()));
+		var layout = await svc.GetLayoutAsync(LayoutScopes.WikiIndex);
+
+		await Assert.That(layout.Zones[WidgetZone.MainContent][0].WidgetName).IsEqualTo("WikiIndex");
+	}
+
+	/// <summary>Back-compat: a cached client hitting an older server that still 404s must still work.</summary>
 	[Test]
 	public async Task GetLayoutAsync_WhenNotFound_ReturnsScopeDefault()
 	{

--- a/SharpMUSH.Tests/Functions/JsonFunctionUnitTests.cs
+++ b/SharpMUSH.Tests/Functions/JsonFunctionUnitTests.cs
@@ -120,8 +120,12 @@ public class JsonFunctionUnitTests
 		var pages = doc.RootElement.GetProperty("pages");
 		await Assert.That(pages.GetArrayLength()).IsEqualTo(1);
 		var sections = pages[0].GetProperty("sections");
-		// Public read-only schema: Demographics + Status + Description.
-		await Assert.That(sections.GetArrayLength()).IsEqualTo(3);
+		// Public read-only schema: one Identity section, holding only fields every character has.
+		await Assert.That(sections.GetArrayLength()).IsEqualTo(1);
+		await Assert.That(sections[0].GetProperty("name").GetString()).IsEqualTo("Identity");
+		var keys = sections[0].GetProperty("elements").EnumerateArray()
+			.Select(e => e.GetProperty("key").GetString()!).ToArray();
+		await Assert.That(keys).IsEquivalentTo(new[] { "created", "objid" });
 	}
 
 	[Test]

--- a/examples/packages/index.yaml
+++ b/examples/packages/index.yaml
@@ -25,7 +25,7 @@ packages:
     description: Inbound HTTP verb routers (attach mode)
   - path: profile-handler/
     package: profile-handler
-    version: 1.1.0
+    version: 1.2.0
     description: Read-only character directory, online list + profile API (requires http-handler)
   - path: room-contents/
     package: room-contents

--- a/examples/packages/profile-handler/package.yaml
+++ b/examples/packages/profile-handler/package.yaml
@@ -1,6 +1,6 @@
 format: 1
 package: profile-handler
-version: 1.1.0
+version: 1.2.0
 authors: [SharpMUSH]
 description: "Read-only character directory, online list, and profile API, served through the HTTP verb routers."
 license: MIT
@@ -23,7 +23,14 @@ objects:
     target: "{{$http_handler}}"
     attributes:
       # ── Helpers (me-relative; redefinable per game) ──────────────────────
-      # One profile field as the {value, visible} shape. %0 = objid, %1 = key.
+      # One already-computed value as the {value, visible} shape the portal reads. %0 = the value.
+      # Args are split before evaluation, so a result containing commas survives intact.
+      FN`VALUE: |-
+        json(object,value,json(string,%0),visible,json(boolean,true))
+      # One player-authored profile field as the {value, visible} shape. %0 = objid, %1 = key.
+      # get() and never u(): PROFILE`* holds text a player typed, and evaluating it would run
+      # whatever they hid in it with this wizard handler's permissions.
+      # Unused by the shipped schema — see the opt-in block under GET`PROFILE`SCHEMA.
       FN`FIELD: |-
         json(object,value,json(string,get(%0/PROFILE`%1)),visible,json(boolean,true))
       # Directory category for one player (%0). Wizard > Royalty > Guest; blank otherwise.
@@ -63,11 +70,39 @@ objects:
       GET`ONLINE: |-
         @respond/type application/json; think json_array(iter(filter(me/FN`ONLINEVIS,mwho()),u(me/FN`CHARROW,%i0),,%r),%r)
       # GET /http/profile?objid=#1:123 — one character's public profile.
+      # `fields` carries only facts the engine itself knows, so a brand-new character's profile
+      # renders real state instead of a table of blanks. Anything a game wants beyond that is a
+      # PROFILE`* attribute it also adds to the schema — see the opt-in block below.
+      # objid is repeated inside `fields` on purpose: the envelope's copy addresses the character,
+      # but the schema renderer only resolves element keys against `fields`, so a field the schema
+      # declares has to live there to render at all.
       GET`PROFILE: |-
-        @assert cand(isdbref(%q<form.objid>),hastype(%q<form.objid>,player))=@respond 404 NO SUCH CHARACTER; @respond/type application/json; think json(object,character,json(string,name(%q<form.objid>)),objid,json(string,objid(%q<form.objid>)),dbref,json(string,num(%q<form.objid>)),fields,json(object,fullname,u(FN`FIELD,%q<form.objid>,fullname),alias,u(FN`FIELD,%q<form.objid>,alias),age,u(FN`FIELD,%q<form.objid>,age),concept,u(FN`FIELD,%q<form.objid>,concept),faction,u(FN`FIELD,%q<form.objid>,faction),description,u(FN`FIELD,%q<form.objid>,description)))
+        @assert cand(isdbref(%q<form.objid>),hastype(%q<form.objid>,player))=@respond 404 NO SUCH CHARACTER; @respond/type application/json; think json(object,character,json(string,name(%q<form.objid>)),objid,json(string,objid(%q<form.objid>)),dbref,json(string,num(%q<form.objid>)),fields,json(object,created,u(FN`VALUE,ctime(%q<form.objid>)),objid,u(FN`VALUE,objid(%q<form.objid>))))
       # GET /http/profile/schema — the Portal Schema Document the portal renders from
       # (Area 21, kind:"view"). The character profile is the canonical view instance:
       # sections → keyvalue-style field elements; the GET`PROFILE data endpoint supplies
       # {value, visible} per key.
+      #
+      # The shipped schema declares only what a character has from the moment it is created:
+      # its creation date and its objid. A schema field with no data behind it still renders —
+      # as an empty row — so declaring fullname/age/concept/faction out of the box gave every
+      # character, including its own owner, a profile of blank labels. Those fields are a game's
+      # choice, not the engine's: opt back into them below.
       GET`PROFILE`SCHEMA: |-
-        @respond/type application/json; think json(object,kind,json(string,view),schema_version,json(number,1),pages,json(array,json(object,key,json(string,profile),order,json(number,1),sections,json(array,json(object,name,json(string,Demographics),order,json(number,1),elements,json(array,json(object,kind,json(string,field),key,json(string,fullname),label,json(string,Full Name),type,json(string,text),visible_to,json(string,public)),json(object,kind,json(string,field),key,json(string,alias),label,json(string,Alias),type,json(string,text),visible_to,json(string,public)),json(object,kind,json(string,field),key,json(string,age),label,json(string,Age),type,json(string,text),visible_to,json(string,public)),json(object,kind,json(string,field),key,json(string,concept),label,json(string,Concept),type,json(string,text),visible_to,json(string,public)))),json(object,name,json(string,Status),order,json(number,2),elements,json(array,json(object,kind,json(string,field),key,json(string,faction),label,json(string,Faction),type,json(string,text),visible_to,json(string,public)))),json(object,name,json(string,Description),order,json(number,3),elements,json(array,json(object,kind,json(string,field),key,json(string,description),label,json(string,Description),type,json(string,mstring),visible_to,json(string,public))))))))
+        @respond/type application/json; think json(object,kind,json(string,view),schema_version,json(number,1),pages,json(array,json(object,key,json(string,profile),order,json(number,1),sections,json(array,json(object,name,json(string,Identity),order,json(number,1),elements,json(array,json(object,kind,json(string,field),key,json(string,created),label,json(string,Created),type,json(string,text),visible_to,json(string,public)),json(object,kind,json(string,field),key,json(string,objid),label,json(string,Object ID),type,json(string,text),visible_to,json(string,public))))))))
+
+      # ── Opt-in: the richer demographic schema ────────────────────────────
+      # Demonstrating the schema system is the point of this package, so the fuller example is kept
+      # here rather than deleted. To adopt it on your game, add the fields to the data route and the
+      # matching elements to the schema — both, or the portal renders labels with nothing behind
+      # them, which is the defect the shipped schema above exists to avoid.
+      #
+      # Players fill these in with `&PROFILE`FULLNAME me=Gandalf the Grey` (etc.); FN`FIELD reads
+      # PROFILE`<key> with get(), never u(). Set `show_when_empty: false` on an element if you would
+      # rather an unfilled field vanish than render blank.
+      #
+      #   GET`PROFILE: |-
+      #     @assert cand(isdbref(%q<form.objid>),hastype(%q<form.objid>,player))=@respond 404 NO SUCH CHARACTER; @respond/type application/json; think json(object,character,json(string,name(%q<form.objid>)),objid,json(string,objid(%q<form.objid>)),dbref,json(string,num(%q<form.objid>)),fields,json(object,created,u(FN`VALUE,ctime(%q<form.objid>)),objid,u(FN`VALUE,objid(%q<form.objid>)),fullname,u(FN`FIELD,%q<form.objid>,fullname),alias,u(FN`FIELD,%q<form.objid>,alias),age,u(FN`FIELD,%q<form.objid>,age),concept,u(FN`FIELD,%q<form.objid>,concept),faction,u(FN`FIELD,%q<form.objid>,faction),description,u(FN`FIELD,%q<form.objid>,description)))
+      #
+      #   GET`PROFILE`SCHEMA: |-
+      #     @respond/type application/json; think json(object,kind,json(string,view),schema_version,json(number,1),pages,json(array,json(object,key,json(string,profile),order,json(number,1),sections,json(array,json(object,name,json(string,Demographics),order,json(number,1),elements,json(array,json(object,kind,json(string,field),key,json(string,fullname),label,json(string,Full Name),type,json(string,text),visible_to,json(string,public)),json(object,kind,json(string,field),key,json(string,alias),label,json(string,Alias),type,json(string,text),visible_to,json(string,public)),json(object,kind,json(string,field),key,json(string,age),label,json(string,Age),type,json(string,text),visible_to,json(string,public)),json(object,kind,json(string,field),key,json(string,concept),label,json(string,Concept),type,json(string,text),visible_to,json(string,public)))),json(object,name,json(string,Status),order,json(number,2),elements,json(array,json(object,kind,json(string,field),key,json(string,faction),label,json(string,Faction),type,json(string,text),visible_to,json(string,public)))),json(object,name,json(string,Description),order,json(number,3),elements,json(array,json(object,kind,json(string,field),key,json(string,description),label,json(string,Description),type,json(string,mstring),visible_to,json(string,public))))))))


### PR DESCRIPTION
**PR 8 of a 10-PR stack. Base is its predecessor, `fix/audit2-07-command-parity`, not `main`.**

Two portal findings from the live audit: the layout API 404ing on every page view (N-11), and character profiles rendering empty for everyone including their owner (N-12), plus the "this page does not exist yet" empty state on the same page.

---

## N-11 — the layout API answered 404 on every page view

### The choice: 204, not boot-time seeding

Both shapes were on the table. Seeding the defaults into the database at boot would also have removed the 404, but it answers the wrong question:

- **The defaults live in the client.** `LayoutService.GetDefaultLayout` is the source of truth for what each scope renders when nobody has customised it. Copying that into the DB gives it a second home to drift from.
- **It would break the customised/default distinction.** `GET /api/layouts` lists "scopes that have a stored layout" and drives the admin UI; seeding makes every scope report as customised when none is.
- **It does not generalise.** A scope nobody seeded — a new page, a plugin's scope — 404s again. `DELETE /api/layouts/{scope}` already means "reset to the code default", and the state it resets *to* is exactly the one that was 404ing. Seeding would have to re-seed on delete to stay quiet.

So the honest answer is the second one: a missing layout is not an error, it is the ordinary state of a game nobody has customised. `GET /api/layouts/{scope}` now returns **204 No Content** — the request succeeded, there is no stored override, use your default. The client accepts 404 as well, so a cached build and an older server keep working through a rollout.

### Before / after — 285 page loads, 5 personas, Release build, `ASPNETCORE_ENVIRONMENT=Production`

Client published and its `wwwroot` copied into the Server's publish output so one origin serves both; Server on 8080, ConnectionServer on 4201/4202, shared NATS, ArangoDB in Podman. Personas built through the real API (`/api/setup/complete` for the admin, `/api/auth/account-register` + `/api/account/characters` for the rest), sessions injected into `sessionStorage` before boot. Every response with status ≥ 400 recorded, headless Chromium.

| | before | after |
|---|---:|---:|
| page loads | 285 | 285 |
| routes × personas | 57 × 5 | 57 × 5 |
| **4xx from `/api/layouts/*`** | **186** | **0** |
| all 4xx | 212 | 26 |

Where the 186 came from, and where they went:

| path | before | after |
|---|---:|---:|
| `/api/layouts/global` | 148 | 0 |
| `/api/layouts/profile` | 20 | 0 |
| `/api/layouts/home` | 13 | 0 |
| `/api/layouts/wiki-index` | 5 | 0 |

Direct probe on a clean install after the change:

```
/api/layouts/global          204
/api/layouts/home            204
/api/layouts/wiki-index      204
/api/layouts/profile         204
/api/layouts/anything        204
```

---

## N-12 — the shipped profile schema declared fields no character has

The repo owner's diagnosis was right and the schema is softcode, not C#. A declared schema field with no datum behind it still renders — as an empty row — and none of `PROFILE`FULLNAME` / `ALIAS` / `AGE` / `CONCEPT` / `FACTION` / `DESCRIPTION` is set on a character the game just created. Hence six blank labels on every profile, including its owner's own.

### The new shipped schema

One section, two fields, both of which the engine knows from the moment a character exists:

```json
{"kind":"view","schema_version":1,"pages":[{"key":"profile","order":1,"sections":[
  {"name":"Identity","order":1,"elements":[
    {"kind":"field","key":"created","label":"Created","type":"text","visible_to":"public"},
    {"kind":"field","key":"objid","label":"Object ID","type":"text","visible_to":"public"}]}]}]}
```

and the matching data, live from a character created by the sweep:

```json
{"character":"Aurelia","objid":"#12:1786252085797","dbref":"#12",
 "fields":{"created":{"value":"8/9/2026 12:08:05 AM -05:00","visible":true},
           "objid":{"value":"#12:1786252085797","visible":true}}}
```

`objid` is repeated inside `fields` deliberately: the envelope's copy addresses the character, but `SchemaViewRenderer` resolves element keys only against `fields`, so a field the schema declares has to live there to render at all.

A new `FN`VALUE` helper wraps an already-computed value in the `{value, visible}` shape (`u()`'s arguments are split before evaluation, so a result containing commas survives intact). `FN`FIELD` — `get()` and never `u()`, because `PROFILE`*` holds player-typed text — is kept for the opt-in schema.

### How a game opts back into the richer schema

Both the full `GET`PROFILE` and the full `GET`PROFILE`SCHEMA` are kept verbatim as a commented block directly under the shipped ones, with the rule stated: restore **both**, or the portal renders labels with nothing behind them, which is the defect the shipped schema exists to avoid. Demonstrating the schema system is the point of this package, so the capability is not deleted — only the default is.

Version bumped 1.1.0 → **1.2.0**, so `DefaultPackagesBootstrapService` upgrades an existing game in place; its three-way merge still resolves in favour of local edits, so a game that customised the schema keeps its version.

### Rendered profile, before and after

Before — every field blank, above the wiki empty state:

```
Aurelia
Demographics
Full Name

Alias

Age

Concept

Status
Faction

Description
Description

Nothing to see here.
```

After, as the character's own owner:

```
Aurelia
Identity
Created

8/9/2026 12:08:05 AM -05:00

Object ID

#12:1786252085797

Aurelia has no biography yet.

Write a biography
```

Zero 4xx from `/api/layouts/*` on both loads.

---

## The empty state (separate commit)

`/character/{name}` fetches `/api/wiki/ns/character/general/{name}` and, when that 404s, used to render the wiki's empty state: a back-link to `/wiki` the reader never came from, an info alert, and *"This page does not exist yet. You can create it by clicking the button below."* A reader without `wiki.create` got *"Nothing to see here."* on a character who plainly exists.

`WikiDisplay` now recognises a character biography (`WikiRoutes.IsCharacterProfile`) and states the fact plainly — **"Aurelia has no biography yet."** — offering **"Write a biography"** to anyone who can create pages and nothing more to anyone who cannot. No alert, no back-link, no "does not exist" wording. The wiki's own empty state is untouched; it is honest wording for a wiki page.

---

## i18n

Two new keys (`WikiCharacterNoBio`, `WikiCharacterWriteBio`) across all 16 locales.

```
$ python3 tools/i18n/validate_resx.py
en           1118 keys  (neutral)
bg … zh-Hans 1118 keys  100%   (all 15 satellites)

all gates passed
```

## Tests

| suite | total | failed |
|---|---:|---:|
| `SharpMUSH.Tests` | 5401 | 0 (5209 passed, 192 pre-existing skips) |
| `SharpMUSH.Tests.Integration` | 304 | 0 |
| `SharpMUSH.Tests.BUnit` | 466 | 0 |

New coverage:

- `LayoutsApiTests` (integration, real HTTP, unauthenticated) — 204 with an empty body for `global` / `home` / `wiki-index` / `profile` and an unknown scope.
- `LayoutServiceTests` — 204 resolves to the scope default; the 404 back-compat path kept as its own test.
- `ProfileApiTests.ProfileSchemaAndData_Agree_EveryDeclaredFieldHasAValue` — creates a fresh character and asserts **every** key the schema declares arrives visible and non-empty. This is the regression itself, pinned so a future schema addition without matching data fails the build.
- `JsonFunctionUnitTests.SeededProfileSchema_EvaluatesToValidJson` — now pins the Identity section and its two keys.
- `CharacterRouteTests` (bUnit) — three tests: the empty state offers the action without the "does not exist" wording, an unprivileged reader still gets the plain statement rather than "Nothing to see here", and the ordinary wiki empty state is unchanged. `[Authorize]` does nothing below `AuthorizeRouteView` in bUnit, so these assert rendered behaviour rather than a redirect that would prove nothing.

`dotnet build`: 0 errors, no new warnings, no suppressions, `TreatWarningsAsErrors` untouched. `dotnet format whitespace` converged (run twice per touched project).

## Found but out of scope

The sweep surfaced four things this PR does not touch:

- **`/api/profile/{name}/gallery` 404s for a character with no images** (5 of the residual 26 4xx) — the same shape as the layout bug: an empty gallery is the normal state, not a missing resource.
- **`/api/wiki/ns/main/general/help-index` and `.../markdown_guide` 404** (10 of 26) — `/help` looks up pages under a path the startup seeding does not create; the guide is seeded under `help/general/markdown_guide`.
- **`/api/wiki/ns/character/general/{name}` 404** (10 of 26) — the wiki API's own answer for a page that does not exist. Defensible REST; the user-facing half is fixed here, the request itself is untouched.
- **`ctime()` returns `DateTimeOffset.ToString()`**, so the profile's Created value is culture-dependent (`8/9/2026 12:08:05 AM -05:00`). It is a real value and the existing `FN`CHARROW` already depends on `ctime`, but a stable format would be better. Changing it is an engine-wide behaviour change with PennMUSH-compatibility implications, so it belongs in its own PR.

The residual 5xx in the sweep (20, mostly `/api/wiki/recent`) are pre-existing and unrelated to these changes; they appear in the before run too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MPRzndB5egy4F2A3q5852
