### PR TITLE
Fix the channel privilege documentation, and split MYOPIC back out of MISTRUST

### DIFF
--- a/SharpMUSH.Database.ArangoDB/Migrations/Migration_CreateDatabase.cs
+++ b/SharpMUSH.Database.ArangoDB/Migrations/Migration_CreateDatabase.cs
@@ -3217,19 +3217,20 @@ public class Migration_CreateDatabase : IArangoMigration
 			Name = "MISTRUST",
 			Symbol = "m",
 			System = true,
-			TypeRestrictions = DatabaseConstants.typesContent,
+			TypeRestrictions = DatabaseConstants.typesNonPlayer,
 			SetPermissions = DatabaseConstants.permissionsTrusted,
 			UnsetPermissions = DatabaseConstants.permissionsTrusted
 		}),
+		// MYOPIC shares MISTRUST's letter and is told apart from it by object type, exactly as in
+		// PennMUSH (hdrs/flag_tab.h:51 and src/flags.c:778; game/txt/hlp/pennflag.hlp:37 prints the
+		// shared letter as "m - Mistrust/Myopic"). SharpObjectFlag.Symbol is documented as not unique
+		// and the seed already ships ABODE/ANSI on 'A' and CHOWN_OK/COLOR on 'C' the same way.
 		await migrator.Context.Document.CreateAsync(handle, DatabaseConstants.ObjectFlags, new
 		{
-			Name = "MISTRUST",
-			Aliases = (string[])["MYOPIC"],
+			Name = "MYOPIC",
 			Symbol = "m",
 			System = true,
-			TypeRestrictions = DatabaseConstants.typesContent,
-			SetPermissions = DatabaseConstants.permissionsTrusted,
-			UnsetPermissions = DatabaseConstants.permissionsTrusted
+			TypeRestrictions = DatabaseConstants.typesPlayer
 		}),
 		await migrator.Context.Document.CreateAsync(handle, DatabaseConstants.ObjectFlags, new
 		{

--- a/SharpMUSH.Database.ArangoDB/Migrations/Migration_RepairMistrustMyopic.cs
+++ b/SharpMUSH.Database.ArangoDB/Migrations/Migration_RepairMistrustMyopic.cs
@@ -1,0 +1,114 @@
+using Core.Arango;
+using Core.Arango.Migration;
+
+namespace SharpMUSH.Database.ArangoDB.Migrations;
+
+/// <summary>
+/// Splits MYOPIC back out of MISTRUST, and removes the duplicate MISTRUST row that carried it.
+///
+/// <para>PennMUSH has two flags on the letter <c>m</c>, told apart by object type: MISTRUST
+/// (<c>src/flags.c:778</c> — <c>TYPE_THING | TYPE_EXIT | TYPE_ROOM</c>, which stops an object
+/// controlling others via Control/Zone locks or same-owner control) and MYOPIC
+/// (<c>hdrs/flag_tab.h:51</c> — <c>TYPE_PLAYER</c>, which hides dbrefs and flag lists after the names
+/// of objects you control). <c>game/txt/hlp/pennflag.hlp:37</c> prints the shared letter as
+/// "m - Mistrust/Myopic", and that line is the likely origin of the error:
+/// <see cref="Migration_CreateDatabase"/> wrote MISTRUST twice — once plain, once carrying
+/// <c>Aliases = ["MYOPIC"]</c> — and gave both <c>typesContent</c> (PLAYER, EXIT, THING), which
+/// wrongly admits players and wrongly omits rooms.</para>
+///
+/// <para>Two flags may share a letter here: <c>SharpObjectFlag.Symbol</c> documents itself as not
+/// unique, and the seed already ships ABODE/ANSI on 'A', CHOWN_OK/COLOR on 'C' and NO_LEAVE/NO_TEL
+/// on 'N', each pair separated by its type restrictions. Nothing needed changing to allow it.</para>
+///
+/// <para>The duplicate row is not simply deleted. Either document could be the one an object's
+/// <c>edge_has_flags</c> edge points at — which of the two a lookup found was down to iteration
+/// order — so the edges move to the surviving document first. Nothing loses a flag it had.</para>
+///
+/// <para>Idempotent and safe on a fresh database: the corrected seed writes one MISTRUST with the
+/// right types and a separate MYOPIC, so every statement below either matches nothing or writes what
+/// it already finds. This does <em>not</em> implement MYOPIC's display behaviour — that is a change
+/// to the look/examine rendering path, deliberately left out.</para>
+/// </summary>
+public class Migration_RepairMistrustMyopic : IArangoMigration
+{
+	public long Id => 20260809_002;
+
+	public string Name => "repair_mistrust_myopic";
+
+	/// <summary>The MISTRUST document every other one collapses into: lowest <c>_key</c>, so the choice is stable.</summary>
+	private const string Survivor =
+		"""
+		LET survivor = FIRST(
+			FOR flag IN @@flags
+				FILTER flag.Name == "MISTRUST"
+				SORT flag._key
+				RETURN flag)
+		""";
+
+	public async Task Up(IArangoMigrator migrator, ArangoHandle handle)
+	{
+		await migrator.Context.Query.ExecuteAsync<object>(
+			handle,
+			$$"""
+			{{Survivor}}
+			FOR flag IN @@flags
+				FILTER flag.Name == "MISTRUST" AND flag._id != survivor._id
+					FOR edge IN @@edges
+						FILTER edge._to == flag._id
+						UPDATE edge WITH { _to: survivor._id } IN @@edges
+			""",
+			bindVars: new Dictionary<string, object>
+			{
+				{ "@flags", DatabaseConstants.ObjectFlags },
+				{ "@edges", DatabaseConstants.HasFlags }
+			});
+
+		// ArangoDB rejects a bind parameter the query does not mention, so every statement declares only
+		// the collections it names.
+		await migrator.Context.Query.ExecuteAsync<object>(
+			handle,
+			$$"""
+			{{Survivor}}
+			FOR flag IN @@flags
+				FILTER flag.Name == "MISTRUST" AND flag._id != survivor._id
+				REMOVE flag IN @@flags
+			""",
+			bindVars: new Dictionary<string, object>
+			{
+				{ "@flags", DatabaseConstants.ObjectFlags }
+			});
+
+		// The survivor keeps its permissions and gains PennMUSH's type list; a stale MYOPIC alias goes.
+		await migrator.Context.Query.ExecuteAsync<object>(
+			handle,
+			"""
+			FOR flag IN @@flags
+				FILTER flag.Name == "MISTRUST"
+				UPDATE flag WITH {
+					Symbol: "m",
+					TypeRestrictions: @types,
+					Aliases: REMOVE_VALUE(flag.Aliases == null ? [] : flag.Aliases, "MYOPIC")
+				} IN @@flags
+			""",
+			bindVars: new Dictionary<string, object>
+			{
+				{ "@flags", DatabaseConstants.ObjectFlags },
+				{ "types", DatabaseConstants.typesNonPlayer }
+			});
+
+		await migrator.Context.Query.ExecuteAsync<object>(
+			handle,
+			"""
+			UPSERT { Name: "MYOPIC" }
+			INSERT { Name: "MYOPIC", Symbol: "m", System: true, TypeRestrictions: @types }
+			UPDATE { Symbol: "m", System: true, TypeRestrictions: @types } IN @@flags
+			""",
+			bindVars: new Dictionary<string, object>
+			{
+				{ "@flags", DatabaseConstants.ObjectFlags },
+				{ "types", DatabaseConstants.typesPlayer }
+			});
+	}
+
+	public Task Down(IArangoMigrator migrator, ArangoHandle handle) => Task.CompletedTask;
+}

--- a/SharpMUSH.Database.Memgraph/MemgraphDatabase.Migration.cs
+++ b/SharpMUSH.Database.Memgraph/MemgraphDatabase.Migration.cs
@@ -285,6 +285,8 @@ MERGE (o)-[:HAS_OWNER]->(pm)
 
 			await CreateInitialFlags(cancellationToken);
 
+			await RepairMistrustMyopicFlag(cancellationToken);
+
 			await CreateInitialAttributeFlags(cancellationToken);
 
 			await CreateInitialPowers(cancellationToken);
@@ -405,7 +407,10 @@ MERGE (o)-[:HAS_FLAG]->(f)
 ("JURY_OK", "j", ["JURYOK"], ["royalty"], ["royalty"], ["PLAYER"]),
 ("KEEPALIVE", "k", null, [], [], ["PLAYER"]),
 ("LIGHT", "l", null, [], [], ["ROOM","PLAYER","EXIT","THING"]),
-("MISTRUST", "m", ["MYOPIC"], ["trusted"], ["trusted"], ["PLAYER","EXIT","THING"]),
+("MISTRUST", "m", null, ["trusted"], ["trusted"], ["THING","EXIT","ROOM"]),
+// MYOPIC shares MISTRUST's letter and is told apart from it by object type, as in PennMUSH
+// (hdrs/flag_tab.h:51, src/flags.c:778). Symbols are not unique here — see ABODE/ANSI on 'A'.
+("MYOPIC", "m", null, [], [], ["PLAYER"]),
 ("NO_COMMAND", "n", ["NOCOMMAND"], [], [], ["ROOM","PLAYER","EXIT","THING"]),
 ("ON_VACATION", "o", ["ONVACATION","ON-VACATION"], [], [], ["PLAYER"]),
 ("PUPPET", "P", null, [], [], ["THING"]),
@@ -447,6 +452,28 @@ f.typeRestrictions = $typeRestrictions
 			}, ct);
 		}
 	}
