### PR TITLE
Portal audit 2/11: three security follow-ups the earlier PRs left out of scope

### DIFF
--- a/SharpMUSH.Database.ArangoDB/ArangoDatabase.Sessions.cs
+++ b/SharpMUSH.Database.ArangoDB/ArangoDatabase.Sessions.cs
@@ -123,4 +123,17 @@ public partial class ArangoDatabase
 				"FOR d IN @@c FILTER d.OriginIp == @ip REMOVE d IN @@c",
 				bindVars: new Dictionary<string, object> { { "@c", DatabaseConstants.Sessions }, { "ip", originIp } },
 				cancellationToken: cancellationToken), cancellationToken);
+
+	// Read, so no transaction — same reasoning as GetSessionAsync. Ban enforcement runs off the
+	// admin path, not the request path, and the answer only has to be as current as the moment the
+	// ban landed: a session created after this returns is one the validation-time sitelock check
+	// refuses anyway.
+	public async ValueTask<string[]> GetSessionOriginIpsAsync(CancellationToken cancellationToken = default)
+	{
+		var result = await arangoDb.Query.ExecuteAsync<string>(handle,
+			"FOR d IN @@c RETURN DISTINCT d.OriginIp",
+			bindVars: new Dictionary<string, object> { { "@c", DatabaseConstants.Sessions } },
+			cancellationToken: cancellationToken);
+		return [.. result.Where(ip => !string.IsNullOrEmpty(ip))];
+	}
 }

--- a/SharpMUSH.Database.ArangoDB/Migrations/Migration_CreateDatabase.cs
+++ b/SharpMUSH.Database.ArangoDB/Migrations/Migration_CreateDatabase.cs
@@ -3133,7 +3133,7 @@ public class Migration_CreateDatabase : IArangoMigration
 			System = true,
 			TypeRestrictions = DatabaseConstants.typesAll,
 			SetPermissions = DatabaseConstants.permissionsODark,
-			UnSetPermissions = DatabaseConstants.permissionsODark
+			UnsetPermissions = DatabaseConstants.permissionsODark
 		}),
 		await migrator.Context.Document.CreateAsync(handle, DatabaseConstants.ObjectFlags, new
 		{
@@ -3172,7 +3172,7 @@ public class Migration_CreateDatabase : IArangoMigration
 			System = true,
 			TypeRestrictions = DatabaseConstants.typesPlayer,
 			SetPermissions = DatabaseConstants.permissionsWizard,
-			UnSetPermissions = DatabaseConstants.permissionsWizard
+			UnsetPermissions = DatabaseConstants.permissionsWizard
 		}),
 		await migrator.Context.Document.CreateAsync(handle, DatabaseConstants.ObjectFlags, new
 		{
@@ -3196,7 +3196,7 @@ public class Migration_CreateDatabase : IArangoMigration
 			System = true,
 			TypeRestrictions = DatabaseConstants.typesPlayer,
 			SetPermissions = DatabaseConstants.permissionsRoyalty,
-			UnSetPermissions = DatabaseConstants.permissionsRoyalty
+			UnsetPermissions = DatabaseConstants.permissionsRoyalty
 		}),
 		await migrator.Context.Document.CreateAsync(handle, DatabaseConstants.ObjectFlags, new
 		{
@@ -3219,7 +3219,7 @@ public class Migration_CreateDatabase : IArangoMigration
 			System = true,
 			TypeRestrictions = DatabaseConstants.typesContent,
 			SetPermissions = DatabaseConstants.permissionsTrusted,
-			UnSetPermissions = DatabaseConstants.permissionsTrusted
+			UnsetPermissions = DatabaseConstants.permissionsTrusted
 		}),
 		await migrator.Context.Document.CreateAsync(handle, DatabaseConstants.ObjectFlags, new
 		{
@@ -3229,7 +3229,7 @@ public class Migration_CreateDatabase : IArangoMigration
 			System = true,
 			TypeRestrictions = DatabaseConstants.typesContent,
 			SetPermissions = DatabaseConstants.permissionsTrusted,
-			UnSetPermissions = DatabaseConstants.permissionsTrusted
+			UnsetPermissions = DatabaseConstants.permissionsTrusted
 		}),
 		await migrator.Context.Document.CreateAsync(handle, DatabaseConstants.ObjectFlags, new
 		{
@@ -3263,7 +3263,7 @@ public class Migration_CreateDatabase : IArangoMigration
 			SetPermissions = DatabaseConstants.permissionsTrusted
 				.Union(DatabaseConstants.permissionsRoyalty)
 				.Union(DatabaseConstants.permissionsLog),
-			UnSetPermissions = DatabaseConstants.permissionsTrusted
+			UnsetPermissions = DatabaseConstants.permissionsTrusted
 				.Union(DatabaseConstants.permissionsRoyalty)
 		}),
 		await migrator.Context.Document.CreateAsync(handle, DatabaseConstants.ObjectFlags, new
@@ -3275,7 +3275,7 @@ public class Migration_CreateDatabase : IArangoMigration
 			SetPermissions = DatabaseConstants.permissionsWizard
 				.Union(DatabaseConstants.permissionsMDark)
 				.Union(DatabaseConstants.permissionsLog),
-			UnSetPermissions = DatabaseConstants.permissionsWizard
+			UnsetPermissions = DatabaseConstants.permissionsWizard
 				.Union(DatabaseConstants.permissionsMDark)
 		}),
 		await migrator.Context.Document.CreateAsync(handle, DatabaseConstants.ObjectFlags, new
@@ -3315,7 +3315,7 @@ public class Migration_CreateDatabase : IArangoMigration
 			System = true,
 			TypeRestrictions = DatabaseConstants.typesAll,
 			SetPermissions = DatabaseConstants.permissionsTrusted,
-			UnSetPermissions = DatabaseConstants.permissionsTrusted
+			UnsetPermissions = DatabaseConstants.permissionsTrusted
 		}),
 		await migrator.Context.Document.CreateAsync(handle, DatabaseConstants.ObjectFlags, new
 		{
@@ -3346,7 +3346,7 @@ public class Migration_CreateDatabase : IArangoMigration
 			SetPermissions = DatabaseConstants.permissionsWizard
 				.Union(DatabaseConstants.permissionsMDark)
 				.Union(DatabaseConstants.permissionsLog),
-			UnSetPermissions = DatabaseConstants.permissionsWizard
+			UnsetPermissions = DatabaseConstants.permissionsWizard
 				.Union(DatabaseConstants.permissionsMDark)
 		}),
 		await migrator.Context.Document.CreateAsync(handle, DatabaseConstants.ObjectFlags, new
@@ -3355,7 +3355,7 @@ public class Migration_CreateDatabase : IArangoMigration
 			System = true,
 			TypeRestrictions = DatabaseConstants.typesPlayer,
 			SetPermissions = DatabaseConstants.permissionsODark,
-			UnSetPermissions = DatabaseConstants.permissionsODark
+			UnsetPermissions = DatabaseConstants.permissionsODark
 		}),
 		await migrator.Context.Document.CreateAsync(handle, DatabaseConstants.ObjectFlags, new
 		{
@@ -3376,7 +3376,7 @@ public class Migration_CreateDatabase : IArangoMigration
 			System = true,
 			TypeRestrictions = DatabaseConstants.typesAll,
 			SetPermissions = DatabaseConstants.permissionsRoyalty,
-			UnSetPermissions = DatabaseConstants.permissionsRoyalty
+			UnsetPermissions = DatabaseConstants.permissionsRoyalty
 		}),
 		await migrator.Context.Document.CreateAsync(handle, DatabaseConstants.ObjectFlags, new
 		{
@@ -3391,7 +3391,7 @@ public class Migration_CreateDatabase : IArangoMigration
 			System = true,
 			TypeRestrictions = DatabaseConstants.typesAll,
 			SetPermissions = DatabaseConstants.permissionsWizard,
-			UnSetPermissions = DatabaseConstants.permissionsWizard
+			UnsetPermissions = DatabaseConstants.permissionsWizard
 		}),
 		await migrator.Context.Document.CreateAsync(handle, DatabaseConstants.ObjectFlags, new
 		{
@@ -3399,7 +3399,7 @@ public class Migration_CreateDatabase : IArangoMigration
 			System = true,
 			TypeRestrictions = DatabaseConstants.typesAll,
 			SetPermissions = DatabaseConstants.permissionsWizard,
-			UnSetPermissions = DatabaseConstants.permissionsWizard
+			UnsetPermissions = DatabaseConstants.permissionsWizard
 		}),
 	];
 

