### PR TITLE
Serve the portal's help from the game's helpfiles, not the wiki

### DIFF
--- a/SharpMUSH.Client/Components/Help/HelpEntryPanel.razor
+++ b/SharpMUSH.Client/Components/Help/HelpEntryPanel.razor
@@ -1,0 +1,70 @@
+@inject GameHelpService Help
+@inject IStringLocalizer<SharedResource> Loc
+
+@* Renders one help topic out of the server's shipped helpfile corpus. Not a wiki page: there is
+   nothing to create here, so a topic nobody wrote about is a plain "no such topic", never an
+   invitation to write one. *@
+
+@if (_loading)
+{
+    <MudProgressLinear Indeterminate="true" />
+}
+else if (_failed)
+{
+    <MudAlert Severity="Severity.Error" Dense="true">@Loc["HelpLoadFailed"]</MudAlert>
+}
+else if (_entry is not null && _entry.Topic is not null)
+{
+    <article class="help-entry">@((MarkupString)(_entry.Html ?? string.Empty))</article>
+}
+else if (_entry is not null && _entry.Candidates.Count > 0)
+{
+    <p class="help-ambiguous">@string.Format(Loc["HelpSeveralTopicsMatch"], Topic)</p>
+    <ul class="help-candidates">
+        @foreach (var candidate in _entry.Candidates)
+        {
+            <li><a href="@HrefFor(candidate)">@candidate</a></li>
+        }
+    </ul>
+}
+else
+{
+    <MudAlert Severity="Severity.Info" Dense="true">@string.Format(Loc["HelpNoSuchTopic"], Topic)</MudAlert>
+}
+
+@code {
+    /// <summary>The topic to resolve, exactly as it came out of the URL.</summary>
+    [Parameter]
+    public string Topic { get; set; } = string.Empty;
+
+    /// <summary>Read the administrator corpus (<c>ahelp</c>) instead of the general one.</summary>
+    [Parameter]
+    public bool Admin { get; set; }
+
+    private GameHelpEntry? _entry;
+    private bool _loading = true;
+    private bool _failed;
+    private string? _loadedTopic;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        // Navigating between topics reuses this component instance, so reload on topic change only.
+        var key = $"{Admin}|{Topic}";
+        if (_loadedTopic == key)
+        {
+            return;
+        }
+        _loadedTopic = key;
+
+        _loading = true;
+        _failed = false;
+        _entry = Admin ? await Help.GetAdminEntryAsync(Topic) : await Help.GetEntryAsync(Topic);
+        _failed = _entry is null;
+        _loading = false;
+    }
+
+    private string HrefFor(string topic) =>
+        Admin
+            ? $"/help/admin/{Uri.EscapeDataString(topic)}"
+            : $"/help/{Uri.EscapeDataString(topic)}";
+}

--- a/SharpMUSH.Client/Components/Help/HelpEntryPanel.razor.css
+++ b/SharpMUSH.Client/Components/Help/HelpEntryPanel.razor.css
@@ -1,0 +1,66 @@
+/* The entry body is HTML the server rendered from the helpfile markdown, so every rule that has to
+   reach inside it needs ::deep. */
+.help-entry ::deep h1 {
+    margin: 0 0 0.75rem;
+    font-family: var(--font-display);
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--text);
+    overflow-wrap: anywhere;
+}
+
+.help-entry ::deep a {
+    color: var(--accent);
+}
+
+.help-entry ::deep code {
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+}
+
+.help-entry ::deep pre {
+    overflow-x: auto;
+    padding: 0.75rem;
+    border-radius: var(--radius-sm);
+    background: var(--surface-alt, rgba(127, 127, 127, 0.08));
+}
+
+.help-entry ::deep table {
+    display: block;
+    overflow-x: auto;
+    max-width: 100%;
+    border-collapse: collapse;
+}
+
+.help-entry ::deep td,
+.help-entry ::deep th {
+    padding: 0.25rem 0.625rem;
+    border: 1px solid var(--border-soft);
+}
+
+.help-ambiguous {
+    margin: 0 0 0.75rem;
+    font-size: 0.875rem;
+    color: var(--text-dim);
+}
+
+.help-candidates {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(13rem, 1fr));
+    gap: 0.125rem 1rem;
+}
+
+.help-candidates a {
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    color: var(--accent);
+    text-decoration: none;
+    overflow-wrap: anywhere;
+}
+
+.help-candidates a:hover {
+    text-decoration: underline;
+}

--- a/SharpMUSH.Client/Pages/Help.razor
+++ b/SharpMUSH.Client/Pages/Help.razor
@@ -1,5 +1,10 @@
 @page "/help"
+@inject GameHelpService HelpFiles
 @inject IStringLocalizer<SharedResource> Loc
+
+@* The index of the help files the server ships — the same corpus `help` answers from at a telnet
+   prompt. It is not a wiki page: nothing here is editable from the portal, and a fresh game shows
+   the full index rather than an invitation to write one. *@
 
 <PageTitle>@Loc["Help"] — @Loc["AppTitle"]</PageTitle>
 
@@ -10,7 +15,95 @@
         <p class="help-subtitle">@Loc["AdmHelpSubtitle"]</p>
     </header>
 
-    <section class="help-body">
-        <WikiView Slug="help-index" Mode="WikiView.WikiMode.View" />
-    </section>
+    @if (_loading)
+    {
+        <MudProgressLinear Indeterminate="true" />
+    }
+    else if (_index is null)
+    {
+        <MudAlert Severity="Severity.Error" Dense="true">@Loc["HelpLoadFailed"]</MudAlert>
+    }
+    else
+    {
+        <section class="help-body">
+            <article class="help-entry">@((MarkupString)(_index.Html ?? string.Empty))</article>
+        </section>
+
+        <section class="help-body help-topics">
+            <h2 class="help-section-title">@string.Format(Loc["HelpAllTopics"], _index.Topics.Count)</h2>
+            <MudTextField T="string" @bind-Value="_filter" Immediate="true"
+                          Placeholder="@Loc["HelpFilterTopics"]"
+                          Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+                          Class="help-filter" />
+
+            @if (Filtered.Count == 0)
+            {
+                <p class="help-empty">@Loc["HelpNoTopicsMatch"]</p>
+            }
+            else
+            {
+                <ul class="help-topic-list">
+                    @foreach (var topic in Filtered)
+                    {
+                        <li><a href="/help/@Uri.EscapeDataString(topic)">@topic</a></li>
+                    }
+                </ul>
+            }
+        </section>
+
+        <AuthorizeView Roles="Wizard,God">
+            <Authorized>
+                @if (_adminIndex is not null)
+                {
+                    <section class="help-body help-topics help-admin">
+                        <h2 class="help-section-title">@Loc["HelpAdminTitle"]</h2>
+                        <p class="help-subtitle">@Loc["HelpAdminSubtitle"]</p>
+                        <ul class="help-topic-list">
+                            @foreach (var topic in _adminIndex.Topics)
+                            {
+                                <li><a href="/help/admin/@Uri.EscapeDataString(topic)">@topic</a></li>
+                            }
+                        </ul>
+                    </section>
+                }
+            </Authorized>
+        </AuthorizeView>
+    }
 </div>
+
+@code {
+    private GameHelpIndex? _index;
+    private GameHelpIndex? _adminIndex;
+    private bool _loading = true;
+    private string _filter = string.Empty;
+
+    // 1500+ topics is far too many to scroll, and far too few to need paging: filter in the browser.
+    private IReadOnlyList<string> Filtered =>
+        _index is null
+            ? []
+            : string.IsNullOrWhiteSpace(_filter)
+                ? _index.Topics
+                : _index.Topics.Where(t => t.Contains(_filter, StringComparison.OrdinalIgnoreCase)).ToList();
+
+    [CascadingParameter]
+    private Task<AuthenticationState>? AuthState { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        _index = await HelpFiles.GetIndexAsync();
+
+        // Only staff ask for the admin corpus. The gate that matters is the server's 403 on
+        // /api/help/admin — this check just keeps every anonymous page view from spending a
+        // rejected request to learn what it already knows.
+        if (AuthState is not null)
+        {
+            var user = (await AuthState).User;
+            if (user.IsInRole("Wizard") || user.IsInRole("God"))
+            {
+                _adminIndex = await HelpFiles.GetAdminIndexAsync();
+            }
+        }
+
+        _loading = false;
+    }
+}

--- a/SharpMUSH.Client/Pages/Help.razor.css
+++ b/SharpMUSH.Client/Pages/Help.razor.css
@@ -45,3 +45,70 @@
         padding: 1rem;
     }
 }
+
+.help-topics {
+    margin-top: 1.25rem;
+}
+
+.help-section-title {
+    margin: 0 0 0.75rem;
+    font-family: var(--font-display);
+    font-size: 1.0625rem;
+    font-weight: 600;
+    color: var(--text);
+}
+
+.help-filter {
+    margin-bottom: 1rem;
+}
+
+.help-topic-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(13rem, 1fr));
+    gap: 0.125rem 1rem;
+    max-height: 32rem;
+    overflow-y: auto;
+}
+
+.help-topic-list a {
+    display: block;
+    padding: 0.1875rem 0;
+    font-family: var(--font-mono);
+    font-size: 0.8125rem;
+    color: var(--accent);
+    text-decoration: none;
+    overflow-wrap: anywhere;
+}
+
+.help-topic-list a:hover {
+    text-decoration: underline;
+}
+
+.help-empty {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--text-dim);
+}
+
+.help-admin {
+    border-color: var(--accent);
+}
+
+/* The index entry is server-rendered markdown, so its tags are not in this component's markup and
+   scoped CSS would not reach them without ::deep. */
+.help-entry ::deep a {
+    color: var(--accent);
+}
+
+.help-entry ::deep pre {
+    overflow-x: auto;
+}
+
+.help-entry ::deep table {
+    display: block;
+    overflow-x: auto;
+    max-width: 100%;
+}