+
+	/// <summary>
+	/// Splits MYOPIC back out of MISTRUST on a database seeded before the two were told apart.
+	/// </summary>
+	/// <remarks>
+	/// PennMUSH has two flags on the letter <c>m</c>, separated by object type: MISTRUST
+	/// (<c>src/flags.c:778</c> — THING, EXIT, ROOM) and MYOPIC (<c>hdrs/flag_tab.h:51</c> — PLAYER).
+	/// The seed above collapsed them, giving MISTRUST a MYOPIC alias and the wrong type list.
+	/// <para>
+	/// MYOPIC itself needs no repair — it is a new name, so the seed's <c>MERGE</c> creates it. Only the
+	/// MISTRUST row needs correcting, and the <c>ON CREATE SET</c> the seed uses will not touch a row
+	/// that already exists. The <c>WHERE</c> clause is what keeps this from being a standing overwrite:
+	/// it matches only a row still carrying the collapsed alias, so the statement fires at most once per
+	/// database and never reverts an operator's later customisation of the flag.
+	/// </para>
+	/// </remarks>
+	private async Task RepairMistrustMyopicFlag(CancellationToken ct) =>
+		await ExecuteWithRetryAsync("""
+MATCH (f:ObjectFlag {name: 'MISTRUST'})
+WHERE 'MYOPIC' IN f.aliases
+SET f.aliases = [], f.symbol = 'm', f.typeRestrictions = ['THING', 'EXIT', 'ROOM']
+""", ct: ct);
 
 	/// <summary>
 	/// Seed plugin-contributed flags (Phase 2a <see cref="IFlagSource"/>) via the same idempotent MERGE

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Migration.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Migration.cs
@@ -441,7 +441,13 @@ public partial class SurrealDatabase
 			("JURY_OK", "j", ["JURYOK"], ["royalty"], ["royalty"], ["PLAYER"]),
 			("KEEPALIVE", "k", null, [], [], ["PLAYER"]),
 			("LIGHT", "l", null, [], [], ["ROOM","PLAYER","EXIT","THING"]),
-			("MISTRUST", "m", ["MYOPIC"], ["trusted"], ["trusted"], ["PLAYER","EXIT","THING"]),
+			("MISTRUST", "m", null, ["trusted"], ["trusted"], ["THING","EXIT","ROOM"]),
+			// MYOPIC shares MISTRUST's letter and is told apart from it by object type, as in PennMUSH
+			// (hdrs/flag_tab.h:51, src/flags.c:778). Symbols are not unique here — see ABODE/ANSI on 'A'.
+			// No separate repair migration is needed on this provider: the UPSERT below sets every field
+			// unconditionally on each Migrate(), so an existing MISTRUST row loses the MYOPIC alias and
+			// gains the right types, and MYOPIC is created, the next time the game boots.
+			("MYOPIC", "m", null, [], [], ["PLAYER"]),
 			("NO_COMMAND", "n", ["NOCOMMAND"], [], [], ["ROOM","PLAYER","EXIT","THING"]),
 			("ON_VACATION", "o", ["ONVACATION","ON-VACATION"], [], [], ["PLAYER"]),
 			("PUPPET", "P", null, [], [], ["THING"]),

--- a/SharpMUSH.Database/DatabaseConstants.cs
+++ b/SharpMUSH.Database/DatabaseConstants.cs
@@ -191,6 +191,10 @@ public static class DatabaseConstants
 
 	public static readonly string[] typesContainer = [TypeRoom, TypePlayer, TypeThing];
 	public static readonly string[] typesContent = [TypePlayer, TypeExit, TypeThing];
