### PR TITLE
Approve characters before they can be part of a scene

### DIFF
--- a/SharpMUSH.Database.ArangoDB/Migrations/Migration_AddApprovedFlag.cs
+++ b/SharpMUSH.Database.ArangoDB/Migrations/Migration_AddApprovedFlag.cs
@@ -1,0 +1,49 @@
+using Core.Arango;
+using Core.Arango.Migration;
+
+namespace SharpMUSH.Database.ArangoDB.Migrations;
+
+/// <summary>
+/// Adds the engine-level <c>APPROVED</c> player flag: "this character has cleared whatever bar this
+/// game sets for full participation". The engine ships the flag and the predicate that reads it
+/// (<c>HelperFunctions.IsApproved</c> / the <c>isapproved()</c> function) and deliberately ships NO
+/// policy for what earns it — a game decides that and sets the flag however it likes.
+///
+/// <para>Royalty-settable rather than wizard-settable so staff below wizard can run an approval
+/// queue, matching the other staff-managed player flags (JUDGE, UNREGISTERED).</para>
+///
+/// <para>Runs on fresh and existing databases alike — an UPSERT keyed on the flag name, so a
+/// database that somehow already carries an APPROVED flag is updated rather than duplicated. The
+/// Memgraph and SurrealDB providers reach the same end through their always-run idempotent flag
+/// seeds; only Arango needs a migration id.</para>
+/// </summary>
+public class Migration_AddApprovedFlag : IArangoMigration
+{
+	public long Id => 20260808_001;
+
+	public string Name => "add_approved_flag";
+
+	public async Task Up(IArangoMigrator migrator, ArangoHandle handle) =>
+		await migrator.Context.Query.ExecuteAsync<object>(
+			handle,
+			"UPSERT { Name: @name } INSERT @doc UPDATE @doc IN @@c",
+			bindVars: new Dictionary<string, object>
+			{
+				{ "@c", DatabaseConstants.ObjectFlags },
+				{ "name", "APPROVED" },
+				{
+					"doc", new
+					{
+						Name = "APPROVED",
+						Aliases = (string[])[],
+						Symbol = "+",
+						System = true,
+						SetPermissions = DatabaseConstants.permissionsRoyalty,
+						UnsetPermissions = DatabaseConstants.permissionsRoyalty,
+						TypeRestrictions = DatabaseConstants.typesPlayer
+					}
+				}
+			});
+
+	public Task Down(IArangoMigrator migrator, ArangoHandle handle) => Task.CompletedTask;
+}

--- a/SharpMUSH.Database.Memgraph/MemgraphDatabase.Migration.cs
+++ b/SharpMUSH.Database.Memgraph/MemgraphDatabase.Migration.cs
@@ -369,6 +369,7 @@ MERGE (o)-[:HAS_FLAG]->(f)
 		{
 ("WIZARD", "W", null, ["trusted","wizard","log"], ["trusted","wizard"], ["ROOM","PLAYER","EXIT","THING"]),
 ("ABODE", "A", null, [], [], ["ROOM"]),
+("APPROVED", "+", null, ["royalty"], ["royalty"], ["PLAYER"]),
 ("ANSI", "A", null, [], [], ["PLAYER"]),
 ("CHOWN_OK", "C", null, [], [], ["ROOM","PLAYER","THING"]),
 ("COLOR", "C", ["COLOUR"], [], [], ["PLAYER"]),

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Migration.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Migration.cs
@@ -405,6 +405,7 @@ public partial class SurrealDatabase
 		{
 			("WIZARD", "W", null, ["trusted","wizard","log"], ["trusted","wizard"], ["ROOM","PLAYER","EXIT","THING"]),
 			("ABODE", "A", null, [], [], ["ROOM"]),
+			("APPROVED", "+", null, ["royalty"], ["royalty"], ["PLAYER"]),
 			("ANSI", "A", null, [], [], ["PLAYER"]),
 			("CHOWN_OK", "C", null, [], [], ["ROOM","PLAYER","THING"]),
 			("COLOR", "C", ["COLOUR"], [], [], ["PLAYER"]),

--- a/SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpflag.md
+++ b/SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpflag.md
@@ -57,7 +57,7 @@ Note: The object type (player, thing, room, exit or garbage) is not actually a f
 | n | No_command | o | On-vacation | p | Puppet |
 | r | Royalty | s | Suspect | t | Transparent |
 | u | Uninspected | v | Verbose | w | No_warn |
-| x | Cloudy/Terse |
+| x | Cloudy/Terse | + | Approved |  |  |
 
 Additional Flags:
 * Chan_usefirstmatch
@@ -101,6 +101,22 @@ ANSI highlight can also be enabled on a per-connection basis with `@sockset`.
 - [XTERM256]
 - [@config]
 - [@sockset]
+
+# APPROVED
+
+**Flag: APPROVED (players)**
+
+Marks a character as approved: it has cleared whatever bar this game sets for full participation. Royalty and above can set and unset it.
+
+SharpMUSH ships the flag and the `isapproved()` predicate — "royalty or above, or APPROVED" — and deliberately ships no policy for what earns it. Each game decides that for itself (a finished chargen, a staff review, a waiting period) and sets the flag when its own bar is met. Nothing in the engine sets APPROVED on its own.
+
+Systems built on top of it use `isapproved()` rather than testing the flag directly, so staff are implicitly approved and a game that wants a different rule can change it in one place. The bundled `scene` package works this way: any character may browse the schedule and read scene information, but only an approved character may join, own, administer or otherwise be associated with a scene.
+
+
+**See Also:**
+- [isapproved()]
+- [ROYALTY]
+- [@flag]
 
 # AUDIBLE
 

--- a/SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpfunc.md
+++ b/SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpfunc.md
@@ -150,14 +150,14 @@ You say, "is"
 | [ctime()]        | [elock()]        | [findable()]     | [flags()]        |
 | [fullalias()]    | [fullname()]     | [getpids()]      | [hasattr()]      |
 | [hasattrp()]     | [hasflag()]      | [haspower()]     | [hastype()]      |
-| [iname()]        | [lflags()]       | [lock()]         | [lockflags()]    |
-| [lockowner()]    | [locks()]        | [lpids()]        | [lstats()]       |
-| [money()]        | [moniker()]      | [msecs()]        | [mtime()]        |
-| [mudname()]      | [mudurl()]       | [name()]         | [nattr()]        |
-| [nearby()]       | [objid()]        | [objmem()]       | [orflags()]      |
-| [orlflags()]     | [orlpowers()]    | [pidinfo()]      | [playermem()]    |
-| [poll()]         | [powers()]       | [quota()]        | [restarts()]     |
-| [type()]         | [version()]      | [visible()]      |                  |
+| [iname()]        | [isapproved()]   | [lflags()]       | [lock()]         |
+| [lockflags()]    | [lockowner()]    | [locks()]        | [lpids()]        |
+| [lstats()]       | [money()]        | [moniker()]      | [msecs()]        |
+| [mtime()]        | [mudname()]      | [mudurl()]       | [name()]         |
+| [nattr()]        | [nearby()]       | [objid()]        | [objmem()]       |
+| [orflags()]      | [orlflags()]     | [orlpowers()]    | [pidinfo()]      |
+| [playermem()]    | [poll()]         | [powers()]       | [quota()]        |
+| [restarts()]     | [type()]         | [version()]      | [visible()]      |
 
 **See Also:**
 - [Dbref functions]
@@ -2594,6 +2594,27 @@ You say, "meep GOOP bleep gleep"
 **See Also:**
 - [timezones]
 - [secs()]
+# ISAPPROVED()
+`isapproved(<object>)`
+
+  Returns 1 if `<object>` is royalty or above, or carries the APPROVED flag, and 0 otherwise. A guest is never approved, whatever else is set on it.
+
+  APPROVED is the engine's general "this character has cleared whatever bar this game sets for full participation" flag. The engine ships the flag and this predicate and deliberately ships no policy for what earns it — a game decides that and sets the flag however it likes (royalty and above can set and unset it).
+
+  Softcode and the server answer this question with the same code, so a game's `+`-verbs cannot drift from the engine's own checks. Games that want a different rule should wrap this in one function attribute and call that everywhere, rather than re-implementing the test.
+
+  Example:
+```sharp
+think isapproved(me)
+1
+&FUN`IS`APPROVED #100=isapproved(%0)
+```
+
+
+**See Also:**
+- [hasflag()]
+- [@flag]
+- [flags list]
 # ISDBREF()
 # ISOBJID()
 `isdbref(<string>)`<br>

--- a/SharpMUSH.Implementation/Commands/AccountSocketCommands.cs
+++ b/SharpMUSH.Implementation/Commands/AccountSocketCommands.cs
@@ -189,8 +189,8 @@ public partial class Commands
 
 		if (connectionData?.State != IConnectionService.ConnectionState.AccountMode)
 		{
-			await NotifyService!.Notify(handle,
-				"You must be logged in to an account first. Use: login <display-name-or-email> <password>");
+			await NotifyNotInAccountModeAsync(handle, connectionData?.State,
+				"Character creation happens from the account menu, before you enter the game.");
 			return new None();
 		}
 
@@ -273,8 +273,8 @@ public partial class Commands
 
 		if (connectionData?.State != IConnectionService.ConnectionState.AccountMode)
 		{
-			await NotifyService!.Notify(handle,
-				"You must be logged in to an account first. Use: login <display-name-or-email> <password>");
+			await NotifyNotInAccountModeAsync(handle, connectionData?.State,
+				"A telnet session plays one character for its whole life.");
 			return new None();
 		}
 
@@ -337,6 +337,27 @@ public partial class Commands
 		await NotifyService!.Notify(handle, "Access from your location is restricted.");
 		return true;
 	}
+
+	/// <summary>
+	/// Refuses an account-menu command (MAKE / PLAY) that arrived outside AccountMode, saying which of the
+	/// two very different reasons applies.
+	///
+	/// <para>Both surfaces used to answer "You must be logged in to an account first", which is only true
+	/// for a connection that has not authenticated. The other way in is a connection that is already
+	/// PLAYING: it authenticated, then bound a character, and left AccountMode by succeeding. Telling that
+	/// player to log in reads as a bug in their own session and invites them to try a login that will be
+	/// refused as well. Telnet is one session per character by design — no in-session character switching —
+	/// so the honest answer is that switching means reconnecting.</para>
+	/// </summary>
+	/// <param name="handle">The connection to notify.</param>
+	/// <param name="state">The connection's current state; <c>LoggedIn</c> selects the in-game wording.</param>
+	/// <param name="inGameReason">One sentence saying why this command has no meaning once in play.</param>
+	private static async ValueTask NotifyNotInAccountModeAsync(
+		long handle, IConnectionService.ConnectionState? state, string inGameReason) =>
+		await NotifyService!.Notify(handle, state is IConnectionService.ConnectionState.LoggedIn
+			? $"You are already playing a character. {inGameReason} " +
+				"To play a different one, disconnect and connect again."
+			: "You must be logged in to an account first. Use: login <display-name-or-email> <password>");
 
 	/// <summary>
 	/// PennMUSH-style refusal for a disabled <c>Net.PlayerCreation</c>: prefer the configured

--- a/SharpMUSH.Implementation/Functions/InformationFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/InformationFunctions.cs
@@ -393,6 +393,23 @@ public partial class Functions
 		return new CallState(hasPower);
 	}
 