--- a/SharpMUSH.Database.ArangoDB/Migrations/Migration_RepairFlagUnsetPermissions.cs
+++ b/SharpMUSH.Database.ArangoDB/Migrations/Migration_RepairFlagUnsetPermissions.cs
@@ -1,0 +1,80 @@
+using Core.Arango;
+using Core.Arango.Migration;
+
+namespace SharpMUSH.Database.ArangoDB.Migrations;
+
+/// <summary>
+/// Repairs the thirteen object-flag seeds that <see cref="Migration_CreateDatabase"/> wrote with the
+/// property spelled <c>UnSetPermissions</c> (capital S) instead of <c>UnsetPermissions</c>. The seed
+/// used anonymous objects, the serializer preserves PascalCase verbatim, and
+/// <c>SharpObjectFlagQueryResult</c> reads <c>UnsetPermissions</c> — so the two never met and those
+/// flags read back with no unset restriction at all.
+///
+/// <para>That is not a cosmetic mismatch. <c>ManipulateSharpObjectService.SetOrUnsetFlag</c> treats an
+/// absent or empty permission list as "unrestricted" (matching PennMUSH's <c>can_set_flag_generic()</c>,
+/// where a flag with no F_* permission bits is settable by anyone who controls the object), so the
+/// missing property let anyone who controls an object clear ROYALTY, SUSPECT, NO_LOG, GAGGED, MISTRUST
+/// and PARANOID off it.
+///
+/// <para>The standing decision is that a pre-existing SharpMUSH database is dropped and re-migrated,
+/// which would also fix this. This migration exists anyway because it is three lines of AQL and it
+/// removes the need to trust that every operator did the drop — silently keeping an unenforced
+/// ROYALTY unset permission is not a failure mode worth leaving to convention.</para>
+///
+/// <para>Idempotent and safe to run on a fresh database: the corrected seed already writes the right
+/// property, so the UPDATE writes the same value it finds. <c>keepNull: false</c> is what removes the
+/// stale misspelled property rather than setting it to null.</para>
+///
+/// <para>Arango only. Memgraph and SurrealDB seed their flags from positional named tuples
+/// (<c>MemgraphDatabase.Migration.cs</c>, <c>SurrealDatabase.Migration.cs</c>) whose fields the compiler
+/// checks, so the same class of typo cannot occur there — verified by reading both seeds, and by the
+/// round-trip test running green on all three providers.</para>
+/// </summary>
+public class Migration_RepairFlagUnsetPermissions : IArangoMigration
+{
+	public long Id => 20260809_001;
+
+	public string Name => "repair_flag_unset_permissions";
+
+	/// <summary>
+	/// The flags <see cref="Migration_CreateDatabase"/> misspelled, with the permission list each was
+	/// meant to carry. Kept as data rather than re-deriving from the seed so the repair is auditable
+	/// against the migration history.
+	/// </summary>
+	private static readonly (string Name, string[] UnsetPermissions)[] Repairs =
+	[
+		("NOSPOOF", DatabaseConstants.permissionsODark),
+		("GAGGED", DatabaseConstants.permissionsWizard),
+		("JURY_OK", DatabaseConstants.permissionsRoyalty),
+		("MISTRUST", DatabaseConstants.permissionsTrusted),
+		("ROYALTY", DatabaseConstants.permissionsTrusted),
+		("SUSPECT", DatabaseConstants.permissionsWizard),
+		("CHAN_USEFIRSTMATCH", DatabaseConstants.permissionsTrusted),
+		("NO_LOG", DatabaseConstants.permissionsWizard),
+		("PARANOID", DatabaseConstants.permissionsODark),
+		("MONIKER", DatabaseConstants.permissionsRoyalty),
+		("GOING", DatabaseConstants.permissionsWizard),
+		("GOING_TWICE", DatabaseConstants.permissionsWizard)
+	];
+
+	public async Task Up(IArangoMigrator migrator, ArangoHandle handle) =>
+		await migrator.Context.Query.ExecuteAsync<object>(
+			handle,
+			"""
+			FOR repair IN @repairs
+				FOR flag IN @@c
+					FILTER flag.Name == repair.name
+					UPDATE flag WITH { UnsetPermissions: repair.perms, UnSetPermissions: null } IN @@c
+						OPTIONS { keepNull: false }
+			""",
+			bindVars: new Dictionary<string, object>
+			{
+				{ "@c", DatabaseConstants.ObjectFlags },
+				{
+					"repairs",
+					Repairs.Select(repair => new { name = repair.Name, perms = repair.UnsetPermissions }).ToArray()
+				}
+			});
+
+	public Task Down(IArangoMigrator migrator, ArangoHandle handle) => Task.CompletedTask;
+}

--- a/SharpMUSH.Database.ArangoDB/Migrations/Migration_RepairFlagUnsetPermissions.cs
+++ b/SharpMUSH.Database.ArangoDB/Migrations/Migration_RepairFlagUnsetPermissions.cs
@@ -6,20 +6,25 @@ namespace SharpMUSH.Database.ArangoDB.Migrations;
 /// <summary>
 /// Repairs the thirteen object-flag seeds that <see cref="Migration_CreateDatabase"/> wrote with the
 /// property spelled <c>UnSetPermissions</c> (capital S) instead of <c>UnsetPermissions</c>. The seed
-/// used anonymous objects, the serializer preserves PascalCase verbatim, and
-/// <c>SharpObjectFlagQueryResult</c> reads <c>UnsetPermissions</c> — so the two never met and those
-/// flags read back with no unset restriction at all.
+/// used anonymous objects, which the serializer writes verbatim, while
+/// <c>SharpObjectFlagQueryResult</c> reads <c>UnsetPermissions</c>.
 ///
-/// <para>That is not a cosmetic mismatch. <c>ManipulateSharpObjectService.SetOrUnsetFlag</c> treats an
-/// absent or empty permission list as "unrestricted" (matching PennMUSH's <c>can_set_flag_generic()</c>,
-/// where a flag with no F_* permission bits is settable by anyone who controls the object), so the
-/// missing property let anyone who controls an object clear ROYALTY, SUSPECT, NO_LOG, GAGGED, MISTRUST
-/// and PARANOID off it.
+/// <para><b>Those flags were still enforced.</b> <c>Core.Arango</c>'s <c>ArangoJsonSerializer</c> is
+/// constructed from <c>JsonSerializerDefaults.Web</c>, which sets <c>PropertyNameCaseInsensitive</c>,
+/// so the misspelled key landed on the right member and nothing was ever settable that should not have
+/// been. This migration removes a coincidence, not a permission bypass — say so plainly, because the
+/// mismatch reads like a bypass and the next person to find it will assume it was one.</para>
+///
+/// <para>The coincidence is still worth removing. AQL attribute access is case-sensitive, so the first
+/// query that filters or projects on this field drops the restriction on twelve flags with no error;
+/// changing the serializer's naming policy would do the same; and a document carrying both spellings
+/// resolves last-key-wins rather than to the correct one (reachable only if the <c>System</c> guard on
+/// <c>UpdateObjectFlagAsync</c>'s merge UPDATE ever moves, since all thirteen are system flags).</para>
 ///
 /// <para>The standing decision is that a pre-existing SharpMUSH database is dropped and re-migrated,
-/// which would also fix this. This migration exists anyway because it is three lines of AQL and it
-/// removes the need to trust that every operator did the drop — silently keeping an unenforced
-/// ROYALTY unset permission is not a failure mode worth leaving to convention.</para>
+/// which would also fix this. This migration exists anyway because it is three lines of AQL, and
+/// leaving correctness resting on a third-party serializer default is not worth the alternative of
+/// trusting that every operator did the drop.</para>
 ///
 /// <para>Idempotent and safe to run on a fresh database: the corrected seed already writes the right
 /// property, so the UPDATE writes the same value it finds. <c>keepNull: false</c> is what removes the

--- a/SharpMUSH.Database.Memgraph/MemgraphDatabase.Sessions.cs
+++ b/SharpMUSH.Database.Memgraph/MemgraphDatabase.Sessions.cs
@@ -78,5 +78,19 @@ public partial class MemgraphDatabase
 			"MATCH (s:Session {originIp: $originIp}) DELETE s", new { originIp }, cancellationToken);
 	}
 
+	/// <inheritdoc />
+	public async ValueTask<string[]> GetSessionOriginIpsAsync(CancellationToken cancellationToken = default)
+	{
+		var result = await ExecuteWithRetryAsync(
+			"MATCH (s:Session) RETURN DISTINCT s.originIp AS originIp", ct: cancellationToken);
+		return
+		[
+			.. result.Result
+				.Select(record => record["originIp"].As<string?>())
+				.Where(ip => !string.IsNullOrEmpty(ip))
+				.Select(ip => ip!)
+		];
+	}
+
 	#endregion
 }

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Sessions.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Sessions.cs
@@ -92,5 +92,20 @@ public partial class SurrealDatabase
 			new Dictionary<string, object?> { ["originIp"] = originIp }, cancellationToken);
 	}
 
+	/// <inheritdoc />
+	public async ValueTask<string[]> GetSessionOriginIpsAsync(CancellationToken cancellationToken = default)
+	{
+		var response = await ExecuteAsync("SELECT VALUE originIp FROM session",
+			new Dictionary<string, object?>(), cancellationToken);
+		var results = response.GetValue<List<string?>>(0) ?? [];
+		return
+		[
+			.. results
+				.Where(ip => !string.IsNullOrEmpty(ip))
+				.Select(ip => ip!)
+				.Distinct(StringComparer.OrdinalIgnoreCase)
+		];
+	}
+
 	#endregion
 }

--- a/SharpMUSH.Implementation/Handlers/EvaluateAttributeForLockQueryHandler.cs
+++ b/SharpMUSH.Implementation/Handlers/EvaluateAttributeForLockQueryHandler.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Mediator;
+using OneOf;
 using OneOf.Types;
 using SharpMUSH.Library;
 using SharpMUSH.Library.DiscriminatedUnions;
@@ -16,12 +17,20 @@ namespace SharpMUSH.Implementation.Handlers;
 /// PennMUSH eval locks (ATTR/pattern) evaluate the attribute on the gated object
 /// with the unlocker as enactor, then compare the result to the pattern.
 /// </summary>
+/// <remarks>
+/// An evaluation that throws returns <see cref="LockEvaluationFailure"/>, not a value. It used to
+/// return <c>null</c>, which the caller then compared against the lock's pattern — a failure and a
+/// non-matching result were the same answer. They deny alike, but only one of them says the game is
+/// broken, and a caller that wanted to treat them differently had no way to.
+/// </remarks>
 public class EvaluateAttributeForLockQueryHandler(
 	IAttributeService attributeService,
 	IMUSHCodeParser parser,
-	ILogger<EvaluateAttributeForLockQueryHandler> logger) : IQueryHandler<EvaluateAttributeForLockQuery, string?>
+	ILogger<EvaluateAttributeForLockQueryHandler> logger)
+	: IQueryHandler<EvaluateAttributeForLockQuery, OneOf<string, LockEvaluationFailure>>
 {
-	public async ValueTask<string?> Handle(EvaluateAttributeForLockQuery query, CancellationToken cancellationToken)
+	public async ValueTask<OneOf<string, LockEvaluationFailure>> Handle(EvaluateAttributeForLockQuery query,
+		CancellationToken cancellationToken)
 	{
 		// PennMUSH: call_ufun(&ufun, buff, player, player, pe_info, NULL)
 		// where player = unlocker, and the attribute is on target (gated object)
@@ -62,13 +71,13 @@ public class EvaluateAttributeForLockQueryHandler(
 				evalParent: false,
 				ignorePermissions: true);
 
-			return result?.ToPlainText();
+			return result.ToPlainText();
 		}
 		catch (Exception ex)
 		{
 			logger.LogWarning(ex, "Failed to evaluate attribute {Attribute} on {Object} for lock evaluation",
 				query.AttributeName, query.GatedObject);
-			return null;
+			return new LockEvaluationFailure(query.AttributeName, ex.Message);
 		}
 	}
 }