+
+	/// <summary>Everything but a player — PennMUSH's <c>TYPE_THING | TYPE_EXIT | TYPE_ROOM</c>.</summary>
+	public static readonly string[] typesNonPlayer = [TypeThing, TypeExit, TypeRoom];
+
 	public static readonly string[] typesAll = [TypeRoom, TypePlayer, TypeExit, TypeThing];
 
 	public static readonly string[] permissionsWizard = ["wizard"];

--- a/SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpchat.md
+++ b/SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpchat.md
@@ -247,22 +247,23 @@ For all four of these commands, you can specify a single channel to affect, or o
 # @channel/mogrifier
 # @channel/chown
 # @channel/name
-# @channel/desc
+# @channel/rename
+# @channel/describe
 # @channel/privs
 # @channel/wipe
-# @channel/clock
 
-- `@channel/add <channel>[=<description>]`
+- `@channel/add <channel>=<privlist>`
 - `@channel/delete <channel>`
 - `@channel/mogrifier <channel>=<object>`
 - `@channel/chown <channel>=<player>`
 - `@channel/name <channel>=<newname>`
-- `@channel/desc <channel>=<description>`
+- `@channel/rename <channel>=<newname>`
+- `@channel/describe <channel>=<description>`
 - `@channel/privs <channel>=<privlist>`
 - `@channel/wipe <channel>`
-- `@channel/clock[/on|/off|/clear|/add|/remove|/hide|/unhide|/list] <channel>[=<lock>]`
+- `@clock/join|/speak|/see|/hide|/mod <channel>[=<lock>]`
 
-`@channel/add` creates a new channel. You must be able to pay the cost of the channel. The channel's description is optional.
+`@channel/add` creates a new channel with the privileges in *<privlist>* — the same list `@channel/privs` takes, and it is required. You may not own more channels than the `max_channels` limit allows unless you are staff.
 
 `@channel/delete` removes a channel. Only channel admins can do this.
 
@@ -270,15 +271,15 @@ For all four of these commands, you can specify a single channel to affect, or o
 
 `@channel/chown` changes the owner of a channel. Only channel admins can do this.
 
-`@channel/name` renames a channel. Only channel admins can do this.
+`@channel/name` and `@channel/rename` both rename a channel. Only channel admins can do this.
 
-`@channel/desc` changes a channel's description. Only channel admins can do this.
+`@channel/describe` changes a channel's description. Only channel admins can do this.
 
 `@channel/privs` changes a channel's privileges. Only channel admins can do this. See [@channel privs] for details.
 
 `@channel/wipe` removes all players from a channel. Only channel admins can do this.
 
-`@channel/clock` manages channel locks. Only channel admins can do this. See [@channel clock] for details.
+Channel locks are managed by the separate `@clock` command, not by a `@channel` switch. See [@clock] for details.
 
 **See Also:**
 - [@channel/who]
@@ -313,60 +314,80 @@ The Lock column shows:
 - [@clock]
 
 # @CHANNEL PRIVS
+# CHANNEL-PRIVS
 
-Channel privileges control what players can do with a channel. They are set with `@channel/privs <channel>=<privlist>`, where *<privlist>* is a space-separated list of privilege names, optionally prefixed with `no_` to remove the privilege.
+`@channel/privs <channel>=<privlist>`
+
+Channel privileges say who a channel admits and how its messages are rendered. They are set with `@channel/privs`, and on a brand new channel with `@channel/add <channel>=<privlist>`.
+
+*<privlist>* is a space-separated list of privilege names, or of the single-letter abbreviations below. The list **replaces** the channel's current privileges rather than adding to them, so name every privilege the channel is to keep. Names match without regard to case; the letters do not, because `O` is Object and `o` is Open.
 
 Available privileges:
-- **join**: Players must pass the join lock to join the channel
-- **speak**: Players must pass the speak lock to speak on the channel
-- **hide**: Players must pass the hide lock to hide on the channel
-- **open**: Players can speak on the channel without joining it
-- **quiet**: Don't show connect/disconnect messages
-- **hide_ok**: Players can hide on the channel
-- **loud**: Show channel prefix even on @cemit/silent
-- **disabled**: Channel cannot be used
+- **player** (`P`): Players may use the channel
+- **object** (`O`): Non-players may use the channel
+- **admin** (`A`): Only royalty, wizards, and holders of the `chat_privs` power may use the channel
+- **wizard** (`W`): Only wizards may use the channel
+- **quiet** (`Q`): The channel does not show connection messages
+- **open** (`o`): You may speak on the channel even when you are not listening to it
+- **hide_ok** (`H`): You may hide yourself from the channel's who list
+- **notitles** (`T`): Channel titles are not shown in channel messages
+- **nonames** (`N`): Speakers' names are not shown in channel messages
+- **nocemit** (`C`): [@cemit] is prohibited on the channel
+- **interact** (`I`): Channel output is filtered through the game's interaction rules
+- **disabled** (`D`): No one can join or speak on the channel
+
+These are privileges, not locks. A privilege says which *kind* of thing the channel is open to; a lock says which particular objects get through. Joining, speaking, seeing, hiding and modifying are each governed by a lock of their own — see [@clock].
+
+`loud` is not a channel privilege and cannot be given to a channel. It is a flag set on an object — see [flag list].
 
 **Examples**
 ```sharp
-@channel/privs Public=no_join no_speak
-@channel/privs Admin=join speak no_hide_ok
+@channel/privs Public=player quiet open nocemit
+@channel/privs Admin=player admin
+@channel/privs Public=P Q o C
 ```
 
 **See Also:**
 - [@channel/who]
 - [@channel clock]
 - [@clock]
+- [CFLAGS()]
 
 # @CHANNEL CLOCK
+# @channel/clock
 # @clock
 
-`@channel/clock[/switch] <channel>[=<lock>]`
+`@clock/join <channel>[=<lock>]`<br>
+`@clock/speak <channel>[=<lock>]`<br>
+`@clock/see <channel>[=<lock>]`<br>
+`@clock/hide <channel>[=<lock>]`<br>
+`@clock/mod <channel>[=<lock>]`
 
-Channel locks control who can join, speak on, or hide on a channel. The basic switches are:
-- **/on** *<lock>*: Set the speak lock
-- **/off**: Remove the speak lock
-- **/clear**: Remove all locks
-- **/add** *<lock>*: Set the join lock
-- **/remove**: Remove the join lock
-- **/hide** *<lock>*: Set the hide lock
-- **/unhide**: Remove the hide lock
-- **/list**: Show all locks
+Channel locks are set with `@clock`, which is its own command — there is no `@channel/clock` switch. Each switch names the one lock it sets, and omitting *<lock>* removes that lock. With no switch at all, `@clock` sets the join lock. See [lock keys] for what may go in a *<lock>*.
 