+	/// <summary>
+	/// <c>isapproved(&lt;object&gt;)</c> — 1 when the object is royalty or above, or carries the
+	/// <c>APPROVED</c> flag; 0 otherwise (and always 0 for a guest). The softcode face of
+	/// <see cref="HelperFunctions.IsApproved"/>, so a game's <c>+</c>-verbs and the engine answer the
+	/// approval question with the same code rather than two copies of the same rule.
+	/// </summary>
+	[SharpFunction(Name = "isapproved", MinArgs = 1, MaxArgs = 1, Flags = FunctionFlags.Regular | FunctionFlags.StripAnsi, ParameterNames = ["object"])]
+	public static async ValueTask<CallState> IsApproved(IMUSHCodeParser parser, SharpFunctionAttribute _2)
+	{
+		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
+		var toLocate = parser.CurrentState.Arguments["0"].Message!.ToPlainText();
+
+		return await LocateService!.LocateAndNotifyIfInvalidWithCallStateFunction(
+			parser, executor, executor, toLocate, LocateFlags.All | LocateFlags.NoVisibilityCheck,
+			async found => new CallState(await found.IsApproved()));
+	}
+
 	[SharpFunction(Name = "hastype", MinArgs = 2, MaxArgs = 2, Flags = FunctionFlags.Regular | FunctionFlags.StripAnsi, ParameterNames = ["object", "type"])]
 	public static async ValueTask<CallState> HasType(IMUSHCodeParser parser, SharpFunctionAttribute _2)
 	{

--- a/SharpMUSH.Library/HelperFunctions.cs
+++ b/SharpMUSH.Library/HelperFunctions.cs
@@ -51,6 +51,19 @@ public static partial class HelperFunctions
 		=> await obj.HasPower("Guest");
 
 	/// <summary>
+	/// The one approval predicate: <b>royalty or above, or carrying the <c>APPROVED</c> flag</b> — and
+	/// never a guest, whatever else is true of it.
+	///
+	/// <para>The engine ships the rule, not the policy: what earns a character its <c>APPROVED</c> flag is
+	/// each game's decision, expressed by setting the flag. Softcode reaches this same method through the
+	/// <c>isapproved()</c> function, so a game's <c>+</c>-verbs and the C# side cannot drift into two
+	/// different answers.</para>
+	/// </summary>
+	public static async ValueTask<bool> IsApproved(this AnySharpObject obj)
+		=> !await obj.IsGuest()
+			&& (await obj.IsPriv() || await obj.HasFlag("APPROVED"));
+
+	/// <summary>
 	/// Evaluates an <c>@function/restrict</c> restriction string against <paramref name="executor"/>,
 	/// returning whether the executor is PERMITTED to call the function.
 	///

--- a/SharpMUSH.Library/Services/ManipulateSharpObjectService.cs
+++ b/SharpMUSH.Library/Services/ManipulateSharpObjectService.cs
@@ -317,10 +317,14 @@ public class ManipulateSharpObjectService(
 
 		var allPowers = mediator.CreateStream(new GetPowersQuery());
 
+		// Alias is declared non-nullable but the seeded powers store null for "no alias", so an unguarded
+		// x.Alias.Equals throws on the first aliasless power the stream yields — which, since the predicate
+		// runs over every power until one matches, made setting or clearing ANY power a NullReferenceException.
+		// GetPowerQueryHandler already guards the same comparison this way.
 		var found = await allPowers
 			.FirstOrDefaultAsync(x =>
 				x.Name.Equals(powerOrPowerAlias, StringComparison.InvariantCultureIgnoreCase)
-				|| x.Alias.Equals(powerOrPowerAlias, StringComparison.InvariantCultureIgnoreCase));
+				|| (x.Alias is not null && x.Alias.Equals(powerOrPowerAlias, StringComparison.InvariantCultureIgnoreCase)));
 
 		if (found is null)
 		{
@@ -385,10 +389,14 @@ public class ManipulateSharpObjectService(
 
 		var allPowers = mediator.CreateStream(new GetPowersQuery());
 
+		// Alias is declared non-nullable but the seeded powers store null for "no alias", so an unguarded
+		// x.Alias.Equals throws on the first aliasless power the stream yields — which, since the predicate
+		// runs over every power until one matches, made setting or clearing ANY power a NullReferenceException.
+		// GetPowerQueryHandler already guards the same comparison this way.
 		var found = await allPowers
 			.FirstOrDefaultAsync(x =>
 				x.Name.Equals(powerOrPowerAlias, StringComparison.InvariantCultureIgnoreCase)
-				|| x.Alias.Equals(powerOrPowerAlias, StringComparison.InvariantCultureIgnoreCase));
+				|| (x.Alias is not null && x.Alias.Equals(powerOrPowerAlias, StringComparison.InvariantCultureIgnoreCase)));
 
 		if (found is null)
 		{

--- a/SharpMUSH.Plugins.Scene/Functions/SceneFunctions.cs
+++ b/SharpMUSH.Plugins.Scene/Functions/SceneFunctions.cs
@@ -168,7 +168,21 @@ public static class SceneFunctions
 		var viewer = await ViewerDbrefAsync(parser);
 		var scenes = await service.ListScenesAsync(filter, viewer, from, to);
 
-		return new CallState(string.Join(" ", scenes.Select(s => s.Id)));
+		// Every other read function gates on SceneVisibleToAsync, so a private scene answers
+		// #-1 PERMISSION — but the storage's `active`/`finished`/`recent`/`scheduled` filters carry no
+		// visibility clause at all, so an ungated listing handed any player the id of every private
+		// scene in the game and let them count them. Ids are cheap to try; filter the listing through
+		// the same predicate the field reads use, so what a player can list is exactly what they can read.
+		var visible = new List<string>(scenes.Count);
+		foreach (var scene in scenes)
+		{
+			if (await SceneVisibleToAsync(service, scene, parser))
+			{
+				visible.Add(scene.Id);
+			}
+		}
+
+		return new CallState(string.Join(" ", visible));
 	}
 
 	/// <summary>

--- a/SharpMUSH.Tests.Integration/Integration/SceneRoleplayIntegrationTests.cs
+++ b/SharpMUSH.Tests.Integration/Integration/SceneRoleplayIntegrationTests.cs
@@ -164,13 +164,22 @@ public class SceneRoleplayIntegrationTests
 		return NotificationsSince(before);
 	}
 
-	/// <summary>Creates a non-God player, registers + binds a connection handle, returns its full objid.</summary>
+	/// <summary>
+	/// Creates a non-God player, registers + binds a connection handle, returns its full objid.
+	///
+	/// <para>The player is set APPROVED. Every character in this narrative is a full participant — they own,
+	/// join, administer and pose into scenes — and association with a scene requires approval since the
+	/// package's 1.6.0 guard. The refusal path is the subject of
+	/// <see cref="Scenes.SceneApprovalIntegrationTests"/>; here approval is fixture, not subject.</para>
+	/// </summary>
 	private async Task<string> CreatePlayerAsync(string name, string password, long handle)
 	{
 		await God1($"@pcreate {name}={password}");
 		var dbref = (await God1($"think [pmatch({name})]")).Message?.ToPlainText()?.Trim() ?? string.Empty;
 		if (string.IsNullOrEmpty(dbref) || dbref.StartsWith("#-") || !DBRef.TryParse(dbref, out var parsed))
 			throw new InvalidOperationException($"Failed to create player {name}; pmatch returned '{dbref}'.");
+
+		await God1($"@set {dbref}=APPROVED");
 
 		await ConnectionService.Register(handle, "localhost", "localhost", "test",
 			_ => ValueTask.CompletedTask, _ => ValueTask.CompletedTask, () => Encoding.UTF8);

--- a/SharpMUSH.Tests.Integration/Packages/ScenePackageTests.cs
+++ b/SharpMUSH.Tests.Integration/Packages/ScenePackageTests.cs
@@ -29,7 +29,7 @@ public class ScenePackageTests(ServerWebAppFactory factory)
 	{
 		var package = await Registry.GetInstalledPackageAsync("scene");
 		await Assert.That(package.IsT0).IsTrue();
-		await Assert.That(package.AsT0.Version).IsEqualTo("1.5.0");
+		await Assert.That(package.AsT0.Version).IsEqualTo("1.6.0");
 
 		var objects = await Registry.GetPackageObjectsAsync("scene");
 		await Assert.That(objects.Count).IsEqualTo(1);
@@ -43,6 +43,8 @@ public class ScenePackageTests(ServerWebAppFactory factory)
 		await Assert.That(attrs).Contains("CMD`CREATE");
 		await Assert.That(attrs).Contains("CMD`WHO");
 		await Assert.That(attrs).Contains("FUN`OWNS");
+		await Assert.That(attrs).Contains("FUN`IS`APPROVED");
+		await Assert.That(attrs).Contains("DATA`DENY_APPROVAL");
 		await Assert.That(attrs).Contains("AINSTALL");
 		await Assert.That(attrs).Contains("STARTUP");
 

--- a/SharpMUSH.Tests.Integration/Scenes/SceneApprovalIntegrationTests.cs
+++ b/SharpMUSH.Tests.Integration/Scenes/SceneApprovalIntegrationTests.cs
@@ -1,0 +1,368 @@
+using System.Text;
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NSubstitute.Core;
+using OneOf;
+using SharpMUSH.Library;
+using SharpMUSH.Library.DiscriminatedUnions;
+using SharpMUSH.Library.Extensions;
+using SharpMUSH.Library.Definitions;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.Queries.Database;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Services;
+using SharpMUSH.Library.Services.Interfaces;
+
+namespace SharpMUSH.Tests.Integration.Scenes;
+
+/// <summary>
+/// The approval boundary, end to end: the engine's <c>APPROVED</c> flag and <c>isapproved()</c> predicate,
+/// the bundled <c>scene</c> package's <c>+scene</c> verbs that consume them, and the wizard lockdown on the
+/// primitive <c>@scene</c> surface underneath.
+///
+/// <para>The rule under test: a CHARACTER is required for any scene participation, viewing is open to every
+/// character approved or not, and ASSOCIATION — joining, owning, administering, posing into a scene — needs
+/// approval. An unapproved character has no scenes and must not be able to acquire one by any route the
+/// package exposes. Guests are never approved, whatever else is set on them.</para>
+///
+/// <para>The negative assertions are the point. Each refused verb is checked twice: the player is told no,
+/// AND the membership list is re-read to prove nothing was written anyway.</para>
+/// </summary>
+[NotInParallel]
+public class SceneApprovalIntegrationTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactoryArg { get; init; }
+
+	private IMUSHCodeParser Parser => WebAppFactoryArg.CommandParser;
+	private IMUSHCodeParser FunctionParser => WebAppFactoryArg.FunctionParser;
+	private INotifyService NotifyService => WebAppFactoryArg.Services.GetRequiredService<INotifyService>();
+	private IConnectionService ConnectionService => WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
+
+	private static readonly string Tag = Guid.NewGuid().ToString("N")[..8];
+
+	/// <summary>The refusal the package's INC`REQUIRE`APPROVED guard emits.</summary>
+	private const string NotApproved = "You are not approved to take part in scenes.";
+
+	private async Task<string> Eval(string expression) =>
+		(await FunctionParser.FunctionParse(MModule.single(expression)))!.Message!.ToPlainText().Trim();
+
+	private async Task<CallState> God1(string command) =>
+		await Parser.CommandParse(1, ConnectionService, MModule.single(command));
+
+	private static string Num(string dbref)
+	{
+		var s = dbref.Trim();
+		var colon = s.IndexOf(':');
+		return colon < 0 ? s : s[..colon];
+	}
+
+	private async Task<string> EvalNum(string expression) => Num(await Eval(expression));
+
+	private static bool IsNotification(ICall call) =>
+		call.GetMethodInfo().Name is nameof(INotifyService.Notify) or nameof(INotifyService.NotifyLocalized);
+
+	private int NotificationCount() => NotifyService.ReceivedCalls().Count(IsNotification);
+
+	/// <summary>
+	/// One line of what a command said. Refusals travel by two different routes — a literal string through
+	/// <c>Notify</c>, or a resource KEY through <c>NotifyLocalized</c> (the engine's CommandLock refusal is
+	/// localized) — and a test that watches only one of them reads a real refusal as silence.
+	/// </summary>
+	private static string? ExtractMessageText(ICall call)
+	{
+		var args = call.GetArguments();
+		switch (call.GetMethodInfo().Name)
+		{
+			case nameof(INotifyService.Notify) when args.Length >= 2:
+				return args[1] switch
+				{
+					OneOf<MString, string> oneOf => oneOf.Match(m => m.ToPlainText(), s => s),
+					string s => s,
+					MString m => m.ToPlainText(),
+					_ => null
+				};
+			case nameof(INotifyService.NotifyLocalized) when args.Length >= 2:
+				return args[1] as string;
+			default:
+				return null;
+		}
+	}
+
+	/// <summary>Runs a command as a connection handle and returns everything it said, joined.</summary>
+	private async Task<string> RunAs(long handle, string command)
+	{
+		var before = NotificationCount();
+		await Parser.CommandParse(handle, ConnectionService, MModule.single(command));
+		var all = NotifyService.ReceivedCalls().Where(IsNotification).ToList();
+		return string.Join("\n", all.Skip(before).Select(ExtractMessageText).OfType<string>());
+	}
+
+	/// <summary>Evaluates an expression AS a player, by making them <c>think</c> it — real mortal softcode.</summary>
+	private async Task<string> EvalAs(long handle, string expression) =>
+		(await RunAs(handle, $"think {expression}")).Trim();
+
+	private async Task<string> CreatePlayerAsync(string name, long handle)
+	{
+		await God1($"@pcreate {name}=pw_{Tag}_123");
+		var dbref = (await God1($"think [pmatch({name})]")).Message?.ToPlainText()?.Trim() ?? string.Empty;
+		if (string.IsNullOrEmpty(dbref) || dbref.StartsWith("#-") || !DBRef.TryParse(dbref, out var parsed))
+			throw new InvalidOperationException($"Failed to create player {name}; pmatch returned '{dbref}'.");
+
+		await ConnectionService.Register(handle, "localhost", "localhost", "test",
+			_ => ValueTask.CompletedTask, _ => ValueTask.CompletedTask, () => Encoding.UTF8);
+		await ConnectionService.Bind(handle, parsed!.Value);
+		return dbref;
+	}
+
+	/// <summary>
+	/// Grants the Guest power. <c>@power</c> only administers power DEFINITIONS — it has no branch that sets
+	/// one on an object — and the <c>power()</c> side-effect function depends on a config switch, so the test
+	/// goes straight at the service the function would have called.
+	/// </summary>
+	private async Task GrantGuestPowerAsync(string playerDbref)
+	{
+		var mediator = WebAppFactoryArg.Services.GetRequiredService<IMediator>();
+		var manipulate = WebAppFactoryArg.Services.GetRequiredService<IManipulateSharpObjectService>();
+		DBRef.TryParse(playerDbref, out var parsed);
+		var god = (await mediator.Send(new GetObjectNodeQuery(new DBRef(1)))).Known;
+		var target = (await mediator.Send(new GetObjectNodeQuery(parsed!.Value))).Known;
+		await manipulate.SetPower(god, target, "Guest", false);
+	}
+
+	private async Task<IReadOnlyList<string>> MembersAsync(string sceneId) =>
+		(await Eval($"scenemembers({sceneId})"))
+			.Split(' ', StringSplitOptions.RemoveEmptyEntries).Select(Num).ToList();
+
+	[Test]
+	public async Task ApprovalBoundary_FullMatrix()
+	{
+		static void Log(string m) => Console.WriteLine(m);
+
+		await God1("@set #1=WIZARD");
+
+		// ---- 1. The predicate itself ------------------------------------------------------------
+		var approved = await CreatePlayerAsync($"App_{Tag}", 51L);
+		var unapproved = await CreatePlayerAsync($"Unapp_{Tag}", 52L);
+		var guest = await CreatePlayerAsync($"Guesty_{Tag}", 53L);
+
+		await God1($"@set {approved}=APPROVED");
+		await GrantGuestPowerAsync(guest);
+		// Deliberately ALSO flag the guest APPROVED: the guest term must win regardless.
+		await God1($"@set {guest}=APPROVED");
+		await Assert.That(await Eval($"haspower({guest}, Guest)")).IsEqualTo("1")
+			.Because("the rest of this beat is meaningless if the Guest power did not take");
+
+		await Assert.That(await Eval($"isapproved({approved})")).IsEqualTo("1")
+			.Because("the APPROVED flag makes an ordinary character approved");
+		await Assert.That(await Eval($"isapproved({unapproved})")).IsEqualTo("0")
+			.Because("a character with neither staff bit nor the flag is not approved");
+		await Assert.That(await Eval("isapproved(#1)")).IsEqualTo("1")
+			.Because("staff are implicitly approved — 'royalty or above, or approved'");
+		await Assert.That(await Eval($"isapproved({guest})")).IsEqualTo("0")
+			.Because("a guest is never approved even when the flag is set on it");
+		Log($"[PREDICATE] approved={approved} unapproved={unapproved} guest={guest} — all four answers correct");
+
+		// ---- 2. Stage: a room, the three players, and the Scene Logger co-located ----------------
+		var digOut = (await God1($"@dig ApprovalStage_{Tag}")).Message!.ToPlainText().Trim();
+		var roomDbref = Num(digOut);
+		foreach (var who in new[] { approved, unapproved, guest })
+			await God1($"@tel {who}={digOut}");
+
+		var registry = (IPackageRegistryService)WebAppFactoryArg.Services.GetRequiredService<ISharpDatabase>();
+		var packageObjects = await registry.GetPackageObjectsAsync("scene");
+		var loggerDbref = PackageInstallService.ParseObjid(packageObjects.Single().Objid)!.Value.ToString();
+		await God1($"@tel {loggerDbref}={digOut}");
+		await Assert.That(await EvalNum($"loc({loggerDbref})")).IsEqualTo(roomDbref);
+
+		// ---- 3. An APPROVED character may own a scene -------------------------------------------
+		var createOut = await RunAs(51L, $"+scene/create Approval Test {Tag}");
+		Log($"[CREATE approved] {createOut}");
+		var sceneId = await Eval($"get({approved}/MY.SID)");
+		await Assert.That(sceneId).IsNotEmpty().Because("an approved character may create and own a scene");
+		await Assert.That(sceneId).DoesNotStartWith("#-1");
+		await God1($"@scene/set {sceneId}/public=1");
+		await Assert.That(await EvalNum($"scene({sceneId}, owner)")).IsEqualTo(Num(approved));
+
+		// ---- 4. Every ASSOCIATING route is closed to an unapproved character ---------------------
+		// Each of these is a distinct way the package could hand out a membership edge.
+		var associatingVerbs = new (string Command, string What)[]
+		{
+			($"+scene/join {sceneId}", "join"),
+			($"+scene/tag {sceneId}", "RSVP"),
+			($"+scene/activate {sceneId}", "re-activate"),
+			("+scene/as The Interloper", "set a persona"),
+			($"+scene/create Sneaky {Tag}", "create/own"),
+			($"+scene/schedule Sneaky Later {Tag}=1893456000", "schedule/own")
+		};
+
+		foreach (var (command, what) in associatingVerbs)
+		{
+			var output = await RunAs(52L, command);
+			Log($"[REFUSED unapproved] {command} -> {output.Replace("\n", " | ")}");
+			await Assert.That(output).Contains(NotApproved)
+				.Because($"an unapproved character must be refused when trying to {what}");
+			await Assert.That(await MembersAsync(sceneId)).DoesNotContain(Num(unapproved))
+				.Because($"the refusal of {what} must also mean nothing was written");
+		}
+
+		await Assert.That(await MembersAsync(sceneId)).DoesNotContain(Num(unapproved))
+			.Because("no refused verb may leave a membership edge behind");
+		await Assert.That(await Eval($"scenefocus({unapproved})")).StartsWith("#-1")
+			.Because("an unapproved character is focused on nothing");
+		await Assert.That(await EvalAs(52L, "scenelist(mine)")).IsEmpty()
+			.Because("an unapproved character has no scenes");
+
+		// ---- 5. A GUEST is refused too, flag or no flag ------------------------------------------
+		var guestJoin = await RunAs(53L, $"+scene/join {sceneId}");
+		Log($"[REFUSED guest] +scene/join -> {guestJoin.Replace("\n", " | ")}");
+		await Assert.That(guestJoin).Contains(NotApproved)
+			.Because("guests never participate in scenes");
+		await Assert.That(await MembersAsync(sceneId)).DoesNotContain(Num(guest));
+
+		// ---- 6. Viewing stays OPEN to an unapproved character ------------------------------------
+		var browse = await RunAs(52L, "+scene");
+		Log($"[VIEW unapproved] +scene -> {browse.Replace("\n", " | ")[..Math.Min(160, browse.Replace("\n", " | ").Length)]}");
+		await Assert.That(browse).DoesNotContain(NotApproved)
+			.Because("browsing the scene list needs no approval");
+		await Assert.That(browse).Contains("Scenes:");
+
+		var upcoming = await RunAs(52L, "+scene/upcoming");
+		await Assert.That(upcoming).DoesNotContain(NotApproved)
+			.Because("viewing the schedule needs no approval");
+		await Assert.That(upcoming).Contains("Scheduled Scenes");
+
+		var info = await RunAs(52L, $"+scene {sceneId}");
+		Log($"[VIEW unapproved] +scene {sceneId} -> {info.Replace("\n", " | ")[..Math.Min(160, info.Replace("\n", " | ").Length)]}");
+		await Assert.That(info).DoesNotContain(NotApproved)
+			.Because("reading scene information needs no approval");
+		await Assert.That(info).Contains($"Scene {sceneId}");
+
+		// ---- 7. Approval is checked at POSE time, so revoking it stops capture immediately --------
+		var posesBefore = await Eval($"scene({sceneId}, posecount)");
+		await RunAs(51L, "pose tests that capture works while approved.");
+		var posesWhileApproved = await Eval($"scene({sceneId}, posecount)");
+		await Assert.That(int.Parse(posesWhileApproved)).IsGreaterThan(int.Parse(posesBefore))
+			.Because("an approved, focused character's pose is captured");
+
+		await God1($"@set {approved}=!APPROVED");
+		await Assert.That(await Eval($"isapproved({approved})")).IsEqualTo("0");
+		await RunAs(51L, "pose tests that capture stops the moment approval is revoked.");
+		var posesAfterRevoke = await Eval($"scene({sceneId}, posecount)");
+		Log($"[REVOKE] posecount before={posesBefore} approved={posesWhileApproved} after-revoke={posesAfterRevoke}");
+		await Assert.That(posesAfterRevoke).IsEqualTo(posesWhileApproved)
+			.Because("membership and focus survive revocation, so capture itself has to re-check approval");
+	}
+
+	[Test]
+	public async Task AtScene_Command_IsWizardOnly_ForEverySwitch()
+	{
+		await God1("@set #1=WIZARD");
+		var mortal = await CreatePlayerAsync($"Mortal_{Tag}", 61L);
+		await Assert.That(mortal).IsNotEmpty();
+
+		// The 18 action switches plus the bare (display) form. All 19 go through one wizard gate at the
+		// top of SceneCommandModule.Scene, so this pins that none of them grew a path around it.
+		string[] switches =
+		[
+			"list", "get", "create", "set", "addpose", "setpose", "editpose", "undo", "redo",
+			"move", "delete", "member", "unmember", "focus", "showas", "plot", "link", "unlink"
+		];
+
+		foreach (var name in switches)
+		{
+			var result = await Parser.CommandParse(61L, ConnectionService, MModule.single($"@scene/{name} something=else"));
+			await Assert.That(result.Message!.ToPlainText()).IsEqualTo("#-1 PERMISSION DENIED")
+				.Because($"@scene/{name} is wizard-only — players drive the system through +scene");
+		}
+
+		var bareResult = await Parser.CommandParse(61L, ConnectionService, MModule.single("@scene something"));
+		await Assert.That(bareResult.Message!.ToPlainText()).IsEqualTo("#-1 PERMISSION DENIED")
+			.Because("the bare display form is gated by the same check");
+
+		// And the player is told, not silently ignored. The FLAG^WIZARD CommandLock refuses first, so the
+		// message is the engine's localized PermissionDenied rather than the plugin's own SCENE: prefix —
+		// the plugin's explicit IsWizard() gate is the second line of defence behind it, not the first.
+		var refusalOutput = await RunAs(61L, "@scene/list");
+		await Assert.That(refusalOutput).Contains(nameof(ErrorMessages.Notifications.PermissionDenied))
+			.Because("a refused command has to say so");
+	}
+
+	[Test]
+	public async Task SceneWriteFunctions_AreUnreachableFromMortalSoftcode()
+	{
+		await God1("@set #1=WIZARD");
+		var mortal = await CreatePlayerAsync($"FnMortal_{Tag}", 62L);
+		var sceneId = await Eval($"scenecreate(,#1,Function Surface {Tag})");
+		await Assert.That(sceneId).DoesNotStartWith("#-1");
+
+		// Every write function carries FunctionFlags.WizardOnly, which the parser checks against the
+		// EXECUTOR. A player evaluating one in their own softcode is the executor, so all of these
+		// refuse — the command lock on @scene would be worthless if the functions did not.
+		var writes = new[]
+		{
+			$"scenecreate(,{mortal},Mortal Scene {Tag})",
+			$"sceneset({sceneId},status,active)",
+			$"sceneaddmember({sceneId},{mortal},participant)",
+			$"sceneunmember({sceneId},{mortal})",
+			$"scenesetfocus({mortal},{sceneId})",
+			$"sceneshowas({sceneId},{mortal},Sneaky)",
+			$"sceneaddpose({sceneId},{mortal},,{mortal},pose,,intruding)",
+			$"sceneplot(create,Mortal Plot {Tag}|desc|{mortal})"
+		};
+
+		foreach (var expression in writes)
+		{
+			var result = await EvalAs(62L, expression);
+			await Assert.That(result).StartsWith("#-1")
+				.Because($"{expression} is a wizard-only side-effect function and a player is not a wizard");
+		}
+
+		await Assert.That(await MembersAsync(sceneId)).DoesNotContain(Num(mortal))
+			.Because("no refused write function may have taken effect anyway");
+	}
+
+	[Test]
+	public async Task SceneList_DoesNotLeakPrivateSceneIdsToNonMembers()
+	{
+		await God1("@set #1=WIZARD");
+		await CreatePlayerAsync($"Lister_{Tag}", 63L);
+
+		var privateScene = await Eval($"scenecreate(,#1,Private {Tag})");
+		await God1($"@scene/set {privateScene}/status=active");
+		var publicScene = await Eval($"scenecreate(,#1,Public {Tag})");
+		await God1($"@scene/set {publicScene}/status=active");
+		await God1($"@scene/set {publicScene}/public=1");
+
+		var listed = await EvalAs(63L, "scenelist(active)");
+
+		await Assert.That(listed).Contains(publicScene)
+			.Because("a public scene is listable by anyone");
+		await Assert.That(listed).DoesNotContain(privateScene)
+			.Because("the storage filters carry no visibility clause, so the function layer must");
+		await Assert.That(await EvalAs(63L, $"scene({privateScene}, status)")).StartsWith("#-1")
+			.Because("and reading its fields stays refused, as it always was");
+	}
+
+	[Test]
+	public async Task ApprovedFlag_CannotBeSetOrUnsetByAnUnprivilegedPlayer()
+	{
+		await God1("@set #1=WIZARD");
+		var setter = await CreatePlayerAsync($"Setter_{Tag}", 64L);
+		var target = await CreatePlayerAsync($"Target_{Tag}", 65L);
+
+		await RunAs(64L, $"@set {target}=APPROVED");
+		await Assert.That(await Eval($"isapproved({target})")).IsEqualTo("0")
+			.Because("APPROVED is royalty-settable; an ordinary player cannot approve anyone");
+
+		await God1($"@set {target}=APPROVED");
+		await Assert.That(await Eval($"isapproved({target})")).IsEqualTo("1");
+
+		await RunAs(64L, $"@set {target}=!APPROVED");
+		await Assert.That(await Eval($"isapproved({target})")).IsEqualTo("1")
+			.Because("nor can an ordinary player revoke someone else's approval");
+
+		await Assert.That(await Eval($"isapproved({setter})")).IsEqualTo("0");
+	}
+}

--- a/SharpMUSH.Tests/Commands/AccountModeRefusalTests.cs
+++ b/SharpMUSH.Tests/Commands/AccountModeRefusalTests.cs
@@ -1,0 +1,116 @@
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using OneOf;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Services.Interfaces;
+using System.Text;
+
+namespace SharpMUSH.Tests.Commands;
+
+/// <summary>
+/// The MAKE and PLAY socket commands require AccountMode, and there are two ways to not be in it:
+/// never having authenticated, and having already bound a character. Exact-match SOCKET commands are
+/// dispatched for ANY handle (see <c>SharpMUSHParserVisitor</c>'s socket block — only the abbreviation
+/// path is pre-login-only), so a player in the game who types <c>play &lt;other&gt;</c> reaches these
+/// commands and must be told the truth: telnet is one session per character, and switching means
+/// reconnecting. Telling them to log in is false — they are logged in, which is the whole problem.
+/// </summary>
+public class AccountModeRefusalTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactoryArg { get; init; }
+
+	private INotifyService NotifyService => WebAppFactoryArg.Services.GetRequiredService<INotifyService>();
+	private IConnectionService ConnectionService => WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
+	private IMUSHCodeParser Parser => WebAppFactoryArg.CommandParser;
+
+	private const string LoginPrompt = "You must be logged in to an account first.";
+	private const string ReconnectAdvice = "To play a different one, disconnect and connect again.";
+
+	private async Task RegisterAsync(long handle) =>
+		await ConnectionService.Register(handle, "127.0.0.1", "localhost", "test",
+			_ => ValueTask.CompletedTask, _ => ValueTask.CompletedTask, () => Encoding.UTF8);
+
+	/// <summary>
+	/// Drops the handle again. <c>IConnectionService</c> is a session-wide singleton, so a handle left
+	/// registered here stays in the connection list every later test reads — WHO and DOING would count and
+	/// render this test's fake sessions and fail on the extra rows.
+	/// </summary>
+	private async Task DisconnectAsync(long handle) => await ConnectionService.Disconnect(handle);
+
+	private async Task<bool> SawAsync(long handle, string fragment)
+	{
+		var received = NotifyService.ReceivedCalls()
+			.Where(c => c.GetMethodInfo().Name == nameof(INotifyService.Notify))
+			.Select(c => c.GetArguments())
+			.Where(a => a.Length > 1 && a[0] is long h && h == handle)
+			.Select(a => a[1])
+			.OfType<OneOf<MString, string>>()
+			.Any(m => TestHelpers.MessagePlainTextContains(m, fragment));
+
+		return await Task.FromResult(received);
+	}
+
+	[Test]
+	public async ValueTask Play_WhenNeverAuthenticated_SaysToLogIn()
+	{
+		const long handle = 24601L;
+		await RegisterAsync(handle);
+		try
+		{
+			await Parser.CommandParse(handle, ConnectionService, MModule.single("play Someone"));
+
+			await Assert.That(await SawAsync(handle, LoginPrompt)).IsTrue()
+				.Because("a connection that never authenticated genuinely does need to log in first");
+		}
+		finally
+		{
+			await DisconnectAsync(handle);
+		}
+	}
+
+	[Test]
+	public async ValueTask Play_WhenAlreadyPlayingACharacter_SaysReconnectInstead()
+	{
+		const long handle = 24602L;
+		await RegisterAsync(handle);
+		try
+		{
+			await ConnectionService.BindAccount(handle, "accounts/refusal-play");
+			await ConnectionService.Bind(handle, new DBRef(1, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()));
+
+			await Parser.CommandParse(handle, ConnectionService, MModule.single("play Someone"));
+
+			await Assert.That(await SawAsync(handle, ReconnectAdvice)).IsTrue()
+				.Because("switching characters on telnet means reconnecting — that is the actual rule");
+			await Assert.That(await SawAsync(handle, LoginPrompt)).IsFalse()
+				.Because("this connection IS logged in; telling it to log in is the misleading refusal");
+		}
+		finally
+		{
+			await DisconnectAsync(handle);
+		}
+	}
+
+	[Test]
+	public async ValueTask Make_WhenAlreadyPlayingACharacter_SaysReconnectInstead()
+	{
+		const long handle = 24603L;
+		await RegisterAsync(handle);
+		try
+		{
+			await ConnectionService.BindAccount(handle, "accounts/refusal-make");
+			await ConnectionService.Bind(handle, new DBRef(1, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()));
+
+			await Parser.CommandParse(handle, ConnectionService, MModule.single("make Newbie secretpassword"));
+
+			await Assert.That(await SawAsync(handle, ReconnectAdvice)).IsTrue();
+			await Assert.That(await SawAsync(handle, LoginPrompt)).IsFalse();
+		}
+		finally
+		{
+			await DisconnectAsync(handle);
+		}
+	}
+}

--- a/examples/packages/scene/package.yaml
+++ b/examples/packages/scene/package.yaml
@@ -1,8 +1,8 @@
 format: 1
 package: scene
-version: 1.5.0
+version: 1.6.0
 authors: [SharpMUSH]
-description: "Scene Logger: pose/say/semipose capture into the Scene System, plus the +scene/* player verbs. Ships the game policy the C# engine deliberately omits."
+description: "Scene Logger: pose/say/semipose capture into the Scene System, plus the +scene/* player verbs. Ships the game policy the C# engine deliberately omits, including who may be associated with a scene."
 license: MIT
 homepage: https://github.com/SharpMUSH/SharpMUSH-Packages
 keywords: [scene, rp, logging, capture, hooks]
@@ -47,12 +47,38 @@ objects:
       FUN`OWNS: |-
         or(orflags(%0,Wz),strmatch(scene(%1,owner),%0))
 
+      # ---- approval guard -------------------------------------------------------
+      # The ONE place +scene asks "may this thing be ASSOCIATED with a scene?". Two halves:
+      #   • it must be a CHARACTER — a scene associates players, not things or rooms; and
+      #   • it must be APPROVED — isapproved() is the engine predicate, "royalty or above,
+      #     or carrying the APPROVED flag", and it is false for a guest whatever else is set.
+      # The engine ships that rule and no policy for what earns the flag; a game decides that
+      # and sets APPROVED itself. A game that wants a DIFFERENT bar edits this one attribute —
+      # nothing else in the package tests the flag, and the engine and the verbs cannot drift
+      # because both sides run the same isapproved() code.
+      #
+      # Association is the line, not visibility: viewing a schedule or a scene's information is
+      # open to any character (see CMD`BROWSE / OLD / UPCOMING / SHOW / WHO / RECALL / POT, none
+      # of which include this guard), and leaving is always allowed (CMD`LEAVE / UNTAG /
+      # DEACTIVATE). Joining, owning, administering and posing into a scene all require approval.
+      #
+      # The guard is written INLINE at the head of each gated verb, as a bare @assert — NOT factored into
+      # an INC` attribute and @included. A single-target @include runs its body as its own command list and
+      # the list boundary CONTAINS the break, so an @assert inside an @include emits its message and then
+      # lets the caller carry straight on to the write it was supposed to prevent. (Proven: routed through
+      # an @include, +scene/join printed the refusal AND still created the membership edge.) The one-line
+      # @assert keeps the refusal text in one place via DATA`DENY_APPROVAL — get() reads it without
+      # evaluating it — while keeping the break where it has to be, in the verb's own list.
+      FUN`IS`APPROVED: |-
+        and(hastype(%0,PLAYER),isapproved(%0))
+      DATA`DENY_APPROVAL: |-
+        You are not approved to take part in scenes. You can still browse the schedule with +scene and +scene/upcoming, and read any scene with +scene <id>.
+
       # ---- capture hooks --------------------------------------------------------
       # Each hook RE-BROADCASTS its type-specific speech via @message/spoof, then records
-      # the rendered line. The capture tail is INLINED into each hook (not factored into
-      # an @include attribute): @include cannot resolve an attribute name that contains a
-      # backtick (e.g. INCLUDE`CAPTURE) — only get()/u() do — so an @include of the shared
-      # tail silently no-ops and nothing is captured.
+      # the rendered line. The @scene/addpose call itself stays inline in each hook because
+      # each speech type renders a different line; only the shared header/footer rules are
+      # factored out into INC`CAP_HEADER / INC`CAP_FOOTER and @included.
       #
       # Why @message/spoof instead of hand-rolled @remit/@pemit/@oemit (the old form):
       #   • /spoof makes the notification SENDER the real speaker (%# / enactor), NOT the