--- a/SharpMUSH.Implementation/Visitors/SharpMUSHBooleanExpressionVisitor.cs
+++ b/SharpMUSH.Implementation/Visitors/SharpMUSHBooleanExpressionVisitor.cs
@@ -604,11 +604,15 @@ public class SharpMUSHBooleanExpressionVisitor(
 				.AsTask()
 				.ConfigureAwait(false).GetAwaiter().GetResult();
 
-			if (evalResult == null)
-				return false;
-
-			// Compare with expected value (case-insensitive, per PennMUSH strcasecmp)
-			return evalResult.Equals(expected, StringComparison.OrdinalIgnoreCase);
+			return evalResult.Match(
+				// Compare with expected value (case-insensitive, per PennMUSH strcasecmp)
+				value => value.Equals(expected, StringComparison.OrdinalIgnoreCase),
+				// An evaluation that could not run denies, deliberately and in one place. PennMUSH's
+				// check_attrib_lock() (src/boolexp.c) returns 0 for every way the evaluation can fail —
+				// no attribute name, no comparison string, no such attribute — and pennlock.hlp says of a
+				// permission failure inside the eval that "the person will automatically fail to pass the
+				// lock". A lock that cannot be evaluated is a lock that has not been passed.
+				_ => false);
 		};
 
 		return Expression.Invoke(Expression.Constant(func), gated, unlocker, Expression.Constant(attribute), Expression.Constant(expectedValue));

--- a/SharpMUSH.Library/ISharpDatabase.cs
+++ b/SharpMUSH.Library/ISharpDatabase.cs
@@ -851,5 +851,17 @@ public interface ISharpDatabase
 	ValueTask DeleteSessionsForAccountAsync(string accountId, CancellationToken cancellationToken = default);
 	ValueTask DeleteSessionsForIpAsync(string originIp, CancellationToken cancellationToken = default);
 
+	/// <summary>
+	/// The distinct origin IPs of the sessions that currently exist.
+	/// </summary>
+	/// <remarks>
+	/// Ban enforcement needs this because sitelock rules are patterns — globs and CIDR blocks — while
+	/// <see cref="DeleteSessionsForIpAsync"/> is exact equality on one address. Matching a pattern
+	/// inside the query would mean writing the same glob/CIDR semantics three times, once per query
+	/// language, and AQL/Cypher/SurrealQL do not agree on how. Returning the candidate addresses lets
+	/// <c>SitelockMatcher</c> stay the single implementation of what a rule matches.
+	/// </remarks>
+	ValueTask<string[]> GetSessionOriginIpsAsync(CancellationToken cancellationToken = default);
+
 	#endregion
 }

--- a/SharpMUSH.Library/Queries/EvaluateAttributeForLockQuery.cs
+++ b/SharpMUSH.Library/Queries/EvaluateAttributeForLockQuery.cs
@@ -1,18 +1,38 @@
 using Mediator;
+using OneOf;
 using SharpMUSH.Library.DiscriminatedUnions;
 using SharpMUSH.Library.Models;
 
 namespace SharpMUSH.Library.Queries;
 
 /// <summary>
+/// An eval lock's attribute could not be evaluated at all — the evaluation threw rather than producing
+/// a value to compare against the lock's pattern.
+/// </summary>
+/// <remarks>
+/// This exists so a caller cannot mistake "the evaluation blew up" for "the evaluation produced
+/// something that did not match". Both deny, so the two are easy to conflate; they are not the same
+/// event, and only one of them means the game is misconfigured or broken.
+/// </remarks>
+/// <param name="AttributeName">The attribute whose evaluation failed.</param>
+/// <param name="Reason">The exception message, for a caller that wants to report or log it.</param>
+public readonly record struct LockEvaluationFailure(string AttributeName, string Reason);
+
+/// <summary>
 /// Query to evaluate an attribute on an object as MUSHcode for lock evaluation.
 /// In PennMUSH, evaluation locks (ATTR/pattern) fetch the attribute from the gated object,
 /// evaluate it as MUSHcode with the unlocker as the enactor (%#), and compare the result.
 /// </summary>
+/// <remarks>
+/// Returns a union rather than a nullable string. A lock decides who may enter, take, use or modify an
+/// object; answering <c>null</c> for a failed evaluation left the caller comparing a null against the
+/// lock's pattern and reaching a verdict that had nothing to do with the lock's intent. The union makes
+/// the compiler ask every caller what a failure means to it.
+/// </remarks>
 /// <param name="GatedObject">The object whose attribute is being evaluated</param>
 /// <param name="Unlocker">The object attempting to pass the lock (becomes %# during eval)</param>
 /// <param name="AttributeName">The attribute name to evaluate</param>
 public record EvaluateAttributeForLockQuery(
 	AnySharpObject GatedObject,
 	AnySharpObject Unlocker,
-	string AttributeName) : IQuery<string?>;
+	string AttributeName) : IQuery<OneOf<string, LockEvaluationFailure>>;

--- a/SharpMUSH.Library/Services/DatabaseAccountSessionStore.cs
+++ b/SharpMUSH.Library/Services/DatabaseAccountSessionStore.cs
@@ -93,4 +93,7 @@ public sealed class DatabaseAccountSessionStore(ISharpDatabase database) : IAcco
 
 	public Task RevokeAllForIpAsync(string originIp, CancellationToken ct = default)
 		=> database.DeleteSessionsForIpAsync(originIp, ct).AsTask();
+
+	public Task<string[]> GetKnownOriginIpsAsync(CancellationToken ct = default)
+		=> database.GetSessionOriginIpsAsync(ct).AsTask();
 }

--- a/SharpMUSH.Library/Services/InMemoryAccountSessionStore.cs
+++ b/SharpMUSH.Library/Services/InMemoryAccountSessionStore.cs
@@ -58,4 +58,12 @@ public sealed class InMemoryAccountSessionStore : IAccountSessionStore
 			_tokens.TryRemove(pair.Key, out _);
 		return Task.CompletedTask;
 	}
+
+	public Task<string[]> GetKnownOriginIpsAsync(CancellationToken ct = default)
+		=> Task.FromResult<string[]>([
+			.. _tokens.Values
+				.Select(session => session.OriginIp)
+				.Where(ip => !string.IsNullOrEmpty(ip))
+				.Distinct(StringComparer.OrdinalIgnoreCase)
+		]);
 }

--- a/SharpMUSH.Library/Services/Interfaces/IAccountSessionStore.cs
+++ b/SharpMUSH.Library/Services/Interfaces/IAccountSessionStore.cs
@@ -41,4 +41,17 @@ public interface IAccountSessionStore
 
 	/// <summary>Invalidates every session token created from the given origin IP (ban enforcement).</summary>
 	Task RevokeAllForIpAsync(string originIp, CancellationToken ct = default);
+
+	/// <summary>
+	/// The distinct origin IPs of the sessions that currently exist, so ban enforcement can decide which
+	/// of them a glob or CIDR sitelock rule matches.
+	/// </summary>
+	/// <remarks>
+	/// <see cref="RevokeAllForIpAsync"/> takes one literal address, and sitelock rules are patterns. A
+	/// rule like <c>10.0.0.0/8</c> or <c>*.example.net</c> therefore had nothing to revoke unless the
+	/// banned party happened to be connected at that instant, because the only addresses ban enforcement
+	/// knew about were the ones it read off live connections. This is how it learns about the sessions
+	/// that exist without one.
+	/// </remarks>
+	Task<string[]> GetKnownOriginIpsAsync(CancellationToken ct = default);
 }

--- a/SharpMUSH.Library/Services/SitelockMatcher.cs
+++ b/SharpMUSH.Library/Services/SitelockMatcher.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Net;
 using System.Text.RegularExpressions;
 
@@ -84,16 +85,22 @@ public static class SitelockMatcher
 	}
 
 	/// <summary>
+	/// Compiled glob patterns, keyed by the rule text they came from. Matching now runs on the
+	/// authentication path of every authenticated request, not only at login, so rebuilding the pattern
+	/// string and re-parsing it once per rule per call is worth avoiding. The rule set is admin-authored
+	/// and small, and every caller passes a rule as the pattern, so its keys are bounded by the rule set
+	/// and this never grows unbounded.
+	/// </summary>
+	private static readonly ConcurrentDictionary<string, Regex> GlobCache = new();
+
+	/// <summary>
 	/// Simple wildcard matching for sitelock patterns (<c>*</c> and <c>?</c> wildcards), lifted
 	/// from the former private <c>WizardCommands.WildcardMatch</c> so it is shared across the
 	/// connect-time check and ban-enforcement matchers.
 	/// </summary>
 	private static bool WildcardMatch(string text, string pattern)