-Only channel admins can set locks. Players must pass:
-- The join lock to join the channel (if the channel has the 'join' priv)
-- The speak lock to speak on the channel (if the channel has the 'speak' priv)
-- The hide lock to hide on the channel (if the channel has the 'hide_ok' priv)
+There are five locks:
+- **join**: Restricts who can join the channel
+- **speak**: Restricts who can speak on the channel
+- **see**: Restricts who can see the channel on `@channel/list`
+- **hide**: Restricts `@channel/hide` on a channel that is `hide_ok`
+- **mod**: Restricts who can modify the channel. Passing the mod lock lets you do anything to a channel short of deleting it
+
+A lock is evaluated against the object trying to pass it, exactly as if it had been set on that object.
+
+You may set a channel's locks if you own it, if you pass its mod lock, or if you are a wizard. A new channel starts with none of the five set, and an unset lock is one everybody passes.
 
 **Examples**
 ```sharp
-@channel/clock/on Public=WIZARD
-@channel/clock/add Admin=WIZARD
-@channel/clock/hide Secret=WIZARD
+@clock/join Public=flag^wizard
+@clock/speak Public=!flag^gagged
+@clock/mod Secret=#123
+@clock/speak Public=
 ```
 
 **See Also:**
 - [@lock]
 - [locks]
+- [lock keys]
 - [@channel privs]
 
 # CHANNEL FUNCTIONS
@@ -394,8 +415,8 @@ These functions provide information about channels:
 
 - **cowner()**: Returns the dbref of *\<channel\>*'s owner
 
-- **cflags()**: Returns channel flags for *\<channel\>*, or status flags for *\<player\>* on *\<channel\>*:
-  - Channel flags: DISABLED LOUD OPEN QUIET
+- **cflags()**: Returns *\<channel\>*'s privileges, or status flags for *\<player\>* on *\<channel\>*:
+  - Channel privileges, uppercased, any of: PLAYER OBJECT ADMIN WIZARD QUIET OPEN HIDE_OK NOTITLES NONAMES NOCEMIT INTERACT DISABLED. See [@channel privs].
   - Status flags: COMBINE GAG HIDE MUTE
 
 - **cstatus()**: Returns information about *\<player\>*'s channel status:

--- a/SharpMUSH.Implementation/Commands/GeneralCommands.cs
+++ b/SharpMUSH.Implementation/Commands/GeneralCommands.cs
@@ -5057,7 +5057,10 @@ public partial class Commands
 					Configuration!, arg0, arg1),
 			["CHOWN"] when arg0 is not null => await ChannelChown.Handle(parser, LocateService!, PermissionService!,
 				Mediator!, NotifyService!, arg0, emptyIfMissing1),
-			["RENAME"] when arg0 is not null && arg1 is not null
+			// NAME and RENAME are the same operation, as in PennMUSH (src/extchat.c:3605-3608, where both
+			// switches call do_chan_admin with CH_ADMIN_RENAME). NAME was declared in the switch list above
+			// but had no arm, so `@channel/name` fell through to the "What do you want to do" usage line.
+			(["RENAME"] or ["NAME"]) when arg0 is not null && arg1 is not null
 				=> await ChannelRename.Handle(parser, LocateService!, PermissionService!, Mediator!, NotifyService!,
 					Configuration!, arg0, arg1),
 			["WIPE"] when arg0 is not null => await ChannelWipe.Handle(parser, LocateService!, PermissionService!, Mediator!,

--- a/SharpMUSH.Tests/Commands/ChannelCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/ChannelCommandTests.cs
@@ -109,6 +109,35 @@ public class ChannelCommandTests
 				TestHelpers.MessagePlainTextEquals(msg, $"<{TestChannelName}> NscemitCommand: Test message")), TestHelpers.MatchingObject(executor), INotifyService.NotificationType.NSEmit);
 	}
 
+	/// <summary>
+	/// NAME and RENAME are the same operation, as in PennMUSH — <c>src/extchat.c:3605-3608</c> sends
+	/// both switches to <c>do_chan_admin</c> with <c>CH_ADMIN_RENAME</c>. SharpMUSH declared NAME in
+	/// <c>@CHANNEL</c>'s switch list but had no arm for it, so <c>@channel/name</c> fell through to the
+	/// "What do you want to do with the channel?" usage line while sharpchat.md documented it as working.
+	/// </summary>
+	[Test]
+	[Arguments("name")]
+	[Arguments("rename")]
+	public async ValueTask ChannelRenameAcceptsBothSwitchSpellings(string switchName)
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var suffix = Random.Shared.Next(100000, 999999);
+		var before = $"Ren{switchName}{suffix}";
+		var after = $"Post{switchName}{suffix}";
+
+		await Mediator.Send(new CreateChannelCommand(MModule.single(before), [TestChannelPrivilege], _testPlayer!));
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@channel/{switchName} {before}={after}"));
+
+		await NotifyService
+			.Received()
+			.Notify(TestHelpers.MatchingObject(executor), Arg.Is<OneOf<MString, string>>(msg =>
+					TestHelpers.MessagePlainTextEquals(msg, "CHAT: Renamed channel.")),
+				TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
+
+		await Assert.That(await Mediator.Send(new GetChannelQuery(after))).IsNotNull();
+	}
+
 	[Test]
 	[Category("NotImplemented")]
 	[Skip("Not Yet Implemented")]

--- a/SharpMUSH.Tests/Commands/HelpCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/HelpCommandTests.cs
@@ -113,4 +113,60 @@ public class HelpCommandTests
 				(msg.IsT0 && msg.AsT0.ToString().Contains("If you are new to MUSHing")) ||
 				(msg.IsT1 && msg.AsT1.Contains("If you are new to MUSHing"))), TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
 	}