@@ -81,10 +107,14 @@ objects:
       #   The recorded @scene/addpose line below is NOT RSArgs in the same way, so it still uses \,.
       #
       # Flow per hook (one physical line, `;`-separated):
-      #   1. setr(WillCaptureAsPose, <room has an active scene I am focused on>) — computing %q<SceneID>
-      #      and %q<RoomID> along the way. The check is `strmatch(scenefocus(%#),scenewhere(loc(%#)))
-      #      AND not(strmatch(scenewhere,#-1*))` — a real, focused, in-room active scene (NOT just
-      #      words(), which is truthy on "#-1 NOT FOUND").
+      #   1. setr(WillCaptureAsPose, <room has an active scene I am focused on, and I am approved>)
+      #      — computing %q<SceneID> and %q<RoomID> along the way. The check is
+      #      `strmatch(scenefocus(%#),scenewhere(loc(%#))) AND not(strmatch(scenewhere,#-1*)) AND
+      #      FUN`IS`APPROVED(%#)` — a real, focused, in-room active scene (NOT just words(), which is
+      #      truthy on "#-1 NOT FOUND"), posed by a character still approved RIGHT NOW. The approval
+      #      term is what makes revocation take effect immediately: without it, a character approved
+      #      when they joined would keep writing poses into the scene after losing the flag, since
+      #      their focus and membership survive the revocation.
       #   2. @if %q<WillCaptureAsPose> ⇒ record with @scene/addpose, then emit the CAP_HEADER rule.
       #   3. ALWAYS @message/spoof the pose to the room (so a pose outside any scene behaves exactly
       #      like the un-hooked built-in — the emit is never gated).