-	{
-		var regexPattern = "^" + Regex.Escape(pattern)
-			.Replace("\\*", ".*")
-			.Replace("\\?", ".") + "$";
-
-		return Regex.IsMatch(text, regexPattern, RegexOptions.IgnoreCase);
-	}
+		=> GlobCache.GetOrAdd(pattern, static p => new Regex(
+				"^" + Regex.Escape(p).Replace("\\*", ".*").Replace("\\?", ".") + "$",
+				RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
+			.IsMatch(text);
 }

--- a/SharpMUSH.Server/Authentication/AccountSessionAuthenticationHandler.cs
+++ b/SharpMUSH.Server/Authentication/AccountSessionAuthenticationHandler.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SharpMUSH.Library.Authorization;
@@ -15,9 +16,22 @@ namespace SharpMUSH.Server.Authentication;
 /// and emitting the <see cref="GameHub.CharacterDbrefClaim"/> the hub authorizes on.
 /// </summary>
 /// <remarks>
-/// Nothing the client sends participates in choosing the acting character — there is no header or
+/// <para>Nothing the client sends participates in choosing the acting character — there is no header or
 /// query hint to spoof. The choice is <see cref="ActingCharacterResolver"/>'s alone, made from the
-/// session the token names plus the account's live character roster.
+/// session the token names plus the account's live character roster.</para>
+///
+/// <para>Sitelock is re-checked here against the address the request is actually coming from, not the
+/// one the session was created at. A session records one origin IP; sitelock rules are patterns
+/// evaluated against the current request, and a session that changes address otherwise walks straight
+/// through a ban on the address it is being used from. Revoking at ban time (see
+/// <c>BanEnforcementService.EnforceHostRuleAsync</c>) cannot cover that case, because the address in
+/// question did not exist anywhere when the ban landed.</para>
+///
+/// <para>The check runs before the session store is read, so a banned address costs strictly less than
+/// it did — the sitelock decision is a scan of the in-memory rule set behind an
+/// <c>IOptionsMonitor</c> snapshot, with no I/O of any kind. That is deliberately unlike the
+/// per-request database write PR #754 removed from this path: the concern there was a write per
+/// request contending on one document, and nothing here writes or reads anything.</para>
 /// </remarks>
 public class AccountSessionAuthenticationHandler(
 	IOptionsMonitor<AuthenticationSchemeOptions> options,
@@ -25,16 +39,33 @@ public class AccountSessionAuthenticationHandler(
 	UrlEncoder encoder,
 	IAccountSessionStore sessionStore,
 	IAccountService accountService,
-	AccountClaimsService accountClaims)
+	AccountClaimsService accountClaims,
+	SitelockGuard sitelockGuard)
 	: AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
 {
 	public const string SchemeName = "AccountSession";
+
+	/// <summary>
+	/// Set when this request was refused for sitelock rather than for a bad credential, so the
+	/// challenge answers 403 instead of 401. Handler instances are per-request, so this holds no state
+	/// across requests.
+	/// </summary>
+	private bool _sitelocked;
 
 	protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
 	{
 		var token = ExtractToken();
 		if (string.IsNullOrWhiteSpace(token))
 			return AuthenticateResult.NoResult();
+
+		// Same "unknown" fallback the session-minting surfaces use (AuthController.ClientIp), so a rule
+		// written against one is understood by the other.
+		var clientIp = Context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+		if (sitelockGuard.IsBlocked(clientIp, host: string.Empty, SitelockGuard.Connect))
+		{
+			_sitelocked = true;
+			return AuthenticateResult.Fail("Sitelocked address.");
+		}
 
 		var session = await sessionStore.ValidateAsync(token);
 		if (session is null)
@@ -69,6 +100,24 @@ public class AccountSessionAuthenticationHandler(
 
 		var identity = new ClaimsIdentity(claims, SchemeName);
 		return AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName));
+	}
+
+	/// <summary>
+	/// A banned address is not a bad credential. Without this the sitelock refusal above would reach the
+	/// client as 401, telling a browser its session had expired and sending it round the login loop,
+	/// and it would silently replace the 403 the sitelocked auth surfaces have always answered with
+	/// (<c>AuthController.IsSitelocked</c>, pinned by <c>SitelockCheckTests</c> and
+	/// <c>SwitchCharacterTests</c>) on every <c>[Authorize]</c>-gated endpoint.
+	/// </summary>
+	protected override Task HandleChallengeAsync(AuthenticationProperties properties)
+	{
+		if (!_sitelocked)
+		{
+			return base.HandleChallengeAsync(properties);
+		}
+
+		Response.StatusCode = StatusCodes.Status403Forbidden;
+		return Task.CompletedTask;
 	}
 
 	private string? ExtractToken()

--- a/SharpMUSH.Server/Services/BanEnforcementService.cs
+++ b/SharpMUSH.Server/Services/BanEnforcementService.cs
@@ -113,13 +113,18 @@ public sealed class BanEnforcementService(
 	/// <summary>
 	/// For every live game connection or SignalR connection whose IP or hostname matches
 	/// <paramref name="hostPattern"/>, revokes sessions from that connection's origin IP,
-	/// disconnects the game handle, and aborts the SignalR connection.
+	/// disconnects the game handle, and aborts the SignalR connection — plus every session the store
+	/// holds whose own origin IP the rule matches, connected or not.
 	/// </summary>
 	/// <remarks>
-	/// The connection walk (per-handle publish), the session-revoke fan-out, and the SignalR-abort
-	/// fan-out are each independently guarded (see <see cref="RunGuardedAsync"/> and the per-item
-	/// try/catch inside each loop): a ban must land as completely as possible, so one failing step
-	/// must never prevent the others from running.
+	/// <para>The connection walk (per-handle publish), the stored-origin sweep, the session-revoke
+	/// fan-out, and the SignalR-abort fan-out are each independently guarded (see
+	/// <see cref="RunGuardedAsync"/> and the per-item try/catch inside each loop): a ban must land as
+	/// completely as possible, so one failing step must never prevent the others from running.</para>
+	///
+	/// <para>This still cannot reach a session used from an address it was not created at — that
+	/// address does not exist anywhere when the ban lands. <c>AccountSessionAuthenticationHandler</c>
+	/// re-checks sitelock per request for exactly that case.</para>
 	/// </remarks>
 	public async ValueTask EnforceHostRuleAsync(string hostPattern, CancellationToken ct = default)
 	{
@@ -162,19 +167,36 @@ public sealed class BanEnforcementService(
 
 		// The pattern itself counts as an extra revoke/abort target when it is already a literal
 		// IP. The session store's own lookup (RevokeAllForIpAsync) is keyed by exact IP only — it
-		// has no CIDR/glob awareness — so CIDR/glob host rules only revoke sessions/abort
-		// connections for the concrete IPs observed live above (matchedIps), never for the pattern
-		// itself. Never target the literal "unknown" sentinel — a session legitimately carries
-		// that origin IP when the client's remote address could not be resolved (see
-		// AuthController.ClientIp()), and it is not what an admin means when banning a host.
+		// has no CIDR/glob awareness. Never target the literal "unknown" sentinel — a session
+		// legitimately carries that origin IP when the client's remote address could not be
+		// resolved (see AuthController.ClientIp()), and it is not what an admin means when banning
+		// a host.
 		var literalTarget = !IsGlobPattern(hostPattern)
 				&& !string.Equals(hostPattern, UnknownOrigin, StringComparison.OrdinalIgnoreCase)
 			? hostPattern
 			: null;
 
-		// Revoke sessions from every concrete IP we found live traffic from, plus the literal
-		// pattern target. Each IP is independently guarded so one un-revokable IP doesn't block
-		// the rest.
+		// Sessions that exist with no live connection behind them. Reading the live connection list
+		// above only finds the addresses of people currently connected, so a CIDR or glob rule used
+		// to leave every idle session from the banned range valid until its own TTL ran out — the
+		// credential outlived the ban. Ask the store which origin IPs it actually holds and put every
+		// one the rule matches through the same exact-IP revoke, so the pattern semantics stay in
+		// SitelockMatcher and the providers keep their one simple query.
+		await RunGuardedAsync("collect stored session origins for host rule", hostPattern, async () =>
+		{
+			foreach (var ip in await sessionStore.GetKnownOriginIpsAsync(ct))
+			{
+				if (!string.Equals(ip, UnknownOrigin, StringComparison.OrdinalIgnoreCase)
+					&& MatchesConnection(ip, string.Empty, hostPattern))
+				{
+					matchedIps.Add(ip);
+				}
+			}
+		});
+
+		// Revoke sessions from every concrete IP the rule matched — whether it was found on a live
+		// connection or only in the session store — plus the literal pattern target. Each IP is
+		// independently guarded so one un-revokable IP doesn't block the rest.
 		await RunGuardedAsync("revoke sessions for host rule", hostPattern, async () =>
 		{
 			foreach (var ip in matchedIps)

--- a/SharpMUSH.Tests/Authentication/AccountSessionAuthHandlerTests.cs
+++ b/SharpMUSH.Tests/Authentication/AccountSessionAuthHandlerTests.cs
@@ -7,6 +7,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using OneOf.Types;
+using SharpMUSH.Configuration;
+using SharpMUSH.Configuration.Options;
 using SharpMUSH.Library.Authorization;
 using SharpMUSH.Library.Models;
 using SharpMUSH.Library.Services.Interfaces;
@@ -94,6 +96,20 @@ public class AccountSessionAuthHandlerTests
 			cache, new AccountClaimsInvalidator(cache), NullLogger<AccountClaimsService>.Instance);
 	}
 
+	/// <summary>A guard with no rules, so the sitelock re-check never fires for tests about other things.</summary>
+	private static SitelockGuard PermissiveSitelockGuard() => SitelockGuardFor([]);
+
+	private static SitelockGuard SitelockGuardFor(Dictionary<string, string[]> rules)
+	{
+		var options = Substitute.For<IOptionsWrapper<SharpMUSHOptions>>();
+		options.CurrentValue.Returns(
+			ReadPennMushConfig.Create("Configuration/Testfile/mushcnf.dst") with
+			{
+				SitelockRules = new SitelockRulesOptions(rules)
+			});
+		return new SitelockGuard(options);
+	}
+
 	private static async Task<AccountSessionAuthenticationHandler> CreateHandlerWithHeaderAsync(
 		IAccountSessionStore sessionStore,
 		IAccountService accountService,
@@ -101,7 +117,9 @@ public class AccountSessionAuthHandlerTests
 		string? authorizationHeader = null,
 		string? accessTokenQuery = null,
 		string? actingCharacterHeader = null,
-		string? actingCharacterQuery = null)
+		string? actingCharacterQuery = null,
+		SitelockGuard? sitelockGuard = null,
+		string? remoteIp = null)
 	{
 		var optionsMonitor = Substitute.For<IOptionsMonitor<AuthenticationSchemeOptions>>();
 		optionsMonitor.Get(Arg.Any<string>()).Returns(new AuthenticationSchemeOptions());
@@ -113,12 +131,15 @@ public class AccountSessionAuthHandlerTests
 			UrlEncoder.Default,
 			sessionStore,
 			accountService,
-			accountClaims);
+			accountClaims,
+			sitelockGuard ?? PermissiveSitelockGuard());
 
 		var httpContext = new DefaultHttpContext
 		{
 			RequestServices = new ServiceCollection().BuildServiceProvider(),
 		};
+		if (remoteIp is not null)
+			httpContext.Connection.RemoteIpAddress = System.Net.IPAddress.Parse(remoteIp);
 		if (authorizationHeader is not null)
 			httpContext.Request.Headers.Authorization = authorizationHeader;
 		if (actingCharacterHeader is not null)
@@ -441,5 +462,89 @@ public class AccountSessionAuthHandlerTests
 
 		await Assert.That(result.Succeeded).IsTrue();
 		await Assert.That(result.Principal!.FindFirst(GameHub.CharacterDbrefClaim)).IsNull();
+	}
+
+	/// <summary>
+	/// A session records the one address it was created at; sitelock rules are patterns judged against
+	/// the address a request is actually coming from. Revoking at ban time can only ever reach the
+	/// former. This is the case it cannot reach: a live, valid session presented from an address inside
+	/// a banned range that it was never created at.
+	/// </summary>
+	[Test]
+	public async Task ValidToken_PresentedFromASitelockedAddress_DoesNotAuthenticate()
+	{
+		var sessionStore = Substitute.For<IAccountSessionStore>();
+		var accountService = Substitute.For<IAccountService>();
+
+		sessionStore.ValidateAsync("good").Returns(Task.FromResult<IAccountSessionStore.SessionIdentity?>(
+			new IAccountSessionStore.SessionIdentity("node_accounts/1", null, null)));
+		accountService.GetByIdAsync("node_accounts/1").Returns(new ValueTask<SharpAccount?>(MakeAccount()));
+		accountService.GetCharactersAsync("node_accounts/1")
+			.Returns(new ValueTask<IReadOnlyList<SharpPlayer>>((IReadOnlyList<SharpPlayer>)[]));
+
+		var accountClaims = MakeAccountClaims(Substitute.For<IAccountService>(), PortalRole.Player);
+		var guard = SitelockGuardFor(new Dictionary<string, string[]> { ["10.0.0.0/8"] = [SitelockGuard.Connect] });
+
+		var handler = await CreateHandlerWithHeaderAsync(sessionStore, accountService, accountClaims,
+			authorizationHeader: "Bearer good", sitelockGuard: guard, remoteIp: "10.11.12.13");
+
+		var result = await handler.AuthenticateAsync();
+
+		await Assert.That(result.Succeeded)
+			.IsFalse()
+			.Because("sitelock is a rule about the address a request comes from, not about where a session was minted");
+		// The session store is never consulted, so a banned address costs less than an allowed one.
+		await sessionStore.DidNotReceive().ValidateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+	}
+
+	/// <summary>The control: the same session from an address the rule does not cover still works.</summary>
+	[Test]
+	public async Task ValidToken_PresentedFromAnAddressOutsideTheRule_StillAuthenticates()
+	{
+		var sessionStore = Substitute.For<IAccountSessionStore>();
+		var accountService = Substitute.For<IAccountService>();
+
+		sessionStore.ValidateAsync("good").Returns(Task.FromResult<IAccountSessionStore.SessionIdentity?>(
+			new IAccountSessionStore.SessionIdentity("node_accounts/1", null, null)));
+		accountService.GetByIdAsync("node_accounts/1").Returns(new ValueTask<SharpAccount?>(MakeAccount()));
+		accountService.GetCharactersAsync("node_accounts/1")
+			.Returns(new ValueTask<IReadOnlyList<SharpPlayer>>((IReadOnlyList<SharpPlayer>)[]));
+
+		var accountClaims = MakeAccountClaims(Substitute.For<IAccountService>(), PortalRole.Player);
+		var guard = SitelockGuardFor(new Dictionary<string, string[]> { ["10.0.0.0/8"] = [SitelockGuard.Connect] });
+
+		var handler = await CreateHandlerWithHeaderAsync(sessionStore, accountService, accountClaims,
+			authorizationHeader: "Bearer good", sitelockGuard: guard, remoteIp: "198.51.100.7");
+
+		var result = await handler.AuthenticateAsync();
+
+		await Assert.That(result.Succeeded).IsTrue();
+	}
+
+	/// <summary>
+	/// A rule carrying only <c>!create</c> gates registration, not an existing session. Re-checking on
+	/// every authenticated request must not quietly widen what a rule means.
+	/// </summary>
+	[Test]
+	public async Task ValidToken_FromAnAddressBannedOnlyForCreate_StillAuthenticates()
+	{
+		var sessionStore = Substitute.For<IAccountSessionStore>();
+		var accountService = Substitute.For<IAccountService>();
+
+		sessionStore.ValidateAsync("good").Returns(Task.FromResult<IAccountSessionStore.SessionIdentity?>(
+			new IAccountSessionStore.SessionIdentity("node_accounts/1", null, null)));
+		accountService.GetByIdAsync("node_accounts/1").Returns(new ValueTask<SharpAccount?>(MakeAccount()));
+		accountService.GetCharactersAsync("node_accounts/1")
+			.Returns(new ValueTask<IReadOnlyList<SharpPlayer>>((IReadOnlyList<SharpPlayer>)[]));
+
+		var accountClaims = MakeAccountClaims(Substitute.For<IAccountService>(), PortalRole.Player);
+		var guard = SitelockGuardFor(new Dictionary<string, string[]> { ["10.0.0.0/8"] = [SitelockGuard.Create] });
+
+		var handler = await CreateHandlerWithHeaderAsync(sessionStore, accountService, accountClaims,
+			authorizationHeader: "Bearer good", sitelockGuard: guard, remoteIp: "10.11.12.13");
+
+		var result = await handler.AuthenticateAsync();
+
+		await Assert.That(result.Succeeded).IsTrue();
 	}
 }