+
+	/// <summary>
+	/// The privileges a channel actually has, delivered by the in-game <c>help</c> command.
+	///
+	/// <para>The topic used to list join, speak, hide, open, quiet, hide_ok, loud and disabled. Only
+	/// three of those are privileges. <c>src/extchat.c:118</c> is the authoritative list and it holds
+	/// twelve; join, speak and hide are <em>locks</em> (<c>hdrs/extchat.h:228</c>,
+	/// <c>enum clock_type</c>); and loud is a player flag (<c>src/flags.c:783</c>), consulted at
+	/// <c>src/extchat.c:1539</c> to bypass the speak check, not a channel priv at all.</para>
+	/// </summary>
+	[Test]
+	[MethodDataSource(nameof(RealChannelPrivileges))]
+	public async ValueTask HelpChannelPrivsNamesARealPrivilege(string privilege)
+	{
+		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, $"HelpPriv{privilege}");
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("help @channel privs"));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef), Arg.Is<OneOf<MString, string>>(msg =>
+					TestHelpers.MessagePlainTextContains(msg, privilege)),
+				TestHelpers.MatchingObject(testPlayer.DbRef), INotifyService.NotificationType.Announce);
+	}
+
+	/// <summary>PennMUSH's channel privileges, <c>src/extchat.c:118</c> minus the undocumented Thing alias.</summary>
+	public static IEnumerable<string> RealChannelPrivileges() =>
+	[
+		"player", "object", "admin", "wizard", "quiet", "open",
+		"hide_ok", "notitles", "nonames", "nocemit", "interact", "disabled"
+	];
+
+	/// <summary>
+	/// The five channel locks, delivered by <c>help @clock</c>. The topic used to describe eight
+	/// switches of which none exist, on a <c>@channel/clock</c> that is not a switch of <c>@channel</c>
+	/// at all — <c>@CLOCK</c> is its own command with switches JOIN, SPEAK, MOD, SEE and HIDE, matching
+	/// <c>enum clock_type</c> at <c>hdrs/extchat.h:228</c>.
+	/// </summary>
+	[Test]
+	[Arguments("join")]
+	[Arguments("speak")]
+	[Arguments("see")]
+	[Arguments("hide")]
+	[Arguments("mod")]
+	public async ValueTask HelpClockCoversEveryChannelLock(string lockName)
+	{
+		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, $"HelpClock{lockName}");
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("help @clock"));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef), Arg.Is<OneOf<MString, string>>(msg =>
+					TestHelpers.MessagePlainTextContains(msg, $"@clock/{lockName}")),
+				TestHelpers.MatchingObject(testPlayer.DbRef), INotifyService.NotificationType.Announce);
+	}
 }

--- a/SharpMUSH.Tests/Database/FlagSeedIntegrityTests.cs
+++ b/SharpMUSH.Tests/Database/FlagSeedIntegrityTests.cs
@@ -1,0 +1,180 @@
+using Core.Arango;
+using Core.Arango.Migration;
+using Core.Arango.Protocol;
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using SharpMUSH.Database.ArangoDB.Migrations;
+using SharpMUSH.Library.Queries.Database;
+
+namespace SharpMUSH.Tests.Database;
+
+/// <summary>
+/// Pins the object-flag seed against PennMUSH for the two flags that share the letter <c>m</c>, and
+/// against itself for the invariant that a flag name is seeded exactly once.
+///
+/// <para>PennMUSH has two flags on <c>m</c>, told apart by object type: MISTRUST
+/// (<c>src/flags.c:778</c> — <c>TYPE_THING | TYPE_EXIT | TYPE_ROOM</c>) and MYOPIC
+/// (<c>game/txt/hlp/pennflag.hlp:333</c> — players). <c>pennflag.hlp:37</c> lists the shared letter as
+/// "m - Mistrust/Myopic", and that line is the likely source of the error this fixes: all three
+/// SharpMUSH providers seeded MYOPIC as an <em>alias</em> of MISTRUST, so the two flags could not be
+/// set independently and MISTRUST carried the wrong type list into the bargain.</para>
+///
+/// <para>A shared symbol is normal here and needs no special handling —
+/// <c>SharpObjectFlag.Symbol</c> documents itself as not unique, and the seed already ships
+/// ABODE/ANSI on 'A', CHOWN_OK/COLOR on 'C' and NO_LEAVE/NO_TEL on 'N', each pair separated by its
+/// type restrictions.</para>
+/// </summary>
+public class FlagSeedIntegrityTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactoryArg { get; init; }
+
+	private IMediator Mediator => WebAppFactoryArg.Services.GetRequiredService<IMediator>();
+
+	[Test]
+	public async Task MistrustIsSeededWithPennMushTypesAndNoMyopicAlias()
+	{
+		var flag = await Mediator.Send(new GetObjectFlagQuery("MISTRUST"));
+
+		await Assert.That(flag).IsNotNull();
+		await Assert.That(flag!.Name).IsEqualTo("MISTRUST");
+		await Assert.That(flag.Symbol).IsEqualTo("m");
+		await Assert.That(flag.Aliases ?? [])
+			.DoesNotContain("MYOPIC")
+			.Because("MYOPIC is its own flag in PennMUSH, not another name for MISTRUST");
+		await Assert.That(flag.TypeRestrictions.Order(StringComparer.Ordinal).ToArray())
+			.IsEquivalentTo(new[] { "EXIT", "ROOM", "THING" })
+			.Because("src/flags.c:778 declares MISTRUST as TYPE_THING | TYPE_EXIT | TYPE_ROOM");
+	}
+
+	[Test]
+	public async Task MyopicIsSeededAsItsOwnPlayerFlag()
+	{
+		var flag = await Mediator.Send(new GetObjectFlagQuery("MYOPIC"));
+
+		await Assert.That(flag).IsNotNull();
+		await Assert.That(flag!.Name)
+			.IsEqualTo("MYOPIC")
+			.Because("asking for MYOPIC must not resolve to MISTRUST");
+		await Assert.That(flag.Symbol).IsEqualTo("m");
+		await Assert.That(flag.TypeRestrictions)
+			.IsEquivalentTo(new[] { "PLAYER" })
+			.Because("pennflag.hlp:333 documents MYOPIC as a player flag");
+	}
+
+	/// <summary>
+	/// The ArangoDB seed wrote MISTRUST twice — once correctly and once carrying the MYOPIC alias — so
+	/// which of the two documents any lookup found was down to iteration order. Name is the identity of a
+	/// flag on every provider (SurrealDB and Memgraph key their records on it), so a duplicate is a seed
+	/// bug wherever it appears.
+	/// </summary>
+	[Test]
+	public async Task NoFlagNameIsSeededTwice()
+	{
+		var duplicates = await Mediator.CreateStream(new GetAllObjectFlagsQuery())
+			.ToListAsync();
+
+		var offenders = duplicates
+			.GroupBy(flag => flag.Name, StringComparer.OrdinalIgnoreCase)
+			.Where(group => group.Count() > 1)
+			.Select(group => $"{group.Key} x{group.Count()}")
+			.ToArray();
+
+		await Assert.That(offenders)
+			.IsEmpty()
+			.Because("a flag name is its identity; two rows sharing one makes every lookup order-dependent");
+	}
+
+	/// <summary>
+	/// The forward repair, run against a database that actually holds the broken seed.
+	///
+	/// <para>The seeds above only prove a <em>fresh</em> database comes out right;
+	/// <see cref="Migration_RepairMistrustMyopic"/> exists for the ones already deployed, and on a fresh
+	/// database it matches nothing, so running the suite would never exercise it. This builds the broken
+	/// shape by hand in a throwaway ArangoDB database — two MISTRUST documents, the second carrying the
+	/// MYOPIC alias, and an object edge pointing at that second one — runs the migration, and checks
+	/// both that the duplicate is gone and that the object did not silently lose its flag.</para>
+	///
+	/// <para>Arango only: SurrealDB re-runs its flag seed as an unconditional UPSERT on every boot and so
+	/// corrects itself, and Memgraph's repair is a <c>WHERE 'MYOPIC' IN f.aliases</c> statement inside
+	/// its own migration path. The non-Arango legs skip.</para>
+	/// </summary>
+	[Test]
+	public async Task RepairMigration_SplitsAnAlreadyBrokenDatabase()
+	{
+		if (WebAppFactoryArg.Services.GetService<IArangoContext>() is not { } context)
+		{
+			return;
+		}
+
+		var scratch = new ArangoHandle($"flagrepair{Guid.NewGuid():N}"[..24]);
+		await context.Database.CreateAsync(scratch);
+
+		try
+		{
+			await context.Collection.CreateAsync(scratch, new ArangoCollection
+			{
+				Name = SharpMUSH.Database.DatabaseConstants.ObjectFlags,
+				Type = ArangoCollectionType.Document
+			});
+			await context.Collection.CreateAsync(scratch, new ArangoCollection
+			{
+				Name = SharpMUSH.Database.DatabaseConstants.HasFlags,
+				Type = ArangoCollectionType.Edge
+			});
+
+			var wrongTypes = new[] { "PLAYER", "EXIT", "THING" };
+			await context.Document.CreateAsync(scratch, SharpMUSH.Database.DatabaseConstants.ObjectFlags,
+				new { Name = "MISTRUST", Symbol = "m", System = true, TypeRestrictions = wrongTypes });
+			var aliased = await context.Document.CreateAsync(scratch, SharpMUSH.Database.DatabaseConstants.ObjectFlags,
+				new
+				{
+					Name = "MISTRUST",
+					Aliases = (string[])["MYOPIC"],
+					Symbol = "m",
+					System = true,
+					TypeRestrictions = wrongTypes
+				});
+
+			const string ObjectId = "node_objects/12345";
+			await context.Document.CreateAsync(scratch, SharpMUSH.Database.DatabaseConstants.HasFlags,
+				new Dictionary<string, object> { ["_from"] = ObjectId, ["_to"] = aliased.Id });
+
+			await new Migration_RepairMistrustMyopic().Up(new ArangoMigrator(context), scratch);
+
+			var mistrusts = await context.Query.ExecuteAsync<FlagRow>(scratch,
+				$"FOR f IN {SharpMUSH.Database.DatabaseConstants.ObjectFlags:@} FILTER f.Name == \"MISTRUST\" RETURN f");
+
+			await Assert.That(mistrusts.Count)
+				.IsEqualTo(1)
+				.Because("the migration collapses the duplicate rows into one");
+			await Assert.That(mistrusts[0].Aliases ?? []).DoesNotContain("MYOPIC");
+			await Assert.That(mistrusts[0].TypeRestrictions.Order(StringComparer.Ordinal).ToArray())
+				.IsEquivalentTo(new[] { "EXIT", "ROOM", "THING" });
+
+			var myopics = await context.Query.ExecuteAsync<FlagRow>(scratch,
+				$"FOR f IN {SharpMUSH.Database.DatabaseConstants.ObjectFlags:@} FILTER f.Name == \"MYOPIC\" RETURN f");
+
+			await Assert.That(myopics.Count).IsEqualTo(1);
+			await Assert.That(myopics[0].TypeRestrictions).IsEquivalentTo(new[] { "PLAYER" });
+
+			var edgeTargets = await context.Query.ExecuteAsync<string>(scratch,
+				$"FOR e IN {SharpMUSH.Database.DatabaseConstants.HasFlags:@} RETURN e._to");
+
+			await Assert.That(edgeTargets)
+				.IsEquivalentTo(new[] { mistrusts[0].Id })
+				.Because("an object that was MISTRUST must still be MISTRUST after the duplicate is removed");
+		}
+		finally
+		{
+			await context.Database.DropAsync(scratch);
+		}
+	}
+
+	private sealed record FlagRow(
+		[property: System.Text.Json.Serialization.JsonPropertyName("_id")]
+		string Id,
+		string Name,
+		string[]? Aliases,
+		string[] TypeRestrictions);
+}