--- a/SharpMUSH.Client/Pages/HelpAdminTopic.razor
+++ b/SharpMUSH.Client/Pages/HelpAdminTopic.razor
@@ -1,0 +1,32 @@
+@page "/help/admin/{Topic}"
+@using SharpMUSH.Client.Components.Help
+@attribute [Authorize(Roles = "Wizard,God")]
+@inject IStringLocalizer<SharedResource> Loc
+
+@* The administrator corpus. The [Authorize] here only hides the route; the refusal that matters is
+   the one on /api/help/admin/*, which answers 403 to a mortal exactly as `ahelp` does in game. *@
+
+<PageTitle>@Topic — @Loc["HelpAdminTitle"] — @Loc["AppTitle"]</PageTitle>
+
+<div class="help-page">
+    <header class="help-header">
+        <div class="help-kicker">
+            <a class="help-kicker-link" href="/help">@Loc["Help"]</a>
+            <span class="help-kicker-sep">/</span>
+            <span class="help-kicker-current">@Loc["HelpAdminTitle"]</span>
+            <span class="help-kicker-sep">/</span>
+            <span class="help-kicker-current">@Topic</span>
+        </div>
+        <h1 class="help-title">@Topic</h1>
+    </header>
+
+    <section class="help-body">
+        <HelpEntryPanel Topic="@Topic" Admin="true" />
+    </section>
+</div>
+
+@code {
+    /// <summary>The administrator help topic, decoded from the route.</summary>
+    [Parameter]
+    public string Topic { get; set; } = string.Empty;
+}

--- a/SharpMUSH.Client/Pages/HelpAdminTopic.razor.css
+++ b/SharpMUSH.Client/Pages/HelpAdminTopic.razor.css
@@ -1,0 +1,60 @@
+.help-page {
+    padding: var(--cpad);
+    width: 100%;
+}
+
+.help-header {
+    margin-bottom: 1.375rem;
+}
+
+.help-kicker {
+    display: flex;
+    align-items: center;
+    gap: 0.4375rem;
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    margin-bottom: 0.5rem;
+}
+
+.help-kicker-link {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+.help-kicker-link:hover {
+    text-decoration: underline;
+}
+
+.help-kicker-sep {
+    color: var(--text-faint);
+}
+
+.help-kicker-current {
+    color: var(--text-faint);
+}
+
+.help-title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 1.625rem;
+    font-weight: 600;
+    color: var(--text);
+    line-height: 1.15;
+    word-break: break-word;
+}
+
+.help-body {
+    background: var(--surface);
+    border: 1px solid var(--border-soft);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow);
+    padding: 1.375rem 1.625rem;
+}
+
+@media (max-width: 760px) {
+    .help-page .help-body {
+        padding: 1rem;
+    }
+}

--- a/SharpMUSH.Client/Pages/HelpTopic.razor
+++ b/SharpMUSH.Client/Pages/HelpTopic.razor
@@ -1,24 +1,30 @@
-@page "/help/{Slug}"
+@page "/help/{Topic}"
+@using SharpMUSH.Client.Components.Help
 @inject IStringLocalizer<SharedResource> Loc
 
-<PageTitle>@Slug — @Loc["Help"] — @Loc["AppTitle"]</PageTitle>
+<PageTitle>@Topic — @Loc["Help"] — @Loc["AppTitle"]</PageTitle>
 
 <div class="help-page">
     <header class="help-header">
         <div class="help-kicker">
             <a class="help-kicker-link" href="/help">@Loc["Help"]</a>
             <span class="help-kicker-sep">/</span>
-            <span class="help-kicker-current">@Slug</span>
+            <span class="help-kicker-current">@Topic</span>
         </div>
-        <h1 class="help-title">@Slug</h1>
+        <h1 class="help-title">@Topic</h1>
     </header>
 
     <section class="help-body">
-        <WikiView Slug="@Slug" Mode="WikiView.WikiMode.View" />
+        <HelpEntryPanel Topic="@Topic" />
     </section>
 </div>
 
 @code {
+    /// <summary>
+    /// The help topic, decoded from the route. Topics are the markdown headers inside the
+    /// helpfiles — <c>@@mail</c>, <c>getting started</c>, <c>mail-sending</c> — not filenames, so
+    /// this arrives percent-decoded and is passed through verbatim.
+    /// </summary>
     [Parameter]
-    public string Slug { get; set; } = string.Empty;
+    public string Topic { get; set; } = string.Empty;
 }

--- a/SharpMUSH.Client/Program.cs
+++ b/SharpMUSH.Client/Program.cs
@@ -57,6 +57,9 @@ builder.Services.AddSingleton<HelpService>(sp =>
 	var factory = sp.GetRequiredService<IHttpClientFactory>();
 	return new HelpService(factory.CreateClient("help"));
 });
+// The server's shipped helpfile corpus (/api/help). Distinct from HelpService above, which indexes
+// mush-defs.json for the softcode editor's function drawer.
+builder.Services.AddSingleton<GameHelpService>();
 builder.Services.AddSingleton<AccountAuthService>();
 builder.Services.AddSingleton<IAccountAuthState>(sp => sp.GetRequiredService<AccountAuthService>());
 builder.Services.AddSingleton<DatabaseConversionService>();

--- a/SharpMUSH.Client/Resources/SharedResource.bg.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.bg.resx
@@ -4484,4 +4484,36 @@
     <value>Вашият акаунт е готов. Създаването на герой е последната стъпка, преди да можете да играете.</value>
     <comment>MT</comment>
   </data>
+  <data name="HelpLoadFailed" xml:space="preserve">
+    <value>Файловете с помощ не можаха да бъдат заредени.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAllTopics" xml:space="preserve">
+    <value>Всички теми ({0})</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpFilterTopics" xml:space="preserve">
+    <value>Филтриране на темите</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoTopicsMatch" xml:space="preserve">
+    <value>Няма тема, отговаряща на този филтър.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoSuchTopic" xml:space="preserve">
+    <value>Няма запис за „{0}“.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpSeveralTopicsMatch" xml:space="preserve">
+    <value>Няколко теми съвпадат с „{0}“. Изберете една:</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminTitle" xml:space="preserve">
+    <value>Администраторска помощ</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminSubtitle" xml:space="preserve">
+    <value>Темите от ahelp. Само за магьосници и Бог, в портала както и в играта.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.da.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.da.resx
@@ -4484,4 +4484,36 @@
     <value>Din konto er klar. At oprette en karakter er det sidste trin, før du kan spille.</value>
     <comment>MT</comment>
   </data>
+  <data name="HelpLoadFailed" xml:space="preserve">
+    <value>Hjælpefilerne kunne ikke indlæses.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAllTopics" xml:space="preserve">
+    <value>Alle emner ({0})</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpFilterTopics" xml:space="preserve">
+    <value>Filtrer emner</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoTopicsMatch" xml:space="preserve">
+    <value>Intet emne matcher det filter.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoSuchTopic" xml:space="preserve">
+    <value>Ingen post for „{0}“.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpSeveralTopicsMatch" xml:space="preserve">
+    <value>Flere emner matcher „{0}“. Vælg et:</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminTitle" xml:space="preserve">
+    <value>Administratorhjælp</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminSubtitle" xml:space="preserve">
+    <value>Ahelp-emnerne. Kun for Troldmænd og Gud, i portalen som i spillet.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.de.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.de.resx
@@ -4484,4 +4484,36 @@
     <value>Ihr Konto ist bereit. Das Erstellen eines Charakters ist der letzte Schritt, bevor Sie spielen können.</value>
     <comment>MT</comment>
   </data>
+  <data name="HelpLoadFailed" xml:space="preserve">
+    <value>Die Hilfedateien konnten nicht geladen werden.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAllTopics" xml:space="preserve">
+    <value>Alle Themen ({0})</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpFilterTopics" xml:space="preserve">
+    <value>Themen filtern</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoTopicsMatch" xml:space="preserve">
+    <value>Kein Thema entspricht diesem Filter.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoSuchTopic" xml:space="preserve">
+    <value>Kein Eintrag für „{0}“.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpSeveralTopicsMatch" xml:space="preserve">
+    <value>Mehrere Themen passen zu „{0}“. Wählen Sie eines aus:</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminTitle" xml:space="preserve">
+    <value>Administratorhilfe</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminSubtitle" xml:space="preserve">
+    <value>Die ahelp-Themen. Nur für Zauberer und Gott, im Portal wie im Spiel.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.es.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.es.resx
@@ -4484,4 +4484,36 @@
     <value>Tu cuenta está lista. Crear un personaje es el último paso antes de poder jugar.</value>
     <comment>MT</comment>
   </data>
+  <data name="HelpLoadFailed" xml:space="preserve">
+    <value>No se pudieron cargar los archivos de ayuda.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAllTopics" xml:space="preserve">
+    <value>Todos los temas ({0})</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpFilterTopics" xml:space="preserve">
+    <value>Filtrar temas</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoTopicsMatch" xml:space="preserve">
+    <value>Ningún tema coincide con ese filtro.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoSuchTopic" xml:space="preserve">
+    <value>No hay ninguna entrada para «{0}».</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpSeveralTopicsMatch" xml:space="preserve">
+    <value>Varios temas coinciden con «{0}». Elige uno:</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminTitle" xml:space="preserve">
+    <value>Ayuda de administrador</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminSubtitle" xml:space="preserve">
+    <value>Los temas de ahelp. Solo para Magos y Dios, tanto en el portal como en el juego.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.fr.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.fr.resx
@@ -3677,4 +3677,36 @@
     <value>Votre compte est prêt. Créer un personnage est la dernière étape avant de pouvoir jouer.</value>
     <comment>MT</comment>
   </data>
+  <data name="HelpLoadFailed" xml:space="preserve">
+    <value>Impossible de charger les fichiers d’aide.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAllTopics" xml:space="preserve">
+    <value>Tous les sujets ({0})</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpFilterTopics" xml:space="preserve">
+    <value>Filtrer les sujets</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoTopicsMatch" xml:space="preserve">
+    <value>Aucun sujet ne correspond à ce filtre.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoSuchTopic" xml:space="preserve">
+    <value>Aucune entrée pour « {0} ».</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpSeveralTopicsMatch" xml:space="preserve">
+    <value>Plusieurs sujets correspondent à « {0} ». Choisissez-en un :</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminTitle" xml:space="preserve">
+    <value>Aide administrateur</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminSubtitle" xml:space="preserve">
+    <value>Les sujets ahelp. Réservés aux Sorciers et à Dieu, dans le portail comme dans le jeu.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.hr.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.hr.resx
@@ -4484,4 +4484,36 @@
     <value>Vaš je račun spreman. Stvaranje lika posljednji je korak prije nego što možete igrati.</value>
     <comment>MT</comment>
   </data>
+  <data name="HelpLoadFailed" xml:space="preserve">
+    <value>Datoteke pomoći nije bilo moguće učitati.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAllTopics" xml:space="preserve">
+    <value>Sve teme ({0})</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpFilterTopics" xml:space="preserve">
+    <value>Filtriraj teme</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoTopicsMatch" xml:space="preserve">
+    <value>Nijedna tema ne odgovara tom filtru.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoSuchTopic" xml:space="preserve">
+    <value>Nema unosa za „{0}“.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpSeveralTopicsMatch" xml:space="preserve">
+    <value>Više tema odgovara „{0}“. Odaberite jednu:</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminTitle" xml:space="preserve">
+    <value>Pomoć za administratore</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminSubtitle" xml:space="preserve">
+    <value>Teme iz ahelpa. Samo za Čarobnjake i Boga, na portalu kao i u igri.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.hu.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.hu.resx
@@ -4484,4 +4484,36 @@
     <value>A fiókja készen áll. Egy karakter létrehozása az utolsó lépés, mielőtt játszhatna.</value>
     <comment>MT</comment>
   </data>
+  <data name="HelpLoadFailed" xml:space="preserve">
+    <value>A súgófájlokat nem sikerült betölteni.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAllTopics" xml:space="preserve">
+    <value>Összes témakör ({0})</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpFilterTopics" xml:space="preserve">
+    <value>Témakörök szűrése</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoTopicsMatch" xml:space="preserve">
+    <value>Egyetlen témakör sem felel meg ennek a szűrőnek.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoSuchTopic" xml:space="preserve">
+    <value>Nincs bejegyzés a(z) „{0}” elemhez.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpSeveralTopicsMatch" xml:space="preserve">
+    <value>Több témakör is illeszkedik a(z) „{0}” elemre. Válasszon egyet:</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminTitle" xml:space="preserve">
+    <value>Rendszergazdai súgó</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminSubtitle" xml:space="preserve">
+    <value>Az ahelp témakörök. Csak Varázslóknak és Istennek, a portálon is, mint a játékban.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.nb.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.nb.resx
@@ -4484,4 +4484,36 @@
     <value>Kontoen din er klar. Å opprette en karakter er det siste trinnet før du kan spille.</value>
     <comment>MT</comment>
   </data>
+  <data name="HelpLoadFailed" xml:space="preserve">
+    <value>Hjelpefilene kunne ikke lastes inn.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAllTopics" xml:space="preserve">
+    <value>Alle emner ({0})</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpFilterTopics" xml:space="preserve">
+    <value>Filtrer emner</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoTopicsMatch" xml:space="preserve">
+    <value>Ingen emner samsvarer med det filteret.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoSuchTopic" xml:space="preserve">
+    <value>Ingen oppføring for «{0}».</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpSeveralTopicsMatch" xml:space="preserve">
+    <value>Flere emner samsvarer med «{0}». Velg ett:</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminTitle" xml:space="preserve">
+    <value>Administratorhjelp</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminSubtitle" xml:space="preserve">
+    <value>Ahelp-emnene. Kun for Trollmenn og Gud, i portalen som i spillet.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.nl.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.nl.resx
@@ -4484,4 +4484,36 @@
     <value>Je account is klaar. Een personage aanmaken is de laatste stap voordat je kunt spelen.</value>
     <comment>MT</comment>
   </data>
+  <data name="HelpLoadFailed" xml:space="preserve">
+    <value>De helpbestanden konden niet worden geladen.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAllTopics" xml:space="preserve">
+    <value>Alle onderwerpen ({0})</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpFilterTopics" xml:space="preserve">
+    <value>Onderwerpen filteren</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoTopicsMatch" xml:space="preserve">
+    <value>Geen onderwerp komt overeen met dat filter.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoSuchTopic" xml:space="preserve">
+    <value>Geen vermelding voor ‘{0}’.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpSeveralTopicsMatch" xml:space="preserve">
+    <value>Meerdere onderwerpen komen overeen met ‘{0}’. Kies er een:</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminTitle" xml:space="preserve">
+    <value>Beheerdershulp</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminSubtitle" xml:space="preserve">
+    <value>De ahelp-onderwerpen. Alleen voor Tovenaars en God, in het portaal net als in het spel.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.pl.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.pl.resx
@@ -4484,4 +4484,36 @@
     <value>Twoje konto jest gotowe. Utworzenie postaci to ostatni krok przed rozpoczęciem gry.</value>
     <comment>MT</comment>
   </data>
+  <data name="HelpLoadFailed" xml:space="preserve">
+    <value>Nie udało się wczytać plików pomocy.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAllTopics" xml:space="preserve">
+    <value>Wszystkie tematy ({0})</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpFilterTopics" xml:space="preserve">
+    <value>Filtruj tematy</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoTopicsMatch" xml:space="preserve">
+    <value>Żaden temat nie pasuje do tego filtra.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoSuchTopic" xml:space="preserve">
+    <value>Brak wpisu dla „{0}”.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpSeveralTopicsMatch" xml:space="preserve">
+    <value>Kilka tematów pasuje do „{0}”. Wybierz jeden:</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminTitle" xml:space="preserve">
+    <value>Pomoc administratora</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminSubtitle" xml:space="preserve">
+    <value>Tematy ahelp. Tylko dla Czarodziejów i Boga, w portalu tak samo jak w grze.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.pt-BR.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.pt-BR.resx
@@ -4484,4 +4484,36 @@
     <value>Sua conta está pronta. Criar um personagem é o último passo antes de você poder jogar.</value>
     <comment>MT</comment>
   </data>
+  <data name="HelpLoadFailed" xml:space="preserve">
+    <value>Não foi possível carregar os arquivos de ajuda.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAllTopics" xml:space="preserve">
+    <value>Todos os tópicos ({0})</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpFilterTopics" xml:space="preserve">
+    <value>Filtrar tópicos</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoTopicsMatch" xml:space="preserve">
+    <value>Nenhum tópico corresponde a esse filtro.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoSuchTopic" xml:space="preserve">
+    <value>Nenhuma entrada para “{0}”.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpSeveralTopicsMatch" xml:space="preserve">
+    <value>Vários tópicos correspondem a “{0}”. Escolha um:</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminTitle" xml:space="preserve">
+    <value>Ajuda do administrador</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminSubtitle" xml:space="preserve">
+    <value>Os tópicos do ahelp. Apenas para Magos e Deus, no portal como no jogo.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.resx
@@ -3504,4 +3504,28 @@
   <data name="OnboardingCreateFirstCharacter" xml:space="preserve">
     <value>Your account is ready. Creating a character is the last step before you can play.</value>
   </data>
+  <data name="HelpLoadFailed" xml:space="preserve">
+    <value>The help files could not be loaded.</value>
+  </data>
+  <data name="HelpAllTopics" xml:space="preserve">
+    <value>All topics ({0})</value>
+  </data>
+  <data name="HelpFilterTopics" xml:space="preserve">
+    <value>Filter topics</value>
+  </data>
+  <data name="HelpNoTopicsMatch" xml:space="preserve">
+    <value>No topic matches that filter.</value>
+  </data>
+  <data name="HelpNoSuchTopic" xml:space="preserve">
+    <value>No entry for ‘{0}’.</value>
+  </data>
+  <data name="HelpSeveralTopicsMatch" xml:space="preserve">
+    <value>Several topics match ‘{0}’. Pick one:</value>
+  </data>
+  <data name="HelpAdminTitle" xml:space="preserve">
+    <value>Administrator help</value>
+  </data>
+  <data name="HelpAdminSubtitle" xml:space="preserve">
+    <value>The ahelp topics. Wizards and God only, in the portal as in the game.</value>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.ro.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.ro.resx
@@ -4484,4 +4484,36 @@
     <value>Contul tău este gata. Crearea unui personaj este ultimul pas înainte de a putea juca.</value>
     <comment>MT</comment>
   </data>
+  <data name="HelpLoadFailed" xml:space="preserve">
+    <value>Fișierele de ajutor nu au putut fi încărcate.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAllTopics" xml:space="preserve">
+    <value>Toate subiectele ({0})</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpFilterTopics" xml:space="preserve">
+    <value>Filtrează subiectele</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoTopicsMatch" xml:space="preserve">
+    <value>Niciun subiect nu corespunde acelui filtru.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoSuchTopic" xml:space="preserve">
+    <value>Nicio intrare pentru „{0}”.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpSeveralTopicsMatch" xml:space="preserve">
+    <value>Mai multe subiecte corespund lui „{0}”. Alegeți unul:</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminTitle" xml:space="preserve">
+    <value>Ajutor pentru administratori</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminSubtitle" xml:space="preserve">
+    <value>Subiectele ahelp. Doar pentru Vrăjitori și Dumnezeu, atât în portal, cât și în joc.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.ru.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.ru.resx
@@ -4484,4 +4484,36 @@
     <value>Ваша учётная запись готова. Создание персонажа — последний шаг перед началом игры.</value>
     <comment>MT</comment>
   </data>
+  <data name="HelpLoadFailed" xml:space="preserve">
+    <value>Не удалось загрузить файлы справки.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAllTopics" xml:space="preserve">
+    <value>Все темы ({0})</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpFilterTopics" xml:space="preserve">
+    <value>Фильтр тем</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoTopicsMatch" xml:space="preserve">
+    <value>Ни одна тема не соответствует этому фильтру.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoSuchTopic" xml:space="preserve">
+    <value>Нет записи для «{0}».</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpSeveralTopicsMatch" xml:space="preserve">
+    <value>Несколько тем соответствуют «{0}». Выберите одну:</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminTitle" xml:space="preserve">
+    <value>Справка администратора</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminSubtitle" xml:space="preserve">
+    <value>Темы ahelp. Только для волшебников и Бога — как в портале, так и в игре.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.sv.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.sv.resx
@@ -4484,4 +4484,36 @@
     <value>Ditt konto är klart. Att skapa en karaktär är det sista steget innan du kan spela.</value>
     <comment>MT</comment>
   </data>
+  <data name="HelpLoadFailed" xml:space="preserve">
+    <value>Hjälpfilerna kunde inte läsas in.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAllTopics" xml:space="preserve">
+    <value>Alla ämnen ({0})</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpFilterTopics" xml:space="preserve">
+    <value>Filtrera ämnen</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoTopicsMatch" xml:space="preserve">
+    <value>Inget ämne matchar det filtret.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoSuchTopic" xml:space="preserve">
+    <value>Ingen post för ”{0}”.</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpSeveralTopicsMatch" xml:space="preserve">
+    <value>Flera ämnen matchar ”{0}”. Välj ett:</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminTitle" xml:space="preserve">
+    <value>Administratörshjälp</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminSubtitle" xml:space="preserve">
+    <value>Ahelp-ämnena. Endast för Trollkarlar och Gud, i portalen liksom i spelet.</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Resources/SharedResource.zh-Hans.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.zh-Hans.resx
@@ -4484,4 +4484,36 @@
     <value>您的账户已就绪。创建一个角色是开始游戏前的最后一步。</value>
     <comment>MT</comment>
   </data>
+  <data name="HelpLoadFailed" xml:space="preserve">
+    <value>无法加载帮助文件。</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAllTopics" xml:space="preserve">
+    <value>全部主题（{0}）</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpFilterTopics" xml:space="preserve">
+    <value>筛选主题</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoTopicsMatch" xml:space="preserve">
+    <value>没有主题符合该筛选条件。</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpNoSuchTopic" xml:space="preserve">
+    <value>找不到“{0}”的条目。</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpSeveralTopicsMatch" xml:space="preserve">
+    <value>多个主题符合“{0}”。请选择一个：</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminTitle" xml:space="preserve">
+    <value>管理员帮助</value>
+    <comment>MT</comment>
+  </data>
+  <data name="HelpAdminSubtitle" xml:space="preserve">
+    <value>ahelp 主题。仅限巫师和上帝查看，门户与游戏一致。</value>
+    <comment>MT</comment>
+  </data>
 </root>

--- a/SharpMUSH.Client/Services/GameHelpService.cs
+++ b/SharpMUSH.Client/Services/GameHelpService.cs
@@ -1,0 +1,99 @@
+using System.Net;
+using System.Net.Http.Json;
+
+namespace SharpMUSH.Client.Services;
+
+/// <summary>A corpus index: its front-page entry rendered to HTML, plus every topic name in it.</summary>
+public record GameHelpIndex(string Corpus, string? Topic, string? Html, IReadOnlyList<string> Topics);
+
+/// <summary>
+/// The result of asking for one topic. <see cref="Topic"/> is set when exactly one entry answered;
+/// <see cref="Candidates"/> is non-empty when several did; both are empty on a miss.
+/// </summary>
+public record GameHelpEntry(
+	string Corpus,
+	string RequestedTopic,
+	string? Topic,
+	string? Markdown,
+	string? Html,
+	IReadOnlyList<string> Candidates)
+{
+	/// <summary>True when nothing in the corpus answered to the requested topic.</summary>
+	public bool IsMiss => Topic is null && Candidates.Count == 0;
+}
+
+/// <summary>
+/// Reads the server's shipped help files over <c>/api/help</c>.
+/// </summary>
+/// <remarks>
+/// This is deliberately not the wiki. The portal's help pages used to render wiki slugs, which meant
+/// a fresh game answered "This page does not exist yet" to every visitor while the same topics were
+/// being served perfectly well over telnet. The server resolves topics here with the very
+/// <c>IHelpTopicResolver</c> the <c>help</c> command uses, so the two surfaces agree by construction.
+/// <para>
+/// Note the separate <see cref="HelpService"/>: that one indexes <c>mush-defs.json</c> for the
+/// softcode editor's function drawer, and has nothing to do with the helpfile corpus.
+/// </para>
+/// </remarks>
+public sealed class GameHelpService(IHttpClientFactory httpClientFactory, ILogger<GameHelpService> logger)
+{
+	/// <summary>Loads the general help index, or <see langword="null"/> if the server would not answer.</summary>
+	public Task<GameHelpIndex?> GetIndexAsync() => GetIndexAsync("api/help");
+
+	/// <summary>Loads the administrator help index. Returns <see langword="null"/> for a reader who may not read it.</summary>
+	public Task<GameHelpIndex?> GetAdminIndexAsync() => GetIndexAsync("api/help/admin");
+
+	/// <summary>Resolves one topic in the general corpus.</summary>
+	public Task<GameHelpEntry?> GetEntryAsync(string topic) => GetEntryAsync("api/help/entry", topic);
+
+	/// <summary>Resolves one topic in the administrator corpus.</summary>
+	public Task<GameHelpEntry?> GetAdminEntryAsync(string topic) => GetEntryAsync("api/help/admin/entry", topic);
+
+	private async Task<GameHelpIndex?> GetIndexAsync(string route)
+	{
+		try
+		{
+			var http = httpClientFactory.CreateClient("api");
+			return await http.GetFromJsonAsync<GameHelpIndex>(route);
+		}
+		catch (Exception ex) when (ex is HttpRequestException or NotSupportedException or System.Text.Json.JsonException)
+		{
+			logger.LogWarning(ex, "Failed to load the help index from {Route}.", route);
+			return null;
+		}
+	}
+
+	private async Task<GameHelpEntry?> GetEntryAsync(string route, string topic)
+	{
+		// Topic names include '@mail', 'getting started', '%#' and '#-1 exception'. Escaping them as a
+		// query value is the only encoding that survives all of them intact.
+		var url = $"{route}?topic={Uri.EscapeDataString(topic)}";
+
+		try
+		{
+			var http = httpClientFactory.CreateClient("api");
+			var response = await http.GetAsync(url);
+
+			// A miss is a documented answer, not a transport failure: the page says "no such topic"
+			// rather than "something went wrong".
+			if (response.StatusCode == HttpStatusCode.NotFound)
+			{
+				return await response.Content.ReadFromJsonAsync<GameHelpEntry>()
+					?? new GameHelpEntry(string.Empty, topic, null, null, null, []);
+			}
+
+			if (!response.IsSuccessStatusCode)
+			{
+				logger.LogWarning("Help lookup for {Topic} returned {Status}.", topic, response.StatusCode);
+				return null;
+			}
+
+			return await response.Content.ReadFromJsonAsync<GameHelpEntry>();
+		}
+		catch (Exception ex) when (ex is HttpRequestException or NotSupportedException or System.Text.Json.JsonException)
+		{
+			logger.LogWarning(ex, "Failed to load help topic {Topic}.", topic);
+			return null;
+		}
+	}
+}

--- a/SharpMUSH.Documentation/MarkdownToAsciiRenderer/HelpHtmlRenderer.cs
+++ b/SharpMUSH.Documentation/MarkdownToAsciiRenderer/HelpHtmlRenderer.cs
@@ -1,0 +1,94 @@
+using Markdig;
+using Markdig.Renderers;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+using System.Text;
+
+namespace SharpMUSH.Documentation.MarkdownToAsciiRenderer;
+
+/// <summary>
+/// Renders a help entry to HTML for the web portal, from the same markdown and through the same
+/// syntax extensions the terminal renderer uses (<see cref="RecursiveMarkdownHelper.ConfigureHelpSyntax"/>).
+/// </summary>
+/// <remarks>
+/// The one thing that has to differ is what a topic reference points at. In game, <c>[@mail]</c>
+/// becomes an OSC 8 hyperlink whose target is the command <c>help @mail</c>; in a browser it has to
+/// become a portal URL. So this renderer parses with the shared extensions and then rewrites the
+/// synthetic <c>help &lt;topic&gt;</c> URLs the parser produced, rather than re-deciding what a
+/// topic link is.
+/// <para>
+/// Raw HTML is <b>not</b> disabled. Unlike wiki pages, help files are not user-authored content —
+/// they ship with the server, and the index deliberately uses <c>&lt;br&gt;</c> for its layout.
+/// Anyone who can edit <c>TextFiles/</c> already has the server's filesystem.
+/// </para>
+/// </remarks>
+public static class HelpHtmlRenderer
+{
+	/// <summary>The URL scheme the shared <c>[topic]</c> parser emits: <c>help &lt;topic&gt;</c>.</summary>
+	private const string TopicUrlPrefix = "help ";
+
+	private static readonly MarkdownPipeline Pipeline =
+		RecursiveMarkdownHelper.ConfigureHelpSyntax(new MarkdownPipelineBuilder()).Build();
+
+	/// <summary>
+	/// Renders help markdown to an HTML fragment.
+	/// </summary>
+	/// <param name="markdown">The entry body as the resolver returned it.</param>
+	/// <param name="topicHref">
+	/// Maps a topic name to the URL a reader should be sent to. Called for every <c>[topic]</c>
+	/// reference in the body; return <see langword="null"/> to leave the reference as plain text.
+	/// </param>
+	public static string RenderToHtml(string markdown, Func<string, string?> topicHref)
+	{
+		ArgumentNullException.ThrowIfNull(markdown);
+		ArgumentNullException.ThrowIfNull(topicHref);
+
+		var document = Markdown.Parse(markdown, Pipeline);
+
+		foreach (var link in document.Descendants<LinkInline>())
+		{
+			if (link.Url is null || !link.Url.StartsWith(TopicUrlPrefix, StringComparison.Ordinal))
+			{
+				continue;
+			}
+
+			var topic = link.Url[TopicUrlPrefix.Length..];
+			link.Url = topicHref(topic) ?? string.Empty;
+		}
+
+		var writer = new StringWriter();
+		var renderer = new HtmlRenderer(writer);
+		Pipeline.Setup(renderer);
+		renderer.Render(document);
+		writer.Flush();
+
+		return writer.ToString();
+	}
+
+	/// <summary>
+	/// Strips markup to readable text — used for prerender meta descriptions and search snippets.
+	/// </summary>
+	public static string ExtractPlainText(string markdown, int maxLength = 300)
+	{
+		ArgumentNullException.ThrowIfNull(markdown);
+
+		var document = Markdown.Parse(markdown, Pipeline);
+		var sb = new StringBuilder();
+
+		foreach (var literal in document.Descendants<LiteralInline>())
+		{
+			if (sb.Length > 0 && sb[^1] != ' ')
+			{
+				sb.Append(' ');
+			}
+			sb.Append(literal.Content.ToString());
+			if (sb.Length >= maxLength)
+			{
+				break;
+			}
+		}
+
+		var text = sb.ToString().Trim();
+		return text.Length <= maxLength ? text : text[..maxLength].TrimEnd() + "…";
+	}
+}

--- a/SharpMUSH.Documentation/MarkdownToAsciiRenderer/RecursiveMarkdownHelper.cs
+++ b/SharpMUSH.Documentation/MarkdownToAsciiRenderer/RecursiveMarkdownHelper.cs
@@ -33,15 +33,23 @@ public static class RecursiveMarkdownHelper
 	/// </list>
 	/// </summary>
 	private static MarkdownPipeline BuildPipeline() =>
-		new MarkdownPipelineBuilder()
-			.UsePipeTables()
+		ConfigureHelpSyntax(new MarkdownPipelineBuilder())
 			.EnableTrackTrivia() // Track HTML
+			.Build();
+
+	/// <summary>
+	/// Applies the syntax extensions that define what SharpMUSH help-file markdown <em>means</em>.
+	/// Shared with <see cref="HelpHtmlRenderer"/> so the portal and the terminal cannot disagree
+	/// about which brackets are a topic link — add an extension here, not in one renderer.
+	/// </summary>
+	public static MarkdownPipelineBuilder ConfigureHelpSyntax(MarkdownPipelineBuilder builder) =>
+		builder
+			.UsePipeTables()
 			.UseHelpTopicLinks() // [topic] → help <topic> hyperlinks
 			.UseGenericAttributes()
 			.UseCustomContainers()
 			.UseTaskLists()
-			.Use<WikiLinkExtension>() // parser only; its HTML renderer hook is a no-op here
-			.Build();
+			.Use<WikiLinkExtension>(); // parser only; its HTML renderer hook is a no-op for ASCII
 
 	/// <summary>
 	/// Renders markdown text to MString using the recursive renderer

--- a/SharpMUSH.Implementation/Commands/Commands.cs
+++ b/SharpMUSH.Implementation/Commands/Commands.cs
@@ -54,6 +54,8 @@ public partial class Commands : ILibraryProvider<CommandDefinition>
 
 	private static ITextFileService? TextFileService { get; set; }
 
+	private static IHelpTopicResolver? HelpTopicResolver { get; set; }
+
 	private static IMessageBus? MessageBus { get; set; }
 
 	private static IGameBroadcastService? GameBroadcastService { get; set; }
@@ -98,6 +100,7 @@ public partial class Commands : ILibraryProvider<CommandDefinition>
 		ITelemetryService telemetryService,
 		IWarningService warningService,
 		ITextFileService textFileService,
+		IHelpTopicResolver helpTopicResolver,
 		IMessageBus messageBus,
 		ILocalizationService localizationService,
 		IGameBroadcastService gameBroadcastService,
@@ -132,6 +135,7 @@ public partial class Commands : ILibraryProvider<CommandDefinition>
 		TelemetryService = telemetryService;
 		WarningService = warningService;
 		TextFileService = textFileService;
+		HelpTopicResolver = helpTopicResolver;
 		MessageBus = messageBus;
 		LocalizationService = localizationService;
 		GameBroadcastService = gameBroadcastService;

--- a/SharpMUSH.Implementation/Commands/HelpCommand.cs
+++ b/SharpMUSH.Implementation/Commands/HelpCommand.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using SharpMUSH.Documentation.MarkdownToAsciiRenderer;
 using SharpMUSH.Library.Attributes;
 using SharpMUSH.Library.DiscriminatedUnions;
@@ -17,7 +16,7 @@ public partial class Commands
 		var args = parser.CurrentState.Arguments;
 		var switches = parser.CurrentState.Switches;
 
-		if (TextFileService == null)
+		if (HelpTopicResolver == null)
 		{
 			await NotifyService!.Notify(executor, "Help system not initialized.", executor);
 			return new CallState(ErrorMessages.Returns.HelpSystemNotInitialized);
@@ -26,10 +25,10 @@ public partial class Commands
 		// No arguments - show main help (PennMUSH shows the command's own entry)
 		if (args.Count == 0)
 		{
-			var mainHelp = await TextFileService.GetEntryAsync("help", "help");
+			var mainHelp = await HelpTopicResolver.GetExactAsync(HelpCorpora.Help, "help");
 			if (mainHelp != null)
 			{
-				var rendered = RecursiveMarkdownHelper.RenderMarkdown(mainHelp, mushParser: parser);
+				var rendered = RecursiveMarkdownHelper.RenderMarkdown(mainHelp.Markdown, mushParser: parser);
 				await NotifyService!.Notify(executor, rendered, executor);
 			}
 			else
@@ -44,9 +43,7 @@ public partial class Commands
 		// /search switch - search entry bodies for content containing the term (PennMUSH behavior)
 		if (switches.Contains("SEARCH"))
 		{
-			var matches = (await TextFileService.SearchContentAsync("help", topic))
-				.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
-				.ToList();
+			var matches = await HelpTopicResolver.SearchContentAsync(HelpCorpora.Help, topic);
 			if (matches.Count == 0)
 			{
 				await NotifyService!.Notify(executor, $"No matches.", executor);
@@ -58,124 +55,27 @@ public partial class Commands
 			return CallState.Empty;
 		}
 
-		if (topic.Contains('*') || topic.Contains('?'))
+		var isWildcard = topic.Contains('*') || topic.Contains('?');
+		var resolution = await HelpTopicResolver.ResolveAsync(HelpCorpora.Help, topic);
+
+		if (resolution.TryPickT0(out var entry, out var notAnEntry))
 		{
-			var matches = (await TextFileService.SearchEntriesAsync("help", topic))
-				.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
-				.ToList();
-			if (matches.Count == 0)
-			{
-				await NotifyService!.Notify(executor, $"No entries matching '{topic}' were found.", executor);
-			}
-			else if (matches.Count == 1)
-			{
-				var wildcardContent = await TextFileService.GetEntryAsync("help", matches[0]);
-				if (wildcardContent != null)
-				{
-					var rendered = RecursiveMarkdownHelper.RenderMarkdown(wildcardContent, mushParser: parser);
-					await NotifyService!.Notify(executor, rendered, executor);
-				}
-			}
-			else
-			{
-				await NotifyService!.Notify(executor, $"Here are the entries which match '{topic}':", executor);
-				await NotifyService!.Notify(executor, string.Join(", ", matches), executor);
-			}
-			return CallState.Empty;
+			var rendered = RecursiveMarkdownHelper.RenderMarkdown(entry.Markdown, mushParser: parser);
+			await NotifyService!.Notify(executor, rendered, executor);
 		}
-
-		// Non-wildcard: PennMUSH does prefix match first (name LIKE 'topic%', takes first alphabetically).
-		// If nothing found, build a fuzzy pattern with * between words and at alpha-digit boundaries.
-		var prefixMatches = (await TextFileService.SearchEntriesAsync("help", topic + "*"))
-			.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
-			.ToList();
-
-		if (prefixMatches.Count > 0)
+		else if (notAnEntry.TryPickT0(out var candidates, out _))
 		{
-			// Show the first alphabetically matching entry (matches PennMUSH's LIMIT 1 ORDER BY name)
-			var firstMatch = prefixMatches[0];
-			var prefixContent = await TextFileService.GetEntryAsync("help", firstMatch);
-			if (prefixContent != null)
-			{
-				var rendered = RecursiveMarkdownHelper.RenderMarkdown(prefixContent, mushParser: parser);
-				await NotifyService!.Notify(executor, rendered, executor);
-			}
-			return CallState.Empty;
-		}
-
-		var fuzzyPattern = BuildFuzzyPattern(topic);
-		var fuzzyMatches = (await TextFileService.SearchEntriesAsync("help", fuzzyPattern))
-			.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
-			.ToList();
-
-		if (fuzzyMatches.Count == 0)
-		{
-			await NotifyService!.Notify(executor, $"No entry for '{topic}'.", executor);
-		}
-		else if (fuzzyMatches.Count == 1)
-		{
-			var fuzzyContent = await TextFileService.GetEntryAsync("help", fuzzyMatches[0]);
-			if (fuzzyContent != null)
-			{
-				var rendered = RecursiveMarkdownHelper.RenderMarkdown(fuzzyContent, mushParser: parser);
-				await NotifyService!.Notify(executor, rendered, executor);
-			}
+			await NotifyService!.Notify(executor, $"Here are the entries which match '{topic}':", executor);
+			await NotifyService!.Notify(executor, string.Join(", ", candidates.Topics), executor);
 		}
 		else
 		{
-			await NotifyService!.Notify(executor, $"Here are the entries which match '{topic}':", executor);
-			await NotifyService!.Notify(executor, string.Join(", ", fuzzyMatches), executor);
+			// PennMUSH words the miss differently depending on whether the reader wildcarded.
+			await NotifyService!.Notify(executor, isWildcard
+				? $"No entries matching '{topic}' were found."
+				: $"No entry for '{topic}'.", executor);
 		}
 
 		return CallState.Empty;
-	}
-
-	/// <summary>
-	/// Builds a fuzzy wildcard pattern from a plain topic string, matching PennMUSH's behavior:
-	/// - Inserts '*' between words (at space boundaries)
-	/// - Inserts '*' at transitions from alphabetic to digit characters
-	/// Note: digit→alpha transitions do NOT get a wildcard (matches PennMUSH source).
-	/// </summary>
-	private static string BuildFuzzyPattern(string topic)
-	{
-		if (string.IsNullOrEmpty(topic))
-			return topic;
-
-		var sb = new StringBuilder();
-		const int StateNone = 0;
-		const int StateAlpha = 1;
-		const int StateDigit = 2;
-		var state = StateNone;
-
-		foreach (var c in topic)
-		{
-			if (char.IsWhiteSpace(c))
-			{
-				if (state != StateNone)
-				{
-					state = StateNone;
-					sb.Append('*');
-				}
-				sb.Append(c);
-			}
-			else if (char.IsAsciiDigit(c))
-			{
-				if (state == StateAlpha)
-				{
-					// alpha → digit transition: insert * (PennMUSH behavior)
-					state = StateDigit;
-					sb.Append('*');
-				}
-				sb.Append(c);
-			}
-			else
-			{
-				if (state != StateAlpha)
-					state = StateAlpha;
-				sb.Append(c);
-			}
-		}
-
-		return sb.ToString();
 	}
 }

--- a/SharpMUSH.Implementation/Commands/NewsCommands.cs
+++ b/SharpMUSH.Implementation/Commands/NewsCommands.cs
@@ -18,7 +18,7 @@ public partial class Commands
 		var args = parser.CurrentState.Arguments;
 		var switches = parser.CurrentState.Switches;
 
-		if (TextFileService == null)
+		if (HelpTopicResolver == null)
 		{
 			await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.NewsSystemNotInitialized), executor);
 			return new CallState(ErrorMessages.Returns.NewsSystemNotInitialized);
@@ -26,11 +26,10 @@ public partial class Commands
 
 		if (args.Count == 0)
 		{
-			var mainNews = await TextFileService.GetEntryAsync("news", "news");
+			var mainNews = await HelpTopicResolver.GetExactAsync(HelpCorpora.News, "news");
 			if (mainNews != null)
 			{
-				var rendered = RecursiveMarkdownHelper.RenderMarkdown(mainNews);
-				await NotifyService!.Notify(executor, rendered, executor);
+				await NotifyService!.Notify(executor, RecursiveMarkdownHelper.RenderMarkdown(mainNews.Markdown), executor);
 			}
 			else
 			{
@@ -43,62 +42,46 @@ public partial class Commands
 
 		if (switches.Contains("SEARCH"))
 		{
-			var matches = (await TextFileService.SearchEntriesAsync("news", topic)).ToList();
+			var matches = await HelpTopicResolver.SearchTopicsAsync(HelpCorpora.News, topic);
 			if (matches.Count == 0)
 			{
 				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.NewsNoEntriesFoundContaining), executor, topic);
 			}
 			else if (matches.Count == 1)
 			{
-				var searchContent = await TextFileService.GetEntryAsync("news", matches[0]);
+				var searchContent = await HelpTopicResolver.GetExactAsync(HelpCorpora.News, matches[0]);
 				if (searchContent != null)
 				{
-					var rendered = RecursiveMarkdownHelper.RenderMarkdown(searchContent);
-					await NotifyService!.Notify(executor, rendered, executor);
+					await NotifyService!.Notify(executor, RecursiveMarkdownHelper.RenderMarkdown(searchContent.Markdown), executor);
 				}
 			}
 			else
 			{
 				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.NewsEntriesContaining), executor, topic);
-				await NotifyService!.Notify(executor, string.Join(", ", matches.OrderBy(x => x)), executor);
+				await NotifyService!.Notify(executor, string.Join(", ", matches), executor);
 			}
 			return CallState.Empty;
 		}
 
-		if (topic.Contains('*') || topic.Contains('?'))
-		{
-			var matches = (await TextFileService.SearchEntriesAsync("news", topic)).ToList();
-			if (matches.Count == 0)
-			{
-				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.NewsNoNewsForTopic), executor, topic);
-			}
-			else if (matches.Count == 1)
-			{
-				var wildcardContent = await TextFileService.GetEntryAsync("news", matches[0]);
-				if (wildcardContent != null)
-				{
-					var rendered = RecursiveMarkdownHelper.RenderMarkdown(wildcardContent);
-					await NotifyService!.Notify(executor, rendered, executor);
-				}
-			}
-			else
-			{
-				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.NewsTopicsMatchingFormat), executor, topic);
-				await NotifyService!.Notify(executor, string.Join(", ", matches.OrderBy(x => x)), executor);
-			}
-			return CallState.Empty;
-		}
+		var isWildcard = topic.Contains('*') || topic.Contains('?');
+		var resolution = await HelpTopicResolver.ResolveAsync(HelpCorpora.News, topic);
 
-		var exactContent = await TextFileService.GetEntryAsync("news", topic);
-		if (exactContent != null)
+		if (resolution.TryPickT0(out var entry, out var notAnEntry))
 		{
-			var rendered = RecursiveMarkdownHelper.RenderMarkdown(exactContent);
-			await NotifyService!.Notify(executor, rendered, executor);
+			await NotifyService!.Notify(executor, RecursiveMarkdownHelper.RenderMarkdown(entry.Markdown), executor);
+		}
+		else if (notAnEntry.TryPickT0(out var candidates, out _))
+		{
+			await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.NewsTopicsMatchingFormat), executor, topic);
+			await NotifyService!.Notify(executor, string.Join(", ", candidates.Topics), executor);
 		}
 		else
 		{
 			await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.NewsNoNewsForTopic), executor, topic);
-			await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.NewsTryPattern), executor);
+			if (!isWildcard)
+			{
+				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.NewsTryPattern), executor);
+			}
 		}
 
 		return CallState.Empty;
@@ -117,7 +100,7 @@ public partial class Commands
 			return new CallState(ErrorMessages.Returns.PermissionDenied);
 		}
 
-		if (TextFileService == null)
+		if (HelpTopicResolver == null)
 		{
 			await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.AhelpSystemNotInitialized), executor);
 			return new CallState(ErrorMessages.Returns.AhelpSystemNotInitialized);
@@ -125,11 +108,10 @@ public partial class Commands
 
 		if (args.Count == 0)
 		{
-			var mainAhelp = await TextFileService.GetEntryAsync("ahelp", "ahelp");
+			var mainAhelp = await HelpTopicResolver.GetExactAsync(HelpCorpora.Admin, "ahelp");
 			if (mainAhelp != null)
 			{
-				var rendered = RecursiveMarkdownHelper.RenderMarkdown(mainAhelp);
-				await NotifyService!.Notify(executor, rendered, executor);
+				await NotifyService!.Notify(executor, RecursiveMarkdownHelper.RenderMarkdown(mainAhelp.Markdown), executor);
 			}
 			else
 			{
@@ -142,62 +124,46 @@ public partial class Commands
 
 		if (switches.Contains("SEARCH"))
 		{
-			var matches = (await TextFileService.SearchEntriesAsync("ahelp", topic)).ToList();
+			var matches = await HelpTopicResolver.SearchTopicsAsync(HelpCorpora.Admin, topic);
 			if (matches.Count == 0)
 			{
 				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.AhelpNoEntriesFoundContaining), executor, topic);
 			}
 			else if (matches.Count == 1)
 			{
-				var searchContent = await TextFileService.GetEntryAsync("ahelp", matches[0]);
+				var searchContent = await HelpTopicResolver.GetExactAsync(HelpCorpora.Admin, matches[0]);
 				if (searchContent != null)
 				{
-					var rendered = RecursiveMarkdownHelper.RenderMarkdown(searchContent);
-					await NotifyService!.Notify(executor, rendered, executor);
+					await NotifyService!.Notify(executor, RecursiveMarkdownHelper.RenderMarkdown(searchContent.Markdown), executor);
 				}
 			}
 			else
 			{
 				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.AhelpEntriesContaining), executor, topic);
-				await NotifyService!.Notify(executor, string.Join(", ", matches.OrderBy(x => x)), executor);
+				await NotifyService!.Notify(executor, string.Join(", ", matches), executor);
 			}
 			return CallState.Empty;
 		}
 
-		if (topic.Contains('*') || topic.Contains('?'))
-		{
-			var matches = (await TextFileService.SearchEntriesAsync("ahelp", topic)).ToList();
-			if (matches.Count == 0)
-			{
-				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.AhelpNoHelpForTopic), executor, topic);
-			}
-			else if (matches.Count == 1)
-			{
-				var wildcardContent = await TextFileService.GetEntryAsync("ahelp", matches[0]);
-				if (wildcardContent != null)
-				{
-					var rendered = RecursiveMarkdownHelper.RenderMarkdown(wildcardContent);
-					await NotifyService!.Notify(executor, rendered, executor);
-				}
-			}
-			else
-			{
-				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.AhelpTopicsMatchingFormat), executor, topic);
-				await NotifyService!.Notify(executor, string.Join(", ", matches.OrderBy(x => x)), executor);
-			}
-			return CallState.Empty;
-		}
+		var isWildcard = topic.Contains('*') || topic.Contains('?');
+		var resolution = await HelpTopicResolver.ResolveAsync(HelpCorpora.Admin, topic);
 
-		var exactContent = await TextFileService.GetEntryAsync("ahelp", topic);
-		if (exactContent != null)
+		if (resolution.TryPickT0(out var entry, out var notAnEntry))
 		{
-			var rendered = RecursiveMarkdownHelper.RenderMarkdown(exactContent);
-			await NotifyService!.Notify(executor, rendered, executor);
+			await NotifyService!.Notify(executor, RecursiveMarkdownHelper.RenderMarkdown(entry.Markdown), executor);
+		}
+		else if (notAnEntry.TryPickT0(out var candidates, out _))
+		{
+			await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.AhelpTopicsMatchingFormat), executor, topic);
+			await NotifyService!.Notify(executor, string.Join(", ", candidates.Topics), executor);
 		}
 		else
 		{
 			await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.AhelpNoHelpForTopic), executor, topic);
-			await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.AhelpTryPattern), executor);
+			if (!isWildcard)
+			{
+				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.AhelpTryPattern), executor);
+			}
 		}
 
 		return CallState.Empty;

--- a/SharpMUSH.Implementation/Services/HelpTopicResolver.cs
+++ b/SharpMUSH.Implementation/Services/HelpTopicResolver.cs
@@ -1,0 +1,141 @@
+using OneOf;
+using OneOf.Types;
+using SharpMUSH.Library.Services.Interfaces;
+using System.Text;
+
+namespace SharpMUSH.Implementation.Services;
+
+/// <summary>
+/// The one implementation of PennMUSH help-topic resolution. Both the in-game <c>help</c> command
+/// and the portal's read-only help API go through here, so a topic can never resolve to one entry
+/// on telnet and another in a browser.
+/// </summary>
+public sealed class HelpTopicResolver(ITextFileService textFiles) : IHelpTopicResolver
+{
+	/// <inheritdoc />
+	public async ValueTask<OneOf<HelpEntry, HelpCandidates, None>> ResolveAsync(string corpus, string topic)
+	{
+		if (string.IsNullOrWhiteSpace(topic))
+		{
+			return new None();
+		}
+
+		// A topic the reader wildcarded themselves is matched literally — no prefix or fuzzy fallback,
+		// because they already said what shape they wanted.
+		if (topic.Contains('*') || topic.Contains('?'))
+		{
+			return await NarrowAsync(corpus, await SearchAsync(corpus, topic));
+		}
+
+		// PennMUSH tries a prefix match first (name LIKE 'topic%', first alphabetically wins) and only
+		// falls back to the fuzzy pattern when that finds nothing.
+		var prefixMatches = await SearchAsync(corpus, topic + "*");
+		if (prefixMatches.Count > 0)
+		{
+			var entry = await GetExactAsync(corpus, prefixMatches[0]);
+			if (entry is not null)
+			{
+				return entry;
+			}
+		}
+
+		return await NarrowAsync(corpus, await SearchAsync(corpus, BuildFuzzyPattern(topic)));
+	}
+
+	/// <inheritdoc />
+	public async ValueTask<HelpEntry?> GetExactAsync(string corpus, string topic)
+	{
+		var content = await textFiles.GetEntryAsync(corpus, topic);
+		return content is null ? null : new HelpEntry(topic, content);
+	}
+
+	/// <inheritdoc />
+	public ValueTask<IReadOnlyList<string>> ListTopicsAsync(string corpus) => SearchTopicsAsync(corpus, "*");
+
+	/// <inheritdoc />
+	public ValueTask<IReadOnlyList<string>> SearchTopicsAsync(string corpus, string pattern) =>
+		SearchAsync(corpus, pattern);
+
+	/// <inheritdoc />
+	public async ValueTask<IReadOnlyList<string>> SearchContentAsync(string corpus, string searchTerm) =>
+		(await textFiles.SearchContentAsync(corpus, searchTerm))
+		.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+		.ToList();
+
+	private async ValueTask<IReadOnlyList<string>> SearchAsync(string corpus, string pattern) =>
+		(await textFiles.SearchEntriesAsync(corpus, pattern))
+		.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+		.ToList();
+
+	private async ValueTask<OneOf<HelpEntry, HelpCandidates, None>> NarrowAsync(
+		string corpus,
+		IReadOnlyList<string> matches)
+	{
+		switch (matches.Count)
+		{
+			case 0:
+				return new None();
+			case 1:
+				{
+					var entry = await GetExactAsync(corpus, matches[0]);
+					return entry is null ? new None() : entry;
+				}
+			default:
+				return new HelpCandidates(matches);
+		}
+	}
+
+	/// <summary>
+	/// Builds a fuzzy wildcard pattern from a plain topic string, matching PennMUSH's behavior:
+	/// <list type="bullet">
+	/// <item>Inserts <c>*</c> between words (at space boundaries)</item>
+	/// <item>Inserts <c>*</c> at transitions from alphabetic to digit characters</item>
+	/// </list>
+	/// Digit→alpha transitions do NOT get a wildcard (matches PennMUSH source).
+	/// </summary>
+	public static string BuildFuzzyPattern(string topic)
+	{
+		if (string.IsNullOrEmpty(topic))
+		{
+			return topic;
+		}
+
+		var sb = new StringBuilder();
+		const int StateNone = 0;
+		const int StateAlpha = 1;
+		const int StateDigit = 2;
+		var state = StateNone;
+
+		foreach (var c in topic)
+		{
+			if (char.IsWhiteSpace(c))
+			{
+				if (state != StateNone)
+				{
+					state = StateNone;
+					sb.Append('*');
+				}
+				sb.Append(c);
+			}
+			else if (char.IsAsciiDigit(c))
+			{
+				if (state == StateAlpha)
+				{
+					state = StateDigit;
+					sb.Append('*');
+				}
+				sb.Append(c);
+			}
+			else
+			{
+				if (state != StateAlpha)
+				{
+					state = StateAlpha;
+				}
+				sb.Append(c);
+			}
+		}
+
+		return sb.ToString();
+	}
+}

--- a/SharpMUSH.Implementation/Services/TextFileService.cs
+++ b/SharpMUSH.Implementation/Services/TextFileService.cs
@@ -68,7 +68,7 @@ public class TextFileService : ITextFileService
 	{
 		await _initializationTask.WithCancellation(CancellationToken.None);
 
-		var (category, _) = ParseFileReference(fileReference);
+		var category = ResolveEntryCategory(fileReference);
 
 		lock (_indexLock)
 		{
@@ -90,7 +90,7 @@ public class TextFileService : ITextFileService
 	{
 		await _initializationTask.WithCancellation(CancellationToken.None);
 
-		var (category, _) = ParseFileReference(fileReference);
+		var category = ResolveEntryCategory(fileReference);
 
 		IndexEntry? indexEntry = null;
 		lock (_indexLock)
@@ -166,7 +166,7 @@ public class TextFileService : ITextFileService
 	{
 		await _initializationTask.WithCancellation(CancellationToken.None);
 
-		var (category, _) = ParseFileReference(fileReference);
+		var category = ResolveEntryCategory(fileReference);
 		var regexPattern = "^" + Regex.Escape(pattern).Replace("\\*", ".*").Replace("\\?", ".") + "$";
 		var regex = new Regex(regexPattern, RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
@@ -193,7 +193,7 @@ public class TextFileService : ITextFileService
 	{
 		await _initializationTask.WithCancellation(CancellationToken.None);
 
-		var (category, _) = ParseFileReference(fileReference);
+		var category = ResolveEntryCategory(fileReference);
 
 		IEnumerable<KeyValuePair<string, IndexEntry>> entries;
 		lock (_indexLock)
@@ -387,6 +387,40 @@ public class TextFileService : ITextFileService
 		}
 
 		return content;
+	}
+
+	/// <summary>
+	/// Resolves the category an <em>entry</em> lookup is scoped to. A bare reference naming an
+	/// existing category is that category.
+	/// </summary>
+	/// <remarks>
+	/// Entry lookups never use the filename half of a reference — entries are keyed by the topic
+	/// headers inside the markdown, and one category's entries are indexed together regardless of
+	/// which file they came from. So <c>GetEntryAsync("help", …)</c> used to parse as
+	/// <c>(category: null, file: "help")</c> and fall through to "search every category", which let
+	/// <c>help Security</c> answer out of the wizard-only <c>ahelp</c> corpus. Resolving a bare
+	/// reference to the category of that name is what every caller — the HELP/NEWS/AHELP commands
+	/// and PennMUSH's <c>textfile()</c>/<c>textentries()</c> — already means by it. An unrecognised
+	/// reference still searches every category, which is the only way <c>textfile()</c> can be
+	/// asked for something outside the shipped set.
+	/// </remarks>
+	private string? ResolveEntryCategory(string fileReference)
+	{
+		var (category, fileName) = ParseFileReference(fileReference);
+		if (category is not null)
+		{
+			return category;
+		}
+
+		if (fileName is null)
+		{
+			return null;
+		}
+
+		lock (_indexLock)
+		{
+			return _categoryIndexes.ContainsKey(fileName) ? fileName : null;
+		}
 	}
 
 	private (string? Category, string? FileName) ParseFileReference(string fileReference)

--- a/SharpMUSH.Library/Definitions/HelpCorpora.cs
+++ b/SharpMUSH.Library/Definitions/HelpCorpora.cs
@@ -1,0 +1,21 @@
+namespace SharpMUSH.Library.Definitions;
+
+/// <summary>
+/// The shipped text-file corpora, by the category directory name they live under in
+/// <c>TextFiles/</c>. These are the game's help files, not wiki content: the wiki holds the
+/// game's editable world content, and these hold the engine documentation the server ships.
+/// </summary>
+public static class HelpCorpora
+{
+	/// <summary>General help. Readable by anyone, in game and in the portal.</summary>
+	public const string Help = "help";
+
+	/// <summary>
+	/// Administrator help. The in-game <c>ahelp</c> command refuses non-wizards, so every other
+	/// surface that reads this corpus has to refuse them too.
+	/// </summary>
+	public const string Admin = "ahelp";
+
+	/// <summary>Game news. Readable by anyone.</summary>
+	public const string News = "news";
+}

--- a/SharpMUSH.Library/Services/Interfaces/IHelpTopicResolver.cs
+++ b/SharpMUSH.Library/Services/Interfaces/IHelpTopicResolver.cs
@@ -1,0 +1,56 @@
+using OneOf;
+using OneOf.Types;
+
+namespace SharpMUSH.Library.Services.Interfaces;
+
+/// <summary>A single resolved help entry: the canonical topic name and its markdown body.</summary>
+/// <param name="Topic">The topic name as indexed, not as the caller spelled it.</param>
+/// <param name="Markdown">The raw markdown body, exactly as the engine hands it to the renderer.</param>
+public sealed record HelpEntry(string Topic, string Markdown);
+
+/// <summary>Several topics matched and none of them is the answer on its own.</summary>
+/// <param name="Topics">Candidate topic names, ordered case-insensitively.</param>
+public sealed record HelpCandidates(IReadOnlyList<string> Topics);
+
+/// <summary>
+/// Resolves a help topic the way the game's <c>help</c> command does: literal wildcards first,
+/// then a prefix match, then PennMUSH's fuzzy pattern.
+/// </summary>
+/// <remarks>
+/// This exists so the portal and the telnet game cannot drift. <c>help @mail</c> typed at a telnet
+/// prompt and <c>/help/@mail</c> opened in the portal run the same resolution over the same index —
+/// there is deliberately no second implementation to keep in step.
+/// <para>
+/// A "corpus" is a text-file category directory (<c>help</c>, <c>ahelp</c>, <c>news</c>). Resolution
+/// never crosses corpora: <c>ahelp</c> is administrator-only in game, so a <c>help</c> lookup that
+/// could fall through to it would be a disclosure bug, not a convenience.
+/// </para>
+/// </remarks>
+public interface IHelpTopicResolver
+{
+	/// <summary>
+	/// Resolves <paramref name="topic"/> within <paramref name="corpus"/>.
+	/// </summary>
+	/// <param name="corpus">Category directory to search — <c>help</c>, <c>ahelp</c>, <c>news</c>.</param>
+	/// <param name="topic">What the reader asked for; may contain <c>*</c> and <c>?</c> wildcards.</param>
+	/// <returns>
+	/// The entry when exactly one thing matches, the candidate list when several do, or
+	/// <see cref="None"/> when nothing does.
+	/// </returns>
+	ValueTask<OneOf<HelpEntry, HelpCandidates, None>> ResolveAsync(string corpus, string topic);
+
+	/// <summary>Fetches one entry by its exact indexed name, without any fuzzy fallback.</summary>
+	ValueTask<HelpEntry?> GetExactAsync(string corpus, string topic);
+
+	/// <summary>Every topic name in the corpus, ordered case-insensitively.</summary>
+	ValueTask<IReadOnlyList<string>> ListTopicsAsync(string corpus);
+
+	/// <summary>
+	/// Topic <em>names</em> matching a glob pattern (<c>*</c>, <c>?</c>), ordered case-insensitively.
+	/// This is a name match, not a body search — see <see cref="SearchContentAsync"/> for that.
+	/// </summary>
+	ValueTask<IReadOnlyList<string>> SearchTopicsAsync(string corpus, string pattern);
+
+	/// <summary>Topic names whose bodies contain <paramref name="searchTerm"/>, ordered case-insensitively.</summary>
+	ValueTask<IReadOnlyList<string>> SearchContentAsync(string corpus, string searchTerm);
+}

--- a/SharpMUSH.Server/Controllers/HelpController.cs
+++ b/SharpMUSH.Server/Controllers/HelpController.cs
@@ -1,0 +1,174 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using SharpMUSH.Documentation.MarkdownToAsciiRenderer;
+using SharpMUSH.Library.Definitions;
+using SharpMUSH.Library.Services.Interfaces;
+using SharpMUSH.Server.Authentication;
+using System.Text;
+using System.Web;
+
+namespace SharpMUSH.Server.Controllers;
+
+/// <summary>
+/// Read-only REST access to the help files the server ships — the same corpus the telnet
+/// <c>help</c> command answers from, resolved by the same <see cref="IHelpTopicResolver"/>.
+/// <code>
+///   GET /api/help                    — the general index entry plus every topic name
+///   GET /api/help/entry?topic=@mail  — resolve one topic
+///   GET /api/help/admin              — the ahelp index (Wizard/God only)
+///   GET /api/help/admin/entry?topic= — resolve one admin topic (Wizard/God only)
+/// </code>
+/// </summary>
+/// <remarks>
+/// Help is deliberately <b>not</b> wiki content. The wiki holds the game's editable world content;
+/// these files ship with the server and are edited in the repository, so importing them into the
+/// wiki would put engine documentation behind the wiki's edit/revision/protection machinery and
+/// let a game's local edits silently diverge from the engine they document. The portal reads them
+/// straight from <c>TextFiles/</c> instead.
+/// <para>
+/// Topics are keyed by the markdown headers inside the files, never by filename — <c>@mail</c> is a
+/// topic, <c>sharpmail</c> is only the file it happens to live in. Because topic names include
+/// <c>@mail</c>, <c>getting started</c>, <c>%#</c> and <c>#-1 exception</c>, the topic travels as a
+/// query-string value rather than a path segment: several of those cannot survive a URL path at all.
+/// </para>
+/// <para>
+/// The admin corpus is gated at the same trust level the game gates it: <c>ahelp</c> answers
+/// "This command is for administrators only." to a mortal, so these routes answer 403.
+/// </para>
+/// </remarks>
+[ApiController]
+[Route("api/help")]
+[EnableRateLimiting("public-api")]
+[Produces("application/json")]
+public sealed class HelpController(IHelpTopicResolver resolver) : ControllerBase
+{
+	/// <summary>A corpus index: its own front-page entry, plus every topic name it holds.</summary>
+	public record HelpIndexDto(string Corpus, string? Topic, string? Html, IReadOnlyList<string> Topics);
+
+	/// <summary>
+	/// The outcome of resolving one topic. Exactly one of <paramref name="Topic"/> and a non-empty
+	/// <paramref name="Candidates"/> is populated; an outright miss is a 404 instead.
+	/// </summary>
+	public record HelpEntryDto(
+		string Corpus,
+		string RequestedTopic,
+		string? Topic,
+		string? Markdown,
+		string? Html,
+		IReadOnlyList<string> Candidates);
+
+	/// <summary>Portal URL for a topic in the general corpus.</summary>
+	public static string PublicTopicHref(string topic) => $"/help/{Uri.EscapeDataString(topic)}";
+
+	/// <summary>Portal URL for a topic in the admin corpus.</summary>
+	public static string AdminTopicHref(string topic) => $"/help/admin/{Uri.EscapeDataString(topic)}";
+
+	[HttpGet]
+	[AllowAnonymous]
+	public Task<ActionResult<HelpIndexDto>> Index() =>
+		BuildIndexAsync(HelpCorpora.Help, "help", PublicTopicHref);
+
+	[HttpGet("entry")]
+	[AllowAnonymous]
+	public Task<ActionResult<HelpEntryDto>> Entry([FromQuery] string? topic) =>
+		BuildEntryAsync(HelpCorpora.Help, topic, PublicTopicHref);
+
+	/// <summary>
+	/// The admin gate. Pinned to the account-session scheme rather than the default one: in
+	/// Development the default is <c>DebugAuth</c>, which authenticates every request as God, and a
+	/// gate that opens for anyone who points a browser at a dev server is not a gate. Requiring a
+	/// real session here also makes the refusal testable.
+	/// </summary>
+	private const string AdminScheme = AccountSessionAuthenticationHandler.SchemeName;
+
+	[HttpGet("admin")]
+	[Authorize(AuthenticationSchemes = AdminScheme, Roles = "Wizard,God")]
+	public Task<ActionResult<HelpIndexDto>> AdminIndex() =>
+		BuildIndexAsync(HelpCorpora.Admin, "ahelp", AdminTopicHref);
+
+	[HttpGet("admin/entry")]
+	[Authorize(AuthenticationSchemes = AdminScheme, Roles = "Wizard,God")]
+	public Task<ActionResult<HelpEntryDto>> AdminEntry([FromQuery] string? topic) =>
+		BuildEntryAsync(HelpCorpora.Admin, topic, AdminTopicHref);
+
+	/// <summary>
+	/// Bot-facing static HTML for one help entry, served by <c>BotPrerenderMiddleware</c> so
+	/// crawlers see the text instead of an empty SPA shell. Help files carry no locale dimension,
+	/// so unlike the wiki's prerender there are no hreflang alternates to emit.
+	/// </summary>
+	public static string GeneratePrerenderHtml(HelpEntry entry, string canonicalUrl, string siteName = "SharpMUSH")
+	{
+		var title = HttpUtility.HtmlEncode($"{entry.Topic} - {siteName} Help");
+		var description = HttpUtility.HtmlEncode(HelpHtmlRenderer.ExtractPlainText(entry.Markdown, 200));
+		var canonical = HttpUtility.HtmlEncode(canonicalUrl);
+
+		var sb = new StringBuilder();
+		sb.AppendLine("<!DOCTYPE html>");
+		sb.AppendLine("<html lang=\"en\">");
+		sb.AppendLine("<head>");
+		sb.AppendLine("  <meta charset=\"utf-8\" />");
+		sb.AppendLine($"  <title>{title}</title>");
+		sb.AppendLine($"  <link rel=\"canonical\" href=\"{canonical}\" />");
+		sb.AppendLine($"  <meta name=\"description\" content=\"{description}\" />");
+		sb.AppendLine($"  <meta property=\"og:title\" content=\"{title}\" />");
+		sb.AppendLine($"  <meta property=\"og:description\" content=\"{description}\" />");
+		sb.AppendLine("  <meta property=\"og:type\" content=\"article\" />");
+		sb.AppendLine($"  <meta property=\"og:url\" content=\"{canonical}\" />");
+		sb.AppendLine("</head>");
+		sb.AppendLine("<body>");
+		sb.AppendLine($"  <h1>{HttpUtility.HtmlEncode(entry.Topic)}</h1>");
+		sb.AppendLine($"  {HelpHtmlRenderer.RenderToHtml(entry.Markdown, PublicTopicHref)}");
+		sb.AppendLine("</body>");
+		sb.AppendLine("</html>");
+		return sb.ToString();
+	}
+
+	private async Task<ActionResult<HelpIndexDto>> BuildIndexAsync(
+		string corpus,
+		string indexTopic,
+		Func<string, string> href)
+	{
+		var topics = await resolver.ListTopicsAsync(corpus);
+		var index = await resolver.GetExactAsync(corpus, indexTopic);
+
+		return Ok(new HelpIndexDto(
+			corpus,
+			index?.Topic,
+			index is null ? null : HelpHtmlRenderer.RenderToHtml(index.Markdown, href),
+			topics));
+	}
+
+	private async Task<ActionResult<HelpEntryDto>> BuildEntryAsync(
+		string corpus,
+		string? topic,
+		Func<string, string> href)
+	{
+		if (string.IsNullOrWhiteSpace(topic))
+		{
+			return BadRequest("A topic is required.");
+		}
+
+		var resolution = await resolver.ResolveAsync(corpus, topic);
+
+		if (resolution.TryPickT0(out var entry, out var notAnEntry))
+		{
+			return Ok(new HelpEntryDto(
+				corpus,
+				topic,
+				entry.Topic,
+				entry.Markdown,
+				HelpHtmlRenderer.RenderToHtml(entry.Markdown, href),
+				[]));
+		}
+
+		// Several topics matched. That is an answer, not a failure — the reader picks one — so it
+		// is a 200 with the candidate list rather than a 404 the portal would have to special-case.
+		if (notAnEntry.TryPickT0(out var candidates, out _))
+		{
+			return Ok(new HelpEntryDto(corpus, topic, null, null, null, candidates.Topics));
+		}
+
+		return NotFound(new HelpEntryDto(corpus, topic, null, null, null, []));
+	}
+}

--- a/SharpMUSH.Server/Middleware/BotPrerenderMiddleware.cs
+++ b/SharpMUSH.Server/Middleware/BotPrerenderMiddleware.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using SharpMUSH.Library.Definitions;
 using SharpMUSH.Library.Models.Wiki;
 using SharpMUSH.Library.Services;
 using SharpMUSH.Library.Services.Interfaces;
@@ -111,18 +112,21 @@ public sealed class BotPrerenderMiddleware(
 		}
 		else if (path.StartsWith("/help/", StringComparison.OrdinalIgnoreCase))
 		{
+			// Help is the shipped helpfile corpus, not a wiki namespace: this used to look the topic
+			// up as a wiki slug, which never matched anything on a fresh game. The admin corpus
+			// (/help/admin/…) is deliberately absent — a crawler is anonymous, and `ahelp` is
+			// wizard-only in game.
+			// HttpRequest.Path is already percent-decoded, so "%20" has become a space by now.
 			var topic = path["/help/".Length..].Trim('/');
-			if (!string.IsNullOrEmpty(topic))
+			if (!string.IsNullOrEmpty(topic) && !topic.Contains('/'))
 			{
-				var result = await wikiService.GetBySlugAsync(topic, WikiHelpers.DefaultCategory, WikiNamespace.Help);
-				if (result.IsT0 && result.AsT0.Published)
+				var resolver = scope.ServiceProvider.GetRequiredService<IHelpTopicResolver>();
+				var resolution = await resolver.ResolveAsync(HelpCorpora.Help, topic);
+				if (resolution.TryPickT0(out var entry, out _))
 				{
-					var page = result.AsT0;
-					html = WikiController.GeneratePrerenderHtml(
-						await localization.LocalizeAsync(page, normalizedLang, includeDrafts: false),
-						$"{canonicalBase}/help/{topic}",
-						await localization.GetVisibleLocalesAsync(page, includeDrafts: false),
-						localization.DefaultLocale);
+					html = HelpController.GeneratePrerenderHtml(
+						entry,
+						$"{canonicalBase}{HelpController.PublicTopicHref(entry.Topic)}");
 				}
 			}
 		}

--- a/SharpMUSH.Server/Middleware/CanonicalUrlMiddleware.cs
+++ b/SharpMUSH.Server/Middleware/CanonicalUrlMiddleware.cs
@@ -68,7 +68,8 @@ public sealed partial class CanonicalUrlMiddleware(RequestDelegate next, ILogger
 	/// <summary>
 	/// Produces the canonical form of a path:
 	/// 1. Lowercase the first path segment prefix (e.g. /Wiki → /wiki).
-	/// 2. Percent-decode then replace spaces with underscores in each segment.
+	/// 2. Percent-decode then replace spaces with underscores in each segment — except below
+	///    <c>/help</c>, whose tail is a help topic rather than a slug and is left verbatim.
 	/// 3. Strip trailing slash (except root "/").
 	/// 4. Rewrite a character biography's wiki route to its /character/{slug} alias.
 	/// </summary>
@@ -81,10 +82,21 @@ public sealed partial class CanonicalUrlMiddleware(RequestDelegate next, ILogger
 			path = path[..^1];
 
 		var segments = path.Split('/');
+
+		// Help topics are not slugs. They are the markdown headers inside the shipped helpfiles, and
+		// they genuinely contain spaces ("getting started"), case ("MAIL") and punctuation ("@mail",
+		// "#-1 exception"). Slugifying them would 301 every one of those to a topic that does not
+		// exist, so below /help only the prefix itself is canonicalised.
+		var verbatimTail = segments.Length > 2
+			&& string.Equals(segments[1], "help", StringComparison.OrdinalIgnoreCase);
+
 		for (var i = 0; i < segments.Length; i++)
 		{
 			var seg = segments[i];
 			if (string.IsNullOrEmpty(seg))
+				continue;
+
+			if (i > 1 && verbatimTail)
 				continue;
 
 			var decoded = Uri.UnescapeDataString(seg);

--- a/SharpMUSH.Server/SharpMUSH.Server.csproj
+++ b/SharpMUSH.Server/SharpMUSH.Server.csproj
@@ -116,11 +116,15 @@
       <Link>TextFiles\help\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="..\TextFiles\news\*.md">
+    <!-- ahelp/ and news/ live under the same Helpfiles tree as help/. These used to point at a
+         top-level ..\TextFiles\ that does not exist in this repository, so the globs matched nothing
+         and a published server shipped an empty TextFiles/news and TextFiles/ahelp — the in-game
+         `news` and `ahelp` commands had no entries to find. -->
+    <None Include="..\SharpMUSH.Documentation\Helpfiles\SharpMUSH\news\*.md">
       <Link>TextFiles\news\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="..\TextFiles\ahelp\*.md">
+    <None Include="..\SharpMUSH.Documentation\Helpfiles\SharpMUSH\ahelp\*.md">
       <Link>TextFiles\ahelp\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/SharpMUSH.Server/Startup.cs
+++ b/SharpMUSH.Server/Startup.cs
@@ -354,6 +354,9 @@ public class Startup(
 
 		services.AddSingleton<ITextFileService, Implementation.Services.TextFileService>();
 		services.AddSingleton<ILocalizedTextFileService, Implementation.Services.LocalizedTextFileService>();
+		// Shared by the in-game HELP/NEWS/AHELP commands and the portal's /api/help endpoints, so a
+		// topic resolves identically at a telnet prompt and in a browser.
+		services.AddSingleton<IHelpTopicResolver, Implementation.Services.HelpTopicResolver>();
 
 		services.AddSingleton<ILibraryProvider<FunctionDefinition>, Functions>();
 		services.AddSingleton<ILibraryProvider<CommandDefinition>, Commands>();

--- a/SharpMUSH.Tests.BUnit/Pages/HelpPageTests.cs
+++ b/SharpMUSH.Tests.BUnit/Pages/HelpPageTests.cs
@@ -1,0 +1,303 @@
+using Bunit;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging.Abstractions;
+using MudBlazor.Services;
+using NSubstitute;
+using SharpMUSH.Client.Resources;
+using SharpMUSH.Client.Services;
+using SharpMUSH.Implementation.Services;
+using SharpMUSH.Library.Services.Interfaces;
+using SharpMUSH.Server.Controllers;
+using SharpMUSH.Tests.BUnit.Resources;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.RegularExpressions;
+
+namespace SharpMUSH.Tests.BUnit.Pages;
+
+/// <summary>
+/// A text-file index built from a dictionary instead of a directory, so the real
+/// <see cref="HelpTopicResolver"/> can run its actual matching over a corpus a test can state in
+/// four lines. Entry keys are topic names, exactly as the markdown-header indexer produces them.
+/// </summary>
+file sealed class DictionaryTextFileService(Dictionary<string, Dictionary<string, string>> corpora)
+	: ITextFileService
+{
+	private Dictionary<string, string>? Corpus(string reference) =>
+		corpora.TryGetValue(reference.Split('/')[0], out var entries) ? entries : null;
+
+	public Task<IEnumerable<string>> ListCategoriesAsync() =>
+		Task.FromResult<IEnumerable<string>>(corpora.Keys);
+
+	public Task<string> ListEntriesAsync(string fileReference, string separator = " ") =>
+		Task.FromResult(string.Join(separator, Corpus(fileReference)?.Keys ?? Enumerable.Empty<string>()));
+
+	public Task<string?> GetEntryAsync(string fileReference, string entryName)
+	{
+		var corpus = Corpus(fileReference);
+		return Task.FromResult(corpus is not null && corpus.TryGetValue(entryName, out var body) ? body : null);
+	}
+
+	public Task<IEnumerable<string>> ListFilesAsync(string? category = null) =>
+		Task.FromResult<IEnumerable<string>>([]);
+
+	public Task<string?> GetFileContentAsync(string fileReference) => Task.FromResult<string?>(null);
+
+	public Task<IEnumerable<string>> SearchEntriesAsync(string fileReference, string pattern)
+	{
+		var regex = new Regex(
+			"^" + Regex.Escape(pattern).Replace("\\*", ".*").Replace("\\?", ".") + "$",
+			RegexOptions.IgnoreCase);
+		return Task.FromResult<IEnumerable<string>>(
+			(Corpus(fileReference)?.Keys ?? Enumerable.Empty<string>()).Where(k => regex.IsMatch(k)).ToList());
+	}
+
+	public Task<IEnumerable<string>> SearchContentAsync(string fileReference, string searchTerm) =>
+		Task.FromResult<IEnumerable<string>>(
+			(Corpus(fileReference) ?? new Dictionary<string, string>())
+			.Where(kv => kv.Value.Contains(searchTerm, StringComparison.OrdinalIgnoreCase))
+			.Select(kv => kv.Key)
+			.ToList());
+
+	public Task ReindexAsync() => Task.CompletedTask;
+}
+
+/// <summary>
+/// Serves <c>/api/help*</c> by invoking the real <see cref="HelpController"/>, so the pages are
+/// tested against the shapes and the HTML the server actually produces rather than against a
+/// hand-written fixture that could drift from it.
+/// </summary>
+/// <remarks>
+/// The controller's <c>[Authorize(Roles = "Wizard,God")]</c> gate is framework-enforced and does not
+/// run here; that refusal is asserted over real HTTP in
+/// <c>SharpMUSH.Tests.Integration.Portal.HelpApiTests</c>. What this handler does honour is the
+/// <paramref name="isStaff"/> flag, so the page's own decision about whether to ask for the admin
+/// corpus can be observed.
+/// </remarks>
+file sealed class HelpApiHandler(IHelpTopicResolver resolver, bool isStaff) : HttpMessageHandler
+{
+	protected override async Task<HttpResponseMessage> SendAsync(
+		HttpRequestMessage request, CancellationToken cancellationToken)
+	{
+		var controller = new HelpController(resolver);
+		var path = request.RequestUri!.AbsolutePath.TrimStart('/');
+		var topic = System.Web.HttpUtility.ParseQueryString(request.RequestUri.Query)["topic"];
+
+		if (path.StartsWith("api/help/admin", StringComparison.Ordinal) && !isStaff)
+		{
+			return new HttpResponseMessage(HttpStatusCode.Forbidden);
+		}
+
+		object? result = path switch
+		{
+			"api/help" => (await controller.Index()).Result,
+			"api/help/entry" => (await controller.Entry(topic)).Result,
+			"api/help/admin" => (await controller.AdminIndex()).Result,
+			"api/help/admin/entry" => (await controller.AdminEntry(topic)).Result,
+			_ => null
+		};
+
+		return result switch
+		{
+			OkObjectResult ok => Json(ok.Value!, HttpStatusCode.OK),
+			NotFoundObjectResult missing => Json(missing.Value!, HttpStatusCode.NotFound),
+			_ => new HttpResponseMessage(HttpStatusCode.NotFound)
+		};
+	}
+
+	private static HttpResponseMessage Json(object value, HttpStatusCode status) =>
+		new(status) { Content = JsonContent.Create(value, value.GetType()) };
+}
+
+/// <summary>
+/// The portal help pages, rendered against the real help API.
+/// </summary>
+/// <remarks>
+/// These pages used to render <c>WikiView</c> against slugs no install ever seeds, so <c>/help</c>
+/// showed "This page does not exist yet. You can create it…" to every visitor on a fresh game. The
+/// assertions below are about what a reader actually sees: real index content, a real entry, a
+/// disambiguation list, a plain miss — and never an invitation to author a wiki page.
+/// </remarks>
+public class HelpPageTests : BunitContext
+{
+	private const string IndexBody = """
+		# help
+		This is the index to the MUSH online help files.
+		For an explanation of the help system, type: help [newbie]
+		""";
+
+	private const string MailBody = """
+		# MAIL
+		# @MAIL
+		@mail invokes the built-in MUSH mailer.
+		""";
+
+	private static readonly Dictionary<string, Dictionary<string, string>> Corpora = new()
+	{
+		["help"] = new(StringComparer.OrdinalIgnoreCase)
+		{
+			["help"] = IndexBody,
+			["newbie"] = "# newbie\nIf you are new to MUSHing…",
+			["MAIL"] = MailBody,
+			["@MAIL"] = MailBody,
+			["mail-sending"] = "# mail-sending\nHow to send mail.",
+			["mail-reading"] = "# mail-reading\nHow to read mail.",
+			["getting started"] = "# Getting Started\nA walkthrough.",
+		},
+		["ahelp"] = new(StringComparer.OrdinalIgnoreCase)
+		{
+			["ahelp"] = "# ahelp\nAdministrative help.",
+			["Security"] = "# Security\nWizard-only security notes.",
+		},
+	};
+
+	/// <summary>
+	/// Waits for rendered markup to contain <paramref name="expected"/>. Written as a throwing
+	/// assertion rather than a bool-returning lambda: bUnit's WaitForAssertion takes an Action, so a
+	/// lambda that merely *returns* false satisfies it immediately and waits for nothing.
+	/// </summary>
+	private static void WaitForMarkup(Bunit.IRenderedComponent<Microsoft.AspNetCore.Components.IComponent> cut, string expected) =>
+		cut.WaitForAssertion(() =>
+		{
+			if (!cut.Markup.Contains(expected, StringComparison.Ordinal))
+			{
+				throw new InvalidOperationException($"markup does not (yet) contain '{expected}'");
+			}
+		}, TimeSpan.FromSeconds(5));
+
+	private void AddHelpServices(bool isStaff)
+	{
+		var resolver = new HelpTopicResolver(new DictionaryTextFileService(Corpora));
+		var client = new HttpClient(new HelpApiHandler(resolver, isStaff))
+		{
+			BaseAddress = new Uri("https://localhost:8081/")
+		};
+
+		var factory = Substitute.For<IHttpClientFactory>();
+		factory.CreateClient("api").Returns(client);
+
+		Services
+			.AddSingleton(client)
+			.AddMudServices()
+			.AddSingleton(factory)
+			.AddSingleton(sp => new GameHelpService(
+				sp.GetRequiredService<IHttpClientFactory>(),
+				NullLogger<GameHelpService>.Instance))
+			.AddSingleton<IStringLocalizer<SharedResource>, EchoLocalizer<SharedResource>>();
+
+		JSInterop.Mode = JSRuntimeMode.Loose;
+	}
+
+	[TUnit.Core.Test]
+	public async Task Index_RendersTheShippedIndexAndEveryTopic()
+	{
+		AddHelpServices(isStaff: false);
+		this.AddAuthorization();
+
+		var cut = Render<SharpMUSH.Client.Pages.Help>();
+		WaitForMarkup(cut, "This is the index to the MUSH online help files.");
+
+		await Assert.That(cut.Markup).Contains("This is the index to the MUSH online help files.");
+		await Assert.That(cut.Markup).Contains("href=\"/help/mail-sending\"");
+		await Assert.That(cut.Markup).Contains("href=\"/help/getting%20started\"");
+		await Assert.That(cut.Markup).DoesNotContain("does not exist yet")
+			.Because("help is not wiki content — there is nothing here for a reader to create");
+	}
+
+	[TUnit.Core.Test]
+	public async Task Index_OmitsTheAdminCorpusForAMortal()
+	{
+		AddHelpServices(isStaff: false);
+		this.AddAuthorization().SetAuthorized("mortal");
+
+		var cut = Render<SharpMUSH.Client.Pages.Help>();
+		WaitForMarkup(cut, "This is the index to the MUSH online help files.");
+
+		await Assert.That(cut.Markup).DoesNotContain("href=\"/help/admin/Security\"");
+	}
+
+	[TUnit.Core.Test]
+	public async Task Index_ListsTheAdminCorpusForStaff()
+	{
+		AddHelpServices(isStaff: true);
+		this.AddAuthorization().SetAuthorized("headwiz").SetRoles("Wizard");
+
+		var cut = Render<SharpMUSH.Client.Pages.Help>();
+		WaitForMarkup(cut, "href=\"/help/admin/Security\"");
+
+		await Assert.That(cut.Markup).Contains("href=\"/help/admin/Security\"");
+	}
+
+	[TUnit.Core.Test]
+	[Arguments("@mail", "@mail invokes the built-in MUSH mailer.")]
+	[Arguments("getting started", "A walkthrough.")]
+	[Arguments("newbie", "If you are new to MUSHing")]
+	public async Task Topic_RendersTheResolvedEntry(string topic, string expected)
+	{
+		AddHelpServices(isStaff: false);
+		this.AddAuthorization();
+
+		var cut = Render<SharpMUSH.Client.Pages.HelpTopic>(p => p.Add(c => c.Topic, topic));
+		WaitForMarkup(cut, expected);
+
+		await Assert.That(cut.Markup).Contains(expected);
+	}
+
+	[TUnit.Core.Test]
+	public async Task Topic_OffersTheCandidatesWhenSeveralMatch()
+	{
+		AddHelpServices(isStaff: false);
+		this.AddAuthorization();
+
+		var cut = Render<SharpMUSH.Client.Pages.HelpTopic>(p => p.Add(c => c.Topic, "mail-*"));
+		WaitForMarkup(cut, "href=\"/help/mail-reading\"");
+
+		await Assert.That(cut.Markup).Contains("href=\"/help/mail-reading\"");
+		await Assert.That(cut.Markup).Contains("href=\"/help/mail-sending\"");
+	}
+
+	[TUnit.Core.Test]
+	public async Task Topic_SaysNoSuchTopicRatherThanOfferingToCreateOne()
+	{
+		AddHelpServices(isStaff: false);
+		this.AddAuthorization();
+
+		var cut = Render<SharpMUSH.Client.Pages.HelpTopic>(p => p.Add(c => c.Topic, "nosuchtopicxyz"));
+		WaitForMarkup(cut, "HelpNoSuchTopic");
+
+		await Assert.That(cut.Markup).Contains("HelpNoSuchTopic");
+		await Assert.That(cut.Markup).DoesNotContain("does not exist yet");
+	}
+
+	/// <summary>
+	/// The admin page renders below <c>AuthorizeRouteView</c> in bUnit, so its <c>[Authorize]</c>
+	/// has no runtime effect here and a redirect test would prove nothing. What is worth asserting
+	/// is that the page reads the admin corpus rather than the general one — a mortal reaching it
+	/// gets the server's 403, which this handler reproduces, and sees an error rather than content.
+	/// </summary>
+	[TUnit.Core.Test]
+	public async Task AdminTopic_ReadsTheAdminCorpus()
+	{
+		AddHelpServices(isStaff: true);
+		this.AddAuthorization().SetAuthorized("headwiz").SetRoles("Wizard");
+
+		var cut = Render<SharpMUSH.Client.Pages.HelpAdminTopic>(p => p.Add(c => c.Topic, "Security"));
+		WaitForMarkup(cut, "Wizard-only security notes.");
+
+		await Assert.That(cut.Markup).Contains("Wizard-only security notes.");
+	}
+
+	[TUnit.Core.Test]
+	public async Task AdminTopic_ShowsNoContentWhenTheServerRefuses()
+	{
+		AddHelpServices(isStaff: false);
+		this.AddAuthorization().SetAuthorized("mortal");
+
+		var cut = Render<SharpMUSH.Client.Pages.HelpAdminTopic>(p => p.Add(c => c.Topic, "Security"));
+		WaitForMarkup(cut, "HelpLoadFailed");
+
+		await Assert.That(cut.Markup).DoesNotContain("Wizard-only security notes.");
+	}
+}

--- a/SharpMUSH.Tests.BUnit/Pages/WikiRoutePageTests.cs
+++ b/SharpMUSH.Tests.BUnit/Pages/WikiRoutePageTests.cs
@@ -383,31 +383,5 @@ public class CharacterRouteTests : BunitContext
 	}
 }
 
-public class HelpRouteTests : BunitContext
-{
-	public HelpRouteTests()
-	{
-		this.AddWikiTestServices();
-	}
-
-	[TUnit.Core.Test]
-	public async Task HelpIndex_RendersWikiViewWithHelpIndexSlug()
-	{
-		var cut = Render<SharpMUSH.Client.Pages.Help>();
-
-		var wikiView = cut.FindComponent<WikiView>();
-		await Assert.That(wikiView).IsNotNull();
-		await Assert.That(wikiView.Instance.Slug).IsEqualTo("help-index");
-	}
-
-	[TUnit.Core.Test]
-	public async Task HelpTopic_RendersWikiViewWithParameterSlug()
-	{
-		var cut = Render<SharpMUSH.Client.Pages.HelpTopic>(p => p
-				.Add(c => c.Slug, "commands"));
-
-		var wikiView = cut.FindComponent<WikiView>();
-		await Assert.That(wikiView).IsNotNull();
-		await Assert.That(wikiView.Instance.Slug).IsEqualTo("commands");
-	}
-}
+// The /help routes no longer render WikiView: help is the shipped helpfile corpus, not a wiki
+// namespace. Their coverage lives in HelpPageTests.

--- a/SharpMUSH.Tests.Integration/Portal/HelpApiTests.cs
+++ b/SharpMUSH.Tests.Integration/Portal/HelpApiTests.cs
@@ -1,0 +1,247 @@
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NSubstitute.Core;
+using OneOf;
+using SharpMUSH.Documentation.MarkdownToAsciiRenderer;
+using SharpMUSH.Library.DiscriminatedUnions;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Services.Interfaces;
+using SharpMUSH.Tests.Infrastructure;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+
+namespace SharpMUSH.Tests.Integration.Portal;
+
+/// <summary>
+/// The portal's read-only help API over real HTTP.
+///
+/// The point of this suite is the parity test: the portal used to answer help out of the wiki, so a
+/// fresh game showed "This page does not exist yet" at <c>/help</c> while <c>help</c> at a telnet
+/// prompt printed a full index. The fix is that both surfaces now run the same
+/// <see cref="IHelpTopicResolver"/> over the same files, and <see cref="GameAndPortalResolveTheSameEntry"/>
+/// asserts that rather than trusting it.
+/// </summary>
+[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+public class HelpApiTests(ServerWebAppFactory factory)
+{
+	private record HelpIndexDto(string Corpus, string? Topic, string? Html, IReadOnlyList<string> Topics);
+
+	private record HelpEntryDto(
+		string Corpus,
+		string RequestedTopic,
+		string? Topic,
+		string? Markdown,
+		string? Html,
+		IReadOnlyList<string> Candidates);
+
+	private record AccountRegisterRequest(string Username, string? Email, string Password);
+
+	private record AccountLoginResponse(string AccountId, string Username, string AccountSessionToken, string Role);
+
+	private IMUSHCodeParser Parser => factory.CommandParser;
+	private INotifyService NotifyService => factory.Services.GetRequiredService<INotifyService>();
+	private IConnectionService ConnectionService => factory.Services.GetRequiredService<IConnectionService>();
+
+	/// <summary>
+	/// Pinned to https: the server redirects http→https, and HttpClient drops the Authorization
+	/// header when it follows that 307.
+	/// </summary>
+	private HttpClient CreateClient()
+	{
+		var http = factory.CreateHttpClient();
+		http.BaseAddress = new Uri("https://localhost/");
+		return http;
+	}
+
+	[Test]
+	public async Task Index_ServesTheShippedCorpusNotAnEmptyWikiPage()
+	{
+		var http = CreateClient();
+		var response = await http.GetAsync("api/help");
+
+		await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+		var index = await response.Content.ReadFromJsonAsync<HelpIndexDto>();
+		await Assert.That(index).IsNotNull();
+		await Assert.That(index!.Topic).IsEqualTo("help");
+		await Assert.That(index.Topics.Count).IsGreaterThan(500)
+			.Because("the shipped corpus indexes over a thousand topics; a handful would mean it is reading the wrong directory");
+		await Assert.That(index.Html).IsNotNull();
+		await Assert.That(index.Html!).Contains("This is the index to the MUSH online help files.");
+	}
+
+	/// <summary>
+	/// The index's <c>[newbie]</c>-style references must come back as portal links, escaped, so a
+	/// reader can actually click through to the awkward ones.
+	/// </summary>
+	[Test]
+	public async Task Index_LinksTopicReferencesIntoPortalUrls()
+	{
+		var http = CreateClient();
+		var index = await http.GetFromJsonAsync<HelpIndexDto>("api/help");
+
+		await Assert.That(index!.Html!).Contains("href=\"/help/newbie\"");
+		await Assert.That(index.Html!).Contains("href=\"/help/getting%20started\"");
+	}
+
+	[Test]
+	[Arguments("@mail", "@MAIL")]
+	[Arguments("mail-sending", "MAIL-SENDING")]
+	[Arguments("getting started", "Getting Started")]
+	[Arguments("NEWBIE", "newbie")]
+	public async Task Entry_ResolvesTopicsWhoseNamesFightWithUrls(string requested, string expectedTopic)
+	{
+		var http = CreateClient();
+		var response = await http.GetAsync($"api/help/entry?topic={Uri.EscapeDataString(requested)}");
+
+		await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+		var entry = await response.Content.ReadFromJsonAsync<HelpEntryDto>();
+		await Assert.That(entry!.Topic).IsEqualTo(expectedTopic);
+		await Assert.That(entry.Markdown).IsNotNull();
+		await Assert.That(entry.Html).IsNotNull();
+	}
+
+	[Test]
+	public async Task Entry_UnknownTopicIs404NotAnInviteToWriteOne()
+	{
+		var http = CreateClient();
+		var response = await http.GetAsync("api/help/entry?topic=nosuchtopicxyz123");
+
+		await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+
+		var entry = await response.Content.ReadFromJsonAsync<HelpEntryDto>();
+		await Assert.That(entry!.Topic).IsNull();
+		await Assert.That(entry.Candidates.Count).IsEqualTo(0);
+	}
+
+	[Test]
+	public async Task Entry_AmbiguousTopicReturnsCandidates()
+	{
+		var http = CreateClient();
+		var response = await http.GetAsync("api/help/entry?topic=help*");
+
+		await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+		var entry = await response.Content.ReadFromJsonAsync<HelpEntryDto>();
+		await Assert.That(entry!.Topic).IsNull();
+		await Assert.That(entry.Candidates).Contains("helpfile");
+		await Assert.That(entry.Candidates.Count).IsGreaterThan(1);
+	}
+
+	/// <summary>
+	/// The whole point of the change: <c>help @mail</c> at a telnet prompt and
+	/// <c>GET /api/help/entry?topic=@mail</c> must be the same entry, not two systems that happen to
+	/// look similar. Asserted by rendering the API's markdown through the game's own ASCII renderer
+	/// and comparing it to what the command actually notified.
+	/// </summary>
+	[Test]
+	[Arguments("@mail")]
+	[Arguments("getting started")]
+	[Arguments("newbie")]
+	public async Task GameAndPortalResolveTheSameEntry(string topic)
+	{
+		var http = CreateClient();
+		var entry = await http.GetFromJsonAsync<HelpEntryDto>(
+			$"api/help/entry?topic={Uri.EscapeDataString(topic)}");
+		await Assert.That(entry!.Markdown).IsNotNull();
+
+		var before = NotifyCount();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"help {topic}"));
+		var notified = NotifiedSince(before);
+
+		var expected = RecursiveMarkdownHelper.RenderMarkdown(entry.Markdown!).ToString();
+
+		await Assert.That(notified).Contains(expected)
+			.Because($"'help {topic}' in game and /help/{topic} in the portal must reach the same entry");
+	}
+
+	/// <summary>
+	/// Corpus isolation. <c>Security</c> exists only in the wizard-only <c>ahelp</c> files; the
+	/// general corpus must not fall through to it. Before the corpus scoping fix a bare "help"
+	/// reference searched every category, so a mortal typing <c>help security</c> got the admin entry.
+	/// </summary>
+	[Test]
+	public async Task PublicCorpus_DoesNotFallThroughToAdminOnlyTopics()
+	{
+		var resolver = factory.Services.GetRequiredService<IHelpTopicResolver>();
+
+		var admin = await resolver.GetExactAsync("ahelp", "Security");
+		await Assert.That(admin).IsNotNull()
+			.Because("the admin corpus has to actually be indexed for this test to mean anything");
+
+		var http = CreateClient();
+		var response = await http.GetAsync("api/help/entry?topic=Security");
+
+		await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+	}
+
+	[Test]
+	public async Task AdminCorpus_RefusedToAnonymous()
+	{
+		var http = CreateClient();
+
+		await Assert.That((await http.GetAsync("api/help/admin")).StatusCode)
+			.IsEqualTo(HttpStatusCode.Unauthorized);
+		await Assert.That((await http.GetAsync("api/help/admin/entry?topic=Security")).StatusCode)
+			.IsEqualTo(HttpStatusCode.Unauthorized);
+	}
+
+	/// <summary>
+	/// A freshly registered account controls no characters, so it derives no Wizard role — the
+	/// portal equivalent of the mortal that <c>ahelp</c> answers "This command is for administrators
+	/// only." to.
+	/// </summary>
+	[Test]
+	public async Task AdminCorpus_RefusedToMortal()
+	{
+		var http = CreateClient();
+		var register = await http.PostAsJsonAsync(
+			"api/auth/account-register",
+			new AccountRegisterRequest($"help{Guid.NewGuid():N}"[..18], null, "Help-Test-Pw-1!"));
+		await Assert.That(register.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+		var account = await register.Content.ReadFromJsonAsync<AccountLoginResponse>();
+		http.DefaultRequestHeaders.Authorization =
+			new AuthenticationHeaderValue("Bearer", account!.AccountSessionToken);
+
+		// Sanity: the same token reads general help perfectly well, so a 403 below is the corpus
+		// gate and not a broken session.
+		await Assert.That((await http.GetAsync("api/help")).StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+		await Assert.That((await http.GetAsync("api/help/admin")).StatusCode)
+			.IsEqualTo(HttpStatusCode.Forbidden);
+		await Assert.That((await http.GetAsync("api/help/admin/entry?topic=Security")).StatusCode)
+			.IsEqualTo(HttpStatusCode.Forbidden);
+	}
+
+	private int NotifyCount() =>
+		NotifyService.ReceivedCalls().Count(c => c.GetMethodInfo().Name == nameof(INotifyService.Notify));
+
+	private IReadOnlyList<string> NotifiedSince(int count) =>
+		NotifyService.ReceivedCalls()
+			.Select(MessageTextOf)
+			.OfType<string>()
+			.Skip(count)
+			.ToList();
+
+	private static string? MessageTextOf(ICall call)
+	{
+		if (call.GetMethodInfo().Name != nameof(INotifyService.Notify))
+		{
+			return null;
+		}
+
+		var args = call.GetArguments();
+		return args.Length < 2
+			? null
+			: args[1] switch
+			{
+				OneOf<MString, string> oneOf => oneOf.Match(m => m.ToString(), s => s),
+				MString mstring => mstring.ToString(),
+				string text => text,
+				_ => null
+			};
+	}
+}

--- a/docs/design/url-strategy.md
+++ b/docs/design/url-strategy.md
@@ -21,8 +21,9 @@ non-API routes (standard WASM hosting pattern).
 /scenes                     Scene archive (completed, public)
 /scenes/42                  Scene archive detail (numeric ID permalink)
 /scenes/active              Active scenes list
-/help                       Help file index
-/help/Topic_Name            Help file page
+/help                       Help file index (the server's shipped helpfile corpus)
+/help/{topic}               Help file entry, by topic (e.g. /help/@mail)
+/help/admin/{topic}         Administrator (ahelp) entry — Wizard/God only
 /login                      Login page
 /register                   Registration page
 ```
@@ -73,8 +74,35 @@ non-API routes (standard WASM hosting pattern).
 - Underscores replace spaces in the slug; lookup is case-insensitive
 - Display always shows the page's canonical title (original case)
 - Special characters in slugs are percent-encoded
-- `/help/{topic}` and `/character/{name}` are aliases resolving to the `help`
-  and `character` namespaces at the default `general` category
+- `/character/{name}` is an alias resolving to the `character` namespace at the
+  default `general` category
+- `/help/...` is **not** a wiki route. See "Help files" below.
+
+### Help files
+
+The help pages serve the helpfile corpus the server ships (`TextFiles/help`,
+`TextFiles/ahelp`) — the same files, resolved by the same `IHelpTopicResolver`,
+that the in-game `help` and `ahelp` commands answer from. They are not wiki
+pages and are never imported into the wiki: the wiki holds the game's editable
+world content, and engine documentation shipped with the release does not belong
+to a game's editable content.
+
+- A path segment under `/help` is a **topic**, not a slug. Topics are the
+  markdown headers inside the helpfiles (`@mail`, `getting started`,
+  `mail-sending`), never filenames.
+- Because topics carry spaces, case and punctuation that matter, `CanonicalUrlMiddleware`
+  leaves everything below `/help/` verbatim: no slugification, no case folding.
+  Link to a topic with `Uri.EscapeDataString`.
+- `/help/admin/{topic}` reads the `ahelp` corpus and is refused to anyone below
+  Wizard, matching the in-game command.
+- The backing API is `GET /api/help`, `GET /api/help/entry?topic=…`, and their
+  `/api/help/admin` counterparts. The topic travels as a query value because
+  topic names include `%#`, `#-1 exception` and `?`, which a path segment cannot
+  carry intact.
+
+Two wiki pages do live in the `Help` namespace — the Markdown Guide and the
+Application Schema Guide, both seeded at startup. They document the *portal's*
+wiki, not the engine, and stay at `/wiki/help/general/{slug}`.
 
 ### Locale
 


### PR DESCRIPTION
**PR 9 of a 10-PR stack.** Targets `fix/audit2-08-portal-layouts-profiles`, not `main`. Review the diff against that base.

## The finding

The portal and the game had two disjoint help systems.

Telnet `help` answers from the shipped corpus — 16 markdown files under `SharpMUSH.Documentation/Helpfiles/SharpMUSH/`, present in the server publish output at `TextFiles/help/`, **1573 topics**, a real index.

The portal answered from the wiki, and came up empty:

- `Pages/Help.razor` rendered `<WikiView Slug="help-index" />`. No install seeds a page called `help-index`, so a fresh game showed *"This page does not exist yet. You can create it by clicking the button below."* to every visitor, God included.
- `Pages/HelpTopic.razor` rendered `<WikiView Slug="@Slug" />`, which resolves in the `main` namespace — while the two seeded help pages live in the `help` namespace. So `/help/markdown_guide` missed those too.

## Why the wiki was the wrong backing store

Per the repo owner: *"The help files on the game generally are only relevant on the game. But we can likely link in the SharpMUSH helpfiles, but they would and should not be part of the wiki."*

The wiki is the game's **editable world content** — revisions, protection, per-locale translations, rollback. The helpfiles are **engine documentation that ships with the release** and is edited in this repository. Importing them would put 1573 engine topics behind the wiki's edit machinery and let a game's local edits silently diverge from the engine they document, with no way to take an upstream correction. So: nothing is imported, no `help-index` page is seeded, and the two genuinely-wiki pages in the `Help` namespace (Markdown Guide, Application Schema Guide — they document the *portal's* wiki) stay exactly where they are at `/wiki/help/general/{slug}`.

## How topic resolution is shared with the engine

The lookup was inline in `HelpCommand.Help`. It is now `IHelpTopicResolver` (`SharpMUSH.Library/Services/Interfaces/IHelpTopicResolver.cs`) with one implementation (`SharpMUSH.Implementation/Services/HelpTopicResolver.cs`), holding the PennMUSH algorithm lifted verbatim: literal wildcards first, then a prefix match (`topic*`, first alphabetically), then the fuzzy pattern (`*` at word boundaries and alpha→digit transitions).

`HELP`, `NEWS`, `AHELP`/`ANEWS` and `HelpController` all call it. There is deliberately no second implementation to keep in step. Entries are keyed by the markdown **topic headers**, never by filename — `@mail` is a topic, `sharpmail` is only the file it lives in — because that is what the resolver reads.

Unifying it also means `news welcome` and `ahelp sec` get the prefix/fuzzy matching `help` always had, which is what the shipped helpfile documents: *"These commands and switches also work with other things using our helpfile setup: news, ahelp, and any others added."*

### URL encoding

Topic names include `@mail`, `getting started`, `mail-sending`, `%#`, `#-1 exception` and a bare `?`. Several of those cannot survive a URL path segment, so **the topic travels as a query value**: `GET /api/help/entry?topic=%40mail`. The portal route stays `/help/{Topic}` (percent-encoded by `Uri.EscapeDataString`) because that is the canonical route in `url-strategy.md`, and Blazor's router decodes path segments before binding.

`CanonicalUrlMiddleware` had to change for this: it slugified every segment under `/help/`, so `/help/getting started` would have 301'd to `/help/getting_started` — a topic that does not exist. Below `/help/` the tail is now left verbatim.

## `ahelp` / `news`

**Both were broken in the published server, independently of the portal.** `SharpMUSH.Server.csproj` copied them from a top-level `..\TextFiles\` that does not exist in this repository, so the globs matched nothing and a published server shipped an empty `TextFiles/news` and `TextFiles/ahelp`. The in-game `news` and `ahelp` commands had no entries to find. Fixed to point at the real directories; the test projects already had the correct paths, which is why no test caught it.

```
$ ls -R publish/TextFiles          # after the fix
TextFiles/ahelp:  ahelp.md  security.md
TextFiles/help:   markdown.md ... sharpwiki.md      (16 files)
TextFiles/news:   news.md  welcome.md
```

Portal surface:

- **`help`** — public, at `/help` and `/help/{topic}`. This is the finding.
- **`ahelp`** — surfaced, but gated. Listed on `/help` only for Wizard/God, read at `/help/admin/{topic}`, served by `/api/help/admin*`.
- **`news`** — publish copy fixed so the in-game command works, but no portal page. The portal has no news feature to hang it on, and adding one is a feature rather than a fix to this finding.

### Gating, and the disclosure bug it uncovered

`ahelp` in game answers *"Permission denied. This command is for administrators only."* to a mortal, so the API answers 401/403. The gate is pinned to the `AccountSession` scheme rather than the default — in Development the default is `DebugAuth`, which authenticates *every* request as God, and a gate that opens for anyone who points a browser at a dev server is not a gate. It also makes the refusal testable.

Making `ahelp` reachable exposed a second bug that had to be fixed in the same PR. `GetEntryAsync("help", …)` parsed `"help"` as a *filename*, and a filename with no category searches **every** category — so once `TextFiles/ahelp` actually existed, `help Security` in game would have answered out of the wizard-only corpus. A bare reference naming an existing category now scopes to that category (`TextFileService.ResolveEntryCategory`).

## Rendered evidence

Verified in headless Chromium against a **published** Server + Client on one origin, `ASPNETCORE_ENVIRONMENT=Production` (so no debug auth provider), ArangoDB + NATS in Podman.

```
$ curl -s localhost:8090/api/help | jq '{corpus,topic,topics:(.topics|length)}'
{
  "corpus": "help",
  "topic": "help",
  "topics": 1573
}
```

`/help` renders the real index:

```
help

This is the index to the MUSH online help files.
For an explanation of the help system, type:    help newbie
For a walkthrough of SharpMUSH systems, type:   help getting started
For help finding the helpfile you want:         help helpfile
For the list of MUSH commands, type:            help commands
For the list of MUSH topics, type:              help topics
For an alphabetical list of all help entries:   help entries
For information about SharpMUSH:                help code
For a list of flags:                            help flag list
...
```

…followed by a filterable list of all 1573 topics. Every `[topic]` reference in the body is a working portal link, escaped:

```html
help <a href="/help/newbie">newbie</a><br>
help <a href="/help/getting%20started">getting started</a><br>
```

`/help/@mail` — the awkward one — renders the full MAIL entry with its nine see-also topics as links:

```
HELP / @MAIL
@mail

MAIL
  - @mail[/<switches>] [<msg-list>[=<target>]]
  - @mail[/<switches>] <player-list>=[<subject>/]<message>
@mail invokes the built-in MUSH mailer, which allows players to send and receive
mail. Pronoun/function substitution is performed on any messages you may try to send.
...
See Also:
  mail-sending  mail-reading  mail-folders  mail-forward  mail-other
  mail-admin    @malias       mail-reviewing  @mailquota
```

Awkward topics over real HTTP:

```
200  @mail                200  %#
200  getting started      200  #-1 exception
200  mail-sending         200  ?
404  nosuchtopicxyz       (deliberate miss — "No entry for 'nosuchtopicxyz'.")
```

`/help/mail-*` renders a disambiguation list: `MAIL-ADMIN  MAIL-FOLDERS  MAIL-OTHER  MAIL-READING  MAIL-REVIEWING  MAIL-SENDING`.

Gating, live, in Production:

```
anon   GET /api/help/admin                        -> 401
anon   GET /api/help/admin/entry?topic=Security   -> 401
anon   GET /api/help/entry?topic=Security         -> 404   (public corpus does not leak ahelp)
mortal GET /api/help                              -> 200   (same token reads general help)
mortal GET /api/help/admin                        -> 403
God    GET /api/help/admin                        -> 200, renders under "Administrator help"
```

### 4xx from `/api/wiki/*` on these routes

Every network request the browser made on `/help`, `/help/@mail`, `/help/getting%20started`, `/help/mail-sending`, `/help/mail-*` and `/help/admin/Security`, as anonymous and as God:

```
wiki calls: (none)
4xx/5xx:    (none)
```

**10 → 0.** Previously `/help` alone produced `GET /api/wiki/ns/main/general/help-index → 404`, and each topic route another `/api/wiki/ns/main/general/{slug} → 404`.

## Test numbers

| Suite | Result |
|---|---|
| `SharpMUSH.Tests` (full) | **5401 total, 0 failed**, 5209 succeeded, 192 skipped |
| `SharpMUSH.Tests.BUnit` (full) | **474 total, 0 failed** |
| `SharpMUSH.Tests.BUnit` → `HelpPageTests` (new) | **10 total, 0 failed** |
| `SharpMUSH.Tests.Integration` (full) | **318 total, 0 failed**, 0 skipped |
| `SharpMUSH.Tests.Integration` → `HelpApiTests` (new) | **14 total, 0 failed** |
| `dotnet build` (whole solution, format gate on) | **0 errors**, 32 warnings — all pre-existing (`CS0067` in existing bUnit fakes, `NU1603`/`MSB3277` reference conflicts); none in a file this PR touches |
| `python3 tools/i18n/validate_resx.py` | **all gates passed**, 16 locales at 100% (1126 keys each) |

`TreatWarningsAsErrors` untouched; no suppressions added.

### The tests that matter

- **`GameAndPortalResolveTheSameEntry`** (`@mail`, `getting started`, `newbie`) — fetches the entry over HTTP, runs `help <topic>` through the real command parser, renders the API's markdown through the *game's own* ASCII renderer, and asserts the game notified exactly that. This is the claim the PR is making, asserted rather than eyeballed.
- **`AdminCorpus_RefusedToMortal`** — registers a real account (no characters ⇒ no Wizard role), confirms the same token reads `/api/help` fine, then asserts 403 on both admin routes. Plus `AdminCorpus_RefusedToAnonymous` for 401.
- **`PublicCorpus_DoesNotFallThroughToAdminOnlyTopics`** — proves `Security` is indexed in `ahelp`, then asserts `/api/help/entry?topic=Security` is 404. This is the disclosure bug above.
- **`Entry_ResolvesTopicsWhoseNamesFightWithUrls`** — `@mail`→`@MAIL`, `mail-sending`→`MAIL-SENDING`, `getting started`→`Getting Started`, `NEWBIE`→`newbie`.
- **bUnit `HelpPageTests`** — 10 tests driving the pages against the *real* `HelpController` and the *real* `HelpTopicResolver` (only the text-file index is a dictionary), so the DTOs and rendered HTML cannot drift from the server's. Page components render below `AuthorizeRouteView` in bUnit, so `[Authorize]` has no runtime effect there; instead of a redirect test that would prove nothing, these assert behaviour — that the index renders real content and never the words "does not exist yet", that a mortal's index omits the admin links, that staff's lists them, and that the admin topic page shows nothing when the server refuses.

The old `HelpRouteTests`, which asserted `WikiView.Slug == "help-index"`, is deleted — it pinned the bug.

## Found but left out of scope

- **`<msg-list>` placeholders vanish in prose.** Several helpfiles write `*<msg-list>*` outside a code span; CommonMark parses `<msg-list>` as raw HTML, so it disappears. **The game already does this** — its ASCII renderer drops unrecognised HTML inlines too — so parity is preserved and the portal is not making it worse. The fix is in the helpfiles (backtick the placeholders), a content edit across 16 files that wants its own PR.
- **`news/search` and `ahelp/search` do a name match while `help/search` does a body search**, though the shipped `helpfile` topic documents the same behaviour for all three. Left alone: changing it is a behaviour change unrelated to this finding.
- **`docs/design/front-page-and-navigation.md` plans a `HelpSearchProvider` at `/api/help/search`** for omnisearch. Not implemented, and this PR's route namespace leaves room for it. `IHelpTopicResolver.SearchContentAsync` is already the backing call when someone builds it.
- **A route-focus feature puts `tabindex="-1"` on each page's `<h1>` and focuses it**, so every page renders with a browser focus ring around its title. Pre-existing and global (`/characters` and `/wiki` do it too), not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MPRzndB5egy4F2A3q5852