--- a/SharpMUSH.Tests/Database/FlagUnsetPermissionTests.cs
+++ b/SharpMUSH.Tests/Database/FlagUnsetPermissionTests.cs
@@ -1,0 +1,145 @@
+using Core.Arango;
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using SharpMUSH.Library;
+using SharpMUSH.Library.Commands.Database;
+using SharpMUSH.Library.Definitions;
+using SharpMUSH.Library.Extensions;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Queries.Database;
+using SharpMUSH.Library.Services.Interfaces;
+
+namespace SharpMUSH.Tests.Database;
+
+/// <summary>
+/// Pins the seed → read round trip for flag unset permissions.
+///
+/// <para>The ArangoDB seed spelled the property <c>UnSetPermissions</c> on thirteen flags while
+/// <c>SharpObjectFlagQueryResult</c> reads <c>UnsetPermissions</c>. Nothing failed — the flags simply
+/// read back with no unset restriction, and the permission gate in
+/// <c>ManipulateSharpObjectService.SetOrUnsetFlag</c> treats an empty list as "unrestricted". So the
+/// only thing that catches this is asserting on the value that reached the database.</para>
+/// </summary>
+public class FlagUnsetPermissionTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactoryArg { get; init; }
+
+	private ISharpDatabase Database => WebAppFactoryArg.Services.GetRequiredService<ISharpDatabase>();
+	private IMediator Mediator => WebAppFactoryArg.Services.GetRequiredService<IMediator>();
+	private IMUSHCodeParser Parser => WebAppFactoryArg.CommandParser;
+	private IConnectionService ConnectionService => WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
+
+	private IManipulateSharpObjectService ManipulateService
+		=> WebAppFactoryArg.Services.GetRequiredService<IManipulateSharpObjectService>();
+
+	/// <summary>
+	/// Every flag the seeds restrict unsetting on, with the permission level each requires. Staff-only
+	/// flags and the monitoring/punishment flags a badly behaved character would most want to clear.
+	/// </summary>
+	public static IEnumerable<(string Flag, string Permission)> RestrictedUnsetFlags() =>
+	[
+		("NOSPOOF", "odark"),
+		("GAGGED", "wizard"),
+		("JURY_OK", "royalty"),
+		("MISTRUST", "trusted"),
+		("ROYALTY", "trusted"),
+		("SUSPECT", "wizard"),
+		("CHAN_USEFIRSTMATCH", "trusted"),
+		("NO_LOG", "wizard"),
+		("PARANOID", "odark"),
+		("MONIKER", "royalty"),
+		("GOING", "wizard"),
+		("GOING_TWICE", "wizard"),
+		("WIZARD", "wizard"),
+		("FIXED", "wizard"),
+		("TRUST", "trusted"),
+		("JUDGE", "royalty"),
+		("UNREGISTERED", "royalty"),
+		("APPROVED", "royalty")
+	];
+
+	/// <summary>
+	/// The storage-level assertion, and the only one that fails on the misspelled seed.
+	///
+	/// <para>The behavioural tests below pass either way, because <c>ArangoJsonSerializer</c> is built on
+	/// <c>JsonSerializerDefaults.Web</c> and so deserializes case-insensitively — <c>UnSetPermissions</c>
+	/// happens to land on <c>UnsetPermissions</c>. That is the whole reason the misspelling went
+	/// unnoticed, and it is not a property worth relying on: AQL attribute access is case-sensitive,
+	/// swapping the naming policy would silently drop the restriction on twelve flags, and a document
+	/// carrying both spellings resolves last-key-wins rather than to the correct one.</para>
+	///
+	/// <para>Arango only — Memgraph and SurrealDB seed from positional named tuples the compiler checks,
+	/// so this class of typo cannot reach their documents. Those legs skip.</para>
+	/// </summary>
+	[Test]
+	public async Task NoSeededFlag_CarriesAMisspelledPermissionProperty()
+	{
+		if (WebAppFactoryArg.Services.GetService<IArangoContext>() is not { } context)
+		{
+			return;
+		}
+
+		var handle = WebAppFactoryArg.Services.GetRequiredService<ArangoHandle>();
+		var offenders = await context.Query.ExecuteAsync<string>(handle,
+			"""
+			FOR flag IN @@c
+				FILTER LENGTH(ATTRIBUTES(flag)[* FILTER LOWER(CURRENT) == "unsetpermissions"
+					AND CURRENT != "UnsetPermissions"]) > 0
+				RETURN flag.Name
+			""",
+			bindVars: new Dictionary<string, object>
+			{
+				{ "@c", SharpMUSH.Database.DatabaseConstants.ObjectFlags }
+			});
+
+		await Assert.That(offenders)
+			.IsEmpty()
+			.Because("the seed must write the property name the model reads, not one that only matches case-insensitively");
+	}
+
+	[Test]
+	[MethodDataSource(nameof(RestrictedUnsetFlags))]
+	public async Task SeededFlag_ReadsBackItsUnsetPermissions(string flagName, string permission)
+	{
+		var flag = await Mediator.Send(new GetObjectFlagQuery(flagName));
+
+		await Assert.That(flag).IsNotNull();
+		await Assert.That(flag!.UnsetPermissions)
+			.IsNotEmpty()
+			.Because($"{flagName} must not be unsettable by anyone who controls the object");
+		await Assert.That(flag.UnsetPermissions).Contains(permission);
+	}
+
+	/// <summary>
+	/// The whole point of the property, stated as behaviour: a plain player carrying SUSPECT cannot
+	/// take it off themselves. They control themselves, so the ownership gate lets them through and the
+	/// flag's unset permission is the only thing standing in the way. SUSPECT is the flag to test with
+	/// because it has no <c>CheckFlagSpecificPermissions</c> rule of its own — the generic gate is the
+	/// entire defence.
+	/// </summary>
+	[Test]
+	public async Task PlainPlayer_CannotUnsetSuspectFromThemselves()
+	{
+		var name = TestIsolationHelpers.GenerateUniqueName("Suspect");
+		var created = await Parser.CommandParse(1, ConnectionService, MModule.single($"@pcreate {name}=pw_{name}"));
+		var playerDbRef = DBRef.Parse(created.Message!.ToPlainText()!);
+		var player = (await Mediator.Send(new GetObjectNodeQuery(playerDbRef))).Known;
+
+		var suspect = await Mediator.Send(new GetObjectFlagQuery("SUSPECT"));
+		await Mediator.Send(new SetObjectFlagCommand(player, suspect!));
+
+		var reread = (await Mediator.Send(new GetObjectNodeQuery(playerDbRef))).Known;
+		var result = await ManipulateService.SetOrUnsetFlag(reread, reread, "!SUSPECT", false);
+
+		await Assert.That(result.Message!.ToPlainText())
+			.IsEqualTo(ErrorMessages.Returns.PermissionDenied);
+
+		var after = (await Mediator.Send(new GetObjectNodeQuery(playerDbRef))).Known;
+		var flags = await after.Object().Flags.Value.ToArrayAsync();
+		await Assert.That(flags.Any(flag => flag.Name == "SUSPECT"))
+			.IsTrue()
+			.Because("a refused unset must leave the flag in place");
+	}
+}