### PR DESCRIPTION
PR 12, the top of a linear stack. It targets `fix/audit2-11-security-followups`, not `main`.

Two unrelated pieces of work, one commit each.

---

## 1. `sharpchat.md` documented channel privileges that do not exist

The `@CHANNEL PRIVS` topic listed **join, speak, hide, open, quiet, hide_ok, loud, disabled**. Only three of those eight are channel privileges. Every correction below was read off the PennMUSH source in `pennmush/` rather than recalled.

### The privileges

`priv_table[]` at `src/extchat.c:118` is the authoritative list, backed by the `CHANNEL_*` bits at `hdrs/extchat.h:148-161`. `game/txt/hlp/pennchat.hlp:359` documents twelve of the thirteen entries — the table minus `Thing`, which is an undocumented second name for the same `CHANNEL_OBJECT` bit as `Object`. Those twelve are exactly what `ChannelHelper.ChannelPrivileges` already accepts, so **the code was right and the doc was wrong**. The topic now reads:

| Priv | Letter | Meaning |
|---|---|---|
| player | `P` | Players may use the channel |
| object | `O` | Non-players may use the channel |
| admin | `A` | Only royalty, wizards, and holders of `chat_privs` may use the channel |
| wizard | `W` | Only wizards may use the channel |
| quiet | `Q` | The channel does not show connection messages |
| open | `o` | You may speak on the channel even when not listening to it |
| hide_ok | `H` | You may hide yourself from the channel's who list |
| notitles | `T` | Channel titles are not shown in channel messages |
| nonames | `N` | Speakers' names are not shown in channel messages |
| nocemit | `C` | `@cemit` is prohibited on the channel |
| interact | `I` | Channel output is filtered through the interaction rules |
| disabled | `D` | No one can join or speak on the channel |

`O` and `o` are different privileges, so the topic says the letters are case-sensitive while the names are not.