@@ -108,26 +138,26 @@ objects:
       # Built-in POSE (MoreCommands.Pose) emits: "<name> <message>" to the room.
       CMD`CAPTURE`POSE:
         value: |-
-          $(?i)^(pose |\:)(.*)$: @if setr(WillCaptureAsPose,and(strmatch(scenefocus(%#),setr(SceneID,scenewhere(setr(RoomID,loc(%#))))),not(strmatch(%q<SceneID>,#-1*))))={@scene/addpose %q<SceneID>=%#,[scenemember(%q<SceneID>,%#,showas)],%q<RoomID>,pose,,[name(%#)] %2; @include %!/INC`CAP_HEADER}; @message/spoof [lcon(%q<RoomID>)]=[name(%#)] %2,%#/FORMAT`POSE,%2,##; @if %q<WillCaptureAsPose>={@include %!/INC`CAP_FOOTER}
+          $(?i)^(pose |\:)(.*)$: @if setr(WillCaptureAsPose,and(strmatch(scenefocus(%#),setr(SceneID,scenewhere(setr(RoomID,loc(%#))))),not(strmatch(%q<SceneID>,#-1*)),u(%!/FUN`IS`APPROVED,%#)))={@scene/addpose %q<SceneID>=%#,[scenemember(%q<SceneID>,%#,showas)],%q<RoomID>,pose,,[name(%#)] %2; @include %!/INC`CAP_HEADER}; @message/spoof [lcon(%q<RoomID>)]=[name(%#)] %2,%#/FORMAT`POSE,%2,##; @if %q<WillCaptureAsPose>={@include %!/INC`CAP_FOOTER}
         flags: [REGEXP]
 
       # Built-in SAY (MoreCommands.Say) emits "You say, \"<msg>\"" to the speaker
       # and "<name> says, \"<msg>\"" to everyone else in the room.
       CMD`CAPTURE`SAY:
         value: |-
-          $(?i)^(say |")(.*)$: @if setr(WillCaptureAsPose,and(strmatch(scenefocus(%#),setr(SceneID,scenewhere(setr(RoomID,loc(%#))))),not(strmatch(%q<SceneID>,#-1*))))={@scene/addpose %q<SceneID>=%#,[scenemember(%q<SceneID>,%#,showas)],%q<RoomID>,say,,[name(%#)] says\, "%2"; @include %!/INC`CAP_HEADER}; @message/spoof [lcon(%q<RoomID>)]=[name(%#)] says[chr(44)] "%2",%#/FORMAT`SAY,%2,##; @if %q<WillCaptureAsPose>={@include %!/INC`CAP_FOOTER}
+          $(?i)^(say |")(.*)$: @if setr(WillCaptureAsPose,and(strmatch(scenefocus(%#),setr(SceneID,scenewhere(setr(RoomID,loc(%#))))),not(strmatch(%q<SceneID>,#-1*)),u(%!/FUN`IS`APPROVED,%#)))={@scene/addpose %q<SceneID>=%#,[scenemember(%q<SceneID>,%#,showas)],%q<RoomID>,say,,[name(%#)] says\, "%2"; @include %!/INC`CAP_HEADER}; @message/spoof [lcon(%q<RoomID>)]=[name(%#)] says[chr(44)] "%2",%#/FORMAT`SAY,%2,##; @if %q<WillCaptureAsPose>={@include %!/INC`CAP_FOOTER}
         flags: [REGEXP]
 
       # Built-in SEMIPOSE (MoreCommands.SemiPose) emits "<name><message>" (no space).
       CMD`CAPTURE`SEMI:
         value: |-
-          $(?i)^(semipose |;)(.*)$: @if setr(WillCaptureAsPose,and(strmatch(scenefocus(%#),setr(SceneID,scenewhere(setr(RoomID,loc(%#))))),not(strmatch(%q<SceneID>,#-1*))))={@scene/addpose %q<SceneID>=%#,[scenemember(%q<SceneID>,%#,showas)],%q<RoomID>,semipose,,[name(%#)]%2; @include %!/INC`CAP_HEADER}; @message/spoof [lcon(%q<RoomID>)]=[name(%#)]%2,%#/FORMAT`SEMIPOSE,%2,##; @if %q<WillCaptureAsPose>={@include %!/INC`CAP_FOOTER}
+          $(?i)^(semipose |;)(.*)$: @if setr(WillCaptureAsPose,and(strmatch(scenefocus(%#),setr(SceneID,scenewhere(setr(RoomID,loc(%#))))),not(strmatch(%q<SceneID>,#-1*)),u(%!/FUN`IS`APPROVED,%#)))={@scene/addpose %q<SceneID>=%#,[scenemember(%q<SceneID>,%#,showas)],%q<RoomID>,semipose,,[name(%#)]%2; @include %!/INC`CAP_HEADER}; @message/spoof [lcon(%q<RoomID>)]=[name(%#)]%2,%#/FORMAT`SEMIPOSE,%2,##; @if %q<WillCaptureAsPose>={@include %!/INC`CAP_FOOTER}
         flags: [REGEXP]
 
       # Built-in @EMIT emits "<message>" verbatim (no name) to the room.
       CMD`CAPTURE`EMIT:
         value: |-
-          $(?i)^@emit (.*)$: @if setr(WillCaptureAsPose,and(strmatch(scenefocus(%#),setr(SceneID,scenewhere(setr(RoomID,loc(%#))))),not(strmatch(%q<SceneID>,#-1*))))={@scene/addpose %q<SceneID>=%#,[scenemember(%q<SceneID>,%#,showas)],%q<RoomID>,emit,,%1; @include %!/INC`CAP_HEADER}; @message/spoof [lcon(%q<RoomID>)]=%1,%#/FORMAT`EMIT,%1,##; @if %q<WillCaptureAsPose>={@include %!/INC`CAP_FOOTER}
+          $(?i)^@emit (.*)$: @if setr(WillCaptureAsPose,and(strmatch(scenefocus(%#),setr(SceneID,scenewhere(setr(RoomID,loc(%#))))),not(strmatch(%q<SceneID>,#-1*)),u(%!/FUN`IS`APPROVED,%#)))={@scene/addpose %q<SceneID>=%#,[scenemember(%q<SceneID>,%#,showas)],%q<RoomID>,emit,,%1; @include %!/INC`CAP_HEADER}; @message/spoof [lcon(%q<RoomID>)]=%1,%#/FORMAT`EMIT,%1,##; @if %q<WillCaptureAsPose>={@include %!/INC`CAP_FOOTER}
         flags: [REGEXP]
 
       # ---- create / lifecycle ---------------------------------------------------
@@ -139,24 +169,24 @@ objects:
       # `&MY.SID %#=[setr(SceneID,…)]` also failed (setr inside an &attr=<value> RHS doesn't
       # propagate its register); @assert in command position does.
       CMD`CREATE: |-
-        $+scene/create *: @assert setr(SceneID,scenecreate(%L,%#,%0)); @scene/member %q<SceneID>/owner=%#; @scene/focus %#=%q<SceneID>; @scene/set %q<SceneID>/status=[get(%!/DATA`DEFAULT_STATUS)]; @pemit %#=Scene %q<SceneID> created and focused (status: [get(%!/DATA`DEFAULT_STATUS)]).; &MY.SID %#=%q<SceneID>
+        $+scene/create *: @assert u(%!/FUN`IS`APPROVED,%#)=@pemit %#=[get(%!/DATA`DENY_APPROVAL)]; @assert setr(SceneID,scenecreate(%L,%#,%0)); @scene/member %q<SceneID>/owner=%#; @scene/focus %#=%q<SceneID>; @scene/set %q<SceneID>/status=[get(%!/DATA`DEFAULT_STATUS)]; @pemit %#=Scene %q<SceneID> created and focused (status: [get(%!/DATA`DEFAULT_STATUS)]).; &MY.SID %#=%q<SceneID>
 
       # NOTE: verb bodies are written as ONE physical line with `;` separators. In a
       # multi-line ($-command) attribute the FIRST command after the `$pattern:` header does
       # not parse cleanly (the following line's leading `@scene…` leaks into it) and
       # q-registers do not cross newlines — the `;` form is robust on both counts.
       CMD`START: |-
-        $+scene/start: @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/status=active; @pemit %#=Scene is now active.
+        $+scene/start: @assert u(%!/FUN`IS`APPROVED,%#)=@pemit %#=[get(%!/DATA`DENY_APPROVAL)]; @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/status=active; @pemit %#=Scene is now active.
 
       CMD`PAUSE: |-
-        $+scene/pause: @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/status=paused; @pemit %#=Scene paused.
+        $+scene/pause: @assert u(%!/FUN`IS`APPROVED,%#)=@pemit %#=[get(%!/DATA`DENY_APPROVAL)]; @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/status=paused; @pemit %#=Scene paused.
 
       CMD`FINISH: |-
-        $+scene/finish: @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/status=finished; @scene/focus %#=; @pemit %#=Scene finished.
+        $+scene/finish: @assert u(%!/FUN`IS`APPROVED,%#)=@pemit %#=[get(%!/DATA`DENY_APPROVAL)]; @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/status=finished; @scene/focus %#=; @pemit %#=Scene finished.
 
       # ---- membership / RSVP / focus --------------------------------------------
       CMD`JOIN: |-
-        $+scene/join *: @scene/member %0/participant=%#; @scene/focus %#=%0; @pemit %#=Joined and focused on scene %0.
+        $+scene/join *: @assert u(%!/FUN`IS`APPROVED,%#)=@pemit %#=[get(%!/DATA`DENY_APPROVAL)]; @scene/member %0/participant=%#; @scene/focus %#=%0; @pemit %#=Joined and focused on scene %0.
 
       # NOTE: one physical line (q-registers cross `;` but not newlines in a $-command body).
       # Capture the focused scene id into %q<SceneID> BEFORE @scene/focus clears it (@assert sets the
@@ -165,39 +195,39 @@ objects:
         $+scene/leave: @assert setr(SceneID,scenefocus(%#)); @scene/focus %#=; @if not(words(sceneposes(%q<SceneID>,%#)))={@scene/unmember %q<SceneID>=%#}; @pemit %#=Left the scene.; &MY.SID %#=%q<SceneID>
 
       CMD`TAG: |-
-        $+scene/tag *: @scene/member %0/attending=%#; @pemit %#=RSVP'd to scene %0.
+        $+scene/tag *: @assert u(%!/FUN`IS`APPROVED,%#)=@pemit %#=[get(%!/DATA`DENY_APPROVAL)]; @scene/member %0/attending=%#; @pemit %#=RSVP'd to scene %0.
 
       CMD`UNTAG: |-
         $+scene/untag *: @scene/unmember %0=%#; @pemit %#=Removed RSVP from scene %0.
 
       CMD`AS: |-
-        $+scene/as *: @scene/showas [scenefocus(%#)]/%#=%0; @pemit %#=Future poses show as: %0
+        $+scene/as *: @assert u(%!/FUN`IS`APPROVED,%#)=@pemit %#=[get(%!/DATA`DENY_APPROVAL)]; @scene/showas [scenefocus(%#)]/%#=%0; @pemit %#=Future poses show as: %0
 
       # ---- edit your own poses --------------------------------------------------
       # %1 is find^^^replace; author-only is enforced by @scene/editpose. Stash the poseId in %q<pid>
       # and compute the new content into %q<new> in a separate command first (a nested function
       # reference to the verb's %0/%1 inside an @scene arg does not resolve reliably), then edit off them.
       CMD`EDIT: |-
-        $+scene/edit *=*: @assert setr(pid,%0); @assert setr(new,edit(scenepose(scenefocus(%#),%q<pid>,content),before(%1,^^^),after(%1,^^^))); @scene/editpose %q<pid>=%#,%q<new>
+        $+scene/edit *=*: @assert u(%!/FUN`IS`APPROVED,%#)=@pemit %#=[get(%!/DATA`DENY_APPROVAL)]; @assert setr(pid,%0); @assert setr(new,edit(scenepose(scenefocus(%#),%q<pid>,content),before(%1,^^^),after(%1,^^^))); @scene/editpose %q<pid>=%#,%q<new>
 
       CMD`UNDO: |-
-        $+scene/undo *: @scene/undo %0
+        $+scene/undo *: @assert u(%!/FUN`IS`APPROVED,%#)=@pemit %#=[get(%!/DATA`DENY_APPROVAL)]; @scene/undo %0
 
       CMD`REDO: |-
-        $+scene/redo *: @scene/redo %0
+        $+scene/redo *: @assert u(%!/FUN`IS`APPROVED,%#)=@pemit %#=[get(%!/DATA`DENY_APPROVAL)]; @scene/redo %0
 
       CMD`DELETE: |-
-        $+scene/delete *: @scene/delete %0
+        $+scene/delete *: @assert u(%!/FUN`IS`APPROVED,%#)=@pemit %#=[get(%!/DATA`DENY_APPROVAL)]; @scene/delete %0
 
       CMD`MOVE: |-
-        $+scene/move *=*: @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/move %0=%1
+        $+scene/move *=*: @assert u(%!/FUN`IS`APPROVED,%#)=@pemit %#=[get(%!/DATA`DENY_APPROVAL)]; @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/move %0=%1
 
       # ---- visibility -----------------------------------------------------------
       CMD`PUBLIC: |-
-        $+scene/public: @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/public=1; @pemit %#=Scene is now public.
+        $+scene/public: @assert u(%!/FUN`IS`APPROVED,%#)=@pemit %#=[get(%!/DATA`DENY_APPROVAL)]; @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/public=1; @pemit %#=Scene is now public.
 
       CMD`PRIVATE: |-
-        $+scene/private: @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/public=0; @pemit %#=Scene is now private.
+        $+scene/private: @assert u(%!/FUN`IS`APPROVED,%#)=@pemit %#=[get(%!/DATA`DENY_APPROVAL)]; @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/public=0; @pemit %#=Scene is now private.
 
       # ---- viewing --------------------------------------------------------------
       CMD`WHO: |-
@@ -222,14 +252,14 @@ objects:
         [rjust(u(%!/FUN`POT_MS,%0,%1),15,0)]~%1
       FUN`POT_ROW: |-
         align(>3 <[sub(%3,30)] >14 <9,%2,[name(%1)][switch(scenemember(%0,%1,showas),,,%b\([scenemember(%0,%1,showas)]\))],u(%!/FUN`POT_IDLE,%0,%1),switch(%2,1,<- up,))
-      # Control flow is guard-then-display: INC`REQUIRE`FOCUS early-exits via @assert (no switch() for
-      # output) and leaves %q<SceneID> set for the shared display tail, which is @included with that id.
-      INC`REQUIRE`FOCUS: |-
-        @assert not(strmatch(setr(SceneID,scenefocus(%#)),#-1*))=@pemit %#=You are not focused on a scene. Use +scene/join <id> or +scene/create <title>.
+      # Control flow is guard-then-display: the @assert early-exits (no switch() for output) and leaves
+      # %q<SceneID> set for the shared display tail, which is @included with that id. The guard is inline
+      # for the same reason the approval guard is — an @assert behind an @include does not stop the caller,
+      # so the guard used to print "you are not focused" and then render a tracker for scene "#-1 NOT FOUND".
       INC`DISPLAY`POT: |-
         @pemit %#=[header(Pose Tracker - Scene %0,width(%#))]%r[iter(sort(iter(scenemembers(%0),u(%!/FUN`POT_KEY,%0,##))),u(%!/FUN`POT_ROW,%0,after(##,~),inum(0),width(%#)),,%r)]%r[footer([words(scenemembers(%0))] in scene - oldest pose is up next,width(%#))]
       CMD`POT: |-
-        $+pot: @include %!/INC`REQUIRE`FOCUS; @include %!/INC`DISPLAY`POT=%q<SceneID>
+        $+pot: @assert not(strmatch(setr(SceneID,scenefocus(%#)),#-1*))=@pemit %#=You are not focused on a scene. Use +scene/join <id> or +scene/create <title>.; @include %!/INC`DISPLAY`POT=%q<SceneID>
 
       # ---- scene browser: align()'d tables of scenes -----------------------------
       # Volund-style listing: bare `+scene` = active scenes, `+scene/old` = finished, `+scene/mine` =
@@ -253,11 +283,11 @@ objects:
       FUN`SCHED_WHEN: |-
         mul(firstof(convtime(%0),%0),1000)
       CMD`SCHEDULE: |-
-        $+scene/schedule *=*: @assert setr(SceneID,scenecreate(,%#,%0)); @scene/member %q<SceneID>/owner=%#; @scene/set %q<SceneID>/status=scheduled; @scene/set %q<SceneID>/scheduledfor=[u(%!/FUN`SCHED_WHEN,%1)]; @pemit %#=Scheduled scene %q<SceneID> "%0" for [convsecs(div(u(%!/FUN`SCHED_WHEN,%1),1000))].
+        $+scene/schedule *=*: @assert u(%!/FUN`IS`APPROVED,%#)=@pemit %#=[get(%!/DATA`DENY_APPROVAL)]; @assert setr(SceneID,scenecreate(,%#,%0)); @scene/member %q<SceneID>/owner=%#; @scene/set %q<SceneID>/status=scheduled; @scene/set %q<SceneID>/scheduledfor=[u(%!/FUN`SCHED_WHEN,%1)]; @pemit %#=Scheduled scene %q<SceneID> "%0" for [convsecs(div(u(%!/FUN`SCHED_WHEN,%1),1000))].
       CMD`RESCHEDULE: |-
-        $+scene/reschedule *=*: @assert u(%!/FUN`OWNS,%#,%0); @scene/set %0/scheduledfor=[u(%!/FUN`SCHED_WHEN,%1)]; @pemit %#=Rescheduled scene %0 for [convsecs(div(u(%!/FUN`SCHED_WHEN,%1),1000))].
+        $+scene/reschedule *=*: @assert u(%!/FUN`IS`APPROVED,%#)=@pemit %#=[get(%!/DATA`DENY_APPROVAL)]; @assert u(%!/FUN`OWNS,%#,%0); @scene/set %0/scheduledfor=[u(%!/FUN`SCHED_WHEN,%1)]; @pemit %#=Rescheduled scene %0 for [convsecs(div(u(%!/FUN`SCHED_WHEN,%1),1000))].
       CMD`UNSCHEDULE: |-
-        $+scene/unschedule *: @assert u(%!/FUN`OWNS,%#,%0); @scene/delete %0; @pemit %#=Deleted scheduled scene %0.
+        $+scene/unschedule *: @assert u(%!/FUN`IS`APPROVED,%#)=@pemit %#=[get(%!/DATA`DENY_APPROVAL)]; @assert u(%!/FUN`OWNS,%#,%0); @scene/delete %0; @pemit %#=Deleted scheduled scene %0.
       FUN`SCHED_ROW: |-
         align(<10 <[sub(%1,42)] <24 >6,left(%0,10),left(u(%!/FUN`LIST_TITLE,%0),sub(%1,43)),convsecs(div(scene(%0,scheduledfor),1000)),words(scenemembers(%0)))
       CMD`UPCOMING: |-
@@ -270,7 +300,7 @@ objects:
       CMD`DEACTIVATE: |-
         $+scene/deactivate: @assert setr(SceneID,scenefocus(%#)); @scene/focus %#=; @pemit %#=Deactivated scene %q<SceneID> - still a member, poses paused. +scene/activate %q<SceneID> to resume.
       CMD`ACTIVATE: |-
-        $+scene/activate *: @scene/member %0/participant=%#; @scene/focus %#=%0; @pemit %#=Activated scene %0 - your poses are recorded again.
+        $+scene/activate *: @assert u(%!/FUN`IS`APPROVED,%#)=@pemit %#=[get(%!/DATA`DENY_APPROVAL)]; @scene/member %0/participant=%#; @scene/focus %#=%0; @pemit %#=Activated scene %0 - your poses are recorded again.
 
       # ---- summary + info card --------------------------------------------------
       # SCENE_FIELD(scene,field,default) reads a field, substituting <default> for an unset/#-1 result.
@@ -280,15 +310,13 @@ objects:
         switch(setr(val,scene(%0,%1)),#-1*,%2,%q<val>)
       FUN`INFO_LINE: |-
         align(>9 <[sub(%2,11)],ansi(h,%0),%1)
-      INC`REQUIRE`SCENE: |-
-        @assert not(strmatch(scene(setr(SceneID,%0),status),#-1*))=@pemit %#=No such scene: %0
       INC`DISPLAY`INFO: |-
         @pemit %#=[header(Scene %0,width(%#))]%r[u(%!/FUN`INFO_LINE,Title,u(%!/FUN`LIST_TITLE,%0),width(%#))]%r[u(%!/FUN`INFO_LINE,Pitch,u(%!/FUN`SCENE_FIELD,%0,summary,-),width(%#))]%r[u(%!/FUN`INFO_LINE,Owner,scene(%0,ownername),width(%#))]%r[u(%!/FUN`INFO_LINE,Where,u(%!/FUN`SCENE_FIELD,%0,roomname,\(roomless\)),width(%#))]%r[u(%!/FUN`INFO_LINE,Status,scene(%0,status),width(%#))]%r[u(%!/FUN`INFO_LINE,Poses,scene(%0,posecount),width(%#))]%r[u(%!/FUN`INFO_LINE,Cast,scenecast(%0),width(%#))]%r[footer(,width(%#))]
       CMD`PITCH: |-
-        $+scene/pitch *: @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/summary=%0; @pemit %#=Pitch set for scene [scenefocus(%#)].
+        $+scene/pitch *: @assert u(%!/FUN`IS`APPROVED,%#)=@pemit %#=[get(%!/DATA`DENY_APPROVAL)]; @assert u(%!/FUN`OWNS,%#,scenefocus(%#)); @scene/set [scenefocus(%#)]/summary=%0; @pemit %#=Pitch set for scene [scenefocus(%#)].
       # Scene DETAILS card: `+scene <id>` (Volund-style; bare `+scene` is the active list).
       CMD`SHOW: |-
-        $+scene *: @include %!/INC`REQUIRE`SCENE=%0; @include %!/INC`DISPLAY`INFO=%q<SceneID>
+        $+scene *: @assert not(strmatch(scene(setr(SceneID,%0),status),#-1*))=@pemit %#=No such scene: %0; @include %!/INC`DISPLAY`INFO=%q<SceneID>
 
       # ---- lifecycle: (re-)establish the three OVERRIDE capture hooks -----------
       # PennMUSH form: @hook/<type> <command> = <object>, <attribute> (RSArgs comma-split).


### PR DESCRIPTION
**PR 10 of a 10-PR stack. Base is `fix/audit2-09-portal-help`, not `main`** — review the last commits only, or wait until 1–9 land.

`+scene` **is in this PR**, not scoped out. It turned out not to need building: the repo already ships a complete `+scene` player system (`examples/packages/scene`, a bundled create-mode package installed at first boot). The task premise that "there is NO `+scene` softcode layer in the repo today" is wrong. The work was therefore *gating* the existing verbs, which is a far smaller and more reviewable change than writing them.

---

## The audit finding was reframed, not fixed

The audit reported that `SceneVisibility.CanSeeAsync` is `public ∨ owner ∨ member` with no staff override, so a wizard can create a scene for a player and then not read or moderate it.

The repo owner's ruling, verbatim:

> "This is intentional. We want the +scene system to be what interfaces here via a Wizard object. Users should not be using @scene directly. We should be locking off permissions to @scene to non-wizards."

So **no staff override was added to `SceneVisibility`**. The player-facing path is `+scene`, driven by the WIZARD "Scene Logger" object, and that path is what this PR gives a permission model.

## Where APPROVED lives, and why

**In the engine**, not the Scene plugin.

The plugin contributes `SCENE_ROOM` through `IFlagSource`, so a plugin-contributed flag was available. It is the wrong home here. `SCENE_ROOM` describes a room's role in the scene system and means nothing without the plugin loaded. APPROVED describes a *character*, and it means the same thing to chargen, a job queue, a channel lock, or anything else a game builds. Putting it in the plugin would make the general concept unloadable with a specific feature, and would push the next consumer into inventing a second flag.

- `APPROVED`, symbol `+`, PLAYER-only, royalty-settable (matching `JUDGE`/`UNREGISTERED`).
- Arango gets `Migration_AddApprovedFlag` (UPSERT keyed on name, so existing worlds get it); Memgraph and SurrealDB reach the same place through their always-run idempotent flag seeds.
- **The engine sets it never.** Per the owner — "we don't make the decision of what APPROVED means for them yet" — this PR ships the flag and the plumbing and no policy.

## The predicate

Owner's sketch, verbatim: *"FN\`IS\`APPROVED for a scene system is something like: 'is royalty or above, or approved?'"*

- `HelperFunctions.IsApproved` — `!guest && (priv || hasflag APPROVED)`.
- `isapproved(<object>)` — the same method with a softcode face. Not a reimplementation: the two cannot drift because there is one implementation.
- Guest exclusion lives in the predicate, not at call sites. "A guest is never approved" is a property of guests; pushing it outward means remembering it nineteen times.
- The `scene` package calls it through one wrapper attribute, `FUN\`IS\`APPROVED`, so a game moves the bar in one edit and nothing else tests the flag.

## The approval matrix

| Operation | Verbs | Approval |
|---|---|---|
| View the scene list / schedule | `+scene`, `+scene/old`, `+scene/mine`, `+scene/upcoming` | **no** |
| Read a scene / its cast / its log | `+scene <id>`, `+scene/who`, `+scene/recall`, `+pot` | **no** |
| Leave / stop participating | `+scene/leave`, `+scene/untag`, `+scene/deactivate` | **no** |
| Join, RSVP, re-activate | `+scene/join`, `/tag`, `/activate` | **yes** |
| Own a scene | `+scene/create`, `/schedule` | **yes** |
| Administer | `/start`, `/pause`, `/finish`, `/public`, `/private`, `/pitch`, `/move`, `/reschedule`, `/unschedule` | **yes** |
| Edit the log | `/as`, `/edit`, `/undo`, `/redo`, `/delete` | **yes** |
| Have a pose captured into a scene | `pose` / `say` / `semipose` / `@emit` hooks | **yes** |

19 verbs gated. Leaving is deliberately ungated — a character who loses approval must still be able to walk out.

The four capture hooks carry the same term, which is what makes revocation take effect immediately: membership and focus survive a cleared flag, so a hook checking only focus would keep writing poses for a character the game had just un-approved.

### One softcode finding worth the reviewer's attention

The guard is written **inline** in each verb, not factored into an `INC\`` attribute. A single-target `@include` runs its body as its own command list and the list boundary *contains* the break, so an `@assert` behind an `@include` prints its refusal and then lets the caller continue to the write it was supposed to prevent. Observed directly:

```
Mortalia> +scene/join 1
    You are not approved to take part in scenes. ...
    SCENE: Unapp_0907667b is now 'participant' in scene #1.     <-- written anyway
    Joined and focused on scene 1.
```

Two pre-existing guards in the shipped package had the same shape and the same defect (`+pot`'s focus check and `+scene <id>`'s existence check — both printed their refusal and then rendered a table for scene `#-1 NOT FOUND`). Both are inlined here too. **The engine-side `@include` break-propagation gap is left as a finding, not fixed** — see "Found, left out of scope" below.

## The `@scene` lockdown audit

Requested: check all 19 switches and all 25 functions for a path that is not wizard-gated.

**Command — 19/19 closed.** `@SCENE` carries `CommandLock = "FLAG^WIZARD"`; the lock refuses at dispatch, before the module body, so all 19 switches plus the bare display form return `#-1 PERMISSION DENIED`. The module's own `executor.IsWizard()` gate is the second line of defence behind it, never the first. A test walks every switch individually.

**Functions — 25 audited, one real hole, now closed.**

- **14 write functions** (`scenecreate`, `sceneset`, `sceneaddpose`, `scenesetpose`, `sceneeditpose`, `sceneundo`, `sceneredo`, `scenemovepose`, `scenedelpose`, `sceneaddmember`, `sceneunmember`, `scenesetfocus`, `sceneshowas`, `sceneplot`) all carry `FunctionFlags.WizardOnly`, checked against the **executor**. A player evaluating one in their own softcode is the executor, so all 14 refuse. Pinned by test and confirmed over telnet.
- **11 read functions** are `Regular` — deliberately, since `+scene`'s display verbs are exactly these calls made by the player. Ten of them gate every result on `SceneVisibleToAsync`.
- **`scenelist()` was the eleventh and it did not.** It returned whatever the storage handed back, and the `active`/`finished`/`recent`/`scheduled` AQL filters carry no visibility clause at all. **Any player could enumerate the id of every private scene in the game, and count them**, while `scene(<id>, …)` still refused each one. That is a genuine leak and the command lock above it is worth nothing while it exists. Fixed by filtering the listing through the same predicate the field reads use.

## Explicitly not done

No in-session character switching, per the owner: *"DO NOT FIX. On telnet, each Session is their own thing."* Only the misleading refusal text changed — `MAKE`/`PLAY` told a player already in the game "You must be logged in to an account first", which is false and sends them to a login that will also be refused. They now get the actual rule.

---

## Verification

### Real numbers

| | Result |
|---|---|
| `dotnet build` | **0 errors**, 32 warnings — all pre-existing, all in `SharpMUSH.Tests.BUnit` (no `TreatWarningsAsErrors`), none in a file this PR touches. Baseline on the parent commit: 33. |
| `SharpMUSH.Tests` | **5404 total, 0 failed**, 5212 passed, 192 skipped. Parent-commit baseline: 5401 / 0 failed. |
| `SharpMUSH.Tests.Integration` | **323 total, 0 failed** |
| `SharpMUSH.Tests.BUnit` | **474 total, 0 failed** |
| `SharpMUSH.Tests.ScenePlugin` | **20 total, 0 failed** |
| `tools/i18n/validate_resx.py` | **all gates passed** — 16 locales, 1126 keys, 100% each. No key added: every string here is a game-side telnet message, which this codebase keeps as literals; the 16-locale resx set is the web portal's. |
| `dotnet format whitespace` | converged, no changes on the second pass |
| `TreatWarningsAsErrors` | untouched. No suppressions added. |

New tests: 8 (5 integration + 3 unit).

`SceneRoleplayIntegrationTests` needed its fixture updated — its characters own, join and pose, which now requires approval — so `CreatePlayerAsync` there sets APPROVED. That is the coupling working as intended, and it is documented in the helper.

### Live telnet transcripts

Real sockets against ConnectionServer :4211 → NATS → Server :8090 → ArangoDB, `ASPNETCORE_ENVIRONMENT=Production`, fresh database. IAC negotiation and ANSI stripped.

**The predicate, including a guest with the flag deliberately set on it:**

```
God> think powers(Guesty,Guest)
    Guesty - Guest set.
God> @set Guesty=APPROVED
    Guesty - APPROVED set.
God> think [isapproved(Approvia)] [isapproved(Mortalia)] [isapproved(Guesty)] [isapproved(me)]
    1 0 0 1
God> think Approvia flags: [flags(Approvia)] / Guesty flags: [flags(Guesty)]
    Approvia flags: +P / Guesty flags: +P
```

Approvia approved by flag, Mortalia not, God approved as staff, and **Guesty refused despite carrying the flag** because the guest term wins.

**An approved character owns a scene; an unapproved one is refused every associating route:**

```
Approvia> +scene/create The Tavern Night
    Scene 1 created and focused (status: active).

Mortalia> +scene/join 1
    You are not approved to take part in scenes. You can still browse the schedule
    with +scene and +scene/upcoming, and read any scene with +scene <id>.
Mortalia> +scene/create Sneaking In
    You are not approved to take part in scenes. ...
Mortalia> +scene/tag 1
    You are not approved to take part in scenes. ...
Mortalia> think scenelist(mine)
                                          <- empty: an unapproved character has no scenes
God>      think [scenemembers(1)]
    #12                                   <- Approvia only; nothing was written
```

**A guest, refused but free to look:**

```
Guesty> +scene/join 1
    You are not approved to take part in scenes. ...
Guesty> +scene
    =============================== Scenes: active ===============================
    ID         Title                                 Where           Cast Status
    1          The Tavern Night                      Room Zero          1 active
    ================================== 1 scenes ==================================
```

**An unapproved character reads the schedule and a scene, and still cannot RSVP:**

```
Mortalia> +scene/upcoming
    ============================== Scheduled Scenes ==============================
    ID         Title                                When                       RSVP
    3          Harvest Fair                         #-1 INVALID SECONDS           1
    ================================ 1 scheduled =================================
Mortalia> +scene 3
    ================================== Scene 3 ===================================
        Title Harvest Fair
        Owner Approvia
       Status scheduled
    ==============================================================================
Mortalia> +scene/tag 3
    You are not approved to take part in scenes. ...
God>      think [scenemembers(3)]
    #12
```

(The `#-1 INVALID SECONDS` in the When column is a pre-existing `convtime()` bug in the package's scheduling helper, unrelated to approval — see below.)

**Approve the same character and everything opens:**

```
God>      @set Mortalia=APPROVED
Mortalia> think [isapproved(me)]
    1
Mortalia> +scene/join 1
    Joined and focused on scene 1.
Mortalia> +scene/tag 3
    RSVP'd to scene 3.
God>      think [scenemembers(1)] | [scenemembers(3)]
    #12 #13 | #12 #13
Mortalia> think [scenelist(mine)]
    3 1
```

**Capture follows approval, live, on the very next pose:**

```
Mortalia> +scene/join 4
    Joined and focused on scene 4.
God>      think posecount=[scene(4,posecount)]
    posecount=0
Mortalia> pose raises a glass while approved.
    == [ Mortalia posed ] ========================================================
    Mortalia raises a glass while approved.
    ====================================================== [ Scene 4 · Pose 1 ] ==
God>      think posecount=[scene(4,posecount)]
    posecount=1
God>      @set Mortalia=!APPROVED
Mortalia> pose keeps talking after approval was revoked.
    Mortalia keeps talking after approval was revoked.
God>      think posecount=[scene(4,posecount)]
    posecount=1
```

The pose is framed and recorded while approved; after revocation the same character in the same focused scene poses normally to the room and nothing is written. Membership and focus were untouched — only the flag changed.

**`@scene` lockdown from a mortal, and the function surface under it:**

```
Mortalia> @scene/list
    Permission denied.
Mortalia> @scene/member 1/participant=me
    Permission denied.
Mortalia> think scenecreate(here,me,Mortal Scene)
    #-1 PERMISSION DENIED
Mortalia> think sceneaddmember(1,me,participant)
    #-1 PERMISSION DENIED
God>      think scenemembers(1)
    #12
```

**The `scenelist()` leak, before/after in one exchange** (scene 4 is private and owned by Approvia):

```
Approvia> think [scenelist(active)]
    4 1
Mortalia> think [scenelist(active)]
    1
Mortalia> think [scene(4,title)]
    #-1 PERMISSION
```

**The PLAY / MAKE refusal, from inside the game:**

```
Mortalia> play Approvia
    You are already playing a character. A telnet session plays one character for
    its whole life. To play a different one, disconnect and connect again.
Mortalia> make Another audit10pass
    You are already playing a character. Character creation happens from the account
    menu, before you enter the game. To play a different one, disconnect and connect
    again.
```

---

## Found and fixed along the way

**`@power`/`powers()` threw on every set.** `SetPower` and `UnsetPower` look a power up by name-or-alias across the whole power stream. `SharpPower.Alias` is declared non-nullable but the seeded powers store `null`, so `x.Alias.Equals(...)` threw on the first aliasless power the predicate reached — and it runs until something matches, so *setting or clearing any power at all* was a `NullReferenceException`. Found by trying to make a guest. `GetPowerQueryHandler` already guards the same comparison; the same guard is now on both call sites. Its own commit.

## Found, left out of scope

1. **`@include` does not propagate `@break`/`@assert` to its caller.** The documented contract says it does — `GeneralCommands.Include`'s own comment says a chain break works "as it does for a normal @include" — but a single target is run through `CommandListParse`, whose list boundary contains the break. So the guard-in-an-include idiom silently does not guard. This is a parser-semantics change with blast radius across every `@include` in every game, and a security boundary should not be the thing that forces it; the package works around it inline instead. Worth its own PR.

2. **Arango's built-in flags may store `UnSetPermissions` where the model reads `UnsetPermissions`.** `Migration_CreateDatabase` writes the capital-S spelling for every built-in flag; `SharpObjectFlagQueryResult` and the plugin flag seed both use lowercase-s. If Core.Arango's serializer is case-sensitive, the generic unset-permission check in `ManipulateSharpObjectService` sees an empty array for every built-in flag and enforces nothing. Not chased down here because it touches every flag in the database; the new migration is written with the spelling the model reads, so APPROVED is enforced either way, and the test proves an ordinary player can neither set nor clear it.

3. **`@power <object>=<power>` is not implemented.** `@POWER` handles only definition management (`/add`, `/type`, `/letter`, `/restrict`, `/delete`, `/alias`, `/disable`, `/enable`, `/decompile`, `/list`) and falls through to a usage message for the bare PennMUSH form. The only working way to set a power on an object is the `powers()` side-effect function, which depends on a config switch.

4. **`+scene/schedule`'s date parsing is broken.** `FUN\`SCHED_WHEN` runs the argument through `convtime()`, which failed for both an epoch-seconds value and `01/15/2027 19:00:00`, so `scheduledfor` stores garbage and the schedule's When column reads `#-1 INVALID SECONDS`. Pre-existing, orthogonal to approval, and the scene is still created and listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MPRzndB5egy4F2A3q5852