--- a/SharpMUSH.Tests/Database/FlagUnsetPermissionTests.cs
+++ b/SharpMUSH.Tests/Database/FlagUnsetPermissionTests.cs
@@ -15,11 +15,24 @@ namespace SharpMUSH.Tests.Database;
 /// <summary>
 /// Pins the seed → read round trip for flag unset permissions.
 ///
-/// <para>The ArangoDB seed spelled the property <c>UnSetPermissions</c> on thirteen flags while
-/// <c>SharpObjectFlagQueryResult</c> reads <c>UnsetPermissions</c>. Nothing failed — the flags simply
-/// read back with no unset restriction, and the permission gate in
-/// <c>ManipulateSharpObjectService.SetOrUnsetFlag</c> treats an empty list as "unrestricted". So the
-/// only thing that catches this is asserting on the value that reached the database.</para>
+/// <para><b>These flags were never actually unprotected.</b> The ArangoDB seed spelled the property
+/// <c>UnSetPermissions</c> on thirteen flags while <c>SharpObjectFlagQueryResult</c> reads
+/// <c>UnsetPermissions</c>, which looks like it should have left them with no unset restriction at all.
+/// It did not: <c>Core.Arango</c>'s <c>ArangoJsonSerializer</c> is constructed from
+/// <c>JsonSerializerDefaults.Web</c>, which sets <c>PropertyNameCaseInsensitive</c>, so the misspelled
+/// key landed on the right member anyway. ROYALTY, SUSPECT and the rest were enforced the whole time —
+/// measured, by running the behavioural tests below against a database migrated by the unfixed seed
+/// and watching all of them pass.</para>
+///
+/// <para>So what was fixed is a coincidence, not a hole. The coincidence is not worth keeping, for
+/// three reasons: AQL attribute access is case-sensitive, so the first query that filters on this
+/// field loses the restriction silently; changing the serializer's naming policy would do the same;
+/// and a document carrying both spellings resolves last-key-wins rather than to the correct one.</para>
+///
+/// <para>That is also why the assertions split in two. Everything behavioural here passes with or
+/// without the fix and exists to pin the enforcement contract going forward. Only
+/// <see cref="NoSeededFlag_CarriesAMisspelledPermissionProperty"/>, which reads the stored attribute
+/// names, can tell the two seeds apart.</para>
 /// </summary>
 public class FlagUnsetPermissionTests
 {

--- a/SharpMUSH.Tests/Database/SessionStoreDbTests.cs
+++ b/SharpMUSH.Tests/Database/SessionStoreDbTests.cs
@@ -74,4 +74,36 @@ public class SessionStoreDbTests
 		await Db.DeleteSessionsForIpAsync("10.0.0.1");
 		await Assert.That(await Db.GetSessionAsync("tok-b1")).IsNull();
 	}
+
+	/// <summary>
+	/// Ban enforcement asks the store which origin IPs it holds so it can decide which of them a glob or
+	/// CIDR sitelock rule matches — <c>DeleteSessionsForIpAsync</c> only knows one literal address at a
+	/// time. All three providers must answer the same question the same way, so this runs on each leg of
+	/// the matrix.
+	/// </summary>
+	[Test, NotInParallel(nameof(SessionStoreDbTests))]
+	public async Task GetSessionOriginIps_ReturnsTheDistinctOriginsOfLivingSessions()
+	{
+		await Db.UpsertSessionAsync(Make("tok-o1", "acctO", "203.0.113.10"));
+		await Db.UpsertSessionAsync(Make("tok-o2", "acctO", "203.0.113.10"));
+		await Db.UpsertSessionAsync(Make("tok-o3", "acctO", "203.0.113.11"));
+
+		try
+		{
+			var origins = await Db.GetSessionOriginIpsAsync();
+
+			await Assert.That(origins).Contains("203.0.113.10");
+			await Assert.That(origins).Contains("203.0.113.11");
+			await Assert.That(origins.Count(ip => ip == "203.0.113.10"))
+				.IsEqualTo(1)
+				.Because("two sessions from one address are one address to revoke");
+
+			await Db.DeleteSessionsForIpAsync("203.0.113.10");
+			await Assert.That(await Db.GetSessionOriginIpsAsync()).DoesNotContain("203.0.113.10");
+		}
+		finally
+		{
+			await Db.DeleteSessionsForAccountAsync("acctO");
+		}
+	}
 }

--- a/SharpMUSH.Tests/Parser/EvalLockEvaluationFailureTests.cs
+++ b/SharpMUSH.Tests/Parser/EvalLockEvaluationFailureTests.cs
@@ -1,0 +1,109 @@
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using OneOf;
+using SharpMUSH.Implementation;
+using SharpMUSH.Implementation.Handlers;
+using SharpMUSH.Library;
+using SharpMUSH.Library.DiscriminatedUnions;
+using SharpMUSH.Library.Extensions;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Queries;
+using SharpMUSH.Library.Services.Interfaces;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace SharpMUSH.Tests.Parser;
+
+/// <summary>
+/// An eval lock (<c>ATTR/value</c>) evaluates an attribute as MUSHcode and compares the result to the
+/// lock's pattern. When that evaluation throws there is no result to compare, and the question is what
+/// the lock does about it.
+///
+/// <para>PennMUSH answers unambiguously. <c>check_attrib_lock()</c> (src/boolexp.c) returns 0 for every
+/// way the evaluation can fail — empty attribute name, empty comparison string, no such attribute — and
+/// <c>pennlock.hlp</c> says of a permission failure inside the evaluation that "the person will
+/// automatically fail to pass the lock". Failure denies.</para>
+///
+/// <para>These tests pin both halves: the verdict is deny, and the failure arrives as a failure rather
+/// than as a value that happens to compare unequal.</para>
+/// </summary>
+public class EvalLockEvaluationFailureTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactoryArg { get; init; }
+
+	private ISharpDatabase Database => WebAppFactoryArg.Services.GetRequiredService<ISharpDatabase>();
+
+	/// <summary>
+	/// The handler must report a failed evaluation as <see cref="LockEvaluationFailure"/>. Returning a
+	/// string — any string, including the empty one — would put the failure back into the same channel
+	/// as a result, which is what let a broken evaluation reach the lock's comparison.
+	/// </summary>
+	[Test]
+	public async Task EvaluationThatThrows_IsReportedAsAFailure_NotAsAValue()
+	{
+		var one = (await Database.GetObjectNodeAsync(new DBRef(1))).Known();
+
+		var attributeService = Substitute.For<IAttributeService>();
+		attributeService.EvaluateAttributeFunctionAsync(
+				Arg.Any<IMUSHCodeParser>(), Arg.Any<AnySharpObject>(), Arg.Any<AnySharpObject>(), Arg.Any<string>(),
+				Arg.Any<Dictionary<string, CallState>>(), Arg.Any<bool>(), Arg.Any<bool>())
+			.ThrowsAsync(new InvalidOperationException("evaluation exploded"));
+
+		var parser = Substitute.For<IMUSHCodeParser>();
+		parser.Push(Arg.Any<ParserState>()).Returns(parser);
+
+		var handler = new EvaluateAttributeForLockQueryHandler(attributeService, parser,
+			NullLogger<EvaluateAttributeForLockQueryHandler>.Instance);
+
+		var result = await handler.Handle(new EvaluateAttributeForLockQuery(one, one, "BOOM"), CancellationToken.None);
+
+		await Assert.That(result.IsT1)
+			.IsTrue()
+			.Because("a failed evaluation must not be indistinguishable from an evaluated value");
+		await Assert.That(result.AsT1.AttributeName).IsEqualTo("BOOM");
+		await Assert.That(result.AsT1.Reason).Contains("evaluation exploded");
+	}
+
+	/// <summary>
+	/// And the verdict on that failure is deny, matching PennMUSH. A lock that cannot be evaluated is a
+	/// lock that has not been passed.
+	/// </summary>
+	[Test]
+	public async Task EvalLock_WhoseEvaluationFailed_DoesNotPass()
+	{
+		var one = (await Database.GetObjectNodeAsync(new DBRef(1))).Known();
+
+		var mediator = Substitute.For<IMediator>();
+		mediator.Send(Arg.Any<EvaluateAttributeForLockQuery>(), Arg.Any<CancellationToken>())
+			.Returns(new ValueTask<OneOf<string, LockEvaluationFailure>>(
+				new LockEvaluationFailure("FAILING", "evaluation exploded")));
+
+		var parser = new BooleanExpressionParser(mediator, new FusionCache(new FusionCacheOptions()));
+
+		await Assert.That(parser.Compile("FAILING/expected")(one, one))
+			.IsFalse()
+			.Because("PennMUSH's check_attrib_lock() returns 0 when the evaluation cannot produce a value");
+	}
+
+	/// <summary>
+	/// The control: an evaluation that does produce the pattern still passes, so the deny above is the
+	/// failure path and not the eval lock being broken outright.
+	/// </summary>
+	[Test]
+	public async Task EvalLock_WhoseEvaluationMatched_Passes()
+	{
+		var one = (await Database.GetObjectNodeAsync(new DBRef(1))).Known();
+
+		var mediator = Substitute.For<IMediator>();
+		mediator.Send(Arg.Any<EvaluateAttributeForLockQuery>(), Arg.Any<CancellationToken>())
+			.Returns(new ValueTask<OneOf<string, LockEvaluationFailure>>("expected"));
+
+		var parser = new BooleanExpressionParser(mediator, new FusionCache(new FusionCacheOptions()));
+
+		await Assert.That(parser.Compile("MATCHING/expected")(one, one)).IsTrue();
+	}
+}