The old `no_` prefix is gone from the topic and the examples. `ChannelHelper.StringToChannelPrivileges` rejects `no_join` as an invalid priv and `@channel/privs` **replaces** the stored list wholesale (`ChannelPrivs.cs:37-53`), so the topic says that instead. (PennMUSH's `string_to_privs`, `src/privtab.c:36`, does support `!priv` and is additive — noted below as a gap, not fixed here.)

### The locks

`join`, `speak` and `hide` are locks. `hdrs/extchat.h:228`:

```c
enum clock_type { CLOCK_JOIN, CLOCK_SPEAK, CLOCK_SEE, CLOCK_HIDE, CLOCK_MOD };
```

`pennchat.hlp:392` documents all five as `@clock/join`, `/speak`, `/see`, `/hide`, `/mod`. The doc listed three of the five and filed them under privileges. (`hide` is additionally a per-user status bit, `CU_HIDE` at `extchat.h:69` — still not a channel priv.)

SharpMUSH already had all five: `@CLOCK` with `Switches = ["JOIN", "SPEAK", "MOD", "SEE", "HIDE"]` (`MoreCommands.cs:53`) over `JoinLock`/`SpeakLock`/`SeeLock`/`HideLock`/`ModLock`. The `@CHANNEL CLOCK` topic instead described `@channel/clock[/on|/off|/clear|/add|/remove|/hide|/unhide|/list]` — a switch that does not exist, on a command that does not take it, with eight sub-switches of which none exist. Rewritten to `@clock` and its five locks, with the gate stated as it is implemented (owner, or passes the mod lock, or wizard) and the empty-lock default stated as it behaves (`LockService.Evaluate` returns true for an empty string).

### `loud`

**SharpMUSH's speak path does not consult LOUD.** `PermissionService.ChannelCanSpeak` (`PermissionService.cs:318`) is `ChannelCanAccess && lockService.Evaluate(channel.SpeakLock, …)` with no flag check, versus `extchat.c:1539`'s `if (!Loud(player) && !Chan_Can_Speak(chan, player))`. `grep -ri loud` over the engine finds the flag only in the three seeds. Not implemented here, as instructed — see the gap list below. The topic states that `loud` is a flag rather than a channel privilege and points at the flag list; it does not claim behaviour the engine does not have.

### Adjacent corrections in the same topics

- `@channel/add`'s right-hand side is a **privilege list and is required** — `GeneralCommands.cs:5051` matches only `when arg0 is not null && arg1 is not null`, and `ChannelAdd.cs:57` parses it with `StringToChannelPrivileges`. The doc said `[=<description>]`, optional. There is also no cost check anywhere in `ChannelAdd`; the limit it enforces is `max_channels`.
- `@channel/desc` → `@channel/describe` (the declared switch is `DESCRIBE`, and switch matching is exact — `SharpMUSHParserVisitor.cs:1867`). `help @channel/desc` still resolves, by prefix.
- `cflags(<channel>)` returns the channel's privileges uppercased (`ChannelFunctions.cs:150-157`), so the documented `DISABLED LOUD OPEN QUIET` was wrong on both counts.

### One code fix

`@channel/name` was declared in `@CHANNEL`'s switch list but had no arm in the switch expression, so the documented command fell through to `"What do you want to do with the channel?"`. PennMUSH sends both `SWITCH_NAME` and `SWITCH_RENAME` to `do_chan_admin(..., CH_ADMIN_RENAME)` (`src/extchat.c:3605-3608`); SharpMUSH now does too. One line, plus a parameterised test over both spellings.

---

## 2. MYOPIC was collapsed into MISTRUST as an alias, on all three providers

PennMUSH has two flags on the letter `m`, told apart by object type:

- **MISTRUST** — `src/flags.c:778`, `add_flag("MISTRUST", 'm', TYPE_THING | TYPE_EXIT | TYPE_ROOM, F_INHERIT, F_INHERIT)`. Help at `pennflag.hlp:341`: *"things, rooms, exits"*. Stops an object controlling other objects via Control or Zone locks or same-owner control, and stops it inheriting `no_pay`/`no_quota`.
- **MYOPIC** — `hdrs/flag_tab.h:51`, `{"MYOPIC", 'm', TYPE_PLAYER, PLAYER_MYOPIC, F_ANY, F_ANY}`. Help at `pennflag.hlp:333`: *"Flag: MYOPIC (players)"*. Players set MYOPIC do not see the dbref number or flag list of objects they control after their names; anything owned by a MYOPIC player is treated as MYOPIC too.

`pennflag.hlp:37` prints the shared letter as `m - Mistrust/Myopic`, and that line is the likely origin of the error. Every provider seeded MYOPIC as an *alias* of MISTRUST, so the two could not be set independently:

- `Migration_CreateDatabase.cs:3215` **and** `:3224` — two rows, both `Name = "MISTRUST"`, the second carrying `Aliases = ["MYOPIC"]`. Which document a lookup found was down to iteration order.
- `MemgraphDatabase.Migration.cs:407` and `SurrealDatabase.Migration.cs:443` — the alias, without the duplicate.

All three also used `typesContent` (`DatabaseConstants.cs:193` = `[PLAYER, EXIT, THING]`), which wrongly admits players and wrongly omits rooms.

### Was a shared symbol possible?

Yes, with no changes. `SharpObjectFlag.Symbol`'s own doc comment says *"Not unique"*, no provider indexes on it, and the seed already ships **ABODE/ANSI on `A`**, **CHOWN_OK/COLOR on `C`**, **NO_LEAVE/NO_TEL on `N`**, **FIXED/FLOATING on `F`**, **JUDGE/JUMP_OK on `J`** and **GAGGED/GOING on `g`** — every pair separated by its type restrictions, exactly as PennMUSH separates these two. `m` is what players expect and `m` is what they get.

### What ships

MISTRUST: `m`, THING/EXIT/ROOM, no alias, `trusted` to set and unset. MYOPIC: `m`, PLAYER, no permission restrictions (matching `F_ANY, F_ANY`). A new `DatabaseConstants.typesNonPlayer` names PennMUSH's `TYPE_THING | TYPE_EXIT | TYPE_ROOM`.

### The migration

- **ArangoDB** seeds once, so `Migration_RepairMistrustMyopic` (id `20260809_002`, shaped after PR #764's `Migration_RepairFlagUnsetPermissions`) does the work. It **re-points every `edge_has_flags` edge at the surviving MISTRUST before removing the duplicate** — either document could be the one an object was linked to, so a plain delete would silently strip the flag off whatever pointed at the loser. Then it corrects the survivor's types and alias and upserts MYOPIC. Idempotent; on a fresh database every statement matches nothing or rewrites what it finds.
- **Memgraph**'s seed is `MERGE … ON CREATE SET` and will not touch an existing row, so `RepairMistrustMyopicFlag` corrects MISTRUST directly. Its `WHERE 'MYOPIC' IN f.aliases` guard is what keeps it from being a standing overwrite: it fires at most once per database and never reverts an operator's later customisation. MYOPIC needs no repair — it is a new name, so the seed's `MERGE` creates it.
- **SurrealDB**'s seed is an unconditional `UPSERT … SET` run on every `Migrate()`, so an existing MISTRUST loses the alias and gains the right types, and MYOPIC is created, on the next boot. No separate migration; a comment at the seed says so.

`PennMUSHDatabaseGenerator.cs:11` lists MYOPIC among the flags the converter emits, so that path now finds a real flag instead of an alias. The full converter suite is green on all three providers.

**MYOPIC's display behaviour is deliberately not implemented here.** Suppressing dbrefs and flag lists after names is a change to the look/examine rendering path and belongs in its own review. Nothing in SharpMUSH honours it today — `grep -ri myopic` over the engine finds only the seeds, the two helpfiles that already describe it correctly, and flag-function tests. The flag is settable and correctly defined; that is the whole scope.

---

## Verification

Every number below was run locally against Podman (`DOCKER_HOST=unix:///run/user/1000/podman/podman.sock`, Testcontainers, no `docker` binary).

**Confirmed failing before the fix.** `FlagSeedIntegrityTests`, on the unfixed seeds:

```
########## arangodb                        (3 of 3 failed)
MistrustIsSeededWithPennMushTypesAndNoMyopicAlias
  Expected to be equivalent to [EXIT, ROOM, THING], because src/flags.c:778
  declares MISTRUST as TYPE_THING | TYPE_EXIT | TYPE_ROOM
  but collection does not contain expected item: ROOM
MyopicIsSeededAsItsOwnPlayerFlag
  Expected to be equal to "MYOPIC", because asking for MYOPIC must not resolve
  to MISTRUST
  but received "MISTRUST"
NoFlagNameIsSeededTwice
  Expected to be empty, because a flag name is its identity; two rows sharing
  one makes every lookup order-dependent
  but collection contains items: [MISTRUST x2]

########## memgraph                        (2 of 3 failed)
MistrustIsSeededWithPennMushTypesAndNoMyopicAlias
  Expected to not contain MYOPIC ... but the item was found in the collection
MyopicIsSeededAsItsOwnPlayerFlag
  Expected to be equal to "MYOPIC" ... but received "MISTRUST"

########## surrealdb                       (2 of 3 failed)  — same two
```

`ChannelRenameAcceptsBothSwitchSpellings(name)` fails on the unfixed switch expression with `ReceivedCallsException` (no `"CHAT: Renamed channel."` notification); the `(rename)` case passes. Verified by reverting the one-line change, rebuilding, and re-running.

**New tests.** `FlagSeedIntegrityTests` (4): the two flags' identities and type restrictions, the no-duplicate-name invariant, and `RepairMigration_SplitsAnAlreadyBrokenDatabase` — which builds the broken shape by hand in a throwaway Arango database (two MISTRUST documents, the second aliased, plus an object edge pointing at that second one), runs the migration, and asserts the duplicate is gone, MYOPIC exists, **and the edge survived**. Without it the repair would never be exercised, since a fresh database has nothing to repair. `HelpCommandTests` gains 17 cases confirming `help @channel privs` renders each of the twelve privileges and `help @clock` renders each of the five locks in game, through the `IHelpTopicResolver` path PR #762 added. `ChannelCommandTests` gains 2.

**Suites, all green:**

| | arangodb | memgraph | surrealdb |
|---|---|---|---|
| `SharpMUSH.Tests` | 5265 passed, 192 skipped, 0 failed | 5265 / 192 / 0 | 5265 / 192 / 0 |
| `SharpMUSH.Tests.Integration` | 323 passed, 0 failed | 323 / 0 | 323 / 0 |

The known `wiki_translation` write-conflict flake on the surrealdb integration leg did not fire this run.

`dotnet build`: **0 errors**. Warning count unchanged at 32, all pre-existing `MSB3277`/`NU1603`/`NU1510` in fixture and source-generated projects I did not touch. No suppressions added, `TreatWarningsAsErrors` untouched, and the `VerifyEditorConfigFormatting` gate passes on every build.

---

## Found while in here, deliberately left out

Reported rather than fixed — each needs its own review.

1. **LOUD is not honoured on the speak path.** `ChannelCanSpeak` has no flag check, against `extchat.c:1539`'s `if (!Loud(player) && !Chan_Can_Speak(chan, player))`. The flag is seeded on all three providers and does nothing.
2. **Channel privilege and lock enforcement is almost entirely unwired.** `ChannelOkType`, `ChannelStandardCan`, `ChannelCanPrivate`, `ChannelCanJoin`, `ChannelCanSpeak`, `ChannelCanCemit` and `ChannelCanHide` have **no callers outside `PermissionService` itself** — only `ChannelCanSeeAsync` and `ChannelCanModifyAsync` are reached from the command and function layer. So `disabled`, `wizard`, `admin`, `player`/`object`, the join lock and the speak lock are all defined and stored but never consulted when someone joins or speaks. This is much bigger than a doc PR and I did not touch it; it is the reason the privs topic states the contract rather than annotating each priv with whether it currently bites.
3. **`ChannelCanHide` tests the wrong string.** `PermissionService.cs:348` reads `channel.Privs.Contains("CanHide")`, but the priv is stored as `"Hide_Ok"` — the branch can never be true. Moot today because the method has no callers, but it will be wrong the moment it gains one.
4. **`@channel/privs` is not additive and has no negation.** PennMUSH's `string_to_privs` (`src/privtab.c:36`) supports `!priv` and ORs into the existing bits; SharpMUSH replaces the list and rejects anything unrecognised.
5. **`@channel/list`'s documented output is fiction.** The `@CHANNEL LIST` topic shows a `Channel / Status / Lock / Description` table with `*UNLOCKED*`, `J=`, `H=` and `(DISABLED)` markers. `ChannelList.cs` prints `Name: <channel>` lines and nothing else. Left alone because the fix is a feature, not a doc edit.
6. **Undocumented channel functions.** `clock()`, `clflags()` and `ctitle()` are implemented in `ChannelFunctions.cs` but have no help topic; `cdesc()`, `cusers()`, `cmsgs()`, `cbuffer()`, `cwho()` and `cbufferadd()` are documented in PennMUSH and absent from both.

For the record, PR #759 in this stack removed `"Thing"` from `ChannelHelper` because it collided with `"NoTitles"` on `T` and broke a `char -> name` reverse dictionary at static init. Its stated reason — that PennMUSH has no `Thing` priv — was wrong; PennMUSH has it as an undocumented alias for `Object` and tolerates the collision by scanning `priv_table[]` linearly. The outcome still matches PennMUSH's *documented* set, so the code is left as it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MPRzndB5egy4F2A3q5852