--- a/SharpMUSH.Tests/Services/BanEnforcementServiceTests.cs
+++ b/SharpMUSH.Tests/Services/BanEnforcementServiceTests.cs
@@ -59,6 +59,12 @@ public class BanEnforcementServiceTests
 			IAccountSessionStore? sessionStore = null)
 	{
 		var sessions = sessionStore ?? Substitute.For<IAccountSessionStore>();
+		if (sessionStore is null)
+		{
+			// A store with no sessions in it, so tests that say nothing about stored origins keep
+			// exercising only the live-connection path.
+			sessions.GetKnownOriginIpsAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult<string[]>([]));
+		}
 		var claimsInvalidator = Substitute.For<IAccountClaimsInvalidator>();
 		var connections = Substitute.For<IConnectionService>();
 		connections.GetAll().Returns((liveConnections ?? []).ToAsyncEnumerable());
@@ -236,6 +242,57 @@ public class BanEnforcementServiceTests
 			Arg.Is<DisconnectConnectionMessage>(m => m.Handle == 302), Arg.Any<CancellationToken>());
 		await sessions.Received().RevokeAllForIpAsync("10.0.0.42", Arg.Any<CancellationToken>());
 		await sessions.DidNotReceive().RevokeAllForIpAsync("10.0.1.42", Arg.Any<CancellationToken>());
+	}
+
+	/// <summary>
+	/// The case ban enforcement could not reach: a session that exists with nobody connected on it.
+	/// Reading the live connection list finds nothing, so before stored origins were consulted a CIDR
+	/// rule revoked nothing at all and the credential outlived the ban.
+	/// </summary>
+	[Test]
+	public async Task EnforceHostRuleAsync_CidrPattern_RevokesStoredSessionsWithNoLiveConnection()
+	{
+		var sessionStore = Substitute.For<IAccountSessionStore>();
+		sessionStore.GetKnownOriginIpsAsync(Arg.Any<CancellationToken>())
+			.Returns(Task.FromResult<string[]>(["10.0.0.5", "10.255.255.254", "198.51.100.7"]));
+		var (svc, sessions, _, _, _, _, _) = Build(sessionStore: sessionStore);
+
+		await svc.EnforceHostRuleAsync("10.0.0.0/8");
+
+		await sessions.Received().RevokeAllForIpAsync("10.0.0.5", Arg.Any<CancellationToken>());
+		await sessions.Received().RevokeAllForIpAsync("10.255.255.254", Arg.Any<CancellationToken>());
+		await sessions.DidNotReceive().RevokeAllForIpAsync("198.51.100.7", Arg.Any<CancellationToken>());
+	}
+
+	[Test]
+	public async Task EnforceHostRuleAsync_GlobPattern_RevokesStoredSessionsWithNoLiveConnection()
+	{
+		var sessionStore = Substitute.For<IAccountSessionStore>();
+		sessionStore.GetKnownOriginIpsAsync(Arg.Any<CancellationToken>())
+			.Returns(Task.FromResult<string[]>(["10.0.0.42", "10.0.1.42"]));
+		var (svc, sessions, _, _, _, _, _) = Build(sessionStore: sessionStore);
+
+		await svc.EnforceHostRuleAsync("10.0.0.*");
+
+		await sessions.Received().RevokeAllForIpAsync("10.0.0.42", Arg.Any<CancellationToken>());
+		await sessions.DidNotReceive().RevokeAllForIpAsync("10.0.1.42", Arg.Any<CancellationToken>());
+	}
+
+	/// <summary>
+	/// The stored-origin sweep must respect the same "unknown" sentinel rule the live-connection sweep
+	/// does: a session whose origin could not be resolved is not what an admin means by <c>*</c>.
+	/// </summary>
+	[Test]
+	public async Task EnforceHostRuleAsync_StoredOrigins_NeverIncludeTheUnknownBucket()
+	{
+		var sessionStore = Substitute.For<IAccountSessionStore>();
+		sessionStore.GetKnownOriginIpsAsync(Arg.Any<CancellationToken>())
+			.Returns(Task.FromResult<string[]>(["unknown"]));
+		var (svc, sessions, _, _, _, _, _) = Build(sessionStore: sessionStore);
+
+		await svc.EnforceHostRuleAsync("*");
+
+		await sessions.DidNotReceive().RevokeAllForIpAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
 	}
 
 	[Test]


### PR DESCRIPTION
PR 11 of a single linear stack — it targets `feat/audit2-10-approved-and-plus-scene`, its predecessor, **not `main`**. Review it after PRs 1–10.

Three defects, each found by a different agent while fixing something else and deliberately left out of scope at the time. The repo owner asked for all three together. Three commits, one per finding, so any one can be reverted alone.

**Two of the three were not what they looked like, and this PR says so rather than shipping the framing.** Finding 1's enforcement gap does not exist at runtime — the flags it names were enforced the whole time, so what lands here removes a *latent* bypass, not a live one. Finding 2 was already fail-closed and already matched PennMUSH; its fix is a type change with no behaviour change. **Only Finding 3 was exploitable**, and it is the only one where a pre-fix test could fail for the reported reason. The evidence for each is below.

*Branch note: this branch was force-pushed during authoring — the tip commit was amended three times after being pushed. It is unmerged, nothing is based on it, and no other branch in the stack was touched; all ten predecessors are at their original SHAs.*

---

## Finding 1 — the flag seed writes a property name the model does not read

### The defect

Thirteen object-flag seeds in `SharpMUSH.Database.ArangoDB/Migrations/Migration_CreateDatabase.cs` spell the property **`UnSetPermissions`** (capital S). `SharpObjectFlagQueryResult` reads **`UnsetPermissions`**. Anonymous objects, so nothing in the compiler notices.

Affected: NOSPOOF, GAGGED, JURY_OK, MISTRUST (seeded twice), ROYALTY, SUSPECT, CHAN_USEFIRSTMATCH, NO_LOG, PARANOID, MONIKER, GOING, GOING_TWICE.

### The direction: **not exploitable.** The reported enforcement gap does not exist.

The brief predicted that these flags read back with an empty permission list and were therefore unsettable by anyone. Measured, that is false. `Core.Arango.Serialization.Json.ArangoJsonSerializer` is constructed as:

```csharp
_options = new JsonSerializerOptions(JsonSerializerDefaults.Web) { PropertyNamingPolicy = policy, ... };
```

`JsonSerializerDefaults.Web` sets `PropertyNameCaseInsensitive = true`, so `UnSetPermissions` lands on `UnsetPermissions` anyway. Confirmed twice:

- Direct probe of the same options — `misspelled-only: UnsetPermissions=[wizard]`.
- The behavioural tests in this PR, run against a database migrated by the **unfixed** seed: **19/19 passed**, including a plain player being refused `!SUSPECT` on themselves.

So the flags **are** enforced today, and the permission gate at `ManipulateSharpObjectService.cs:182` never saw an empty array for them.

Worth fixing regardless, because the correctness is coincidental:

- **AQL attribute access is case-sensitive.** No AQL touches this field today (all three providers map it in C#), but the first query that does silently loses the restriction on twelve flags.
- **A naming-policy change drops enforcement silently.** Same probe with a genuinely unmapped name: **13 failed / 6 passed**, and the behavioural test reported `Expected to be equal to "#-1 PERMISSION DENIED" but received "1"` — the player cleared their own SUSPECT flag.
- **Duplicate keys resolve last-wins, not correct-wins.** Probe: `both: UnsetPermissions=[royalty]`, `both-reversed: UnsetPermissions=[wizard]`. Reachable only if the `flag.System` guard on `UpdateObjectFlagAsync` (a merge UPDATE) ever moves; all thirteen are System flags today.

### Repair migration: yes

`Migration_RepairFlagUnsetPermissions` (id `20260809_001`) UPDATEs the twelve names with `keepNull: false`, which writes the correct property and drops the stale one. Idempotent, and a no-op on a database migrated by the corrected seed.

The standing decision from #747 is that any pre-existing database is dropped and re-migrated, which would also fix this. It is three lines of AQL, and the alternative is trusting that every operator did the drop. Given the value at stake is whether ROYALTY and SUSPECT stay restricted, "probably nobody has an old database" is not the argument to rest on.

### The fail-open default at `ManipulateSharpObjectService.cs:183` is correct — unchanged

An empty permission list means no check. That matches PennMUSH's `can_set_flag_generic()`, where a flag carrying no `F_*` permission bits is settable by anyone who controls the object, and 42 of the 62 seeded flags legitimately have no unset restriction. Making an empty list deny would lock ordinary players out of DARK, QUIET, OPAQUE and the rest. The bug was the data, not the rule.

### Other providers: verified, unaffected

Memgraph (`MemgraphDatabase.Migration.cs:368`) and SurrealDB (`SurrealDatabase.Migration.cs:404`) seed from positional named tuples — `(string Name, string Symbol, string[]? Aliases, string[] SetPerms, string[] UnsetPerms, string[] TypeRestrictions)` — which the compiler checks. Both carry the correct values for all thirteen flags; read their seeds rather than assuming.

### Confirmed pre-fix failure

`NoSeededFlag_CarriesAMisspelledPermissionProperty` asserts on the stored attribute names, which is the only assertion the case-insensitive deserializer cannot paper over. Against the unfixed seed:

```
failed NoSeededFlag_CarriesAMisspelledPermissionProperty (16ms)
  AssertionException: Expected to be empty, because the seed must write the property name the model reads,
  not one that only matches case-insensitively
  but collection contains items: [NOSPOOF, GAGGED, JURY_OK, MISTRUST, MISTRUST, ROYALTY, SUSPECT,
  CHAN_USEFIRSTMATCH, NO_LOG, PARANOID, and 3 more...]

  total: 20   failed: 1   succeeded: 19
```

After: arangodb 20/20, memgraph 20/20. The Arango-specific assertion skips on the other legs; the eighteen behavioural assertions run everywhere.

---

## Finding 2 — a failed lock evaluation was indistinguishable from a result

### The direction: **fail-closed**, and it already matched PennMUSH

`EvaluateAttributeForLockQuery` has exactly one consumer. Repo-wide grep returns five hits: the record, the handler's declaration (×3), and the call site.

`SharpMUSH.Implementation/Visitors/SharpMUSHBooleanExpressionVisitor.cs:591-615`, `VisitEvaluationExpr`:

```csharp
if (evalResult == null)
    return false;
```

`null` → `false` → the eval-lock term denies. **Fail-closed. Not a security hole.**

`null` was reachable only from the handler's `catch`: `IAttributeService.EvaluateAttributeFunctionAsync` is declared `ValueTask<MString>`, and a missing attribute returns `MModule.empty()` (`AttributeService.cs:241-244`), not null.

PennMUSH agrees, and it is the reference. `pennmush/src/boolexp.c:1976-1990`:

```c
  if (!atrname || !*atrname || !str || !*str)
    return 0;
  if (!fetch_ufun_attrib(atrname, target, &ufun, UFUN_LOCALIZE | UFUN_REQUIRE_ATTR | UFUN_SHARE_STACK))
    return 0; /* fail if there's no matching attribute */
```

and `pennmush/game/txt/hlp/pennlock.hlp:104`: *"if you try to do something ... and `<object>` doesn't have permission to do that, the person will automatically fail to pass the lock."* Every failure path returns 0.

The grammar routing was worth confirming too: the eval lock is `ATTR/value` (`SharpMUSHBoolExpLexer.g4:54` — `EVALUATION: '/'`), matching Penn's `EVAL_TOKEN '/'`. `^` is for typed keyword locks and none of them reach this query.

### The fix

The verdict was right; the type was not. A failure and a value that happened not to match arrived through the same channel, at a caller that could not have told them apart. The query now returns `OneOf<string, LockEvaluationFailure>`, per CLAUDE.md's rule that services put failure in the type rather than in a nullable, and the deny is one explicitly-commented branch instead of an implied null check.

### Confirmed pre-fix failure: **none exists, and that is the finding**

The verdict is unchanged by this commit, so no test can fail for the old behaviour. Claiming otherwise would be the "coverage that proves nothing" this review explicitly warns against.

What the tests do instead is pin the behaviour so it cannot drift, and they have teeth. Flipping the failure branch from `_ => false` to `_ => true`:

```
Test run summary: Failed!
  total: 3   failed: 1   succeeded: 2
```

Restored, 3/3 pass.

---

## Finding 3 — a session outlives, or walks around, a sitelock ban

### The defect

`ArangoDatabase.Sessions.cs:123` — `FILTER d.OriginIp == @ip` — exact equality on the address the session was **created** at. Same shape in Memgraph (`:78`) and SurrealDB (`:91`). Sitelock rules are globs and CIDR blocks.

`BanEnforcementService.cs:163-173` documents the consequence and compensates by harvesting IPs from **live** connections. Two cases survive that:

1. **A session with no live connection.** Nothing to harvest, so a `10.0.0.0/8` ban revoked nothing and every idle session in the range stayed valid until its own TTL. Worse: `IsGlobPattern` only tests `*`/`?`, so `"10.0.0.0/8"` is passed to `RevokeAllForIpAsync` as a literal and matches zero rows.
2. **A session presented from a different address than it was minted at.** That address did not exist anywhere at ban time, so no revocation strategy can reach it.

### The approach: **both**, because neither reaches the other's case

**Pattern-aware revocation** — new `GetSessionOriginIpsAsync` on `ISharpDatabase` (all three providers) and `GetKnownOriginIpsAsync` on `IAccountSessionStore`. `EnforceHostRuleAsync` unions the stored origins the rule matches into `matchedIps` and revokes each. Matching stays in `SitelockMatcher` rather than being rewritten as a glob/CIDR predicate three times over in AQL, Cypher and SurrealQL, where the dialects do not agree. Reads only, off the admin path, no transaction — same reasoning as `GetSessionAsync`.

**Validation-time checking** — `AccountSessionAuthenticationHandler` re-checks sitelock against the request's own address. This is the only thing that catches case 2.

### The performance argument, against #754

I read #754's diff before touching this path. What it removed was an unconditional `UpsertSessionAsync` **per authenticated request** — a database write contending on one document, producing `errorNum: 1200 AQL: write-write conflict` on 17 of 24 concurrent requests, and 1317 ms vs 300 ms at N=200. The fix coalesced the write to at most one per 2% of TTL, ≈ one per 18 seconds of continuous use.

What this PR adds is not that shape:

- **No I/O.** `SitelockGuard.IsBlocked` reads `IOptionsMonitor.CurrentValue` — an in-memory snapshot, refreshed only by a change token — and scans the admin-authored rule set. No database, no cache lookup, no network.
- **No write.** #754's problem was contention on a document. Nothing here writes.
- **It runs before the session read**, so a banned address now costs *less* than it did — it returns without touching the store at all. Pinned by `await sessionStore.DidNotReceive().ValidateAsync(...)`.
- **The remaining per-rule cost is bounded.** `WildcardMatch` rebuilt a pattern string and re-parsed it once per rule per call, relying on `Regex`'s static cache (default cap 15). Glob patterns are now compiled once into a `ConcurrentDictionary` keyed by rule text — bounded by the rule set, which is admin-authored and small. This also speeds up the login path and `@sitelock/check`.

Deliberately **not** done: revoking the session on a sitelocked request. Refusing is enough, matches how sitelock is specified, and keeps the write off the auth path.

Scope check: the re-check uses `!connect` only, so a rule carrying only `!create` still gates registration and does not start rejecting existing sessions. Pinned by a test.

### Confirmed pre-fix failures

Stored-origin revocation, with the sweep removed:

```
failed EnforceHostRuleAsync_GlobPattern_RevokesStoredSessionsWithNoLiveConnection (70ms)
  ReceivedCallsException: Expected to receive a call matching:
failed EnforceHostRuleAsync_CidrPattern_RevokesStoredSessionsWithNoLiveConnection (70ms)
  ReceivedCallsException: Expected to receive a call matching:

  total: 16   failed: 2   succeeded: 14
```

Validation-time check, with the check removed:

```
failed ValidToken_PresentedFromASitelockedAddress_DoesNotAuthenticate (106ms)
  AssertionException: Expected to be false, because sitelock is a rule about the address a request
  comes from, not about where a session was minted
  but found True

  total: 15   failed: 1   succeeded: 14
```

Both restored: 16/16 and 15/15.

### All three providers

`GetSessionOriginIps_ReturnsTheDistinctOriginsOfLivingSessions` in `SessionStoreDbTests` runs on every leg of the matrix — arangodb 4/4, memgraph 4/4, surrealdb 4/4.

---

### One thing this broke, and how

The first integration run failed `SwitchCharacter_FromSitelockedIp_Returns403` — my check ran before the controller's, so `[Authorize]` challenged with **401** where the endpoint had always answered **403**:

```
failed SwitchCharacter_FromSitelockedIp_Returns403 (99ms)
```

A banned address is not a bad credential, and a 401 would have sent the portal round the login loop. `HandleChallengeAsync` now answers 403 when the refusal was sitelock, which restores the contract `AuthController.IsSitelocked` established and `SitelockCheckTests`/`SwitchCharacterTests` pin. That existing test is the regression pin for it.

---

## Tests

Every suite, every provider, run locally against Podman:

| Suite | arangodb | memgraph | surrealdb |
|---|---|---|---|
| `SharpMUSH.Tests` | 5434 total, **0 failed**, 5242 passed, 192 skipped | 5434, **0 failed** | 5434, **0 failed** |
| `SharpMUSH.Tests.Integration` | 323 total, **0 failed** | 323, **0 failed** | 323, **0 failed** |

The 192 skips are the pre-existing `[Skip]`-attributed set, unchanged. The known `wiki_translation` write-conflict flake on the surrealdb integration leg did not occur.

## Build

`dotnet build -t:Rebuild`, 0 errors. Warning counts identical to the unmodified branch, code for code:

```
      2 warning ANT01      14 warning CS0067     394 warning MSB3277
      8 warning NU1510       8 warning NU1603
```

No suppressions added, `TreatWarningsAsErrors` untouched. `dotnet format whitespace` run to convergence over every touched project.

---

## Found but left out of scope

- **`Migration_CreateDatabase` seeds MISTRUST twice** (lines ~3222 and ~3232), the second with `Aliases = ["MYOPIC"]` and no distinct name. Memgraph and SurrealDB each seed one MISTRUST carrying the MYOPIC alias, so Arango has a duplicate document and the other two do not. Not security, and correcting it means deciding what the second entry was meant to be — its own change.
- **Per-provider permission drift.** Arango seeds `ROYALTY` unset as `["trusted"]` and `SUSPECT` as `["wizard"]`; Memgraph and SurrealDB seed `["trusted","royalty"]` and `["wizard","mdark"]`. The check is `AnyAsync`, so Arango is stricter rather than looser — a divergence, not a hole.
- **Eval locks fetch the attribute with `ignorePermissions: true`** (`EvaluateAttributeForLockQueryHandler.cs:63`), so the fetch runs as `#1`. `pennlock.hlp:104` promises evaluation "with the powers of `<object>`" and an automatic fail when the object lacks permission. The subsequent evaluation does run as the gated object; only the fetch escalates. A behaviour change to lock semantics, not a swallow, so not folded into this PR.
- **Two uncached database reads survive per authenticated request** — `GetSessionAsync` and `accountService.GetCharactersAsync`, the latter a duplicate of the roster read already behind `AccountClaimsService`'s 30 s FusionCache. Left alone deliberately: #754's territory, and not something to reopen inside a security PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MPRzndB5egy4F2A3q5852

