### PR TITLE
Enforce the channel privileges and locks that were only ever stored

### DIFF
--- a/SharpMUSH.Database.ArangoDB/ArangoDatabase.Channels.cs
+++ b/SharpMUSH.Database.ArangoDB/ArangoDatabase.Channels.cs
@@ -127,8 +127,6 @@ public partial class ArangoDatabase
 				}
 			}, ct);
 
-		var settled = false;
-
 		try
 		{
 			// Uniqueness is decided INSIDE this transaction, on purpose. The Exclusive scope already holds a
@@ -152,7 +150,6 @@ public partial class ArangoDatabase
 
 			if (existing.Count > 0)
 			{
-				settled = true;
 				await arangoDb.Transaction.AbortAsync(transaction, ct);
 				return new ChannelNameTaken();
 			}
@@ -173,7 +170,6 @@ public partial class ArangoDatabase
 			await arangoDb.Graph.Edge.CreateAsync(transaction, DatabaseConstants.GraphChannels, DatabaseConstants.OnChannel,
 				new SharpEdgeCreateRequest(owner.Object.Id!, createdChannel.New.Id), cancellationToken: ct);
 
-			settled = true;
 			await arangoDb.Transaction.CommitAsync(transaction, ct);
 			return new Success();
 		}
@@ -184,16 +180,16 @@ public partial class ArangoDatabase
 			// created channel.
 			logger.LogError(ex, "Failed to create channel {ChannelName}", channelName);
 
-			if (!settled)
+			// Unconditional, including when the commit itself threw: an uncommitted transaction left open
+			// holds the exclusive lock until it expires, which blocks every other channel create. Aborting
+			// one that did commit answers "not found", which is logged and harmless.
+			try
 			{
-				try
-				{
-					await arangoDb.Transaction.AbortAsync(transaction, ct);
-				}
-				catch (Exception abortEx)
-				{
-					logger.LogError(abortEx, "Failed to abort the transaction for channel {ChannelName}", channelName);
-				}
+				await arangoDb.Transaction.AbortAsync(transaction, ct);
+			}
+			catch (Exception abortEx)
+			{
+				logger.LogError(abortEx, "Failed to abort the transaction for channel {ChannelName}", channelName);
 			}
 
 			return new Error<string>(ex.Message);

--- a/SharpMUSH.Database.ArangoDB/ArangoDatabase.Channels.cs
+++ b/SharpMUSH.Database.ArangoDB/ArangoDatabase.Channels.cs
@@ -113,9 +113,11 @@ public partial class ArangoDatabase
 				}, cancellationToken: ct)
 			.Select(SharpChannelQueryToSharpChannel);
 
-	public async ValueTask CreateChannelAsync(MString channel, string[] privs,
+	public async ValueTask<ChannelCreationResult> CreateChannelAsync(MString channel, string[] privs,
 		SharpPlayer owner, CancellationToken ct = default)
 	{
+		var channelName = channel.ToPlainText();
+
 		var transaction = await arangoDb.Transaction.BeginAsync(handle,
 			new ArangoTransaction
 			{
@@ -125,10 +127,38 @@ public partial class ArangoDatabase
 				}
 			}, ct);
 
+		var settled = false;
+
 		try
 		{
+			// Uniqueness is decided INSIDE this transaction, on purpose. The Exclusive scope already holds a
+			// write lock on Channels for its whole lifetime, so a second creator either waits here or reads
+			// the committed winner — an existence check taken now is atomic with the create that follows it.
+			// ChannelAdd's own read-before-create is outside any transaction and cannot be: it is a fast path
+			// for the friendly "Channel already exists." message, not the guarantee.
+			//
+			// No unique index on Name is added for this. It would be redundant with the exclusive lock on the
+			// only path that writes channels, and it cannot be created at all on a database that already
+			// holds duplicates — which is exactly the state the bug this closes produces. Memgraph does need
+			// a constraint, because snapshot isolation there lets both writers observe "absent"; see
+			// MemgraphDatabase.Migration.cs.
+			var existing = await arangoDb.Query.ExecuteAsync<string>(transaction,
+				"FOR c IN @@C FILTER c.Name == @name LIMIT 1 RETURN c._id",
+				new Dictionary<string, object>
+				{
+					{ "@C", DatabaseConstants.Channels },
+					{ "name", channelName }
+				}, cancellationToken: ct);
+
+			if (existing.Count > 0)
+			{
+				settled = true;
+				await arangoDb.Transaction.AbortAsync(transaction, ct);
+				return new ChannelNameTaken();
+			}
+
 			var newChannel = new SharpChannelCreateRequest(
-				Name: channel.ToPlainText(),
+				Name: channelName,
 				MarkedUpName: MModule.serialize(channel),
 				Privs: privs
 			);
@@ -143,11 +173,30 @@ public partial class ArangoDatabase
 			await arangoDb.Graph.Edge.CreateAsync(transaction, DatabaseConstants.GraphChannels, DatabaseConstants.OnChannel,
 				new SharpEdgeCreateRequest(owner.Object.Id!, createdChannel.New.Id), cancellationToken: ct);
 
+			settled = true;
 			await arangoDb.Transaction.CommitAsync(transaction, ct);
+			return new Success();
 		}
-		catch
+		catch (Exception ex)
 		{
-			await arangoDb.Transaction.AbortAsync(transaction, ct);
+			// This used to be `catch { await AbortAsync(...); }` with no rethrow and no result, so every
+			// failure — schema violation, lost owner, dropped connection — was reported to the caller as a
+			// created channel.
+			logger.LogError(ex, "Failed to create channel {ChannelName}", channelName);
+
+			if (!settled)
+			{
+				try
+				{
+					await arangoDb.Transaction.AbortAsync(transaction, ct);
+				}
+				catch (Exception abortEx)
+				{
+					logger.LogError(abortEx, "Failed to abort the transaction for channel {ChannelName}", channelName);
+				}
+			}
+
+			return new Error<string>(ex.Message);
 		}
 	}
 

--- a/SharpMUSH.Database.Memgraph/MemgraphDatabase.Channels.cs
+++ b/SharpMUSH.Database.Memgraph/MemgraphDatabase.Channels.cs
@@ -46,13 +46,27 @@ RETURN c
 			yield return MapNodeToChannel(record["c"].As<INode>());
 	}
 
-	public async ValueTask CreateChannelAsync(MString name, string[] privs, SharpPlayer owner, CancellationToken cancellationToken = default)
+	/// <summary>
+	/// True when Memgraph rejected a write because it would break the <c>:Channel(name)</c> uniqueness
+	/// constraint. That is the whole atomicity mechanism on this backend, so it has to be told apart from a
+	/// genuine failure rather than surfaced as one.
+	/// </summary>
+	private static bool IsUniqueConstraintViolation(string message)
+		=> message.Contains("unique constraint", StringComparison.OrdinalIgnoreCase);
+
+	public async ValueTask<ChannelCreationResult> CreateChannelAsync(MString name, string[] privs, SharpPlayer owner, CancellationToken cancellationToken = default)
 	{
 		var channelName = name.ToPlainText();
 		var serializedName = MModule.serialize(name);
 		var ownerObjKey = owner.Object.Key;
 
-		await ExecuteWithRetryAsync("""
+		// Uniqueness comes from the constraint, not from a check in this method. Memgraph runs at snapshot
+		// isolation, so a MATCH-then-CREATE in one query still lets two concurrent writers both observe
+		// "absent" and both create; only the constraint rejects the loser at commit. ArangoDB gets the same
+		// guarantee from an exclusive collection lock instead, and SurrealDB from the record id.
+		try
+		{
+			await ExecuteWithRetryAsync("""
 MATCH (o:Object {key: $ownerKey})
 CREATE (c:Channel {name: $name, markedUpName: $markedUpName, description: '', privs: $privs,
 joinLock: '', speakLock: '', seeLock: '', hideLock: '', modLock: '',
@@ -60,6 +74,18 @@ buffer: 0, mogrifier: ''})
 CREATE (c)-[:HAS_CHANNEL_OWNER]->(o)
 CREATE (o)-[:ON_CHANNEL {combine: false, gagged: false, hide: false, mute: false, title: ''}]->(c)
 """, new { name = channelName, markedUpName = serializedName, privs, ownerKey = ownerObjKey }, cancellationToken);
+
+			return new Success();
+		}
+		catch (Neo4jException ex) when (IsUniqueConstraintViolation(ex.Message))
+		{
+			return new ChannelNameTaken();
+		}
+		catch (Exception ex)
+		{
+			logger.LogError(ex, "Failed to create channel {ChannelName}", channelName);
+			return new Error<string>(ex.Message);
+		}
 	}
 
 	public async ValueTask UpdateChannelAsync(SharpChannel channel, MString? name, MString? description, string[]? privs,

--- a/SharpMUSH.Database.Memgraph/MemgraphDatabase.Migration.cs
+++ b/SharpMUSH.Database.Memgraph/MemgraphDatabase.Migration.cs
@@ -66,8 +66,10 @@ public partial class MemgraphDatabase
 			if (_migrated) return;
 			logger.LogInformation("Migrating Memgraph Database");
 
-			// Storage mode IN_MEMORY_ANALYTICAL is set via container startup flags
-			// (--storage-mode=IN_MEMORY_ANALYTICAL) to avoid MVCC transaction conflicts.
+			// Storage mode IN_MEMORY_TRANSACTIONAL is set via container startup flags
+			// (MemgraphTestServer.cs, MemgraphBaseBenchmark.cs). MVCC conflicts are absorbed by
+			// ExecuteWithRetryAsync instead of being avoided by dropping to the analytical mode, which
+			// enforces no constraints — and the :Channel(name) constraint below is load-bearing.
 
 			var indexQueries = new[]
 			{
@@ -109,6 +111,25 @@ public partial class MemgraphDatabase
 				{ /* Index already exists — safe to ignore */ }
 				catch (DatabaseException ex) when (ex.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase))
 				{ /* Index already exists — safe to ignore */ }
+			}
+
+			// Channel names are a global namespace, and this constraint is the only thing that makes
+			// CreateChannelAsync atomic on this backend: under snapshot isolation a MATCH-then-CREATE lets
+			// two concurrent creators both observe "absent" and both create, and only the constraint
+			// rejects the loser at commit. MemgraphDatabase.CreateChannelAsync turns that rejection into
+			// ChannelNameTaken.
+			//
+			// A database that already holds duplicate channel names — the state the missing check produced —
+			// cannot take the constraint. That is logged at warning and left alone: the alternatives are
+			// deleting somebody's channel or renaming it behind their back, and neither belongs in a
+			// start-up migration.
+			try { await indexSession.RunAsync("CREATE CONSTRAINT ON (c:Channel) ASSERT c.name IS UNIQUE"); }
+			catch (Neo4jException ex) when (IsBenignSchemaStatementFailure(ex.Message))
+			{ /* Constraint already present — safe to ignore */ }
+			catch (Neo4jException ex)
+			{
+				logger.LogWarning(ex,
+					"Could not create the :Channel(name) uniqueness constraint. Duplicate channel names must be resolved by hand before channel creation is atomic on this backend.");
 			}
 
 			// Wiki indexes — same auto-commit requirement.

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Channels.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Channels.cs
@@ -54,7 +54,7 @@ public partial class SurrealDatabase
 			yield return MapRecordToChannel(channelRecord);
 	}
 
-	public async ValueTask CreateChannelAsync(MString name, string[] privs, SharpPlayer owner, CancellationToken cancellationToken = default)
+	public async ValueTask<ChannelCreationResult> CreateChannelAsync(MString name, string[] privs, SharpPlayer owner, CancellationToken cancellationToken = default)
 	{
 		var channelName = name.ToPlainText();
 		var serializedName = MModule.serialize(name);
@@ -68,16 +68,36 @@ public partial class SurrealDatabase
 			["ownerKey"] = ownerObjKey
 		};
 
-		// Deterministic record ID so repeated creates are idempotent under the unique name index.
-		// One transaction so the channel node and its owner/membership edges commit together —
-		// otherwise the channel is visible before its owner edge and GetChannelOwnerAsync throws.
-		await ExecuteAsync(
+		// CREATE, not UPSERT. The record ID is the channel name, so UPSERT did not duplicate on a collision
+		// — it OVERWROTE, and it set every field unconditionally: privs became whatever the second caller
+		// asked for and all five locks reset to ''. A wizard-only, join-locked channel silently became an
+		// unrestricted one, and both callers were told the create succeeded. CREATE fails on an existing
+		// record ID, which is what makes this atomic here; the unique index on channel.name cannot help,
+		// because an overwrite of one record never violates it.
+		//
+		// One transaction so the channel node and its owner/membership edges commit together — otherwise
+		// the channel is visible before its owner edge and GetChannelOwnerAsync throws.
+		var response = await ExecuteAsync(
 			"BEGIN TRANSACTION;" +
-			"UPSERT channel:⟨$name⟩ SET name = $name, markedUpName = $markedUpName, description = '', privs = $privs, joinLock = '', speakLock = '', seeLock = '', hideLock = '', modLock = '', buffer = 0, mogrifier = '';" +
+			"CREATE channel:⟨$name⟩ SET name = $name, markedUpName = $markedUpName, description = '', privs = $privs, joinLock = '', speakLock = '', seeLock = '', hideLock = '', modLock = '', buffer = 0, mogrifier = '';" +
 			"RELATE (SELECT VALUE id FROM channel WHERE name = $name LIMIT 1)->owner_of_channel->object:$ownerKey;" +
 			"RELATE object:$ownerKey->member_of_channel->(SELECT VALUE id FROM channel WHERE name = $name LIMIT 1) SET combine = false, gagged = false, hide = false, mute = false, title = '';" +
 			"COMMIT TRANSACTION",
 			parameters, cancellationToken);
+
+		if (!response.HasErrors)
+		{
+			return new Success();
+		}
+
+		var errors = string.Join("; ", response.Errors.Select(FormatError));
+
+		// "Database record `channel:Foo` already exists" — and the index guard, in case a name reaches the
+		// same record by a different id form.
+		return errors.Contains("already exists", StringComparison.OrdinalIgnoreCase)
+					 || errors.Contains("already contains", StringComparison.OrdinalIgnoreCase)
+			? new ChannelNameTaken()
+			: new Error<string>(errors);
 	}
 
 	public async ValueTask UpdateChannelAsync(SharpChannel channel, MString? name, MString? description, string[]? privs,

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Channels.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Channels.cs
@@ -77,28 +77,57 @@ public partial class SurrealDatabase
 		//
 		// One transaction so the channel node and its owner/membership edges commit together — otherwise
 		// the channel is visible before its owner edge and GetChannelOwnerAsync throws.
-		var response = await ExecuteAsync(
+		const string createQuery =
 			"BEGIN TRANSACTION;" +
 			"CREATE channel:⟨$name⟩ SET name = $name, markedUpName = $markedUpName, description = '', privs = $privs, joinLock = '', speakLock = '', seeLock = '', hideLock = '', modLock = '', buffer = 0, mogrifier = '';" +
 			"RELATE (SELECT VALUE id FROM channel WHERE name = $name LIMIT 1)->owner_of_channel->object:$ownerKey;" +
 			"RELATE object:$ownerKey->member_of_channel->(SELECT VALUE id FROM channel WHERE name = $name LIMIT 1) SET combine = false, gagged = false, hide = false, mute = false, title = '';" +
-			"COMMIT TRANSACTION",
-			parameters, cancellationToken);
+			"COMMIT TRANSACTION";
 
-		if (!response.HasErrors)
+		const int maxAttempts = 8;
+
+		for (var attempt = 0; ; attempt++)
 		{
-			return new Success();
+			var response = await ExecuteAsync(createQuery, parameters, cancellationToken);
+
+			if (!response.HasErrors)
+			{
+				return new Success();
+			}
+
+			var errors = string.Join("; ", response.Errors.Select(FormatError));
+
+			// "Database record `channel:Foo` already exists" — and the index guard, in case a name reaches
+			// the same record by a different id form.
+			if (errors.Contains("already exists", StringComparison.OrdinalIgnoreCase)
+					|| errors.Contains("already contains", StringComparison.OrdinalIgnoreCase))
+			{
+				return new ChannelNameTaken();
+			}
+
+			// SurrealDB is optimistic: concurrent writers to one record do not queue, they lose at commit
+			// with "Failed to commit transaction due to a read or write conflict. This transaction can be
+			// retried." Retrying is what turns that into the answer the caller needs, because the retry
+			// finds the winner's record and gets "already exists". Without it the loser of a race is told
+			// the create failed for an unexplained reason — true, but useless.
+			if (attempt < maxAttempts - 1 && IsRetryableConflict(errors))
+			{
+				var backoff = Math.Min(25 * (1 << attempt), 500);
+				await Task.Delay(backoff + Random.Shared.Next(0, (backoff / 2) + 1), cancellationToken);
+				continue;
+			}
+
+			return new Error<string>(errors);
 		}
-
-		var errors = string.Join("; ", response.Errors.Select(FormatError));
-
-		// "Database record `channel:Foo` already exists" — and the index guard, in case a name reaches the
-		// same record by a different id form.
-		return errors.Contains("already exists", StringComparison.OrdinalIgnoreCase)
-					 || errors.Contains("already contains", StringComparison.OrdinalIgnoreCase)
-			? new ChannelNameTaken()
-			: new Error<string>(errors);
 	}
+
+	/// <summary>
+	/// True when SurrealDB refused a commit because another transaction touched the same records. Its own
+	/// message says the transaction can be retried, and on retry the create resolves to "already exists".
+	/// </summary>
+	private static bool IsRetryableConflict(string message)
+		=> message.Contains("read or write conflict", StringComparison.OrdinalIgnoreCase)
+			|| message.Contains("can be retried", StringComparison.OrdinalIgnoreCase);
 
 	public async ValueTask UpdateChannelAsync(SharpChannel channel, MString? name, MString? description, string[]? privs,
 		string? joinLock, string? speakLock, string? seeLock, string? hideLock, string? modLock,

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Channels.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Channels.cs
@@ -54,7 +54,37 @@ public partial class SurrealDatabase
 			yield return MapRecordToChannel(channelRecord);
 	}
 
+	/// <summary>
+	/// Serializes channel creation for this database.
+	/// </summary>
+	/// <remarks>
+	/// SurrealDB is EMBEDDED here — <c>SurrealDb.Embedded.InMemory</c> or the RocksDB engine, in the
+	/// server's own process (<c>Startup.cs:167-190</c>) — so one process owns the whole store and an
+	/// in-process gate is a complete guarantee, not an approximation of one. It is needed: SurrealDB is
+	/// optimistic, and under eight-way contention two <c>CREATE</c>s on the same record ID were both
+	/// observed committing, which is the overwrite this method exists to prevent. The same reasoning
+	/// already produced the in-memory object-key counter at <c>SurrealDatabase.cs:214-220</c>.
+	///
+	/// <para>ArangoDB and Memgraph get no equivalent, and must not: they are real servers with other
+	/// possible clients, so a lock inside one process would guarantee nothing. Their guarantee is an
+	/// exclusive collection lock and a uniqueness constraint respectively.</para>
+	/// </remarks>
+	private readonly SemaphoreSlim _channelCreateLock = new(1, 1);
+
 	public async ValueTask<ChannelCreationResult> CreateChannelAsync(MString name, string[] privs, SharpPlayer owner, CancellationToken cancellationToken = default)
+	{
+		await _channelCreateLock.WaitAsync(cancellationToken);
+		try
+		{
+			return await CreateChannelCoreAsync(name, privs, owner, cancellationToken);
+		}
+		finally
+		{
+			_channelCreateLock.Release();
+		}
+	}
+
+	private async ValueTask<ChannelCreationResult> CreateChannelCoreAsync(MString name, string[] privs, SharpPlayer owner, CancellationToken cancellationToken)
 	{
 		var channelName = name.ToPlainText();
 		var serializedName = MModule.serialize(name);

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelAdd.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelAdd.cs
@@ -28,8 +28,18 @@ public static class ChannelAdd
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		// notify: false — a missing channel is the expected case when creating one; the player should
-		// not be told "Channel not found." on their way to "Channel has been created."
+		// RAW lookup on purpose — do not "fix" this to GetVisibleChannelOrError.
+		//
+		// Channel names are globally unique, so uniqueness has to be tested against every channel, not just
+		// the ones this player may see. A visible lookup here would report "no such channel" for a hidden
+		// one and then let the create succeed, producing two channels with the same name — a data bug worse
+		// than the probe it would close. PennMUSH resolves it the same way: ok_channel_name
+		// (src/extchat.c:1855-1870) walks the whole channel list and returns NAME_NOT_UNIQUE without
+		// consulting Chan_Can_See.
+		//
+		// The residual leak is that "CHAT: Channel already exists." tells a player a name is taken even
+		// when they cannot see the channel holding it. That is inherent to a global namespace and PennMUSH
+		// leaks it identically. notify: false keeps the lookup itself silent.
 		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, false);
 		if (!maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelAdd.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelAdd.cs
@@ -32,10 +32,14 @@ public static class ChannelAdd
 		//
 		// Channel names are globally unique, so uniqueness has to be tested against every channel, not just
 		// the ones this player may see. A visible lookup here would report "no such channel" for a hidden
-		// one and then let the create succeed, producing two channels with the same name — a data bug worse
-		// than the probe it would close. PennMUSH resolves it the same way: ok_channel_name
-		// (src/extchat.c:1855-1870) walks the whole channel list and returns NAME_NOT_UNIQUE without
-		// consulting Chan_Can_See.
+		// one and then let the create proceed — on ArangoDB and Memgraph a duplicate, on SurrealDB a hidden
+		// channel created over by someone who cannot see it. PennMUSH resolves it the same way:
+		// ok_channel_name (src/extchat.c:1855-1870) walks the whole channel list and returns
+		// NAME_NOT_UNIQUE without consulting Chan_Can_See.
+		//
+		// This check is a fast path for the message, NOT the guarantee: it cannot be atomic with a create
+		// that happens several awaits later. CreateChannelAsync decides uniqueness inside its own storage
+		// transaction and answers ChannelNameTaken, which is handled below.
 		//
 		// The residual leak is that "CHAT: Channel already exists." tells a player a name is taken even
 		// when they cannot see the channel holding it. That is inherent to a global namespace and PennMUSH
@@ -43,7 +47,7 @@ public static class ChannelAdd
 		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, false);
 		if (!maybeChannel.IsError)
 		{
-			await NotifyService.Notify(executor, "CHAT: Channel already exists.", executor);
+			await NotifyService.Notify(executor, ErrorMessages.Notifications.ChatAlreadyExists, executor);
 			return new CallState(ErrorMessages.Returns.ChannelAlreadyExists);
 		}
 
@@ -82,9 +86,24 @@ public static class ChannelAdd
 			return new CallState(ErrorMessages.Returns.ChannelPermissionDenied);
 		}
 
-		await Mediator.Send(new CreateChannelCommand(channelName, parsedPrivileges.AsPrivileges, executorOwner));
+		// The check above raced; this one cannot. CreateChannelAsync tests the name inside the same storage
+		// transaction that writes the channel, so the loser is refused rather than duplicating the winner
+		// (ArangoDB, Memgraph) or overwriting its privileges and locks (SurrealDB).
+		var creation = await Mediator.Send(new CreateChannelCommand(channelName, parsedPrivileges.AsPrivileges, executorOwner));
 
-		await NotifyService.Notify(executor, "Channel has been created.", executor);
-		return new CallState("Channel has been created.");
+		if (creation.IsNameTaken)
+		{
+			await NotifyService.Notify(executor, ErrorMessages.Notifications.ChatAlreadyExists, executor);
+			return new CallState(ErrorMessages.Returns.ChannelAlreadyExists);
+		}
+
+		if (creation.IsError)
+		{
+			await NotifyService.Notify(executor, ErrorMessages.Notifications.ChatChannelCreationFailed, executor);
+			return new CallState(ErrorMessages.Returns.ChannelCreationFailed);
+		}
+
+		await NotifyService.Notify(executor, ErrorMessages.Notifications.ChatChannelCreated, executor);
+		return new CallState(ErrorMessages.Notifications.ChatChannelCreated);
 	}
 }

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelAdd.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelAdd.cs
@@ -30,7 +30,7 @@ public static class ChannelAdd
 
 		// notify: false — a missing channel is the expected case when creating one; the player should
 		// not be told "Channel not found." on their way to "Channel has been created."
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService, PermissionService, Mediator, NotifyService, channelName, false);
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, false);
 		if (!maybeChannel.IsError)
 		{
 			await NotifyService.Notify(executor, "CHAT: Channel already exists.", executor);
@@ -55,11 +55,21 @@ public static class ChannelAdd
 			return new CallState(ErrorMessages.Returns.TooManyChannels);
 		}
 
-		var parsedPrivileges = ChannelHelper.StringToChannelPrivileges(privileges);
+		var parsedPrivileges = ChannelHelper.StringToChannelPrivileges(privileges, []);
 		if (parsedPrivileges.IsError)
 		{
 			await NotifyService.Notify(executor, $"Invalid privileges: {string.Join(", ", parsedPrivileges.AsError.Value)}.", executor);
 			return new CallState(ErrorMessages.Returns.InvalidPrivileges);
+		}
+
+		// extchat.c:1736 — `if (!Chan_Can(player, type))`. You cannot create a channel of a type you could
+		// not yourself use, which includes a DISABLED one: Chan_Can is false for that bit for everybody,
+		// wizards included. A wizard disables an existing channel through @channel/privs instead, where
+		// Chan_Can_Priv's `Wizard(p) ||` escape applies.
+		if (!await PermissionService.ChannelStandardCan(executor, parsedPrivileges.AsPrivileges))
+		{
+			await NotifyService.Notify(executor, ErrorMessages.Notifications.ChatCannotCreateThatType, executor);
+			return new CallState(ErrorMessages.Returns.ChannelPermissionDenied);
 		}
 
 		await Mediator.Send(new CreateChannelCommand(channelName, parsedPrivileges.AsPrivileges, executorOwner));

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelBuffer.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelBuffer.cs
@@ -19,7 +19,8 @@ public static class ChannelBuffer
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService, Mediator,
+			NotifyService, executor, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelBuffer.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelBuffer.cs
@@ -19,7 +19,7 @@ public static class ChannelBuffer
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService, PermissionService, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelChown.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelChown.cs
@@ -18,7 +18,7 @@ public static class ChannelChown
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService, PermissionService, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelChown.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelChown.cs
@@ -18,7 +18,8 @@ public static class ChannelChown
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService, Mediator,
+			NotifyService, executor, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelCombine.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelCombine.cs
@@ -38,7 +38,7 @@ public static class ChannelCombine
 		}
 		else
 		{
-			var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService, PermissionService, Mediator, NotifyService, channelName, true);
+			var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
 			if (maybeChannel.IsError)
 			{
 				return maybeChannel.AsError.Value;

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelCombine.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelCombine.cs
@@ -31,14 +31,16 @@ public static class ChannelCombine
 			return new CallState(ErrorMessages.Returns.InvalidOption);
 		}
 
-		var channelList = Mediator.CreateStream(new GetChannelListQuery());
 		if (channelName is null)
 		{
-			channels = [.. await channelList.ToArrayAsync()];
+			// Same enumeration oracle as @channel/hide's bulk path.
+			channels = [.. await ChannelHelper.VisibleChannels(PermissionService, executor,
+				Mediator.CreateStream(new GetChannelListQuery()))];
 		}
 		else
 		{
-			var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
+			var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService, Mediator,
+				NotifyService, executor, channelName, true);
 			if (maybeChannel.IsError)
 			{
 				return maybeChannel.AsError.Value;

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelDecompile.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelDecompile.cs
@@ -17,7 +17,7 @@ public static class ChannelDecompile
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService, PermissionService, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelDecompile.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelDecompile.cs
@@ -17,7 +17,8 @@ public static class ChannelDecompile
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService, Mediator,
+			NotifyService, executor, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelDelete.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelDelete.cs
@@ -18,7 +18,8 @@ public static class ChannelDelete
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService, Mediator,
+			NotifyService, executor, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelDelete.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelDelete.cs
@@ -18,7 +18,7 @@ public static class ChannelDelete
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService, PermissionService, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelDescribe.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelDescribe.cs
@@ -18,7 +18,7 @@ public static class ChannelDescribe
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService, PermissionService, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelDescribe.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelDescribe.cs
@@ -18,7 +18,8 @@ public static class ChannelDescribe
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService, Mediator,
+			NotifyService, executor, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelGag.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelGag.cs
@@ -62,7 +62,9 @@ public static class ChannelGag
 
 			var status = maybeMemberStatus.Status;
 
-			if ((status.Hide ?? false) == gagOn)
+			// @channel/gag read and wrote the Hide flag, so gagging hid you from the who-list and left you
+			// hearing every word. SharpChannelStatus is (Combine, Gagged, Hide, Mute, Title).
+			if ((status.Gagged ?? false) == gagOn)
 			{
 				await NotifyService.Notify(executor, $"CHAT: You are already in that gag state on {channel.Name.ToPlainText()}.", executor);
 				continue;
@@ -71,8 +73,8 @@ public static class ChannelGag
 			await Mediator.Send(new UpdateChannelUserStatusCommand(
 				channel, executor, new SharpChannelStatus(
 					null,
-					null,
 					gagOn,
+					null,
 					null,
 					null
 				)));

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelGag.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelGag.cs
@@ -34,12 +34,15 @@ public static class ChannelGag
 
 		if (channelName is null)
 		{
-			var channelList = Mediator.CreateStream(new GetChannelListQuery());
-			channels = [.. await channelList.ToArrayAsync()];
+			// Same enumeration oracle as @channel/hide's bulk path: this walked every channel and then named
+			// each one back to the executor.
+			channels = [.. await ChannelHelper.VisibleChannels(PermissionService, executor,
+				Mediator.CreateStream(new GetChannelListQuery()))];
 		}
 		else
 		{
-			var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
+			var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService, Mediator,
+				NotifyService, executor, channelName, true);
 			if (maybeChannel.IsError)
 			{
 				return maybeChannel.AsError.Value;

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelGag.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelGag.cs
@@ -39,7 +39,7 @@ public static class ChannelGag
 		}
 		else
 		{
-			var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService, PermissionService, Mediator, NotifyService, channelName, true);
+			var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
 			if (maybeChannel.IsError)
 			{
 				return maybeChannel.AsError.Value;

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelHelper.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelHelper.cs
@@ -2,6 +2,7 @@ using Mediator;
 using OneOf;
 using OneOf.Types;
 using SharpMUSH.Configuration.Options;
+using SharpMUSH.Library;
 using SharpMUSH.Library.DiscriminatedUnions;
 using SharpMUSH.Library.Extensions;
 using SharpMUSH.Library.Models;
@@ -81,30 +82,70 @@ public static class ChannelHelper
 		AnySharpObject member, SharpChannel channel) =>
 		await channel.Members.Value.FirstOrDefaultAsync(x => x.Member.Id() == member.Id());
 
-	public static PrivilegeOrError StringToChannelPrivileges(MString channelName)
+	/// <summary>
+	/// PennMUSH <c>string_to_privs(table, str, origprivs)</c> (<c>src/privtab.c:36</c>): applies a
+	/// space-separated privilege list to an existing set rather than replacing it, and honours a leading
+	/// <c>!</c> as removal. An empty list leaves <paramref name="originalPrivileges"/> untouched.
+	///
+	/// <para>Names are returned in the canonical casing of the <c>chan_privs</c> table, never in whatever
+	/// casing the player typed. <c>@channel/add Foo=wizard</c> used to persist the literal <c>"wizard"</c>,
+	/// which every ordinal <c>Privs.Contains("Wizard")</c> permission check then failed to see.</para>
+	///
+	/// <para>Unlike PennMUSH this matches full names exactly (case-insensitively) rather than by prefix;
+	/// single-character aliases are matched case-sensitively, as 'O' (Object) and 'o' (Open) differ.</para>
+	/// </summary>
+	public static PrivilegeOrError StringToChannelPrivileges(MString privileges, string[] originalPrivileges)
 	{
-		var plainText = channelName.ToPlainText();
-		var list = plainText
+		var tokens = privileges.ToPlainText()
 			.Split(' ')
 			.Where(x => !string.IsNullOrWhiteSpace(x))
 			.ToArray();
 
-		var badList = list.Where(x => x.Length == 1
-			? !ChannelPrivilegesReverse.ContainsKey(x[0])
-			: !ChannelPrivileges.ContainsKey(x)).ToArray();
+		var badList = tokens
+			.Select(TrimNegation)
+			.Where(x => x.Length != 0 && ResolvePrivilege(x) is null)
+			.ToArray();
 
 		if (badList.Length != 0)
 		{
 			return new PrivilegeOrError(new Error<string[]>(badList));
 		}
 
-		var validatedList = list.Select(x => x.Length == 1
-				? ChannelPrivilegesReverse.GetValueOrDefault(x[0], null)
-				: (ChannelPrivileges.ContainsKey(x) ? x : null))
-			.Where(x => x != null).ToArray();
+		var result = new List<string>(originalPrivileges
+			.Select(x => ResolvePrivilege(x) ?? x)
+			.Distinct(StringComparer.OrdinalIgnoreCase));
 
-		return new PrivilegeOrError(validatedList!);
+		foreach (var token in tokens)
+		{
+			var negated = token.StartsWith('!');
+			var name = ResolvePrivilege(TrimNegation(token));
+
+			if (name is null)
+			{
+				continue;
+			}
+
+			result.RemoveAll(x => x.Equals(name, StringComparison.OrdinalIgnoreCase));
+
+			if (!negated)
+			{
+				result.Add(name);
+			}
+		}
+
+		return new PrivilegeOrError([.. result]);
 	}
+
+	private static string TrimNegation(string token)
+		=> token.StartsWith('!') ? token[1..] : token;
+
+	private static string? ResolvePrivilege(string token)
+		=> token.Length switch
+		{
+			0 => null,
+			1 => ChannelPrivilegesReverse.GetValueOrDefault(token[0]),
+			_ => ChannelPrivileges.Keys.FirstOrDefault(x => x.Equals(token, StringComparison.OrdinalIgnoreCase))
+		};
 
 	public static bool IsValidChannelName(IOptionsWrapper<SharpMUSHOptions> Configuration, MString channelName)
 		=> IsValidChannelName(Configuration, channelName.ToPlainText());
@@ -114,10 +155,17 @@ public static class ChannelHelper
 			 && channelName.Length > 3
 			 && !channelName.Contains(' ');
 
+	/// <summary>
+	/// Looks a channel up by name. This is PennMUSH's <c>find_channel()</c> and nothing more: it does not
+	/// decide who may see, join or speak on what it returns.
+	///
+	/// <para>It used to take an <see cref="IPermissionService"/> and never touch it, which made every one
+	/// of its twenty-odd call sites read as though a permission check had already happened. The parameter
+	/// is gone; callers that need a gate ask for one by name — <see cref="GetVisibleChannelOrError"/>,
+	/// <see cref="JoinRefusal"/>, <see cref="SpeechRefusal"/>, <see cref="CemitRefusal"/>.</para>
+	/// </summary>
 	public static async ValueTask<ChannelOrError> GetChannelOrError(
 		IMUSHCodeParser parser,
-		ILocateService LocateService,
-		IPermissionService PermissionService,
 		IMediator Mediator,
 		INotifyService NotifyService,
 		MString channelName,
@@ -143,5 +191,128 @@ public static class ChannelHelper
 					return new ChannelOrError(foundChannel);
 				}
 		}
+	}
+
+	/// <summary>
+	/// Lookup plus PennMUSH's <c>Chan_Can_See</c> gate. A channel the executor may not see is reported as
+	/// no channel at all, exactly as <c>src/extchat.c</c> does at every function and command that reads
+	/// channel state ("#-1 NO SUCH CHANNEL", "CHAT: I don't recognize that channel.").
+	/// </summary>
+	public static async ValueTask<ChannelOrError> GetVisibleChannelOrError(
+		IMUSHCodeParser parser,
+		IPermissionService permissionService,
+		IMediator mediator,
+		INotifyService notifyService,
+		AnySharpObject viewer,
+		MString channelName,
+		bool notify = false)
+	{
+		var maybeChannel = await GetChannelOrError(parser, mediator, notifyService, channelName, notify);
+
+		if (maybeChannel.IsError || await permissionService.ChannelCanSeeAsync(viewer, maybeChannel.AsChannel))
+		{
+			return maybeChannel;
+		}
+
+		if (notify)
+		{
+			await notifyService.Notify(viewer, ErrorMessages.Notifications.DontRecognizeThatChannel, viewer);
+		}
+
+		return new ChannelOrError(new Error<CallState>(new CallState(ErrorMessages.Returns.ChannelNotFound)));
+	}
+
+	/// <summary>
+	/// PennMUSH <c>Chan_Ok_Type</c> (hdrs/extchat.h:196) with the refusal <c>src/extchat.c:1533</c>
+	/// prints. Returns <see langword="null"/> when the object is of a type the channel accepts.
+	/// </summary>
+	public static string? WrongTypeRefusal(IPermissionService permissionService, AnySharpObject who,
+		SharpChannel channel)
+		=> permissionService.ChannelOkType(who, channel)
+			? null
+			: string.Format(ErrorMessages.Notifications.ChatWrongTypeForChannel, channel.Name.ToPlainText());
+
+	/// <summary>
+	/// The outcome of PennMUSH's join checks (<c>src/extchat.c:1241-1268</c> for a third party,
+	/// <c>:1347-1362</c> for oneself). A wizard who fails only the join lock is warned and joined anyway,
+	/// so a plain refusal string cannot express the result.
+	/// </summary>
+	public readonly record struct JoinCheck(string? Refusal, string? Warning)
+	{
+		public bool Refused => Refusal is not null;
+	}
+
+	/// <summary>
+	/// PennMUSH <c>Chan_Ok_Type</c> then <c>Chan_Can_Join</c>, with the wizard override
+	/// (<c>src/extchat.c:1261-1268</c>): a wizard actor who fails the check is warned rather than
+	/// refused. The override is the ACTOR's privilege, not the victim's.
+	/// </summary>
+	public static async ValueTask<JoinCheck> JoinRefusal(IPermissionService permissionService,
+		AnySharpObject actor, AnySharpObject victim, SharpChannel channel)
+	{
+		if (WrongTypeRefusal(permissionService, victim, channel) is not null)
+		{
+			return new JoinCheck(
+				string.Format(ErrorMessages.Notifications.ChatWrongTypeOfThingForChannel, channel.Name.ToPlainText()),
+				null);
+		}
+
+		if (await permissionService.ChannelCanJoin(victim, channel))
+		{
+			return new JoinCheck(null, null);
+		}
+
+		return await actor.IsWizard()
+			? new JoinCheck(null, actor.Id() == victim.Id()
+				? ErrorMessages.Notifications.ChatJoinOverrideSelf
+				: ErrorMessages.Notifications.ChatJoinOverrideTarget)
+			: new JoinCheck(ErrorMessages.Notifications.ChatJoinDenied, null);
+	}
+
+	/// <summary>
+	/// PennMUSH <c>do_chat</c> (<c>src/extchat.c:1533-1546</c>): the type gate, then the speak gate that
+	/// <c>LOUD</c> bypasses. A speaker who cannot even see the channel is told it does not exist rather
+	/// than that they may not speak on it.
+	/// </summary>
+	public static async ValueTask<string?> SpeechRefusal(IPermissionService permissionService, AnySharpObject who,
+		SharpChannel channel)
+	{
+		if (WrongTypeRefusal(permissionService, who, channel) is { } wrongType)
+		{
+			return wrongType;
+		}
+
+		if (await who.IsLoud() || await permissionService.ChannelCanSpeak(who, channel))
+		{
+			return null;
+		}
+
+		return await permissionService.ChannelCanSeeAsync(who, channel)
+			? string.Format(ErrorMessages.Notifications.ChatNotAllowedToSpeak, channel.Name.ToPlainText())
+			: ErrorMessages.Notifications.ChatNoSuchChannel;
+	}
+
+	/// <summary>
+	/// PennMUSH <c>do_cemit</c> (<c>src/extchat.c:1622-1640</c>): See_All + Pemit_All skips the checks
+	/// entirely, since such a player could enumerate the channel's members and <c>@pemit</c> them anyway.
+	/// Otherwise the type gate and <c>Chan_Can_Cemit</c> apply. Note <c>LOUD</c> does NOT bypass this —
+	/// Penn only consults it in <c>do_chat</c>.
+	/// </summary>
+	public static async ValueTask<string?> CemitRefusal(IPermissionService permissionService, AnySharpObject who,
+		SharpChannel channel)
+	{
+		if (await who.IsSee_All() && await who.HasPower("Pemit_All"))
+		{
+			return null;
+		}
+
+		if (WrongTypeRefusal(permissionService, who, channel) is { } wrongType)
+		{
+			return wrongType;
+		}
+
+		return await permissionService.ChannelCanCemit(who, channel)
+			? null
+			: string.Format(ErrorMessages.Notifications.ChatNotAllowedToCemit, channel.Name.ToPlainText());
 	}
 }

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelHelper.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelHelper.cs
@@ -194,9 +194,34 @@ public static class ChannelHelper
 	}
 
 	/// <summary>
-	/// Lookup plus PennMUSH's <c>Chan_Can_See</c> gate. A channel the executor may not see is reported as
-	/// no channel at all, exactly as <c>src/extchat.c</c> does at every function and command that reads
-	/// channel state ("#-1 NO SUCH CHANNEL", "CHAT: I don't recognize that channel.").
+	/// Whether <paramref name="viewer"/> may be told this channel exists at all.
+	///
+	/// <para>PennMUSH's <c>find_channel</c> (<c>src/extchat.c:959</c>) resolves a name only when
+	/// <c>Chan_Can_See(chan, player) || onchannel(player, chan)</c>. The membership half matters on its own:
+	/// <c>Chan_Can_See</c> requires a member to also pass <c>Chan_Can_Speak</c>, so without it a gagged or
+	/// speak-locked member would be told their own channel does not exist.</para>
+	/// </summary>
+	public static async ValueTask<bool> CanSeeChannel(IPermissionService permissionService, AnySharpObject viewer,
+		SharpChannel channel)
+		=> await permissionService.ChannelCanSeeAsync(viewer, channel)
+			 || await IsMemberOfChannel(viewer, channel);
+
+	/// <summary>
+	/// Lookup plus PennMUSH's visibility gate, which is inside <c>find_channel</c> itself
+	/// (<c>src/extchat.c:943-972</c>) and therefore applies to every command and function that resolves a
+	/// channel by name.
+	///
+	/// <para><b>A channel that does not exist and a channel the viewer may not see produce the same
+	/// notification AND the same return value, deliberately.</b> Anything else is an enumeration oracle:
+	/// a caller who can tell "no such channel" from "not for you" can walk the channel list. PennMUSH
+	/// agrees — <c>test_channel_fun</c> (<c>extchat.h:161</c>) answers a missing channel with
+	/// "CHAT: I don't recognize that channel." and <c>#-1 NO SUCH CHANNEL</c>, and every
+	/// <c>Chan_Can_See</c> refusal in <c>extchat.c</c> answers with exactly the same pair.</para>
+	///
+	/// <para>This repository has already made this decision once, for the same reason: PR #750 gave a
+	/// missing scene and an invisible scene one identical answer, recorded at
+	/// <c>SharpMUSH.Plugins.Scene/Web/SceneHub.cs:52-57</c> and <c>SceneLive.razor:120-124</c>. Any future
+	/// edit that wants to explain a not-found here has to keep the two cases sharing an answer.</para>
 	/// </summary>
 	public static async ValueTask<ChannelOrError> GetVisibleChannelOrError(
 		IMUSHCodeParser parser,
@@ -207,9 +232,11 @@ public static class ChannelHelper
 		MString channelName,
 		bool notify = false)
 	{
-		var maybeChannel = await GetChannelOrError(parser, mediator, notifyService, channelName, notify);
+		// notify: false — the caller must not learn which of the two failures it hit, so the one refusal
+		// below is the only thing either path is allowed to emit.
+		var maybeChannel = await GetChannelOrError(parser, mediator, notifyService, channelName, notify: false);
 
-		if (maybeChannel.IsError || await permissionService.ChannelCanSeeAsync(viewer, maybeChannel.AsChannel))
+		if (!maybeChannel.IsError && await CanSeeChannel(permissionService, viewer, maybeChannel.AsChannel))
 		{
 			return maybeChannel;
 		}
@@ -219,7 +246,34 @@ public static class ChannelHelper
 			await notifyService.Notify(viewer, ErrorMessages.Notifications.DontRecognizeThatChannel, viewer);
 		}
 
-		return new ChannelOrError(new Error<CallState>(new CallState(ErrorMessages.Returns.ChannelNotFound)));
+		return new ChannelOrError(new Error<CallState>(new CallState(ErrorMessages.Returns.NoSuchChannel)));
+	}
+
+	/// <summary>
+	/// The channels <paramref name="viewer"/> may be told exist, for the switches that operate on every
+	/// channel at once. Resolving one channel by name goes through
+	/// <see cref="GetVisibleChannelOrError"/>; enumerating them has to apply the same rule or
+	/// <c>@channel/hide</c> with no argument becomes a way to list what that gate hides.
+	/// </summary>
+	public static async ValueTask<SharpChannel[]> VisibleChannels(IPermissionService permissionService,
+		AnySharpObject viewer, IAsyncEnumerable<SharpChannel> channels)
+	{
+		// Materialise the channel list BEFORE testing visibility. The test reads channel.Members, which
+		// opens its own database stream, and Core.Arango 3.12.x races when one ExecuteStreamAsync is
+		// enumerated inside another — it faults on a thread pool thread and takes the process with it.
+		// The same driver race is already worked around in HelperFunctions.HasPower.
+		var all = await channels.ToArrayAsync();
+		var visible = new List<SharpChannel>(all.Length);
+
+		foreach (var channel in all)
+		{
+			if (await CanSeeChannel(permissionService, viewer, channel))
+			{
+				visible.Add(channel);
+			}
+		}
+
+		return [.. visible];
 	}
 
 	/// <summary>

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelHide.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelHide.cs
@@ -35,8 +35,11 @@ public static class ChannelHide
 		// passed a null name to a lookup that cannot take one.
 		if (channelName is null)
 		{
-			var channelList = Mediator.CreateStream(new GetChannelListQuery());
-			channels = [.. await channelList.ToArrayAsync()];
+			// The bulk path routed around GetVisibleChannelOrError entirely and then named each channel in
+			// its per-channel notifications, so `@channel/hide` with no argument listed exactly the channels
+			// that gate exists to hide.
+			channels = [.. await ChannelHelper.VisibleChannels(PermissionService, executor,
+				Mediator.CreateStream(new GetChannelListQuery()))];
 		}
 		else
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelHide.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelHide.cs
@@ -31,14 +31,17 @@ public static class ChannelHide
 			return new CallState(ErrorMessages.Returns.InvalidOption);
 		}
 
-		if (channelName != null)
+		// The sense of this was inverted: naming a channel hid you on EVERY channel, and naming none
+		// passed a null name to a lookup that cannot take one.
+		if (channelName is null)
 		{
 			var channelList = Mediator.CreateStream(new GetChannelListQuery());
 			channels = [.. await channelList.ToArrayAsync()];
 		}
 		else
 		{
-			var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService, PermissionService, Mediator, NotifyService, channelName!, true);
+			var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService, Mediator,
+				NotifyService, executor, channelName, true);
 			if (maybeChannel.IsError)
 			{
 				return maybeChannel.AsError.Value;
@@ -56,11 +59,23 @@ public static class ChannelHide
 			if (maybeMemberStatus is null)
 			{
 				await NotifyService.Notify(executor, $"CHAT: You are not a member of {channel.Name.ToPlainText()}.", executor);
+				continue;
 			}
 
-			var status = maybeMemberStatus?.Status;
+			// extchat.c:2001 — `if (!Chan_Can_Hide(c, player) && !Wizard(player))`. The Hide_Ok privilege and
+			// the hide lock decide who may vanish from a channel's who-list; nothing consulted them before.
+			if (!await PermissionService.ChannelCanHide(executor, channel) && !await executor.IsWizard())
+			{
+				await NotifyService.Notify(executor,
+					string.Format(ErrorMessages.Notifications.ChatCannotHideOnChannel, channel.Name.ToPlainText()),
+					executor);
+				continue;
+			}
 
-			if (status?.Hide ?? false == hideOn)
+			// `status?.Hide ?? false == hideOn` binds as `status?.Hide ?? (false == hideOn)`, which reports
+			// "already in that hide state" whenever the player was NOT hidden and asked to unhide — and
+			// never reported it when they were.
+			if ((maybeMemberStatus.Status.Hide ?? false) == hideOn)
 			{
 				await NotifyService.Notify(executor, $"CHAT: You are already in that hide state on {channel.Name.ToPlainText()}.", executor);
 				continue;

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelMogrifier.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelMogrifier.cs
@@ -19,7 +19,8 @@ public static class ChannelMogrifier
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService, Mediator,
+			NotifyService, executor, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelMogrifier.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelMogrifier.cs
@@ -19,7 +19,7 @@ public static class ChannelMogrifier
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService, PermissionService, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelMute.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelMute.cs
@@ -20,13 +20,24 @@ public static class ChannelMute
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService, Mediator,
+			NotifyService, executor, channelName, true);
 		if (maybeChannel.IsError)
 		{
 			return maybeChannel.AsError.Value;
 		}
 
 		var channel = maybeChannel.AsChannel;
+
+		// @channel/mute writes the status of a player the executor NAMES, unlike /gag, /hide, /combine and
+		// /title, which only ever write the executor's own. A third-party write needs the channel's modify
+		// right; without this any non-guest who knows a channel and a member name could mute that member.
+		// Silencing someone else's channel voice is exactly what ChanModLock exists to control.
+		if (!await PermissionService.ChannelCanModifyAsync(executor, channel))
+		{
+			await NotifyService.Notify(executor, ErrorMessages.Notifications.PermissionDenied, executor);
+			return new CallState(ErrorMessages.Returns.PermissionDenied);
+		}
 
 		var players = Mediator.CreateStream(new GetPlayerQuery(playerName.ToPlainText()));
 		var player = await players.FirstOrDefaultAsync();

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelMute.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelMute.cs
@@ -48,7 +48,9 @@ public static class ChannelMute
 			return new CallState("Player is already muted.");
 		}
 
-		await Mediator.Send(new UpdateChannelUserStatusCommand(channel, executor,
+		// The status was written against the executor, so @channel/mute muted whoever issued it rather
+		// than the player they named.
+		await Mediator.Send(new UpdateChannelUserStatusCommand(channel, player,
 			new SharpChannelStatus(
 				null,
 				null,

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelMute.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelMute.cs
@@ -20,7 +20,7 @@ public static class ChannelMute
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService, PermissionService, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
 		if (maybeChannel.IsError)
 		{
 			return maybeChannel.AsError.Value;

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelOff.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelOff.cs
@@ -33,7 +33,8 @@ public static class ChannelOff
 			target = maybeTarget.AsAnyObject;
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService, Mediator,
+			NotifyService, executor, channelName, true);
 		if (maybeChannel.IsError)
 		{
 			return maybeChannel.AsError.Value;

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelOff.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelOff.cs
@@ -1,4 +1,5 @@
 using Mediator;
+using SharpMUSH.Library;
 using SharpMUSH.Library.Commands.Database;
 using SharpMUSH.Library.Extensions;
 using SharpMUSH.Library.ParserInterfaces;
@@ -32,13 +33,23 @@ public static class ChannelOff
 			target = maybeTarget.AsAnyObject;
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService, PermissionService, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
 		if (maybeChannel.IsError)
 		{
 			return maybeChannel.AsError.Value;
 		}
 
 		var channel = maybeChannel.AsChannel;
+
+		// extchat.c:1289 — "You must control either the victim or the channel". Without this, any mortal
+		// could remove any other player from any channel.
+		if (target.Id() != executor.Id()
+				&& !await PermissionService.Controls(executor, target)
+				&& !await PermissionService.ChannelCanModifyAsync(executor, channel))
+		{
+			await NotifyService.Notify(executor, ErrorMessages.Notifications.ChatInvalidTarget, executor);
+			return new CallState(ErrorMessages.Returns.PermissionDenied);
+		}
 
 		if (!await ChannelHelper.IsMemberOfChannel(target, channel))
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelOn.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelOn.cs
@@ -1,4 +1,5 @@
 using Mediator;
+using SharpMUSH.Library;
 using SharpMUSH.Library.Commands.Database;
 using SharpMUSH.Library.Extensions;
 using SharpMUSH.Library.ParserInterfaces;
@@ -7,6 +8,15 @@ using SharpMUSH.Library.Definitions;
 
 namespace SharpMUSH.Implementation.Commands.ChannelCommand;
 
+/// <summary>
+/// <c>@channel/on</c> — PennMUSH <c>do_channel</c>'s ON branch (<c>src/extchat.c:1240-1284</c>) when a
+/// target is named, and <c>channel_join_self</c> (<c>:1330-1375</c>) when it is not.
+///
+/// <para>Before this, joining ran straight from "does the channel exist?" to
+/// <c>AddUserToChannelCommand</c>: no type gate, no privilege gate, no join lock, no disabled check and
+/// no control check on a named target. A mortal could join themselves — or anyone else — to a wizard-only
+/// channel, a disabled channel, or a channel whose join lock they failed.</para>
+/// </summary>
 public static class ChannelOn
 {
 	public static async ValueTask<CallState> Handle(IMUSHCodeParser parser, ILocateService LocateService, IPermissionService PermissionService, IMediator Mediator, INotifyService NotifyService, MString channelName, MString? arg1)
@@ -32,7 +42,9 @@ public static class ChannelOn
 			target = maybeTarget.AsAnyObject;
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService, PermissionService, Mediator, NotifyService, channelName, true);
+		// extchat.c:1345 — a channel the joiner cannot see is not a channel they can join.
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService, Mediator,
+			NotifyService, executor, channelName, true);
 		if (maybeChannel.IsError)
 		{
 			return maybeChannel.AsError.Value;
@@ -40,11 +52,37 @@ public static class ChannelOn
 
 		var channel = maybeChannel.AsChannel;
 
+		// extchat.c:1245 — guests may not join channels at all.
+		if (await executor.IsGuest())
+		{
+			await NotifyService.Notify(executor, ErrorMessages.Notifications.ChatGuestsCantJoin, executor);
+			return new CallState(ErrorMessages.Returns.PermissionDenied);
+		}
+
+		// extchat.c:1250 — joining somebody else to a channel requires control of them.
+		if (target.Id() != executor.Id() && !await PermissionService.Controls(executor, target))
+		{
+			await NotifyService.Notify(executor, ErrorMessages.Notifications.ChatInvalidTarget, executor);
+			return new CallState(ErrorMessages.Returns.PermissionDenied);
+		}
+
 		if (await ChannelHelper.IsMemberOfChannel(target, channel))
 		{
 			var alreadyOn = $"CHAT: {target.Object().Name} is already on {channel.Name.ToPlainText()}.";
 			await NotifyService.Notify(executor, alreadyOn, executor);
 			return new CallState(alreadyOn);
+		}
+
+		var joinCheck = await ChannelHelper.JoinRefusal(PermissionService, executor, target, channel);
+		if (joinCheck.Refused)
+		{
+			await NotifyService.Notify(executor, joinCheck.Refusal!, executor);
+			return new CallState(ErrorMessages.Returns.ChannelPermissionDenied);
+		}
+
+		if (joinCheck.Warning is not null)
+		{
+			await NotifyService.Notify(executor, joinCheck.Warning, executor);
 		}
 
 		// Channel join/leave announcements are handled by the channel system

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelPrivs.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelPrivs.cs
@@ -19,7 +19,8 @@ public static class ChannelPrivs
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService, Mediator,
+			NotifyService, executor, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelPrivs.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelPrivs.cs
@@ -1,5 +1,6 @@
 using Mediator;
 using SharpMUSH.Library;
+using SharpMUSH.Library.Extensions;
 using SharpMUSH.Library.Commands.Database;
 using SharpMUSH.Library.ParserInterfaces;
 using SharpMUSH.Library.Services.Interfaces;
@@ -18,7 +19,7 @@ public static class ChannelPrivs
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService, PermissionService, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
 
 		if (maybeChannel.IsError)
 		{
@@ -35,11 +36,29 @@ public static class ChannelPrivs
 			return new CallState("You are not the owner of the channel.");
 		}
 
-		var privilegeList = ChannelHelper.StringToChannelPrivileges(privs);
+		// extchat.c:1831 — `type = string_to_privs(priv_table, perms, ChanType(chan))`. The list is applied
+		// TO the channel's current privileges, not substituted for them, and `!priv` removes one. This used
+		// to replace the whole set, so `@channel/privs Pub=quiet` silently dropped the Player bit and left
+		// a channel nobody was the right type for.
+		var privilegeList = ChannelHelper.StringToChannelPrivileges(privs, channel.Privs);
 		if (privilegeList.IsError)
 		{
 			await NotifyService.Notify(executor,
 				$"CHAT: Invalid channel privileges(s):  {string.Join(",", privilegeList.AsError.Value)}", executor);
+			return new CallState(ErrorMessages.Returns.InvalidPrivileges);
+		}
+
+		// extchat.c:1832 — Chan_Can_Priv against the type being SET.
+		if (!await PermissionService.ChannelCanPriv(executor, privilegeList.AsPrivileges))
+		{
+			await NotifyService.Notify(executor, ErrorMessages.Notifications.ChatCannotMakeThatType, executor);
+			return new CallState(ErrorMessages.Returns.ChannelPermissionDenied);
+		}
+
+		// extchat.c:1836
+		if (privilegeList.AsPrivileges.HasPriv("Disabled"))
+		{
+			await NotifyService.Notify(executor, ErrorMessages.Notifications.ChatChannelWillBeDisabled, executor);
 		}
 
 		await Mediator.Send(new UpdateChannelCommand(channel,

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelRecall.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelRecall.cs
@@ -11,7 +11,7 @@ public static class ChannelRecall
 	public static async ValueTask<CallState> Handle(IMUSHCodeParser parser, ILocateService LocateService, IPermissionService PermissionService, IMediator Mediator, INotifyService NotifyService, MString channelName, MString lines, string[] switches)
 	{
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator);
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService, PermissionService, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelRecall.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelRecall.cs
@@ -11,7 +11,8 @@ public static class ChannelRecall
 	public static async ValueTask<CallState> Handle(IMUSHCodeParser parser, ILocateService LocateService, IPermissionService PermissionService, IMediator Mediator, INotifyService NotifyService, MString channelName, MString lines, string[] switches)
 	{
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator);
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService, Mediator,
+			NotifyService, executor, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelRename.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelRename.cs
@@ -27,7 +27,8 @@ public static class ChannelRename
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService, Mediator,
+			NotifyService, executor, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelRename.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelRename.cs
@@ -27,7 +27,7 @@ public static class ChannelRename
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService, PermissionService, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelTitle.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelTitle.cs
@@ -25,7 +25,7 @@ public static class ChannelTitle
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService, PermissionService, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelTitle.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelTitle.cs
@@ -25,7 +25,8 @@ public static class ChannelTitle
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService, Mediator,
+			NotifyService, executor, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelWho.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelWho.cs
@@ -10,7 +10,7 @@ public static class ChannelWho
 	public static async ValueTask<CallState> Handle(IMUSHCodeParser parser, ILocateService locateService, IPermissionService permissionService, IMediator mediator, INotifyService notifyService, MString channelName)
 	{
 		var executor = await parser.CurrentState.KnownExecutorObject(mediator);
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, locateService, permissionService, mediator, notifyService, channelName, notify: true);
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, mediator, notifyService, channelName, notify: true);
 		if (maybeChannel.IsError)
 		{
 			return maybeChannel.AsError.Value;

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelWho.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelWho.cs
@@ -10,7 +10,9 @@ public static class ChannelWho
 	public static async ValueTask<CallState> Handle(IMUSHCodeParser parser, ILocateService locateService, IPermissionService permissionService, IMediator mediator, INotifyService notifyService, MString channelName)
 	{
 		var executor = await parser.CurrentState.KnownExecutorObject(mediator);
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, mediator, notifyService, channelName, notify: true);
+		// extchat.c:1210 gates the WHO branch of do_channel on Chan_Can_See before it will list a member.
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, permissionService, mediator,
+			notifyService, executor, channelName, notify: true);
 		if (maybeChannel.IsError)
 		{
 			return maybeChannel.AsError.Value;

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelWipe.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelWipe.cs
@@ -17,7 +17,8 @@ public static class ChannelWipe
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService, Mediator,
+			NotifyService, executor, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelWipe.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommand/ChannelWipe.cs
@@ -17,7 +17,7 @@ public static class ChannelWipe
 			return new CallState(ErrorMessages.Returns.GuestsCannotModifyChannels);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService, PermissionService, Mediator, NotifyService, channelName, true);
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator, NotifyService, channelName, true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/ChannelCommands.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommands.cs
@@ -31,7 +31,8 @@ public partial class Commands
 		var channelName = arg0CallState!.Message!;
 		var message = arg1CallState!.Message!;
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!, NotifyService!, channelName, true);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, true);
 
 		if (maybeChannel.IsError)
 		{
@@ -39,6 +40,12 @@ public partial class Commands
 		}
 
 		var channel = maybeChannel.AsChannel;
+
+		if (await ChannelHelper.CemitRefusal(PermissionService!, executor, channel) is { } refusal)
+		{
+			await NotifyService!.Notify(executor, refusal, executor);
+			return new CallState(ErrorMessages.Returns.ChannelPermissionDenied);
+		}
 
 		var maybeMemberStatus = await ChannelHelper.ChannelMemberStatus(executor, channel);
 
@@ -81,7 +88,8 @@ public partial class Commands
 		var channelName = arg0CallState!.Message!;
 		var message = arg1CallState!.Message!;
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!, NotifyService!, channelName, true);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, true);
 
 		if (maybeChannel.IsError)
 		{
@@ -89,6 +97,13 @@ public partial class Commands
 		}
 
 		var channel = maybeChannel.AsChannel;
+
+		// extchat.c:1533-1546 — the type gate, then Chan_Can_Speak, which LOUD bypasses.
+		if (await ChannelHelper.SpeechRefusal(PermissionService!, executor, channel) is { } refusal)
+		{
+			await NotifyService!.Notify(executor, refusal, executor);
+			return new CallState(ErrorMessages.Returns.ChannelPermissionDenied);
+		}
 
 		var maybeMemberStatus = await ChannelHelper.ChannelMemberStatus(executor, channel);
 
@@ -150,7 +165,8 @@ public partial class Commands
 		var channelName = arg0CallState!.Message!;
 		var message = arg1CallState!.Message!;
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!, NotifyService!, channelName, true);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, true);
 
 		if (maybeChannel.IsError)
 		{
@@ -158,6 +174,12 @@ public partial class Commands
 		}
 
 		var channel = maybeChannel.AsChannel;
+
+		if (await ChannelHelper.CemitRefusal(PermissionService!, executor, channel) is { } refusal)
+		{
+			await NotifyService!.Notify(executor, refusal, executor);
+			return new CallState(ErrorMessages.Returns.ChannelPermissionDenied);
+		}
 
 		var maybeMemberStatus = await ChannelHelper.ChannelMemberStatus(executor, channel);
 
@@ -211,7 +233,8 @@ public partial class Commands
 			return new CallState(ErrorMessages.Returns.AliasCannotBeEmpty);
 		}
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!, NotifyService!, channelName, true);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, true);
 		if (maybeChannel.IsError)
 		{
 			return maybeChannel.AsError.Value;
@@ -222,6 +245,25 @@ public partial class Commands
 		var isMember = await ChannelHelper.IsMemberOfChannel(executor, channel);
 		if (!isMember)
 		{
+			// addcom joins the channel, so it answers to the same join gate as @channel/on.
+			if (await executor.IsGuest())
+			{
+				await NotifyService!.Notify(executor, ErrorMessages.Notifications.ChatGuestsCantJoin, executor);
+				return new CallState(ErrorMessages.Returns.PermissionDenied);
+			}
+
+			var joinCheck = await ChannelHelper.JoinRefusal(PermissionService!, executor, executor, channel);
+			if (joinCheck.Refused)
+			{
+				await NotifyService!.Notify(executor, joinCheck.Refusal!, executor);
+				return new CallState(ErrorMessages.Returns.ChannelPermissionDenied);
+			}
+
+			if (joinCheck.Warning is not null)
+			{
+				await NotifyService!.Notify(executor, joinCheck.Warning, executor);
+			}
+
 			await Mediator!.Send(new AddUserToChannelCommand(channel, executor));
 		}
 
@@ -291,7 +333,7 @@ public partial class Commands
 
 			if (!hasOtherAlias)
 			{
-				var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!, NotifyService!, channelName, false);
+				var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator!, NotifyService!, channelName, false);
 				if (!maybeChannel.IsError)
 				{
 					await Mediator!.Send(new RemoveUserFromChannelCommand(maybeChannel.AsChannel, executor));
@@ -362,7 +404,8 @@ public partial class Commands
 
 		var channelName = maybeAttribute.AsAttribute.Last().Value;
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!, NotifyService!, channelName, true);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, true);
 		if (maybeChannel.IsError)
 		{
 			return maybeChannel.AsError.Value;

--- a/SharpMUSH.Implementation/Commands/ChannelCommands.cs
+++ b/SharpMUSH.Implementation/Commands/ChannelCommands.cs
@@ -333,6 +333,13 @@ public partial class Commands
 
 			if (!hasOtherAlias)
 			{
+				// RAW lookup on purpose — do not "fix" this to GetVisibleChannelOrError.
+				//
+				// This resolves the channel only to take the executor off it, and nothing about the outcome
+				// reaches the player: the lookup is silent, the result is used solely to decide whether to
+				// send RemoveUserFromChannelCommand, and delcom answers "Alias deleted." either way. There is
+				// no observable difference to leak. A visible lookup would instead strand a membership the
+				// player can no longer reach — leaving them on a channel they just removed their alias for.
 				var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator!, NotifyService!, channelName, false);
 				if (!maybeChannel.IsError)
 				{

--- a/SharpMUSH.Implementation/Commands/MoreCommands.cs
+++ b/SharpMUSH.Implementation/Commands/MoreCommands.cs
@@ -66,9 +66,11 @@ public partial class Commands
 		lockType = lockType.ToUpper();
 
 		// Setting a lock on a channel you cannot see must be refused the same way as setting one on a
-		// channel that does not exist, or @clock reports which names are taken.
+		// channel that does not exist, or @clock reports which names are taken. notify: true because the
+		// gate emits ONE refusal for both cases: suppressing it does not make the two cases more alike, it
+		// only makes a mistyped channel name fail in silence.
 		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
-			NotifyService!, executor, channelName, notify: false);
+			NotifyService!, executor, channelName, notify: true);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/MoreCommands.cs
+++ b/SharpMUSH.Implementation/Commands/MoreCommands.cs
@@ -65,8 +65,7 @@ public partial class Commands
 		var lockType = switches.FirstOrDefault() ?? "JOIN";
 		lockType = lockType.ToUpper();
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!,
-			NotifyService!, channelName, false);
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator!, NotifyService!, channelName, false);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Commands/MoreCommands.cs
+++ b/SharpMUSH.Implementation/Commands/MoreCommands.cs
@@ -65,7 +65,10 @@ public partial class Commands
 		var lockType = switches.FirstOrDefault() ?? "JOIN";
 		lockType = lockType.ToUpper();
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator!, NotifyService!, channelName, false);
+		// Setting a lock on a channel you cannot see must be refused the same way as setting one on a
+		// channel that does not exist, or @clock reports which names are taken.
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, notify: false);
 
 		if (maybeChannel.IsError)
 		{
@@ -74,12 +77,12 @@ public partial class Commands
 
 		var channel = maybeChannel.AsChannel;
 
-		var owner = await channel.Owner.WithCancellation(CancellationToken.None);
-		var isOwner = owner.Object.DBRef.Equals(executor.Object().DBRef);
-		var passesModLock = string.IsNullOrEmpty(channel.ModLock) ||
-												LockService!.Evaluate(channel.ModLock, channel, executor);
-
-		if (!isOwner && !passesModLock && !await executor.IsWizard())
+		// This was Chan_Can_Modify rewritten by hand, and it carried the same defect: an unset ModLock made
+		// `passesModLock` true for everybody, so any non-guest could set the join/speak/see/hide/mod lock on
+		// any channel — and no channel has a ModLock, because CreateChannelCommand never writes one.
+		// ChannelCanModifyAsync now skips an unset lock rather than evaluating it; going through it means
+		// this command cannot drift away from that rule again.
+		if (!await PermissionService!.ChannelCanModifyAsync(executor, channel))
 		{
 			await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.PermissionDenied), executor);
 			return new CallState(ErrorMessages.Returns.PermissionDenied);

--- a/SharpMUSH.Implementation/Functions/ChannelFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/ChannelFunctions.cs
@@ -28,8 +28,9 @@ public partial class Functions
 
 		if (maybePlayer.IsError) return (null, null, maybePlayer.AsError);
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!,
-			NotifyService!, MModule.single(channelName!), false);
+		// extchat.c:2434 (fun_ctitle) / :2491 (fun_cstatus) — "You must pass the channel's see-lock".
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, MModule.single(channelName!), false);
 
 		if (maybeChannel.IsError) return (maybePlayer.AsSharpObject, null, maybeChannel.AsError.Value);
 
@@ -48,8 +49,8 @@ public partial class Functions
 		var message = parser.CurrentState.Arguments["1"].Message!;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!,
-			NotifyService!, channelName, false);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, false);
 
 		if (maybeChannel.IsError)
 		{
@@ -87,8 +88,8 @@ public partial class Functions
 		var channelName = parser.CurrentState.Arguments["0"].Message!;
 		var message = parser.CurrentState.Arguments["1"].Message!;
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!,
-			NotifyService!, channelName, true);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, true);
 
 		if (maybeChannel.IsError)
 		{
@@ -96,6 +97,13 @@ public partial class Functions
 		}
 
 		var channel = maybeChannel.AsChannel;
+
+		// cemit() is @cemit with a different spelling, so it answers to the same gate — otherwise softcode
+		// is a way around it.
+		if (await ChannelHelper.CemitRefusal(PermissionService!, executor, channel) is not null)
+		{
+			return new CallState(ErrorMessages.Returns.ChannelPermissionDenied);
+		}
 
 		var maybeMemberStatus = await ChannelHelper.ChannelMemberStatus(executor, channel);
 
@@ -135,8 +143,8 @@ public partial class Functions
 		var channelName = parser.CurrentState.Arguments["0"].Message!;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!,
-			NotifyService!, channelName, false);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, false);
 
 		if (maybeChannel.IsError)
 		{
@@ -240,8 +248,8 @@ public partial class Functions
 		var channelName = parser.CurrentState.Arguments["0"].Message!;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!,
-			NotifyService!, channelName, false);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, false);
 
 		if (maybeChannel.IsError)
 		{
@@ -295,10 +303,9 @@ public partial class Functions
 	public static async ValueTask<CallState> ChannelLock(IMUSHCodeParser parser, SharpFunctionAttribute _2)
 	{
 		var channelName = parser.CurrentState.Arguments["0"].Message!;
-		await parser.CurrentState.KnownExecutorObject(Mediator!);
+		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!,
-			NotifyService!, channelName, false);
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator!, NotifyService!, channelName, false);
 
 		if (maybeChannel.IsError)
 		{
@@ -306,6 +313,13 @@ public partial class Functions
 		}
 
 		var channel = maybeChannel.AsChannel;
+
+		// extchat.c:3437 — reading a channel's lock needs Chan_Can_Decomp. This handed every channel's
+		// join/speak/see/hide/mod lock key to any mortal who asked for it.
+		if (!await PermissionService!.ChannelCanDecomposeAsync(executor, channel))
+		{
+			return new CallState(ErrorMessages.Returns.PermissionDenied);
+		}
 
 		var lockType = "join";
 		if (parser.CurrentState.Arguments.TryGetValue("1", out var arg1))
@@ -333,8 +347,7 @@ public partial class Functions
 		var channelName = parser.CurrentState.Arguments["0"].Message!;
 		await parser.CurrentState.KnownExecutorObject(Mediator!);
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!,
-			NotifyService!, channelName, false);
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator!, NotifyService!, channelName, false);
 
 		if (maybeChannel.IsError)
 		{
@@ -352,8 +365,7 @@ public partial class Functions
 		var channelName = parser.CurrentState.Arguments["0"].Message!;
 		await parser.CurrentState.KnownExecutorObject(Mediator!);
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!,
-			NotifyService!, channelName, false);
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator!, NotifyService!, channelName, false);
 
 		if (maybeChannel.IsError)
 		{
@@ -372,8 +384,8 @@ public partial class Functions
 		var channelName = parser.CurrentState.Arguments["0"].Message!;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!,
-			NotifyService!, channelName, false);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, false);
 
 		if (maybeChannel.IsError)
 		{
@@ -464,8 +476,7 @@ public partial class Functions
 		var channelName = parser.CurrentState.Arguments["0"].Message!;
 		await parser.CurrentState.KnownExecutorObject(Mediator!);
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!,
-			NotifyService!, channelName, false);
+		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator!, NotifyService!, channelName, false);
 
 		if (maybeChannel.IsError)
 		{
@@ -501,8 +512,8 @@ public partial class Functions
 		var channelName = parser.CurrentState.Arguments["0"].Message!;
 		var message = parser.CurrentState.Arguments["1"].Message!;
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!,
-			NotifyService!, channelName, true);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, true);
 
 		if (maybeChannel.IsError)
 		{
@@ -510,6 +521,11 @@ public partial class Functions
 		}
 
 		var channel = maybeChannel.AsChannel;
+
+		if (await ChannelHelper.CemitRefusal(PermissionService!, executor, channel) is not null)
+		{
+			return new CallState(ErrorMessages.Returns.ChannelPermissionDenied);
+		}
 
 		var maybeMemberStatus = await ChannelHelper.ChannelMemberStatus(executor, channel);
 
@@ -542,9 +558,10 @@ public partial class Functions
 	public static async ValueTask<CallState> ChannelBuffer(IMUSHCodeParser parser, SharpFunctionAttribute _2)
 	{
 		var channelName = parser.CurrentState.Arguments["0"].Message!;
+		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!,
-			NotifyService!, channelName, false);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, false);
 
 		if (maybeChannel.IsError)
 		{
@@ -560,10 +577,10 @@ public partial class Functions
 	public static async ValueTask<CallState> ChannelDescription(IMUSHCodeParser parser, SharpFunctionAttribute _2)
 	{
 		var channelName = parser.CurrentState.Arguments["0"].Message!;
+		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 
-
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!,
-			NotifyService!, channelName, false);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, false);
 
 		if (maybeChannel.IsError)
 		{
@@ -579,10 +596,10 @@ public partial class Functions
 	public static async ValueTask<CallState> ChannelMessages(IMUSHCodeParser parser, SharpFunctionAttribute _2)
 	{
 		var channelName = parser.CurrentState.Arguments["0"].Message!;
+		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 
-
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!,
-			NotifyService!, channelName, false);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, false);
 
 		if (maybeChannel.IsError)
 		{
@@ -601,10 +618,10 @@ public partial class Functions
 	public static async ValueTask<CallState> ChannelUsers(IMUSHCodeParser parser, SharpFunctionAttribute _2)
 	{
 		var channelName = parser.CurrentState.Arguments["0"].Message!;
-		await parser.CurrentState.KnownExecutorObject(Mediator!);
+		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!,
-			NotifyService!, channelName, false);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, false);
 
 		if (maybeChannel.IsError)
 		{
@@ -628,8 +645,8 @@ public partial class Functions
 			: "name";
 
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, LocateService!, PermissionService!, Mediator!,
-			NotifyService!, channelName, false);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, false);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Functions/ChannelFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/ChannelFunctions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using SharpMUSH.Library;
 using SharpMUSH.Implementation.Commands.ChannelCommand;
 using SharpMUSH.Library.Attributes;
 using SharpMUSH.Library.Definitions;
@@ -220,23 +221,56 @@ public partial class Functions
 			type = arg1.Message!.ToPlainText().ToLower();
 		}
 
-		var allChannels = Mediator!.CreateStream(new GetChannelListQuery());
-		var channelArray = await allChannels.ToArrayAsync();
+		// PennMUSH fun_channels (src/extchat.c:3313-3375): "You can see an object's channels if you can
+		// examine it. Otherwise you can see only channels that you share with it where it's not hidden."
+		//
+		// Visibility is judged against the EXECUTOR, never against the object being asked about. Judging it
+		// against the object let any mortal read back a wizard's wizard-only channels by naming the wizard;
+		// and the "on"/"off" arms applied no visibility rule at all, so `channels(me,off)` listed every
+		// channel in the game by name.
+		var askingAboutSomeoneElse = player.Id() != executor.Id();
+		var canExamineTarget = !askingAboutSomeoneElse || await PermissionService!.CanExamine(executor, player);
+		var privWho = await executor.IsPriv() || await executor.HasPower("Who");
+
+		// Materialised before the loop: the per-channel checks below open their own streams, and
+		// Core.Arango faults when one stream is enumerated inside another.
+		var channelArray = await Mediator!.CreateStream(new GetChannelListQuery()).ToArrayAsync();
 
 		var filteredChannels = new List<string>();
 		foreach (var channel in channelArray)
 		{
-			var shouldInclude = type switch
+			var isMember = await ChannelHelper.IsMemberOfChannel(player, channel);
+
+			var matchesType = type switch
 			{
-				"on" => await ChannelHelper.IsMemberOfChannel(player, channel),
-				"off" => !await ChannelHelper.IsMemberOfChannel(player, channel),
-				"quiet" or _ => await PermissionService!.ChannelCanSeeAsync(player, channel)
+				"on" => isMember,
+				"off" => !isMember,
+				"quiet" or _ => true
 			};
 
-			if (shouldInclude)
+			if (!matchesType)
 			{
-				filteredChannels.Add(channel.Name.ToPlainText());
+				continue;
 			}
+
+			if (!canExamineTarget)
+			{
+				// Not examinable: the executor may only learn about channels they can see themselves, that
+				// the object is actually on, and on which the object is not hidden from them.
+				var status = await ChannelHelper.ChannelMemberStatus(player, channel);
+				if (status is null
+						|| (!privWho && (status.Status.Hide ?? false))
+						|| !await ChannelHelper.CanSeeChannel(PermissionService!, executor, channel))
+				{
+					continue;
+				}
+			}
+			else if (!await ChannelHelper.CanSeeChannel(PermissionService!, executor, channel))
+			{
+				continue;
+			}
+
+			filteredChannels.Add(channel.Name.ToPlainText());
 		}
 
 		return new CallState(string.Join(" ", filteredChannels));
@@ -345,9 +379,10 @@ public partial class Functions
 	public static async ValueTask<CallState> ChannelMogrifier(IMUSHCodeParser parser, SharpFunctionAttribute _2)
 	{
 		var channelName = parser.CurrentState.Arguments["0"].Message!;
-		await parser.CurrentState.KnownExecutorObject(Mediator!);
+		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator!, NotifyService!, channelName, false);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, false);
 
 		if (maybeChannel.IsError)
 		{
@@ -363,9 +398,10 @@ public partial class Functions
 	public static async ValueTask<CallState> ChannelOwner(IMUSHCodeParser parser, SharpFunctionAttribute _2)
 	{
 		var channelName = parser.CurrentState.Arguments["0"].Message!;
-		await parser.CurrentState.KnownExecutorObject(Mediator!);
+		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator!, NotifyService!, channelName, false);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, false);
 
 		if (maybeChannel.IsError)
 		{
@@ -474,9 +510,10 @@ public partial class Functions
 	public static async ValueTask<CallState> ChannelWho(IMUSHCodeParser parser, SharpFunctionAttribute _2)
 	{
 		var channelName = parser.CurrentState.Arguments["0"].Message!;
-		await parser.CurrentState.KnownExecutorObject(Mediator!);
+		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator!, NotifyService!, channelName, false);
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, false);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Functions/ChannelFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/ChannelFunctions.cs
@@ -339,7 +339,11 @@ public partial class Functions
 		var channelName = parser.CurrentState.Arguments["0"].Message!;
 		var executor = await parser.CurrentState.KnownExecutorObject(Mediator!);
 
-		var maybeChannel = await ChannelHelper.GetChannelOrError(parser, Mediator!, NotifyService!, channelName, false);
+		// Chan_Can_Decomp below refuses with #-1 PERMISSION DENIED, which a raw lookup's
+		// #-1 NO SUCH CHANNEL is distinguishable from — so softcode could tell an invisible channel from a
+		// nonexistent one even though the lock itself stayed secret.
+		var maybeChannel = await ChannelHelper.GetVisibleChannelOrError(parser, PermissionService!, Mediator!,
+			NotifyService!, executor, channelName, false);
 
 		if (maybeChannel.IsError)
 		{

--- a/SharpMUSH.Implementation/Handlers/Database/ChannelCommandHandler.cs
+++ b/SharpMUSH.Implementation/Handlers/Database/ChannelCommandHandler.cs
@@ -1,16 +1,14 @@
 ﻿using Mediator;
 using SharpMUSH.Library;
 using SharpMUSH.Library.Commands.Database;
+using SharpMUSH.Library.DiscriminatedUnions;
 
 namespace SharpMUSH.Implementation.Handlers.Database;
 
-public class CreateChannelCommandHandler(ISharpDatabase database) : ICommandHandler<CreateChannelCommand>
+public class CreateChannelCommandHandler(ISharpDatabase database) : ICommandHandler<CreateChannelCommand, ChannelCreationResult>
 {
-	public async ValueTask<Unit> Handle(CreateChannelCommand request, CancellationToken cancellationToken)
-	{
-		await database.CreateChannelAsync(request.Channel, request.Privs, request.Owner, cancellationToken);
-		return Unit.Value;
-	}
+	public async ValueTask<ChannelCreationResult> Handle(CreateChannelCommand request, CancellationToken cancellationToken)
+		=> await database.CreateChannelAsync(request.Channel, request.Privs, request.Owner, cancellationToken);
 }
 
 public class UpdateChannelCommandHandler(ISharpDatabase database) : ICommandHandler<UpdateChannelCommand>

--- a/SharpMUSH.Library/Commands/Database/CreateChannelCommand.cs
+++ b/SharpMUSH.Library/Commands/Database/CreateChannelCommand.cs
@@ -8,7 +8,7 @@ namespace SharpMUSH.Library.Commands.Database;
 public record CreateChannelCommand(
 	MString Channel,
 	string[] Privs,
-	SharpPlayer Owner) : ICommand, ICacheInvalidating
+	SharpPlayer Owner) : ICommand<ChannelCreationResult>, ICacheInvalidating
 {
 	public string[] CacheKeys => [$"channel:{Channel.ToPlainText()}"];
 	public string[] CacheTags => [Definitions.CacheTags.ChannelList];

--- a/SharpMUSH.Library/Definitions/ErrorMessages.cs
+++ b/SharpMUSH.Library/Definitions/ErrorMessages.cs
@@ -305,6 +305,8 @@ public static class ErrorMessages
 		public const string InvalidChannelName = "#-1 INVALID CHANNEL NAME";
 		public const string InvalidPrivileges = "#-1 INVALID PRIVILEGES";
 		public const string TooManyChannels = "#-1 TOO MANY CHANNELS";
+		public const string NoSuchChannel = "#-1 NO SUCH CHANNEL";
+		public const string ChannelPermissionDenied = "#-1 CHANNEL PERMISSION DENIED";
 		public const string GetRequestsCannotHaveBody = "#-1 GET REQUESTS CANNOT HAVE A BODY";
 		public const string CannotRenameInbox = "#-1 CANNOT RENAME THE INBOX FOLDER";
 		public const string InvalidMailArguments = "#-1 INVALID ARGUMENTS FOR MAIL COMMAND";
@@ -537,6 +539,40 @@ public static class ErrorMessages
 		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
 		public const string ChatResizingBuffer = "CHAT: Resizing buffer of channel <{0}>";
 		public const string ChatGuestsCantModify = "CHAT: Guests may not modify channels.";
+		public const string ChatGuestsCantJoin = "Guests are not allowed to join channels.";
+		/// <summary>PennMUSH src/extchat.c:1237 / :1252 / :1290.</summary>
+		public const string ChatInvalidTarget = "Invalid target.";
+		/// <summary>PennMUSH src/extchat.c:1533 — <c>do_chat</c> / <c>do_cemit</c> type refusal.</summary>
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string ChatWrongTypeForChannel = "Sorry, you're not the right type to be on channel <{0}>.";
+		/// <summary>PennMUSH src/extchat.c:1241 — <c>@channel/on</c> type refusal.</summary>
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string ChatWrongTypeOfThingForChannel = "Sorry, wrong type of thing for channel <{0}>.";
+		/// <summary>PennMUSH src/extchat.c:1267.</summary>
+		public const string ChatJoinDenied = "Permission to join denied.";
+		/// <summary>PennMUSH src/extchat.c:1355.</summary>
+		public const string ChatJoinOverrideSelf =
+			"CHAT: Warning: You don't meet channel join permissions! (joining anyway)";
+		/// <summary>PennMUSH src/extchat.c:1263.</summary>
+		public const string ChatJoinOverrideTarget =
+			"CHAT: Warning: Target does not meet channel join permissions! (joining anyway)";
+		/// <summary>PennMUSH src/extchat.c:1541.</summary>
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string ChatNotAllowedToSpeak = "Sorry, you're not allowed to speak on channel <{0}>.";
+		/// <summary>PennMUSH src/extchat.c:1636.</summary>
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string ChatNotAllowedToCemit = "Sorry, you're not allowed to @cemit on channel <{0}>.";
+		/// <summary>PennMUSH src/extchat.c:1545.</summary>
+		public const string ChatNoSuchChannel = "CHAT: No such channel.";
+		/// <summary>PennMUSH src/extchat.c:2002.</summary>
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string ChatCannotHideOnChannel = "You are not permitted to hide on channel <{0}>.";
+		/// <summary>PennMUSH src/extchat.c:1737.</summary>
+		public const string ChatCannotCreateThatType = "You can't create channels of that type.";
+		/// <summary>PennMUSH src/extchat.c:1833.</summary>
+		public const string ChatCannotMakeThatType = "You can't make channels that type.";
+		/// <summary>PennMUSH src/extchat.c:1836.</summary>
+		public const string ChatChannelWillBeDisabled = "Warning: channel will be disabled.";
 
 		// --- Lock/Unlock messages aligned with PennMUSH src/lock.c ---
 		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]

--- a/SharpMUSH.Library/Definitions/ErrorMessages.cs
+++ b/SharpMUSH.Library/Definitions/ErrorMessages.cs
@@ -301,6 +301,7 @@ public static class ErrorMessages
 		public const string YouAreNotAMemberOfThatChannel = "#-1 YOU ARE NOT A MEMBER OF THAT CHANNEL";
 		public const string YouCannotModifyThisChannel = "#-1 YOU CANNOT MODIFY THIS CHANNEL";
 		public const string ChannelAlreadyExists = "#-1 CHANNEL ALREADY EXISTS";
+		public const string ChannelCreationFailed = "#-1 CHANNEL COULD NOT BE CREATED";
 		public const string ChannelNotFound = "#-1 CHANNEL NOT FOUND";
 		public const string InvalidChannelName = "#-1 INVALID CHANNEL NAME";
 		public const string InvalidPrivileges = "#-1 INVALID PRIVILEGES";
@@ -733,6 +734,7 @@ public static class ErrorMessages
 		public const string ErrorDetailFormat = "Error: {0}";
 
 		public const string ChatAlreadyExists = "CHAT: Channel already exists.";
+		public const string ChatChannelCreationFailed = "CHAT: The channel could not be created.";
 		public const string ChatInvalidChannelNameShort = "CHAT: Invalid channel name.";
 		public const string ChatChannelCreated = "Channel has been created.";
 		public const string ChatYesOrNoOnly = "CHAT: Yes or No are the only valid options.";

--- a/SharpMUSH.Library/DiscriminatedUnions/ChannelCreationResult.cs
+++ b/SharpMUSH.Library/DiscriminatedUnions/ChannelCreationResult.cs
@@ -1,0 +1,36 @@
+using OneOf;
+using OneOf.Types;
+
+namespace SharpMUSH.Library.DiscriminatedUnions;
+
+/// <summary>
+/// A channel with the requested name already exists, so the create was refused.
+/// </summary>
+/// <remarks>
+/// Distinct from <see cref="Error{T}"/> because it is the one failure a caller can explain to a player.
+/// Channel names are a global namespace (PennMUSH <c>ok_channel_name</c>, <c>src/extchat.c:1855-1870</c>),
+/// so this is reachable without any race whenever two players pick the same name.
+/// </remarks>
+public readonly record struct ChannelNameTaken;
+
+/// <summary>
+/// The outcome of a channel create: it worked, the name was taken, or the storage layer failed.
+/// </summary>
+/// <remarks>
+/// <c>CreateChannelAsync</c> used to return <c>ValueTask</c>, and ArangoDB's implementation caught every
+/// exception, aborted its transaction and returned normally — so a create that failed reported success to
+/// the caller. Every provider now answers with one of these three, and none of them is silence.
+/// </remarks>
+public class ChannelCreationResult(OneOf<Success, ChannelNameTaken, Error<string>> input)
+	: OneOfBase<Success, ChannelNameTaken, Error<string>>(input)
+{
+	public static implicit operator ChannelCreationResult(Success x) => new(x);
+	public static implicit operator ChannelCreationResult(ChannelNameTaken x) => new(x);
+	public static implicit operator ChannelCreationResult(Error<string> x) => new(x);
+
+	public bool IsSuccess => IsT0;
+	public bool IsNameTaken => IsT1;
+	public bool IsError => IsT2;
+
+	public string AsError => AsT2.Value;
+}

--- a/SharpMUSH.Library/Extensions/SharpChannelExtensions.cs
+++ b/SharpMUSH.Library/Extensions/SharpChannelExtensions.cs
@@ -1,0 +1,21 @@
+using SharpMUSH.Library.Models;
+
+namespace SharpMUSH.Library.Extensions;
+
+/// <summary>
+/// Channel privilege membership.
+///
+/// <para>Privileges are persisted as a <see cref="string"/> array of names taken from PennMUSH's
+/// <c>chan_privs</c> table (<c>src/extchat.c</c>). They reach the database from user input, so their
+/// casing is whatever the player typed — <c>@channel/add Foo=wizard</c> stores <c>"wizard"</c>. Every
+/// permission check must therefore compare case-insensitively; an ordinal <c>Contains</c> silently
+/// answers "no such privilege" for a channel that plainly has it.</para>
+/// </summary>
+public static class SharpChannelExtensions
+{
+	public static bool HasPriv(this SharpChannel channel, string priv)
+		=> channel.Privs.HasPriv(priv);
+
+	public static bool HasPriv(this string[] privs, string priv)
+		=> privs.Contains(priv, StringComparer.OrdinalIgnoreCase);
+}

--- a/SharpMUSH.Library/HelperFunctions.cs
+++ b/SharpMUSH.Library/HelperFunctions.cs
@@ -278,6 +278,14 @@ public static partial class HelperFunctions
 		=> await obj.Object().Flags.Value
 			.AnyAsync(x => x.Name.Equals(flag, StringComparison.InvariantCultureIgnoreCase));
 
+	/// <summary>
+	/// PennMUSH <c>LOUD</c> (hlp/pennflag.hlp:256): "LOUD objects bypass all speech, channel speech, and
+	/// interaction @locks. This flag can only be set by royalty or wizards." Penn consults it at the call
+	/// site rather than inside <c>Chan_Can_Speak</c> — see <c>src/extchat.c:1539</c>.
+	/// </summary>
+	public static async ValueTask<bool> IsLoud(this AnySharpObject obj)
+		=> await obj.HasFlag("LOUD");
+
 	public static async ValueTask<bool> CanDark(this AnySharpObject obj)
 		=> await obj.HasPower("Can_Dark") || await obj.IsWizard();
 

--- a/SharpMUSH.Library/ISharpDatabase.cs
+++ b/SharpMUSH.Library/ISharpDatabase.cs
@@ -726,7 +726,17 @@ public interface ISharpDatabase
 
 	IAsyncEnumerable<SharpChannel> GetMemberChannelsAsync(AnySharpObject obj, CancellationToken cancellationToken = default);
 
-	ValueTask CreateChannelAsync(MString name, string[] privs, SharpPlayer owner, CancellationToken cancellationToken = default);
+	/// <summary>
+	/// Creates a channel, its owner edge and its owner's membership edge, atomically with respect to the
+	/// channel name — which is a global namespace, so a create that loses the race must be refused rather
+	/// than duplicating or overwriting the winner.
+	/// </summary>
+	/// <returns>
+	/// <see cref="OneOf.Types.Success"/>, <see cref="ChannelNameTaken"/> when the name is already in use, or
+	/// <see cref="OneOf.Types.Error{T}"/> carrying the storage layer's message. Never silence: the caller
+	/// tells a player which of the three happened.
+	/// </returns>
+	ValueTask<ChannelCreationResult> CreateChannelAsync(MString name, string[] privs, SharpPlayer owner, CancellationToken cancellationToken = default);
 
 	ValueTask UpdateChannelAsync(SharpChannel channel,
 		MString? name,

--- a/SharpMUSH.Library/Services/Interfaces/IPermissionService.cs
+++ b/SharpMUSH.Library/Services/Interfaces/IPermissionService.cs
@@ -63,7 +63,7 @@ public interface IPermissionService
 
 	ValueTask<bool> ChannelStandardCan(AnySharpObject target, string[] channelType);
 
-	ValueTask<bool> ChannelCanPrivate(AnySharpObject target, SharpChannel channel);
+	ValueTask<bool> ChannelCanPriv(AnySharpObject target, string[] channelType);
 
 	ValueTask<bool> ChannelCanAccess(AnySharpObject target, SharpChannel channel);
 

--- a/SharpMUSH.Library/Services/PermissionService.cs
+++ b/SharpMUSH.Library/Services/PermissionService.cs
@@ -329,11 +329,27 @@ public class PermissionService(ILockService lockService, IOptionsMonitor<SharpMU
 	public async ValueTask<bool> ChannelCanCemit(AnySharpObject target, SharpChannel channel)
 		=> !channel.HasPriv("NoCemit") && await ChannelCanSpeak(target, channel);
 
+	/// <summary>
+	/// PennMUSH <c>Chan_Can_Modify</c> — hdrs/extchat.h:210.
+	///
+	/// <para>The mod lock is only consulted when one is actually set. PennMUSH gets away with evaluating
+	/// it unconditionally because it never leaves it unset: <c>do_chan_admin</c> stamps
+	/// <c>=#&lt;creator&gt;</c> onto every channel as it is created (<c>src/extchat.c:1755-1763</c>).
+	/// SharpMUSH's <c>CreateChannelCommand</c> writes no lock, and an empty lock string evaluates TRUE for
+	/// everybody — so evaluating it here handed modify rights over every channel in the game to every
+	/// non-guest, which is <c>@channel/privs</c>, <c>/rename</c>, <c>/wipe</c>, <c>/decompile</c> and
+	/// <c>/mute</c>.</para>
+	///
+	/// <para>This is the same trap, and the same fix, as the control lock in <see cref="Controls"/> above:
+	/// an unset lock must be skipped, not evaluated. Owner and wizard still pass, so the effective result
+	/// matches PennMUSH for every channel PennMUSH would have created.</para>
+	/// </summary>
 	public async ValueTask<bool> ChannelCanModifyAsync(AnySharpObject target, SharpChannel channel) =>
 		await target.IsWizard()
 		|| (await channel.Owner.WithCancellation(CancellationToken.None)).Id == target.Id()
 		|| (
 			!await target.HasPower("guest")
+			&& !string.IsNullOrWhiteSpace(channel.ModLock)
 			&& await ChannelCanAccess(target, channel)
 			&& lockService.Evaluate(channel.ModLock, channel, target)
 		);

--- a/SharpMUSH.Library/Services/PermissionService.cs
+++ b/SharpMUSH.Library/Services/PermissionService.cs
@@ -293,21 +293,29 @@ public class PermissionService(ILockService lockService, IOptionsMonitor<SharpMU
 		return ValueTask.FromResult(true);
 	}
 
+	/// <summary>PennMUSH <c>Chan_Ok_Type</c> — hdrs/extchat.h:196.</summary>
 	public bool ChannelOkType(AnySharpObject target, SharpChannel channel)
-		=> channel.Privs.Contains("Player") && target.IsPlayer
-			 || channel.Privs.Contains("Object") && target.IsThing;
+		=> (target.IsPlayer && channel.HasPriv("Player"))
+			 || (target.IsThing && channel.HasPriv("Object"));
 
+	/// <summary>PennMUSH <c>Chan_Can</c> — hdrs/extchat.h:198. The DISABLED bit lives here, so it gates
+	/// join, speak, see, hide and modify from one place.</summary>
 	public async ValueTask<bool> ChannelStandardCan(AnySharpObject target, string[] channelType)
-		=> !channelType.Contains("Disabled")
-			 && (!channelType.Contains("Wizard")
+		=> !channelType.HasPriv("Disabled")
+			 && (!channelType.HasPriv("Wizard")
 					 || await target.IsWizard())
-			 && (!channelType.Contains("Admin")
+			 && (!channelType.HasPriv("Admin")
 					 || await target.HasPower("CHAT_PRIVS")
 					 || await target.IsPriv());
 
-	public async ValueTask<bool> ChannelCanPrivate(AnySharpObject target, SharpChannel channel)
-		=> !await target.IsWizard()
-			 || await ChannelStandardCan(target, channel.Privs);
+	/// <summary>
+	/// PennMUSH <c>Chan_Can_Priv(p, t) = Wizard(p) || Chan_Can(p, t)</c> — hdrs/extchat.h:203, "who can
+	/// change channel privileges to type t". Note the argument is the type being SET, not the channel's
+	/// current type.
+	/// </summary>
+	public async ValueTask<bool> ChannelCanPriv(AnySharpObject target, string[] channelType)
+		=> await target.IsWizard()
+			 || await ChannelStandardCan(target, channelType);
 
 	public async ValueTask<bool> ChannelCanAccess(AnySharpObject target, SharpChannel channel)
 		=> await ChannelStandardCan(target, channel.Privs);
@@ -319,7 +327,7 @@ public class PermissionService(ILockService lockService, IOptionsMonitor<SharpMU
 		=> await ChannelCanAccess(target, channel) && lockService.Evaluate(channel.SpeakLock, channel, target);
 
 	public async ValueTask<bool> ChannelCanCemit(AnySharpObject target, SharpChannel channel)
-		=> !channel.Privs.Contains("NoCemit") && await ChannelCanSpeak(target, channel);
+		=> !channel.HasPriv("NoCemit") && await ChannelCanSpeak(target, channel);
 
 	public async ValueTask<bool> ChannelCanModifyAsync(AnySharpObject target, SharpChannel channel) =>
 		await target.IsWizard()
@@ -342,10 +350,15 @@ public class PermissionService(ILockService lockService, IOptionsMonitor<SharpMU
 				 && await ChannelCanSpeak(target, channel)
 			 );
 
+	/// <summary>
+	/// PennMUSH <c>Chan_Can_Hide</c> — hdrs/extchat.h:216. The channel privilege is <c>Hide_Ok</c>
+	/// (<c>CHANNEL_CANHIDE</c>, spelled <c>hide_ok</c> in <c>chan_privs</c>); this read
+	/// <c>"CanHide"</c>, a name no channel has ever carried.
+	/// </summary>
 	public async ValueTask<bool> ChannelCanHide(AnySharpObject target, SharpChannel channel)
 		=> await target.CanHide()
 			 || (
-				 channel.Privs.Contains("CanHide")
+				 channel.HasPriv("Hide_Ok")
 				 && await ChannelCanAccess(target, channel)
 				 && lockService.Evaluate(channel.HideLock, channel, target)
 			 );

--- a/SharpMUSH.Tests.Infrastructure/ServerWebAppFactory.cs
+++ b/SharpMUSH.Tests.Infrastructure/ServerWebAppFactory.cs
@@ -171,6 +171,46 @@ public class ServerWebAppFactory : TestWebApplicationFactory<SharpMUSH.Server.Pr
 	/// and connection <paramref name="handle"/>.  Use this in tests that need an isolated executor
 	/// (unique player) so that <see cref="INotifyService"/> mock assertions remain per-player.
 	/// </summary>
+	/// <summary>
+	/// <see cref="FunctionParser"/> with a chosen executor rather than God. Permission tests need to
+	/// evaluate a function AS a mortal: a channel function that is gated at the command surface but open
+	/// to mortal softcode is only testable this way.
+	/// </summary>
+	public IMUSHCodeParser FunctionParserFor(DBRef executor)
+	{
+		var integrationServer = _server!;
+		return new MUSHCodeParser(
+			integrationServer.Services.GetRequiredService<ILogger<MUSHCodeParser>>(),
+			integrationServer.Services.GetRequiredService<LibraryService<string, FunctionDefinition>>(),
+			integrationServer.Services.GetRequiredService<LibraryService<string, CommandDefinition>>(),
+			integrationServer.Services.GetRequiredService<IOptionsWrapper<SharpMUSHOptions>>(),
+			integrationServer.Services,
+			state: new ParserState(
+				Registers: new([[]]),
+				IterationRegisters: [],
+				RegexRegisters: [],
+				SwitchStack: [],
+				ExecutionStack: [],
+				EnvironmentRegisters: [],
+				CurrentEvaluation: null,
+				ParserFunctionDepth: 0,
+				Function: null,
+				Command: "think",
+				CommandInvoker: _ => ValueTask.FromResult(new Option<CallState>(new None())),
+				Switches: [],
+				Arguments: [],
+				Executor: executor,
+				Enactor: executor,
+				Caller: executor,
+				Handle: 1,
+				CallDepth: new InvocationCounter(),
+				FunctionRecursionDepths: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase),
+				TotalInvocations: new InvocationCounter(),
+				LimitExceeded: new LimitExceededFlag(),
+				Flags: ParserStateFlags.DirectInput
+			));
+	}
+
 	public IMUSHCodeParser CommandParserFor(DBRef executor, long handle)
 	{
 		var integrationServer = _server!;

--- a/SharpMUSH.Tests.Infrastructure/ServerWebAppFactory.cs
+++ b/SharpMUSH.Tests.Infrastructure/ServerWebAppFactory.cs
@@ -90,93 +90,18 @@ public class ServerWebAppFactory : TestWebApplicationFactory<SharpMUSH.Server.Pr
 		_sqlPlatform = sqlPlatform;
 	}
 
-	public IMUSHCodeParser FunctionParser
-	{
-		get
-		{
-			var integrationServer = _server!;
-			return new MUSHCodeParser(
-				integrationServer.Services.GetRequiredService<ILogger<MUSHCodeParser>>(),
-				integrationServer.Services.GetRequiredService<LibraryService<string, FunctionDefinition>>(),
-				integrationServer.Services.GetRequiredService<LibraryService<string, CommandDefinition>>(),
-				integrationServer.Services.GetRequiredService<IOptionsWrapper<SharpMUSHOptions>>(),
-				integrationServer.Services,
-				state: new ParserState(
-					Registers: new ConcurrentStack<Dictionary<string, MString>>([[]]),
-					IterationRegisters: [],
-					RegexRegisters: [],
-					SwitchStack: [],
-					ExecutionStack: [],
-					EnvironmentRegisters: [],
-					CurrentEvaluation: null,
-					ParserFunctionDepth: 0,
-					Function: null,
-					Command: "think",
-					CommandInvoker: _ => ValueTask.FromResult(new Option<CallState>(new None())),
-					Switches: [],
-					Arguments: [],
-					Executor: _one,
-					Enactor: _one,
-					Caller: _one,
-					Handle: 1,
-					CallDepth: new InvocationCounter(),
-					FunctionRecursionDepths: new Dictionary<string, int>(),
-					TotalInvocations: new InvocationCounter(),
-					LimitExceeded: new LimitExceededFlag(),
-					Flags: ParserStateFlags.DirectInput
-				));
-		}
-	}
-
-	public IMUSHCodeParser CommandParser
-	{
-		get
-		{
-			var integrationServer = _server!;
-			return new MUSHCodeParser(
-				integrationServer.Services.GetRequiredService<ILogger<MUSHCodeParser>>(),
-				integrationServer.Services.GetRequiredService<LibraryService<string, FunctionDefinition>>(),
-				integrationServer.Services.GetRequiredService<LibraryService<string, CommandDefinition>>(),
-				integrationServer.Services.GetRequiredService<IOptionsWrapper<SharpMUSHOptions>>(),
-				integrationServer.Services,
-				state: new ParserState(
-					Registers: new([[]]),
-					IterationRegisters: [],
-					RegexRegisters: [],
-					SwitchStack: [],
-					ExecutionStack: [],
-					EnvironmentRegisters: [],
-					CurrentEvaluation: null,
-					ParserFunctionDepth: 0,
-					Function: null,
-					Command: null,
-					CommandInvoker: _ => ValueTask.FromResult(new Option<CallState>(new None())),
-					Switches: [],
-					Arguments: [],
-					Executor: _one,
-					Enactor: _one,
-					Caller: _one,
-					Handle: 1,
-					CallDepth: new InvocationCounter(),
-					FunctionRecursionDepths: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase),
-					TotalInvocations: new InvocationCounter(),
-					LimitExceeded: new LimitExceededFlag(),
-					Flags: ParserStateFlags.DirectInput
-				));
-		}
-	}
-
 	/// <summary>
-	/// Creates a command parser whose initial state is bound to the given <paramref name="executor"/>
-	/// and connection <paramref name="handle"/>.  Use this in tests that need an isolated executor
-	/// (unique player) so that <see cref="INotifyService"/> mock assertions remain per-player.
+	/// The one <see cref="MUSHCodeParser"/> the four accessors below hand out. They differed only in the
+	/// executor, the connection handle, and whether <c>Command</c> was set — three parameters against
+	/// thirty-five lines of identical <see cref="ParserState"/>, copied four times.
 	/// </summary>
-	/// <summary>
-	/// <see cref="FunctionParser"/> with a chosen executor rather than God. Permission tests need to
-	/// evaluate a function AS a mortal: a channel function that is gated at the command surface but open
-	/// to mortal softcode is only testable this way.
-	/// </summary>
-	public IMUSHCodeParser FunctionParserFor(DBRef executor)
+	/// <param name="executor">Executor, enactor and caller. Tests that need a mortal pass one here.</param>
+	/// <param name="handle">Connection handle; only the command parsers bind a real one.</param>
+	/// <param name="command">
+	/// <c>"think"</c> for the function parsers and <see langword="null"/> for the command parsers, which
+	/// set their own as they dispatch.
+	/// </param>
+	private IMUSHCodeParser BuildParser(DBRef executor, long handle, string? command)
 	{
 		var integrationServer = _server!;
 		return new MUSHCodeParser(
@@ -195,42 +120,7 @@ public class ServerWebAppFactory : TestWebApplicationFactory<SharpMUSH.Server.Pr
 				CurrentEvaluation: null,
 				ParserFunctionDepth: 0,
 				Function: null,
-				Command: "think",
-				CommandInvoker: _ => ValueTask.FromResult(new Option<CallState>(new None())),
-				Switches: [],
-				Arguments: [],
-				Executor: executor,
-				Enactor: executor,
-				Caller: executor,
-				Handle: 1,
-				CallDepth: new InvocationCounter(),
-				FunctionRecursionDepths: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase),
-				TotalInvocations: new InvocationCounter(),
-				LimitExceeded: new LimitExceededFlag(),
-				Flags: ParserStateFlags.DirectInput
-			));
-	}
-
-	public IMUSHCodeParser CommandParserFor(DBRef executor, long handle)
-	{
-		var integrationServer = _server!;
-		return new MUSHCodeParser(
-			integrationServer.Services.GetRequiredService<ILogger<MUSHCodeParser>>(),
-			integrationServer.Services.GetRequiredService<LibraryService<string, FunctionDefinition>>(),
-			integrationServer.Services.GetRequiredService<LibraryService<string, CommandDefinition>>(),
-			integrationServer.Services.GetRequiredService<IOptionsWrapper<SharpMUSHOptions>>(),
-			integrationServer.Services,
-			state: new ParserState(
-				Registers: new([[]]),
-				IterationRegisters: [],
-				RegexRegisters: [],
-				SwitchStack: [],
-				ExecutionStack: [],
-				EnvironmentRegisters: [],
-				CurrentEvaluation: null,
-				ParserFunctionDepth: 0,
-				Function: null,
-				Command: null,
+				Command: command,
 				CommandInvoker: _ => ValueTask.FromResult(new Option<CallState>(new None())),
 				Switches: [],
 				Arguments: [],
@@ -245,6 +135,22 @@ public class ServerWebAppFactory : TestWebApplicationFactory<SharpMUSH.Server.Pr
 				Flags: ParserStateFlags.DirectInput
 			));
 	}
+
+	/// <summary>Evaluates functions as God.</summary>
+	public IMUSHCodeParser FunctionParser => BuildParser(_one, handle: 1, command: "think");
+
+	/// <summary>Runs commands as God.</summary>
+	public IMUSHCodeParser CommandParser => BuildParser(_one, handle: 1, command: null);
+
+	/// <summary>
+	/// <see cref="FunctionParser"/> with a chosen executor. Permission tests need to evaluate a function
+	/// AS a mortal: a channel function gated at the command surface but open to mortal softcode is only
+	/// testable this way.
+	/// </summary>
+	public IMUSHCodeParser FunctionParserFor(DBRef executor) => BuildParser(executor, handle: 1, command: "think");
+
+	/// <summary><see cref="CommandParser"/> with a chosen executor and its bound connection handle.</summary>
+	public IMUSHCodeParser CommandParserFor(DBRef executor, long handle) => BuildParser(executor, handle, command: null);
 
 	public virtual async Task InitializeAsync()
 	{

--- a/SharpMUSH.Tests.Infrastructure/ServerWebAppFactory.cs
+++ b/SharpMUSH.Tests.Infrastructure/ServerWebAppFactory.cs
@@ -60,6 +60,14 @@ public class ServerWebAppFactory : TestWebApplicationFactory<SharpMUSH.Server.Pr
 	/// </summary>
 	public DBRef ExecutorDBRef => _one;
 
+	/// <summary>
+	/// What the notify substitute was asked to deliver, bucketed by recipient. Read this instead of
+	/// enumerating <c>ReceivedCalls()</c> when a test needs the text of what was said: the substitute is
+	/// one singleton shared by every test in the session, and NSubstitute does not support enumerating it
+	/// while other threads are still recording calls into it.
+	/// </summary>
+	public TestHelpers.NotificationRecorder Notifications { get; } = new();
+
 	// Metrics collected via MeterListener — static so they persist across all factory instances
 	// and can be written from the ProcessExit handler regardless of disposal order.
 	private MeterListener? _meterListener;
@@ -222,7 +230,7 @@ public class ServerWebAppFactory : TestWebApplicationFactory<SharpMUSH.Server.Pr
 		_server = new ServerTestWebApplicationBuilderFactory<SharpMUSH.Server.Program>(
 			_customSqlConnectionString ?? MySqlTestServer.Instance.GetConnectionString(),
 			configFile,
-			TestHelpers.CreateNotifyServiceSubstitute(),
+			TestHelpers.CreateNotifyServiceSubstitute(Notifications),
 			_customDatabaseName,
 			_sqlPlatform);
 

--- a/SharpMUSH.Tests.Infrastructure/TestHelpers.cs
+++ b/SharpMUSH.Tests.Infrastructure/TestHelpers.cs
@@ -5,6 +5,7 @@ using SharpMUSH.Library.DiscriminatedUnions;
 using SharpMUSH.Library.Extensions;
 using SharpMUSH.Library.Models;
 using SharpMUSH.Library.Services.Interfaces;
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 
 namespace SharpMUSH.Tests;
@@ -72,6 +73,37 @@ public static class TestHelpers
 		Arg.Is<AnySharpObject>(o => o.Object().DBRef == dbRef);
 
 	/// <summary>
+	/// Every notification the substitute was asked to deliver, bucketed by recipient dbref number.
+	///
+	/// <para>This exists because <c>ReceivedCalls()</c> must not be enumerated while the substitute is
+	/// still recording: NSubstitute's threading contract requires verification and production activity to
+	/// be disjoint (nsubstitute.github.io/help/threading), and the substitute the test factories install is
+	/// a singleton shared by every test in a session that TUnit runs in parallel. Clearing it is worse
+	/// still — it deletes calls other tests are about to assert on.</para>
+	///
+	/// <para>Recording happens inside the delivery callback, on the thread that made the call, into a
+	/// <see cref="ConcurrentQueue{T}"/> keyed by recipient. Enumeration never touches NSubstitute state,
+	/// and <see cref="ConcurrentQueue{T}.ToArray"/> is a point-in-time snapshot that cannot throw while
+	/// another thread enqueues. Recipient bucketing gives isolation on top of that: a test that reads its
+	/// own uniquely-created player's bucket cannot see another test's notifications at all.</para>
+	/// </summary>
+	public sealed class NotificationRecorder
+	{
+		private readonly ConcurrentDictionary<int, ConcurrentQueue<string>> _byRecipient = new();
+
+		internal void Record(int recipient, string message)
+			=> _byRecipient.GetOrAdd(recipient, _ => new ConcurrentQueue<string>()).Enqueue(message);
+
+		/// <summary>Everything <paramref name="who"/> has been notified of so far, in order.</summary>
+		public List<string> For(DBRef who)
+			=> _byRecipient.TryGetValue(who.Number, out var queue) ? [.. queue] : [];
+
+		/// <summary>How many notifications <paramref name="who"/> has had, for windowing.</summary>
+		public int CountFor(DBRef who)
+			=> _byRecipient.TryGetValue(who.Number, out var queue) ? queue.Count : 0;
+	}
+
+	/// <summary>
 	/// Creates the <see cref="INotifyService"/> substitute used by the test factories. The real
 	/// <see cref="SharpMUSH.Library.Services.NotifyService"/> consults
 	/// <see cref="SharpMUSH.Library.Services.Interfaces.IHttpOutputCapture"/> before delivering to
@@ -80,16 +112,26 @@ public static class TestHelpers
 	/// empty bodies. Received()-style assertions are unaffected — When/Do does not change call
 	/// recording, and capture state lives in an AsyncLocal so non-HTTP test flows are no-ops.
 	/// </summary>
-	public static INotifyService CreateNotifyServiceSubstitute()
+	/// <param name="recorder">
+	/// Optional sink that also receives every delivered message, so a test can read what was said without
+	/// enumerating <c>ReceivedCalls()</c>. See <see cref="NotificationRecorder"/>.
+	/// </param>
+	public static INotifyService CreateNotifyServiceSubstitute(NotificationRecorder? recorder = null)
 	{
 		var capture = new SharpMUSH.Library.Services.HttpOutputCapture();
 		var localization = new SharpMUSH.Library.Services.LocalizationService();
 		var notifier = Substitute.For<INotifyService>();
 
+		void Deliver(int recipient, string message)
+		{
+			capture.TryCapture(recipient, message);
+			recorder?.Record(recipient, message);
+		}
+
 		notifier
 			.When(x => x.Notify(Arg.Any<DBRef>(), Arg.Any<OneOf<MString, string>>(),
 				Arg.Any<AnySharpObject?>(), Arg.Any<INotifyService.NotificationType>()))
-			.Do(call => capture.TryCapture(
+			.Do(call => Deliver(
 				call.ArgAt<DBRef>(0).Number,
 				PlainText(call.ArgAt<OneOf<MString, string>>(1))));
 
@@ -98,7 +140,7 @@ public static class TestHelpers
 		notifier
 			.When(x => x.Notify(Arg.Any<AnySharpObject>(), Arg.Any<OneOf<MString, string>>(),
 				Arg.Any<AnySharpObject?>(), Arg.Any<INotifyService.NotificationType>()))
-			.Do(call => capture.TryCapture(
+			.Do(call => Deliver(
 				call.ArgAt<AnySharpObject>(0).Object().DBRef.Number,
 				PlainText(call.ArgAt<OneOf<MString, string>>(1))));
 
@@ -106,25 +148,25 @@ public static class TestHelpers
 		// HTTP capture, mirroring the real NotifyService — formatted with the neutral locale.
 		notifier
 			.When(x => x.NotifyLocalized(Arg.Any<DBRef>(), Arg.Any<string>(), Arg.Any<object[]>()))
-			.Do(call => capture.TryCapture(
+			.Do(call => Deliver(
 				call.ArgAt<DBRef>(0).Number,
 				localization.Format(call.ArgAt<string>(1), null, call.ArgAt<object[]>(2))));
 
 		notifier
 			.When(x => x.NotifyLocalized(Arg.Any<AnySharpObject>(), Arg.Any<string>(), Arg.Any<object[]>()))
-			.Do(call => capture.TryCapture(
+			.Do(call => Deliver(
 				call.ArgAt<AnySharpObject>(0).Object().DBRef.Number,
 				localization.Format(call.ArgAt<string>(1), null, call.ArgAt<object[]>(2))));
 
 		notifier
 			.When(x => x.NotifyLocalized(Arg.Any<DBRef>(), Arg.Any<string>(), Arg.Any<AnySharpObject?>(), Arg.Any<object[]>()))
-			.Do(call => capture.TryCapture(
+			.Do(call => Deliver(
 				call.ArgAt<DBRef>(0).Number,
 				localization.Format(call.ArgAt<string>(1), null, call.ArgAt<object[]>(3))));
 
 		notifier
 			.When(x => x.NotifyLocalized(Arg.Any<AnySharpObject>(), Arg.Any<string>(), Arg.Any<AnySharpObject?>(), Arg.Any<object[]>()))
-			.Do(call => capture.TryCapture(
+			.Do(call => Deliver(
 				call.ArgAt<AnySharpObject>(0).Object().DBRef.Number,
 				localization.Format(call.ArgAt<string>(1), null, call.ArgAt<object[]>(3))));
 

--- a/SharpMUSH.Tests/Commands/ChannelCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/ChannelCommandTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using SharpMUSH.Library;
 using SharpMUSH.Library.Commands.Database;
+using SharpMUSH.Library.Definitions;
 using SharpMUSH.Library.DiscriminatedUnions;
 using SharpMUSH.Library.Models;
 using SharpMUSH.Library.ParserInterfaces;
@@ -155,7 +156,8 @@ public class ChannelCommandTests
 
 		await NotifyService
 			.Received(1)
-			.Notify(TestHelpers.MatchingObject(executor), "Channel not found.", TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
+			.Notify(TestHelpers.MatchingObject(executor), ErrorMessages.Notifications.DontRecognizeThatChannel,
+				TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
 	}
 
 	[Test]

--- a/SharpMUSH.Tests/Commands/ChannelCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/ChannelCommandTests.cs
@@ -15,7 +15,14 @@ namespace SharpMUSH.Tests.Commands;
 public class ChannelCommandTests
 {
 	private const string TestChannelName = "TestCommandChannel";
-	private const string TestChannelPrivilege = "Open";
+
+	/// <summary>
+	/// A channel players can use needs the <c>Player</c> privilege: PennMUSH's <c>Chan_Ok_Type</c>
+	/// (hdrs/extchat.h:196) admits a player only to a channel carrying it, which is why Penn's default
+	/// <c>channel_flags</c> is <c>player</c>. This fixture asked for <c>Open</c> alone, which was harmless
+	/// only while the type gate went unenforced.
+	/// </summary>
+	private static readonly string[] TestChannelPrivileges = ["Player", "Open"];
 	private const int TestPlayerDbRef = 1;
 
 	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
@@ -43,7 +50,7 @@ public class ChannelCommandTests
 
 		await Mediator.Send(new CreateChannelCommand(
 			MModule.single(TestChannelName),
-			[TestChannelPrivilege],
+			TestChannelPrivileges,
 			_testPlayer
 		));
 
@@ -125,7 +132,7 @@ public class ChannelCommandTests
 		var before = $"Ren{switchName}{suffix}";
 		var after = $"Post{switchName}{suffix}";
 
-		await Mediator.Send(new CreateChannelCommand(MModule.single(before), [TestChannelPrivilege], _testPlayer!));
+		await Mediator.Send(new CreateChannelCommand(MModule.single(before), TestChannelPrivileges, _testPlayer!));
 
 		await Parser.CommandParse(1, ConnectionService, MModule.single($"@channel/{switchName} {before}={after}"));
 

--- a/SharpMUSH.Tests/Commands/ChannelPermissionTests.cs
+++ b/SharpMUSH.Tests/Commands/ChannelPermissionTests.cs
@@ -43,12 +43,25 @@ public class ChannelPermissionTests
 		=> WebAppFactoryArg.FunctionParserFor(executor);
 
 	/// <summary>
-	/// Every message the notify mock was asked to send to <paramref name="who"/> since the last
-	/// <c>ClearReceivedCalls</c>, as plain text. Used to prove two refusals are worded identically, and
-	/// that a bulk switch never names a channel.
+	/// Runs <paramref name="action"/> and returns every message the notify mock was asked to send to
+	/// <paramref name="who"/> while it ran, as plain text. Used to prove two refusals are worded
+	/// identically, and that a bulk switch never names a channel.
+	///
+	/// <para>It snapshots a call index rather than calling <c>ClearReceivedCalls</c>. The notify mock is
+	/// shared for the whole session and TUnit runs tests in parallel, so clearing it deletes calls other
+	/// tests are about to assert on — it made <c>MailCommand</c>, <c>Flag_Delete_RemovesNonSystemFlag</c>
+	/// and <c>Test_Respond_StatusLine_TooLong</c> fail at random. Filtering by recipient is what actually
+	/// isolates these tests: every one of them creates a uniquely named player.</para>
 	/// </summary>
-	private List<string> NotifiedMessages(DBRef who)
-		=> NotifyService.ReceivedCalls()
+	private async Task<List<string>> MessagesWhile(DBRef who, Func<Task> action)
+	{
+		var before = NotifyService.ReceivedCalls().Count();
+		await action();
+		return NotifiedMessagesFrom(who, before);
+	}
+
+	private List<string> NotifiedMessagesFrom(DBRef who, int skip)
+		=> NotifyService.ReceivedCalls().Skip(skip).ToList()
 			.Where(call => call.GetMethodInfo().Name == nameof(INotifyService.Notify))
 			.Select(call => call.GetArguments())
 			.Where(args => args.Length > 1 && args[0] switch
@@ -473,13 +486,8 @@ public class ChannelPermissionTests
 			.IsEqualTo(ErrorMessages.Returns.NoSuchChannel);
 
 		// And the same for the notification the command surface emits.
-		NotifyService.ClearReceivedCalls();
-		await Run(mortal, $"@channel/on {invisible}");
-		var afterInvisible = NotifiedMessages(mortal.DbRef);
-
-		NotifyService.ClearReceivedCalls();
-		await Run(mortal, $"@channel/on {missing}");
-		var afterMissing = NotifiedMessages(mortal.DbRef);
+		var afterInvisible = await MessagesWhile(mortal.DbRef, () => Run(mortal, $"@channel/on {invisible}"));
+		var afterMissing = await MessagesWhile(mortal.DbRef, () => Run(mortal, $"@channel/on {missing}"));
 
 		await Assert.That(afterInvisible).IsEquivalentTo(afterMissing);
 		await Assert.That(afterInvisible).Contains(ErrorMessages.Notifications.DontRecognizeThatChannel);
@@ -587,16 +595,17 @@ public class ChannelPermissionTests
 		var parser = WebAppFactoryArg.CommandParserFor(mortal.DbRef, mortal.Handle);
 		var locate = WebAppFactoryArg.Services.GetRequiredService<ILocateService>();
 
-		NotifyService.ClearReceivedCalls();
-
-		_ = switchName switch
+		var messages = await MessagesWhile(mortal.DbRef, async () =>
 		{
-			"hide" => await ChannelHide.Handle(parser, locate, PermissionService, Mediator, NotifyService, null, null),
-			"gag" => await ChannelGag.Handle(parser, locate, PermissionService, Mediator, NotifyService, null, null, []),
-			_ => await ChannelCombine.Handle(parser, locate, PermissionService, Mediator, NotifyService, null, null)
-		};
+			_ = switchName switch
+			{
+				"hide" => await ChannelHide.Handle(parser, locate, PermissionService, Mediator, NotifyService, null, null),
+				"gag" => await ChannelGag.Handle(parser, locate, PermissionService, Mediator, NotifyService, null, null, []),
+				_ => await ChannelCombine.Handle(parser, locate, PermissionService, Mediator, NotifyService, null, null)
+			};
+		});
 
-		foreach (var message in NotifiedMessages(mortal.DbRef))
+		foreach (var message in messages)
 		{
 			await Assert.That(message).DoesNotContain(name);
 		}
@@ -648,5 +657,125 @@ public class ChannelPermissionTests
 		var afterOwner = await ChannelHelper.ChannelMemberStatus(victimObject,
 			(await Mediator.Send(new GetChannelQuery(name)))!);
 		await Assert.That(afterOwner!.Status.Mute ?? false).IsTrue();
+	}
+
+	// --- The oracle on the lock and admin surfaces -------------------------------------------------
+
+	/// <summary>
+	/// The lock surface is where Copilot could see the problem, and it is the worst place for it because
+	/// <c>clock()</c> hands a return value to mortal softcode. Resolving through the raw lookup answered
+	/// <c>#-1 NO SUCH CHANNEL</c> for a missing channel and let an invisible one through to
+	/// <c>Chan_Can_Decomp</c>, which answers <c>#-1 PERMISSION DENIED</c> — so the lock stayed secret
+	/// while the channel's existence did not.
+	/// </summary>
+	[Test]
+	public async Task ClockFunctionDoesNotDistinguishHiddenFromMissing()
+	{
+		var hidden = UniqueChannel("ClockHidden");
+		await CreateChannel(hidden, "Player", "Wizard");
+		var missing = UniqueChannel("ClockMissing");
+
+		await GodParser.CommandParse(1, ConnectionService, MModule.single($"@clock/join {hidden}=#1"));
+
+		var mortal = await CreateMortal("ChanPermClockFn");
+		var parser = FunctionParserFor(mortal.DbRef);
+
+		var hiddenResult = await parser.FunctionParse(MModule.single($"clock({hidden})"));
+		var missingResult = await parser.FunctionParse(MModule.single($"clock({missing})"));
+
+		await Assert.That(hiddenResult?.Message?.ToPlainText())
+			.IsEqualTo(missingResult?.Message?.ToPlainText());
+		await Assert.That(hiddenResult?.Message?.ToPlainText()).IsEqualTo(ErrorMessages.Returns.NoSuchChannel);
+		// And the lock key itself never appears.
+		await Assert.That(hiddenResult?.Message?.ToPlainText()).DoesNotContain("#1");
+	}
+
+	/// <summary>
+	/// The same oracle on <c>@clock</c>, the command half Copilot flagged.
+	/// </summary>
+	[Test]
+	public async Task ClockCommandDoesNotDistinguishHiddenFromMissing()
+	{
+		var hidden = UniqueChannel("ClockCmdHidden");
+		await CreateChannel(hidden, "Player", "Wizard");
+		var missing = UniqueChannel("ClockCmdMissing");
+
+		var mortal = await CreateMortal("ChanPermClockCmd");
+
+		var afterHidden = await MessagesWhile(mortal.DbRef,
+			() => Run(mortal, $"@clock/join {hidden}=#{mortal.DbRef.Number}"));
+		var afterMissing = await MessagesWhile(mortal.DbRef,
+			() => Run(mortal, $"@clock/join {missing}=#{mortal.DbRef.Number}"));
+
+		await Assert.That(afterHidden).IsEquivalentTo(afterMissing);
+
+		// The lock must not have been set either.
+		// A channel that was never given a lock reads back null, not "".
+		var channel = await Mediator.Send(new GetChannelQuery(hidden));
+		await Assert.That(string.IsNullOrEmpty(channel!.JoinLock)).IsTrue();
+	}
+
+	/// <summary>
+	/// <c>@clock</c> rewrote <c>Chan_Can_Modify</c> by hand, and carried the same defect the service did:
+	/// <c>string.IsNullOrEmpty(channel.ModLock) || Evaluate(...)</c> is TRUE for every channel, because
+	/// <c>CreateChannelCommand</c> never writes a ModLock. Any non-guest could set the join, speak, see,
+	/// hide or mod lock on any channel they could see.
+	/// </summary>
+	[Test]
+	public async Task ClockRequiresModifyRightsOnTheChannel()
+	{
+		var name = UniqueChannel("ClockGate");
+		var channel = await CreateChannel(name, "Player");
+
+		var meddler = await CreateMortal("ChanPermClockMeddler");
+		var meddlerObject = (await Mediator.Send(new GetObjectNodeQuery(meddler.DbRef))).Known;
+		await Mediator.Send(new AddUserToChannelCommand(channel, meddlerObject));
+
+		await Assert.That(await PermissionService.ChannelCanModifyAsync(meddlerObject, channel)).IsFalse();
+
+		await Run(meddler, $"@clock/join {name}=#{meddler.DbRef.Number}");
+		await Assert.That(string.IsNullOrEmpty(
+			(await Mediator.Send(new GetChannelQuery(name)))!.JoinLock)).IsTrue();
+
+		// God owns the channel, so the same command from God does set the lock.
+		await GodParser.CommandParse(1, ConnectionService, MModule.single($"@clock/join {name}=#1"));
+		await Assert.That(string.IsNullOrEmpty(
+			(await Mediator.Send(new GetChannelQuery(name)))!.JoinLock)).IsFalse();
+	}
+
+	/// <summary>
+	/// The whole sweep in one assertion. Every channel-admin switch resolved through the raw lookup, so
+	/// "Channel not found." came from the lookup and "You cannot modify this channel." came from the
+	/// authorization gate — the authorization was correct and the oracle was wide open anyway. This is the
+	/// subtle half of the sweep and the reason it could not be done by inspecting the gates alone.
+	/// </summary>
+	[Test]
+	[Arguments("decompile", "")]
+	[Arguments("wipe", "")]
+	[Arguments("delete", "")]
+	[Arguments("recall", "")]
+	[Arguments("describe", "=a description")]
+	[Arguments("buffer", "=50")]
+	[Arguments("privs", "=quiet")]
+	[Arguments("title", "=a title")]
+	[Arguments("off", "")]
+	public async Task AdminSwitchesDoNotDistinguishHiddenFromMissing(string switchName, string rhs)
+	{
+		var hidden = UniqueChannel($"Adm{switchName}H");
+		await CreateChannel(hidden, "Player", "Wizard");
+		var missing = UniqueChannel($"Adm{switchName}M");
+
+		var mortal = await CreateMortal($"ChanPermAdm{switchName}");
+
+		var afterHidden = await MessagesWhile(mortal.DbRef,
+			() => Run(mortal, $"@channel/{switchName} {hidden}{rhs}"));
+		var afterMissing = await MessagesWhile(mortal.DbRef,
+			() => Run(mortal, $"@channel/{switchName} {missing}{rhs}"));
+
+		await Assert.That(afterHidden).IsEquivalentTo(afterMissing);
+		await Assert.That(afterHidden).Contains(ErrorMessages.Notifications.DontRecognizeThatChannel);
+
+		// The hidden channel must still be there — /delete and /wipe are in this list.
+		await Assert.That(await Mediator.Send(new GetChannelQuery(hidden))).IsNotNull();
 	}
 }

--- a/SharpMUSH.Tests/Commands/ChannelPermissionTests.cs
+++ b/SharpMUSH.Tests/Commands/ChannelPermissionTests.cs
@@ -1,0 +1,402 @@
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using SharpMUSH.Library;
+using SharpMUSH.Library.Commands.Database;
+using SharpMUSH.Library.Extensions;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Queries;
+using SharpMUSH.Library.Queries.Database;
+using SharpMUSH.Library.Services.Interfaces;
+
+namespace SharpMUSH.Tests.Commands;
+
+/// <summary>
+/// Channel privileges and channel locks are enforced, not merely stored.
+///
+/// <para>Every case here is a live reproduction of what a mortal could do before: join a wizard-only
+/// channel, join a disabled channel, join past a join lock they fail, and speak on all three. The
+/// privilege and lock data were being written and displayed correctly the whole time — seven of the nine
+/// channel methods on <c>IPermissionService</c> simply had no callers.</para>
+///
+/// <para>Semantics follow PennMUSH <c>hdrs/extchat.h:196-222</c>; refusal wording follows
+/// <c>src/extchat.c</c>.</para>
+/// </summary>
+public class ChannelPermissionTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactoryArg { get; init; }
+
+	private IMediator Mediator => WebAppFactoryArg.Services.GetRequiredService<IMediator>();
+	private IConnectionService ConnectionService => WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
+	private IPermissionService PermissionService => WebAppFactoryArg.Services.GetRequiredService<IPermissionService>();
+	private IMUSHCodeParser GodParser => WebAppFactoryArg.CommandParser;
+
+	private static string UniqueChannel(string prefix)
+		=> $"{prefix}{Random.Shared.Next(100000, 999999)}";
+
+	/// <summary>Creates a channel owned by God with exactly the given privileges.</summary>
+	private async Task<SharpChannel> CreateChannel(string name, params string[] privileges)
+	{
+		var god = (await Mediator.Send(new GetObjectNodeQuery(new DBRef(1)))).AsPlayer;
+		await Mediator.Send(new CreateChannelCommand(MModule.single(name), privileges, god));
+		return (await Mediator.Send(new GetChannelQuery(name)))!;
+	}
+
+	private async Task<bool> IsMember(string channelName, DBRef who)
+	{
+		var channel = await Mediator.Send(new GetChannelQuery(channelName));
+		return channel is not null
+					 && await channel.Members.Value.AnyAsync(x => x.Member.Object().DBRef.Number == who.Number);
+	}
+
+	private async Task<TestIsolationHelpers.TestPlayer> CreateMortal(string prefix)
+		=> await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, prefix);
+
+	private async Task<TestIsolationHelpers.TestPlayer> CreateFlagged(string prefix, string flag)
+	{
+		var player = await CreateMortal(prefix);
+		await GodParser.CommandParse(1, ConnectionService, MModule.single($"@set {player.DbRef}={flag}"));
+		return player;
+	}
+
+	private async Task Run(TestIsolationHelpers.TestPlayer who, string command)
+		=> await GodParser.CommandParse(who.Handle, ConnectionService, MModule.single(command));
+
+	private async Task<int> MessageCount(string channelName)
+	{
+		var channel = await Mediator.Send(new GetChannelQuery(channelName));
+		return await Mediator.CreateStream(new GetChannelMessagesQuery(channel!.Id ?? string.Empty, int.MaxValue))
+			.CountAsync();
+	}
+
+	// --- Chan_Can: the WIZARD privilege (extchat.h:198) ---------------------------------------------
+
+	[Test]
+	public async Task WizardChannel_RefusesMortalAndAdmitsWizard()
+	{
+		var name = UniqueChannel("WizOnly");
+		await CreateChannel(name, "Player", "Wizard");
+
+		var mortal = await CreateMortal("ChanPermMortal");
+		var wizard = await CreateFlagged("ChanPermWiz", "WIZARD");
+
+		await Run(mortal, $"@channel/on {name}");
+		await Assert.That(await IsMember(name, mortal.DbRef)).IsFalse();
+
+		await Run(wizard, $"@channel/on {name}");
+		await Assert.That(await IsMember(name, wizard.DbRef)).IsTrue();
+	}
+
+	[Test]
+	public async Task WizardChannel_RefusesMortalSpeech()
+	{
+		var name = UniqueChannel("WizSpeak");
+		var channel = await CreateChannel(name, "Player", "Wizard");
+
+		var mortal = await CreateMortal("ChanPermSpeaker");
+		// Put the mortal on the channel behind the gate's back, so the refusal under test is the SPEAK
+		// gate and not merely "you are not on that channel".
+		var mortalObject = (await Mediator.Send(new GetObjectNodeQuery(mortal.DbRef))).Known;
+		await Mediator.Send(new AddUserToChannelCommand(channel, mortalObject));
+
+		var before = await MessageCount(name);
+		await Run(mortal, $"@chat {name}=I should not be able to say this.");
+
+		await Assert.That(await MessageCount(name)).IsEqualTo(before);
+	}
+
+	// --- Chan_Can: the ADMIN privilege (extchat.h:198) ----------------------------------------------
+
+	[Test]
+	public async Task AdminChannel_RefusesMortalAndAdmitsRoyalty()
+	{
+		var name = UniqueChannel("AdminOnly");
+		await CreateChannel(name, "Player", "Admin");
+
+		var mortal = await CreateMortal("ChanPermAdminMortal");
+		var royalty = await CreateFlagged("ChanPermRoyal", "ROYALTY");
+
+		await Run(mortal, $"@channel/on {name}");
+		await Assert.That(await IsMember(name, mortal.DbRef)).IsFalse();
+
+		await Run(royalty, $"@channel/on {name}");
+		await Assert.That(await IsMember(name, royalty.DbRef)).IsTrue();
+	}
+
+	[Test]
+	public async Task AdminChannel_AdmitsChatPrivsPower()
+	{
+		var name = UniqueChannel("AdminPower");
+		await CreateChannel(name, "Player", "Admin");
+
+		var player = await CreateMortal("ChanPermChatPrivs");
+		var chatPrivs = await Mediator.Send(new GetPowerQuery("Chat_Privs"));
+		await Assert.That(chatPrivs).IsNotNull();
+
+		var playerObject = (await Mediator.Send(new GetObjectNodeQuery(player.DbRef))).Known;
+		await Mediator.Send(new SetObjectPowerCommand(playerObject, chatPrivs!));
+
+		await Run(player, $"@channel/on {name}");
+		await Assert.That(await IsMember(name, player.DbRef)).IsTrue();
+	}
+
+	// --- Chan_Can: the DISABLED privilege (extchat.h:198) -------------------------------------------
+
+	[Test]
+	public async Task DisabledChannel_RefusesMortalJoin()
+	{
+		var name = UniqueChannel("Deaded");
+		await CreateChannel(name, "Player", "Disabled");
+
+		var mortal = await CreateMortal("ChanPermDisabled");
+
+		await Run(mortal, $"@channel/on {name}");
+		await Assert.That(await IsMember(name, mortal.DbRef)).IsFalse();
+	}
+
+	/// <summary>
+	/// The DISABLED bit lives inside <c>Chan_Can</c>, so it gates speech for everyone — <c>do_chat</c>
+	/// has no wizard override (<c>src/extchat.c:1539</c>). Note that JOINING a disabled channel is
+	/// different: <c>src/extchat.c:1353-1362</c> lets a wizard through with a warning.
+	/// </summary>
+	[Test]
+	public async Task DisabledChannel_RefusesWizardSpeech()
+	{
+		var name = UniqueChannel("DeadSpeak");
+		var channel = await CreateChannel(name, "Player", "Disabled");
+
+		var wizard = await CreateFlagged("ChanPermDeadWiz", "WIZARD");
+		var wizardObject = (await Mediator.Send(new GetObjectNodeQuery(wizard.DbRef))).Known;
+		await Mediator.Send(new AddUserToChannelCommand(channel, wizardObject));
+
+		var before = await MessageCount(name);
+		await Run(wizard, $"@chat {name}=Wizards do not get to talk on a dead channel.");
+
+		await Assert.That(await MessageCount(name)).IsEqualTo(before);
+	}
+
+	// --- eval_chan_lock: CLOCK_JOIN (extchat.h:204) -------------------------------------------------
+
+	[Test]
+	public async Task JoinLock_RefusesFailingPlayerAndAdmitsPassingPlayer()
+	{
+		var name = UniqueChannel("Locked");
+		await CreateChannel(name, "Player");
+
+		var passing = await CreateMortal("ChanPermJoinPass");
+		var failing = await CreateMortal("ChanPermJoinFail");
+
+		await GodParser.CommandParse(1, ConnectionService,
+			MModule.single($"@clock/join {name}=#{passing.DbRef.Number}"));
+
+		await Run(failing, $"@channel/on {name}");
+		await Assert.That(await IsMember(name, failing.DbRef)).IsFalse();
+
+		await Run(passing, $"@channel/on {name}");
+		await Assert.That(await IsMember(name, passing.DbRef)).IsTrue();
+	}
+
+	// --- eval_chan_lock: CLOCK_SPEAK (extchat.h:206) ------------------------------------------------
+
+	[Test]
+	public async Task SpeakLock_RefusesFailingPlayerAndAdmitsPassingPlayer()
+	{
+		var name = UniqueChannel("SpeakLk");
+		var channel = await CreateChannel(name, "Player");
+
+		var passing = await CreateMortal("ChanPermSpeakPass");
+		var failing = await CreateMortal("ChanPermSpeakFail");
+
+		foreach (var player in new[] { passing, failing })
+		{
+			var obj = (await Mediator.Send(new GetObjectNodeQuery(player.DbRef))).Known;
+			await Mediator.Send(new AddUserToChannelCommand(channel, obj));
+		}
+
+		await GodParser.CommandParse(1, ConnectionService,
+			MModule.single($"@clock/speak {name}=#{passing.DbRef.Number}"));
+
+		var before = await MessageCount(name);
+
+		await Run(failing, $"@chat {name}=Refused.");
+		await Assert.That(await MessageCount(name)).IsEqualTo(before);
+
+		await Run(passing, $"@chat {name}=Allowed.");
+		await Assert.That(await MessageCount(name)).IsEqualTo(before + 1);
+	}
+
+	/// <summary>
+	/// PennMUSH checks LOUD at the call site rather than inside <c>Chan_Can_Speak</c>
+	/// (<c>src/extchat.c:1539</c>): "LOUD objects bypass all speech, channel speech, and interaction
+	/// @locks" (<c>hlp/pennflag.hlp:256</c>). The flag was seeded in every provider's migration and
+	/// consulted nowhere.
+	/// </summary>
+	[Test]
+	public async Task LoudPlayer_BypassesSpeakLock()
+	{
+		var name = UniqueChannel("LoudLk");
+		var channel = await CreateChannel(name, "Player");
+
+		var loud = await CreateFlagged("ChanPermLoud", "LOUD");
+		var loudObject = (await Mediator.Send(new GetObjectNodeQuery(loud.DbRef))).Known;
+		await Mediator.Send(new AddUserToChannelCommand(channel, loudObject));
+
+		// A lock nobody passes: the channel owner is #1, and the speaker is not.
+		await GodParser.CommandParse(1, ConnectionService, MModule.single($"@clock/speak {name}=#1"));
+
+		var before = await MessageCount(name);
+		await Run(loud, $"@chat {name}=LOUD speaks anyway.");
+
+		await Assert.That(await MessageCount(name)).IsEqualTo(before + 1);
+	}
+
+	// --- Chan_Can_Cemit: the NOCEMIT privilege (extchat.h:208) --------------------------------------
+
+	[Test]
+	public async Task NoCemitChannel_RefusesCemitFromSomeoneWhoMaySpeak()
+	{
+		var name = UniqueChannel("NoCem");
+		var channel = await CreateChannel(name, "Player", "NoCemit");
+
+		var player = await CreateMortal("ChanPermNoCemit");
+		var playerObject = (await Mediator.Send(new GetObjectNodeQuery(player.DbRef))).Known;
+		await Mediator.Send(new AddUserToChannelCommand(channel, playerObject));
+
+		// The speak gate lets them through — only the cemit gate should not.
+		await Assert.That(await PermissionService.ChannelCanSpeak(playerObject, channel)).IsTrue();
+		await Assert.That(await PermissionService.ChannelCanCemit(playerObject, channel)).IsFalse();
+
+		var before = await MessageCount(name);
+		await Run(player, $"@cemit {name}=Refused.");
+		await Assert.That(await MessageCount(name)).IsEqualTo(before);
+
+		await Run(player, $"@chat {name}=Allowed.");
+		await Assert.That(await MessageCount(name)).IsEqualTo(before + 1);
+	}
+
+	// --- Chan_Ok_Type (extchat.h:196) ---------------------------------------------------------------
+
+	[Test]
+	public async Task PlayerOnlyChannel_RefusesAThing()
+	{
+		var name = UniqueChannel("PlrOnly");
+		var channel = await CreateChannel(name, "Player");
+
+		var thingDbRef = await TestIsolationHelpers.CreateTestThingAsync(GodParser, ConnectionService, "ChanPermThing");
+		var thing = (await Mediator.Send(new GetObjectNodeQuery(thingDbRef))).Known;
+
+		await Assert.That(PermissionService.ChannelOkType(thing, channel)).IsFalse();
+
+		var objectChannelName = UniqueChannel("ObjOk");
+		var objectChannel = await CreateChannel(objectChannelName, "Player", "Object");
+		await Assert.That(PermissionService.ChannelOkType(thing, objectChannel)).IsTrue();
+	}
+
+	// --- Chan_Can_Hide and the Hide_Ok privilege (extchat.h:216) ------------------------------------
+
+	/// <summary>
+	/// <c>ChannelCanHide</c> tested <c>Privs.Contains("CanHide")</c>. The privilege is spelled
+	/// <c>Hide_Ok</c> in <c>chan_privs</c> and is what <c>@channel/add</c> writes, so the branch could
+	/// never be true — invisible only because nothing called the method.
+	/// </summary>
+	[Test]
+	public async Task HideOkChannel_PermitsHidingAndPlainChannelDoesNot()
+	{
+		var hideOkName = UniqueChannel("HideOk");
+		var hideOk = await CreateChannel(hideOkName, "Player", "Hide_Ok");
+		var plainName = UniqueChannel("NoHide");
+		var plain = await CreateChannel(plainName, "Player");
+
+		var player = await CreateMortal("ChanPermHide");
+		var playerObject = (await Mediator.Send(new GetObjectNodeQuery(player.DbRef))).Known;
+		await Mediator.Send(new AddUserToChannelCommand(hideOk, playerObject));
+		await Mediator.Send(new AddUserToChannelCommand(plain, playerObject));
+
+		await Assert.That(await PermissionService.ChannelCanHide(playerObject, hideOk)).IsTrue();
+		await Assert.That(await PermissionService.ChannelCanHide(playerObject, plain)).IsFalse();
+	}
+
+	// --- Privilege names are stored canonically, and compared case-insensitively --------------------
+
+	/// <summary>
+	/// <c>@channel/add Foo=wizard</c> persisted the literal <c>"wizard"</c>, and every check read
+	/// <c>Privs.Contains("Wizard")</c> — an ordinal comparison that answered "no wizard privilege" for a
+	/// channel whose <c>@channel/what</c> plainly said <c>Flags: wizard</c>.
+	/// </summary>
+	[Test]
+	public async Task ChannelAddStoresPrivilegesInCanonicalCasing()
+	{
+		var name = UniqueChannel("Canon");
+		await GodParser.CommandParse(1, ConnectionService, MModule.single($"@channel/add {name}=wizard player"));
+
+		var channel = await Mediator.Send(new GetChannelQuery(name));
+
+		await Assert.That(channel).IsNotNull();
+		await Assert.That(channel!.Privs).Contains("Wizard");
+		await Assert.That(channel.Privs).Contains("Player");
+	}
+
+	/// <summary>
+	/// PennMUSH <c>string_to_privs</c> (<c>src/privtab.c:36</c>) applies the list to the channel's
+	/// existing privileges and honours <c>!priv</c>; <c>@channel/privs</c> replaced the whole set and had
+	/// no negation, so setting one flag silently dropped every other.
+	/// </summary>
+	[Test]
+	public async Task ChannelPrivsAddsToExistingPrivilegesAndNegates()
+	{
+		var name = UniqueChannel("PrivOr");
+		await CreateChannel(name, "Player", "Quiet");
+
+		await GodParser.CommandParse(1, ConnectionService, MModule.single($"@channel/privs {name}=Wizard"));
+
+		var afterAdd = await Mediator.Send(new GetChannelQuery(name));
+		await Assert.That(afterAdd!.Privs).Contains("Player");
+		await Assert.That(afterAdd.Privs).Contains("Quiet");
+		await Assert.That(afterAdd.Privs).Contains("Wizard");
+
+		await GodParser.CommandParse(1, ConnectionService, MModule.single($"@channel/privs {name}=!Wizard"));
+
+		var afterRemove = await Mediator.Send(new GetChannelQuery(name));
+		await Assert.That(afterRemove!.Privs).Contains("Player");
+		await Assert.That(afterRemove.Privs).DoesNotContain("Wizard");
+	}
+
+	// --- The live reproduction from the bug report, end to end --------------------------------------
+
+	/// <summary>
+	/// The reported reproduction, exactly: as God, create a wizard channel, a disabled channel and a
+	/// join-locked one; then as a plain player join all three and speak on all three. Before this change
+	/// every one of the six operations succeeded.
+	/// </summary>
+	[Test]
+	public async Task MortalCannotJoinOrSpeakOnAnyGatedChannel()
+	{
+		var wizOnly = UniqueChannel("ReproWiz");
+		var deaded = UniqueChannel("ReproDead");
+		var locked = UniqueChannel("ReproLock");
+
+		await GodParser.CommandParse(1, ConnectionService, MModule.single($"@channel/add {wizOnly}=wizard player"));
+		await GodParser.CommandParse(1, ConnectionService, MModule.single($"@channel/add {locked}=player"));
+		await GodParser.CommandParse(1, ConnectionService, MModule.single($"@clock/join {locked}=#1"));
+
+		// PennMUSH refuses `@channel/add <name>=disabled` outright — Chan_Can is false for a disabled type
+		// for everyone, wizards included (extchat.c:1736). A wizard reaches the same state through
+		// @channel/privs, where Chan_Can_Priv's `Wizard(p) ||` escape applies (extchat.c:1832).
+		await GodParser.CommandParse(1, ConnectionService, MModule.single($"@channel/add {deaded}=player"));
+		await GodParser.CommandParse(1, ConnectionService, MModule.single($"@channel/privs {deaded}=disabled"));
+
+		var mortimer = await CreateMortal("Mortimer");
+
+		foreach (var name in new[] { wizOnly, deaded, locked })
+		{
+			await Run(mortimer, $"@channel/on {name}");
+			await Assert.That(await IsMember(name, mortimer.DbRef)).IsFalse();
+
+			var before = await MessageCount(name);
+			await Run(mortimer, $"@chat {name}=Mortimer speaks.");
+			await Assert.That(await MessageCount(name)).IsEqualTo(before);
+		}
+	}
+}

--- a/SharpMUSH.Tests/Commands/ChannelPermissionTests.cs
+++ b/SharpMUSH.Tests/Commands/ChannelPermissionTests.cs
@@ -1,7 +1,5 @@
 using Mediator;
 using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
-using OneOf;
 using SharpMUSH.Implementation.Commands.ChannelCommand;
 using SharpMUSH.Library;
 using SharpMUSH.Library.Commands.Database;
@@ -43,41 +41,33 @@ public class ChannelPermissionTests
 		=> WebAppFactoryArg.FunctionParserFor(executor);
 
 	/// <summary>
-	/// Runs <paramref name="action"/> and returns every message the notify mock was asked to send to
-	/// <paramref name="who"/> while it ran, as plain text. Used to prove two refusals are worded
-	/// identically, and that a bulk switch never names a channel.
+	/// Runs <paramref name="action"/> and returns every message <paramref name="who"/> was notified of
+	/// while it ran, as plain text. Used to prove two refusals are worded identically, and that a bulk
+	/// switch never names a channel.
 	///
-	/// <para>It snapshots a call index rather than calling <c>ClearReceivedCalls</c>. The notify mock is
-	/// shared for the whole session and TUnit runs tests in parallel, so clearing it deletes calls other
-	/// tests are about to assert on — it made <c>MailCommand</c>, <c>Flag_Delete_RemovesNonSystemFlag</c>
-	/// and <c>Test_Respond_StatusLine_TooLong</c> fail at random. Filtering by recipient is what actually
-	/// isolates these tests: every one of them creates a uniquely named player.</para>
+	/// <para><b>It does not touch <c>ReceivedCalls()</c>.</b> The notify substitute is a singleton shared
+	/// by every test in the session and TUnit runs tests in parallel, so it is being written to the entire
+	/// time these assertions run — and NSubstitute's threading contract
+	/// (nsubstitute.github.io/help/threading) says verification and production activity must not overlap.
+	/// Two earlier shapes were both wrong for that reason: <c>ClearReceivedCalls()</c> deleted calls other
+	/// tests were about to assert on (it made <c>MailCommand</c>,
+	/// <c>Flag_Delete_RemovesNonSystemFlag</c> and <c>Test_Respond_StatusLine_TooLong</c> fail at random),
+	/// and snapshotting a call index still enumerated the shared substitute — it moved the race rather
+	/// than removing it.</para>
+	///
+	/// <para>The messages now come from <see cref="TestHelpers.NotificationRecorder"/>, which the
+	/// substitute writes into from its delivery callback, on the calling thread, keyed by recipient. No
+	/// NSubstitute state is read; the per-recipient <c>ConcurrentQueue</c> snapshot is safe under
+	/// concurrent enqueue by construction; and since every test here creates a uniquely named player, no
+	/// other test writes into the bucket being read.</para>
 	/// </summary>
 	private async Task<List<string>> MessagesWhile(DBRef who, Func<Task> action)
 	{
-		var before = NotifyService.ReceivedCalls().Count();
+		var recorder = WebAppFactoryArg.Notifications;
+		var before = recorder.CountFor(who);
 		await action();
-		return NotifiedMessagesFrom(who, before);
+		return [.. recorder.For(who).Skip(before)];
 	}
-
-	private List<string> NotifiedMessagesFrom(DBRef who, int skip)
-		=> NotifyService.ReceivedCalls().Skip(skip).ToList()
-			.Where(call => call.GetMethodInfo().Name == nameof(INotifyService.Notify))
-			.Select(call => call.GetArguments())
-			.Where(args => args.Length > 1 && args[0] switch
-			{
-				AnySharpObject o => o.Object().DBRef.Number == who.Number,
-				DBRef d => d.Number == who.Number,
-				_ => false
-			})
-			.Select(args => args[1] switch
-			{
-				OneOf<MString, string> m => m.Match(ms => ms.ToPlainText(), str => str),
-				MString ms => ms.ToPlainText(),
-				string str => str,
-				_ => string.Empty
-			})
-			.ToList();
 
 	/// <summary>
 	/// Channel names must be unique across the whole session — <see cref="ServerWebAppFactory"/> is

--- a/SharpMUSH.Tests/Commands/ChannelPermissionTests.cs
+++ b/SharpMUSH.Tests/Commands/ChannelPermissionTests.cs
@@ -68,9 +68,10 @@ public class ChannelPermissionTests
 
 	/// <summary>
 	/// Channel names must be unique across the whole session — <see cref="ServerWebAppFactory"/> is
-	/// <see cref="SharedType.PerTestSession"/>, so every test in this class shares one database. A bare
-	/// six-digit random suffix collides often enough to matter; <c>GenerateUniqueName</c> adds a
-	/// millisecond timestamp. Underscores are stripped because a channel name may not contain one.
+	/// <see cref="SharedType.PerTestSession"/>, so every test in this class shares one database, and
+	/// several of these tests create channels in a loop. A bare random suffix collides often enough to
+	/// matter; <c>GenerateUniqueName</c> adds a millisecond timestamp. Its underscores are stripped only
+	/// to keep the names readable in refusal messages — <c>IsValidChannelName</c> accepts them.
 	/// </summary>
 	private static string UniqueChannel(string prefix)
 		=> TestIsolationHelpers.GenerateUniqueName(prefix).Replace("_", string.Empty);

--- a/SharpMUSH.Tests/Commands/ChannelPermissionTests.cs
+++ b/SharpMUSH.Tests/Commands/ChannelPermissionTests.cs
@@ -155,10 +155,18 @@ public class ChannelPermissionTests
 		var mortalObject = (await Mediator.Send(new GetObjectNodeQuery(mortal.DbRef))).Known;
 		await Mediator.Send(new AddUserToChannelCommand(channel, mortalObject));
 
+		var wizard = await CreateFlagged("ChanPermSpeakerWiz", "WIZARD");
+		var wizardObject = (await Mediator.Send(new GetObjectNodeQuery(wizard.DbRef))).Known;
+		await Mediator.Send(new AddUserToChannelCommand(channel, wizardObject));
+
 		var before = await MessageCount(name);
 		await Run(mortal, $"@chat {name}=I should not be able to say this.");
 
 		await Assert.That(await MessageCount(name)).IsEqualTo(before);
+
+		// The positive half, so "the count did not move" cannot pass by @chat being broken outright.
+		await Run(wizard, $"@chat {name}=A wizard may.");
+		await Assert.That(await MessageCount(name)).IsEqualTo(before + 1);
 	}
 
 	// --- Chan_Can: the ADMIN privilege (extchat.h:198) ----------------------------------------------
@@ -203,11 +211,18 @@ public class ChannelPermissionTests
 	{
 		var name = UniqueChannel("Deaded");
 		await CreateChannel(name, "Player", "Disabled");
+		var live = UniqueChannel("NotDeaded");
+		await CreateChannel(live, "Player");
 
 		var mortal = await CreateMortal("ChanPermDisabled");
 
 		await Run(mortal, $"@channel/on {name}");
 		await Assert.That(await IsMember(name, mortal.DbRef)).IsFalse();
+
+		// The same player, the same command, a channel differing only in the DISABLED bit: without this
+		// the refusal could equally well be "@channel/on never joins anybody".
+		await Run(mortal, $"@channel/on {live}");
+		await Assert.That(await IsMember(live, mortal.DbRef)).IsTrue();
 	}
 
 	/// <summary>
@@ -220,15 +235,23 @@ public class ChannelPermissionTests
 	{
 		var name = UniqueChannel("DeadSpeak");
 		var channel = await CreateChannel(name, "Player", "Disabled");
+		var liveName = UniqueChannel("LiveSpeak");
+		var live = await CreateChannel(liveName, "Player");
 
 		var wizard = await CreateFlagged("ChanPermDeadWiz", "WIZARD");
 		var wizardObject = (await Mediator.Send(new GetObjectNodeQuery(wizard.DbRef))).Known;
 		await Mediator.Send(new AddUserToChannelCommand(channel, wizardObject));
+		await Mediator.Send(new AddUserToChannelCommand(live, wizardObject));
 
 		var before = await MessageCount(name);
 		await Run(wizard, $"@chat {name}=Wizards do not get to talk on a dead channel.");
 
 		await Assert.That(await MessageCount(name)).IsEqualTo(before);
+
+		// Same wizard, same command, a channel differing only in the DISABLED bit.
+		var liveBefore = await MessageCount(liveName);
+		await Run(wizard, $"@chat {liveName}=But they may talk on a live one.");
+		await Assert.That(await MessageCount(liveName)).IsEqualTo(liveBefore + 1);
 	}
 
 	// --- eval_chan_lock: CLOCK_JOIN (extchat.h:204) -------------------------------------------------
@@ -533,11 +556,18 @@ public class ChannelPermissionTests
 
 		var mortal = await CreateMortal("ChanPermFnRead");
 		var parser = FunctionParserFor(mortal.DbRef);
+		var wizard = await CreateFlagged("ChanPermFnReadWiz", "WIZARD");
+		var wizardParser = FunctionParserFor(wizard.DbRef);
 
 		foreach (var call in new[] { $"cowner({name})", $"cmogrifier({name})", $"cwho({name})" })
 		{
 			var result = await parser.FunctionParse(MModule.single(call));
 			await Assert.That(result?.Message?.ToPlainText()).IsEqualTo(ErrorMessages.Returns.NoSuchChannel);
+
+			// The gate is what refuses the mortal, not the function being broken: a viewer who passes
+			// Chan_Can_See gets an answer from the same call.
+			var allowed = await wizardParser.FunctionParse(MModule.single(call));
+			await Assert.That(allowed?.Message?.ToPlainText()).IsNotEqualTo(ErrorMessages.Returns.NoSuchChannel);
 		}
 	}
 
@@ -546,28 +576,47 @@ public class ChannelPermissionTests
 	/// naming a wizard read back that wizard's wizard-only channels; and its <c>on</c>/<c>off</c> arms
 	/// applied no visibility rule at all. PennMUSH <c>fun_channels</c> (<c>src/extchat.c:3313</c>) judges
 	/// against the executor and additionally hides members flagged hidden from non-Priv_Who callers.
+	///
+	/// <para>Every assertion about the hidden channel is an ABSENCE, so each is paired with a shared
+	/// channel that must be PRESENT in the same answer. Without that pair the test would pass just as well
+	/// against a <c>channels()</c> that returned the empty string for everything.</para>
 	/// </summary>
 	[Test]
 	public async Task ChannelsFunctionJudgesVisibilityAgainstTheCaller()
 	{
 		var name = UniqueChannel("ChansHidden");
 		var channel = await CreateChannel(name, "Player", "Wizard");
+		var sharedName = UniqueChannel("ChansShared");
+		var shared = await CreateChannel(sharedName, "Player");
 
 		var wizard = await CreateFlagged("ChanPermChansWiz", "WIZARD");
 		var wizardObject = (await Mediator.Send(new GetObjectNodeQuery(wizard.DbRef))).Known;
 		await Mediator.Send(new AddUserToChannelCommand(channel, wizardObject));
+		await Mediator.Send(new AddUserToChannelCommand(shared, wizardObject));
 
 		var mortal = await CreateMortal("ChanPermChans");
+		var mortalObject = (await Mediator.Send(new GetObjectNodeQuery(mortal.DbRef))).Known;
+		await Mediator.Send(new AddUserToChannelCommand(shared, mortalObject));
+
 		var parser = FunctionParserFor(mortal.DbRef);
 
+		// Naming the wizard reads back the channel they share and not the wizard-only one.
 		var named = await parser.FunctionParse(MModule.single($"channels(#{wizard.DbRef.Number})"));
 		await Assert.That(named?.Message?.ToPlainText()).DoesNotContain(name);
+		await Assert.That(named?.Message?.ToPlainText()).Contains(sharedName);
 
+		// `off` listed every channel in the game; it must still list the ones the mortal really is off.
 		var off = await parser.FunctionParse(MModule.single("channels(me,off)"));
 		await Assert.That(off?.Message?.ToPlainText()).DoesNotContain(name);
+		await Assert.That(off?.Message?.ToPlainText()).DoesNotContain(sharedName);
+
+		var on = await parser.FunctionParse(MModule.single("channels(me,on)"));
+		await Assert.That(on?.Message?.ToPlainText()).DoesNotContain(name);
+		await Assert.That(on?.Message?.ToPlainText()).Contains(sharedName);
 
 		var all = await parser.FunctionParse(MModule.single("channels()"));
 		await Assert.That(all?.Message?.ToPlainText()).DoesNotContain(name);
+		await Assert.That(all?.Message?.ToPlainText()).Contains(sharedName);
 	}
 
 	/// <summary>
@@ -581,6 +630,15 @@ public class ChannelPermissionTests
 	/// unreachable from the command surface today and no player can currently trigger the leak. The
 	/// handlers implement it regardless, and whoever wires the argument-less form — PennMUSH has it —
 	/// must not reintroduce the oracle. Testing through the dispatcher would assert nothing.</para>
+	///
+	/// <para>The loop below asserts an ABSENCE over a collection, which asserts nothing at all if the
+	/// collection is empty, so the bulk path is first required to have said SOMETHING. For <c>hide</c> —
+	/// the deterministic case, and the only one reachable from Penn's dispatcher — the requirement is
+	/// sharper: a channel the mortal CAN see must be named, proving the handler walked the list and the
+	/// hidden channel's absence is the gate working rather than the walk never happening. <c>gag</c> and
+	/// <c>combine</c> cannot be pinned that way because they <c>return</c> on the first channel the
+	/// executor is not a member of, and in a session-shared database that is whichever visible channel
+	/// another test happened to create first.</para>
 	/// </summary>
 	[Test]
 	[Arguments("hide")]
@@ -590,8 +648,13 @@ public class ChannelPermissionTests
 	{
 		var name = UniqueChannel($"Bulk{switchName}");
 		await CreateChannel(name, "Player", "Wizard");
+		var visibleName = UniqueChannel($"Seen{switchName}");
+		var visible = await CreateChannel(visibleName, "Player");
 
 		var mortal = await CreateMortal($"ChanPermBulk{switchName}");
+		var mortalObject = (await Mediator.Send(new GetObjectNodeQuery(mortal.DbRef))).Known;
+		await Mediator.Send(new AddUserToChannelCommand(visible, mortalObject));
+
 		var parser = WebAppFactoryArg.CommandParserFor(mortal.DbRef, mortal.Handle);
 		var locate = WebAppFactoryArg.Services.GetRequiredService<ILocateService>();
 
@@ -604,6 +667,13 @@ public class ChannelPermissionTests
 				_ => await ChannelCombine.Handle(parser, locate, PermissionService, Mediator, NotifyService, null, null)
 			};
 		});
+
+		await Assert.That(messages).IsNotEmpty();
+
+		if (switchName == "hide")
+		{
+			await Assert.That(messages.Any(message => message.Contains(visibleName))).IsTrue();
+		}
 
 		foreach (var message in messages)
 		{
@@ -688,10 +758,22 @@ public class ChannelPermissionTests
 		await Assert.That(hiddenResult?.Message?.ToPlainText()).IsEqualTo(ErrorMessages.Returns.NoSuchChannel);
 		// And the lock key itself never appears.
 		await Assert.That(hiddenResult?.Message?.ToPlainText()).DoesNotContain("#1");
+
+		// God set that lock and can see the channel, so the key IS readable by someone — the mortal's
+		// refusal is the Chan_Can_Decomp gate rather than clock() failing to read a lock at all.
+		var ownerResult = await WebAppFactoryArg.FunctionParser.FunctionParse(MModule.single($"clock({hidden})"));
+		await Assert.That(ownerResult?.Message?.ToPlainText()).Contains("#1");
 	}
 
 	/// <summary>
 	/// The same oracle on <c>@clock</c>, the command half Copilot flagged.
+	///
+	/// <para>This test used to compare two notification lists that were BOTH EMPTY, because the lookup was
+	/// resolving with <c>notify: false</c> and no later branch said anything — a mistyped channel name
+	/// failed in total silence. Two empty lists are equal for any implementation, including one that stops
+	/// working entirely, so the test read as coverage and asserted nothing about the refusal. It now pins
+	/// the shared refusal TEXT, the same way
+	/// <see cref="AdminSwitchesDoNotDistinguishHiddenFromMissing"/> always did.</para>
 	/// </summary>
 	[Test]
 	public async Task ClockCommandDoesNotDistinguishHiddenFromMissing()
@@ -708,6 +790,8 @@ public class ChannelPermissionTests
 			() => Run(mortal, $"@clock/join {missing}=#{mortal.DbRef.Number}"));
 
 		await Assert.That(afterHidden).IsEquivalentTo(afterMissing);
+		await Assert.That(afterHidden).Contains(ErrorMessages.Notifications.DontRecognizeThatChannel);
+		await Assert.That(afterMissing).Contains(ErrorMessages.Notifications.DontRecognizeThatChannel);
 
 		// The lock must not have been set either.
 		// A channel that was never given a lock reads back null, not "".

--- a/SharpMUSH.Tests/Commands/ChannelPermissionTests.cs
+++ b/SharpMUSH.Tests/Commands/ChannelPermissionTests.cs
@@ -1,7 +1,12 @@
 using Mediator;
 using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using OneOf;
+using SharpMUSH.Implementation.Commands.ChannelCommand;
 using SharpMUSH.Library;
 using SharpMUSH.Library.Commands.Database;
+using SharpMUSH.Library.Definitions;
+using SharpMUSH.Library.DiscriminatedUnions;
 using SharpMUSH.Library.Extensions;
 using SharpMUSH.Library.Models;
 using SharpMUSH.Library.ParserInterfaces;
@@ -30,10 +35,45 @@ public class ChannelPermissionTests
 	private IMediator Mediator => WebAppFactoryArg.Services.GetRequiredService<IMediator>();
 	private IConnectionService ConnectionService => WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
 	private IPermissionService PermissionService => WebAppFactoryArg.Services.GetRequiredService<IPermissionService>();
+	private INotifyService NotifyService => WebAppFactoryArg.Services.GetRequiredService<INotifyService>();
 	private IMUSHCodeParser GodParser => WebAppFactoryArg.CommandParser;
 
+	/// <summary>A function-evaluating parser whose executor is <paramref name="executor"/>.</summary>
+	private IMUSHCodeParser FunctionParserFor(DBRef executor)
+		=> WebAppFactoryArg.FunctionParserFor(executor);
+
+	/// <summary>
+	/// Every message the notify mock was asked to send to <paramref name="who"/> since the last
+	/// <c>ClearReceivedCalls</c>, as plain text. Used to prove two refusals are worded identically, and
+	/// that a bulk switch never names a channel.
+	/// </summary>
+	private List<string> NotifiedMessages(DBRef who)
+		=> NotifyService.ReceivedCalls()
+			.Where(call => call.GetMethodInfo().Name == nameof(INotifyService.Notify))
+			.Select(call => call.GetArguments())
+			.Where(args => args.Length > 1 && args[0] switch
+			{
+				AnySharpObject o => o.Object().DBRef.Number == who.Number,
+				DBRef d => d.Number == who.Number,
+				_ => false
+			})
+			.Select(args => args[1] switch
+			{
+				OneOf<MString, string> m => m.Match(ms => ms.ToPlainText(), str => str),
+				MString ms => ms.ToPlainText(),
+				string str => str,
+				_ => string.Empty
+			})
+			.ToList();
+
+	/// <summary>
+	/// Channel names must be unique across the whole session — <see cref="ServerWebAppFactory"/> is
+	/// <see cref="SharedType.PerTestSession"/>, so every test in this class shares one database. A bare
+	/// six-digit random suffix collides often enough to matter; <c>GenerateUniqueName</c> adds a
+	/// millisecond timestamp. Underscores are stripped because a channel name may not contain one.
+	/// </summary>
 	private static string UniqueChannel(string prefix)
-		=> $"{prefix}{Random.Shared.Next(100000, 999999)}";
+		=> TestIsolationHelpers.GenerateUniqueName(prefix).Replace("_", string.Empty);
 
 	/// <summary>Creates a channel owned by God with exactly the given privileges.</summary>
 	private async Task<SharpChannel> CreateChannel(string name, params string[] privileges)
@@ -398,5 +438,214 @@ public class ChannelPermissionTests
 			await Run(mortimer, $"@chat {name}=Mortimer speaks.");
 			await Assert.That(await MessageCount(name)).IsEqualTo(before);
 		}
+	}
+
+	// --- Enumeration oracles: a refusal must not tell a caller what it is refusing ------------------
+
+	/// <summary>
+	/// A channel that does not exist and a channel that exists but is invisible to the caller must be
+	/// indistinguishable — in the notification AND in the return value softcode reads. A caller who can
+	/// tell them apart can enumerate every channel on the game by name.
+	///
+	/// <para>PennMUSH answers both with "CHAT: I don't recognize that channel." and
+	/// <c>#-1 NO SUCH CHANNEL</c>: the missing case in <c>test_channel_fun</c> (<c>hdrs/extchat.h:161</c>)
+	/// and the invisible case at every <c>Chan_Can_See</c> refusal in <c>src/extchat.c</c>. This
+	/// repository made the same call for scenes in PR #750 (<c>SceneHub.cs:52-57</c>).</para>
+	/// </summary>
+	[Test]
+	public async Task MissingAndInvisibleChannelsAreIndistinguishable()
+	{
+		var invisible = UniqueChannel("OracleHidden");
+		await CreateChannel(invisible, "Player", "Wizard");
+		var missing = UniqueChannel("OracleMissing");
+
+		var mortal = await CreateMortal("ChanPermOracle");
+		var parser = FunctionParserFor(mortal.DbRef);
+
+		// The function surface is where the return value is observable to a mortal's softcode.
+		var invisibleResult = await parser.FunctionParse(MModule.single($"cwho({invisible})"));
+		var missingResult = await parser.FunctionParse(MModule.single($"cwho({missing})"));
+
+		await Assert.That(invisibleResult?.Message?.ToPlainText())
+			.IsEqualTo(missingResult?.Message?.ToPlainText());
+		await Assert.That(invisibleResult?.Message?.ToPlainText())
+			.IsEqualTo(ErrorMessages.Returns.NoSuchChannel);
+
+		// And the same for the notification the command surface emits.
+		NotifyService.ClearReceivedCalls();
+		await Run(mortal, $"@channel/on {invisible}");
+		var afterInvisible = NotifiedMessages(mortal.DbRef);
+
+		NotifyService.ClearReceivedCalls();
+		await Run(mortal, $"@channel/on {missing}");
+		var afterMissing = NotifiedMessages(mortal.DbRef);
+
+		await Assert.That(afterInvisible).IsEquivalentTo(afterMissing);
+		await Assert.That(afterInvisible).Contains(ErrorMessages.Notifications.DontRecognizeThatChannel);
+		await Assert.That(afterInvisible).DoesNotContain("Channel not found.");
+	}
+
+	/// <summary>
+	/// <c>cwho()</c> is reachable from mortal softcode, so an ungated one is the <c>scenelist()</c> hole
+	/// from PR #763 again: it returned every member's dbref on any channel, named or not.
+	/// </summary>
+	[Test]
+	public async Task CwhoOnInvisibleChannelReturnsNothingUseful()
+	{
+		var name = UniqueChannel("CwhoHidden");
+		var channel = await CreateChannel(name, "Player", "Wizard");
+
+		var wizard = await CreateFlagged("ChanPermCwhoWiz", "WIZARD");
+		var wizardObject = (await Mediator.Send(new GetObjectNodeQuery(wizard.DbRef))).Known;
+		await Mediator.Send(new AddUserToChannelCommand(channel, wizardObject));
+
+		var mortal = await CreateMortal("ChanPermCwho");
+
+		var mortalResult = await FunctionParserFor(mortal.DbRef).FunctionParse(MModule.single($"cwho({name})"));
+		await Assert.That(mortalResult?.Message?.ToPlainText()).IsEqualTo(ErrorMessages.Returns.NoSuchChannel);
+		await Assert.That(mortalResult?.Message?.ToPlainText()).DoesNotContain($"#{wizard.DbRef.Number}");
+
+		// The wizard, who may see it, still gets the member list.
+		var wizardResult = await FunctionParserFor(wizard.DbRef).FunctionParse(MModule.single($"cwho({name})"));
+		await Assert.That(wizardResult?.Message?.ToPlainText()).Contains($"#{wizard.DbRef.Number}");
+	}
+
+	/// <summary>
+	/// <c>cowner()</c> and <c>cmogrifier()</c> looked a channel up without any visibility check. I had
+	/// claimed that matched PennMUSH; re-auditing showed it does not — Penn puts the gate inside
+	/// <c>find_channel</c> itself (<c>src/extchat.c:959</c>), so every channel function is gated there and
+	/// none of them is exempt.
+	/// </summary>
+	[Test]
+	public async Task ChannelReadingFunctionsAreGatedOnVisibility()
+	{
+		var name = UniqueChannel("FnHidden");
+		await CreateChannel(name, "Player", "Wizard");
+
+		var mortal = await CreateMortal("ChanPermFnRead");
+		var parser = FunctionParserFor(mortal.DbRef);
+
+		foreach (var call in new[] { $"cowner({name})", $"cmogrifier({name})", $"cwho({name})" })
+		{
+			var result = await parser.FunctionParse(MModule.single(call));
+			await Assert.That(result?.Message?.ToPlainText()).IsEqualTo(ErrorMessages.Returns.NoSuchChannel);
+		}
+	}
+
+	/// <summary>
+	/// <c>channels(&lt;object&gt;)</c> judged visibility against the OBJECT rather than the caller, so
+	/// naming a wizard read back that wizard's wizard-only channels; and its <c>on</c>/<c>off</c> arms
+	/// applied no visibility rule at all. PennMUSH <c>fun_channels</c> (<c>src/extchat.c:3313</c>) judges
+	/// against the executor and additionally hides members flagged hidden from non-Priv_Who callers.
+	/// </summary>
+	[Test]
+	public async Task ChannelsFunctionJudgesVisibilityAgainstTheCaller()
+	{
+		var name = UniqueChannel("ChansHidden");
+		var channel = await CreateChannel(name, "Player", "Wizard");
+
+		var wizard = await CreateFlagged("ChanPermChansWiz", "WIZARD");
+		var wizardObject = (await Mediator.Send(new GetObjectNodeQuery(wizard.DbRef))).Known;
+		await Mediator.Send(new AddUserToChannelCommand(channel, wizardObject));
+
+		var mortal = await CreateMortal("ChanPermChans");
+		var parser = FunctionParserFor(mortal.DbRef);
+
+		var named = await parser.FunctionParse(MModule.single($"channels(#{wizard.DbRef.Number})"));
+		await Assert.That(named?.Message?.ToPlainText()).DoesNotContain(name);
+
+		var off = await parser.FunctionParse(MModule.single("channels(me,off)"));
+		await Assert.That(off?.Message?.ToPlainText()).DoesNotContain(name);
+
+		var all = await parser.FunctionParse(MModule.single("channels()"));
+		await Assert.That(all?.Message?.ToPlainText()).DoesNotContain(name);
+	}
+
+	/// <summary>
+	/// With no channel named, <c>@channel/hide</c>, <c>/gag</c> and <c>/combine</c> walk every channel from
+	/// <c>GetChannelListQuery</c> and notify per channel, routing around
+	/// <see cref="ChannelHelper.GetVisibleChannelOrError"/> — so the argument-less form named exactly the
+	/// channels that gate exists to hide.
+	///
+	/// <para>These call the handlers directly on purpose. <c>@CHANNEL</c>'s dispatcher matches
+	/// <c>["HIDE"] when arg0 is not null</c> (GeneralCommands.cs:5036-5043), so the bulk path is
+	/// unreachable from the command surface today and no player can currently trigger the leak. The
+	/// handlers implement it regardless, and whoever wires the argument-less form — PennMUSH has it —
+	/// must not reintroduce the oracle. Testing through the dispatcher would assert nothing.</para>
+	/// </summary>
+	[Test]
+	[Arguments("hide")]
+	[Arguments("gag")]
+	[Arguments("combine")]
+	public async Task BulkSwitchesDoNotNameChannelsTheExecutorCannotSee(string switchName)
+	{
+		var name = UniqueChannel($"Bulk{switchName}");
+		await CreateChannel(name, "Player", "Wizard");
+
+		var mortal = await CreateMortal($"ChanPermBulk{switchName}");
+		var parser = WebAppFactoryArg.CommandParserFor(mortal.DbRef, mortal.Handle);
+		var locate = WebAppFactoryArg.Services.GetRequiredService<ILocateService>();
+
+		NotifyService.ClearReceivedCalls();
+
+		_ = switchName switch
+		{
+			"hide" => await ChannelHide.Handle(parser, locate, PermissionService, Mediator, NotifyService, null, null),
+			"gag" => await ChannelGag.Handle(parser, locate, PermissionService, Mediator, NotifyService, null, null, []),
+			_ => await ChannelCombine.Handle(parser, locate, PermissionService, Mediator, NotifyService, null, null)
+		};
+
+		foreach (var message in NotifiedMessages(mortal.DbRef))
+		{
+			await Assert.That(message).DoesNotContain(name);
+		}
+	}
+
+	// --- Third-party status writes need the channel's modify right ---------------------------------
+
+	/// <summary>
+	/// <c>@channel/mute</c> writes the status of a player the executor NAMES. Before this stack it wrote
+	/// against the executor instead, which made it a harmless self-mute; correcting the target without
+	/// adding authorization would have turned a no-op bug into "any non-guest may silence any member of
+	/// any channel", which is worse than the bug.
+	///
+	/// <para><c>/gag</c>, <c>/hide</c>, <c>/combine</c> and <c>/title</c> only ever write the executor's
+	/// own status and correctly require no modify right; <c>/hide</c> has its own <c>Chan_Can_Hide</c>
+	/// gate.</para>
+	/// </summary>
+	[Test]
+	public async Task MuteRequiresModifyRightsOnTheChannel()
+	{
+		var name = UniqueChannel("MuteGate");
+		var channel = await CreateChannel(name, "Player");
+
+		var victim = await CreateMortal("ChanPermMuteVictim");
+		var meddler = await CreateMortal("ChanPermMuteMeddler");
+
+		foreach (var player in new[] { victim, meddler })
+		{
+			var obj = (await Mediator.Send(new GetObjectNodeQuery(player.DbRef))).Known;
+			await Mediator.Send(new AddUserToChannelCommand(channel, obj));
+		}
+
+		var victimObject = (await Mediator.Send(new GetObjectNodeQuery(victim.DbRef))).Known;
+		// @channel/mute resolves its target by name, not dbref.
+		var victimName = victimObject.Object().Name;
+
+		await Assert.That(await PermissionService.ChannelCanModifyAsync(
+			(await Mediator.Send(new GetObjectNodeQuery(meddler.DbRef))).Known, channel)).IsFalse();
+
+		await Run(meddler, $"@channel/mute {name}={victimName}");
+
+		var afterMeddler = await ChannelHelper.ChannelMemberStatus(victimObject,
+			(await Mediator.Send(new GetChannelQuery(name)))!);
+		await Assert.That(afterMeddler!.Status.Mute ?? false).IsFalse();
+
+		// God owns the channel, so the same command from God does mute.
+		await GodParser.CommandParse(1, ConnectionService, MModule.single($"@channel/mute {name}={victimName}"));
+
+		var afterOwner = await ChannelHelper.ChannelMemberStatus(victimObject,
+			(await Mediator.Send(new GetChannelQuery(name)))!);
+		await Assert.That(afterOwner!.Status.Mute ?? false).IsTrue();
 	}
 }

--- a/SharpMUSH.Tests/Commands/ChannelPermissionTests.cs
+++ b/SharpMUSH.Tests/Commands/ChannelPermissionTests.cs
@@ -465,6 +465,19 @@ public class ChannelPermissionTests
 			await Run(mortimer, $"@chat {name}=Mortimer speaks.");
 			await Assert.That(await MessageCount(name)).IsEqualTo(before);
 		}
+
+		// Every assertion above is an ABSENCE, and six of them would read the same way against a
+		// @channel/on and a @chat that had simply stopped working for everyone. An ungated channel,
+		// created by the same command in the same test, must admit the same player and carry his speech.
+		var open = UniqueChannel("ReproOpen");
+		await GodParser.CommandParse(1, ConnectionService, MModule.single($"@channel/add {open}=player"));
+
+		await Run(mortimer, $"@channel/on {open}");
+		await Assert.That(await IsMember(open, mortimer.DbRef)).IsTrue();
+
+		var openBefore = await MessageCount(open);
+		await Run(mortimer, $"@chat {open}=Mortimer speaks.");
+		await Assert.That(await MessageCount(open)).IsEqualTo(openBefore + 1);
 	}
 
 	// --- Enumeration oracles: a refusal must not tell a caller what it is refusing ------------------

--- a/SharpMUSH.Tests/Commands/CommunicationCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/CommunicationCommandTests.cs
@@ -301,6 +301,13 @@ public class CommunicationCommandTests
 		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(NotifyService, nameof(ErrorMessages.Notifications.AliasNameCannotBeEmpty), executor, executor)).IsTrue();
 	}
 
+	/// <summary>
+	/// A channel that does not exist gets the SAME refusal as one the caller may not see —
+	/// "CHAT: I don't recognize that channel." A distinguishable "Channel not found." would let a caller
+	/// tell the two apart and enumerate the channel list, which is why <c>GetVisibleChannelOrError</c>
+	/// gives both one answer. PennMUSH words both cases identically too (<c>hdrs/extchat.h:161</c> for
+	/// missing, every <c>Chan_Can_See</c> refusal in <c>src/extchat.c</c> for invisible).
+	/// </summary>
 	[Test]
 	public async ValueTask AddComChannelNotFound()
 	{
@@ -311,7 +318,8 @@ public class CommunicationCommandTests
 		await testParser.CommandParse(testPlayer.Handle, ConnectionService, MModule.single("addcom test_alias_ADDCOM3=NonExistentChannel"));
 		await NotifyService
 			.Received(1)
-			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef), "Channel not found.", TestHelpers.MatchingObject(testPlayer.DbRef), INotifyService.NotificationType.Announce);
+			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef), ErrorMessages.Notifications.DontRecognizeThatChannel,
+				TestHelpers.MatchingObject(testPlayer.DbRef), INotifyService.NotificationType.Announce);
 	}
 
 	[Test]

--- a/SharpMUSH.Tests/Database/ChannelUniquenessTests.cs
+++ b/SharpMUSH.Tests/Database/ChannelUniquenessTests.cs
@@ -97,7 +97,8 @@ public class ChannelUniquenessTests
 		var refused = results.Count(r => r.IsNameTaken);
 		var failed = results.Where(r => r.IsError).Select(r => r.AsError).ToArray();
 
-		await Assert.That(failed).IsEmpty();
+		// Joined rather than asserted empty as a collection, so a failure prints what the storage layer said.
+		await Assert.That(string.Join(" | ", failed)).IsEqualTo(string.Empty);
 		await Assert.That(winners).IsEqualTo(1);
 		await Assert.That(refused).IsEqualTo(racers - 1);
 		await Assert.That(await CountNamed(name)).IsEqualTo(1);

--- a/SharpMUSH.Tests/Database/ChannelUniquenessTests.cs
+++ b/SharpMUSH.Tests/Database/ChannelUniquenessTests.cs
@@ -1,0 +1,105 @@
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using SharpMUSH.Library;
+using SharpMUSH.Library.Commands.Database;
+using SharpMUSH.Library.DiscriminatedUnions;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.Queries.Database;
+
+namespace SharpMUSH.Tests.Database;
+
+/// <summary>
+/// Channel names are a global namespace, and <c>CreateChannelAsync</c> — not the read-before-create in
+/// <c>ChannelAdd</c> — is what enforces it.
+///
+/// <para>Each provider reaches that guarantee differently, because each has a different primitive:
+/// ArangoDB decides the name inside the exclusive transaction it already opens, Memgraph relies on a
+/// <c>:Channel(name)</c> uniqueness constraint because snapshot isolation lets both writers observe
+/// "absent", and SurrealDB relies on the record ID, which is the channel name.</para>
+///
+/// <para>Losing the race used to mean a duplicate channel on ArangoDB and Memgraph and — worse — a silent
+/// overwrite on SurrealDB, where <c>UPSERT</c> reset <c>privs</c> and all five locks and reported success
+/// to both callers. These tests run against whichever provider
+/// <c>SHARPMUSH_DATABASE_PROVIDER</c> selects, so the matrix covers all three.</para>
+/// </summary>
+public class ChannelUniquenessTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactoryArg { get; init; }
+
+	private ISharpDatabase Database => WebAppFactoryArg.Services.GetRequiredService<ISharpDatabase>();
+	private IMediator Mediator => WebAppFactoryArg.Services.GetRequiredService<IMediator>();
+
+	private static string UniqueChannel(string prefix)
+		=> TestIsolationHelpers.GenerateUniqueName(prefix).Replace("_", string.Empty);
+
+	private async Task<SharpPlayer> God()
+		=> (await Mediator.Send(new GetObjectNodeQuery(new DBRef(1)))).AsPlayer;
+
+	private async Task<ChannelCreationResult> Create(string name, params string[] privs)
+		=> await Mediator.Send(new CreateChannelCommand(MModule.single(name), privs, await God()));
+
+	/// <summary>
+	/// Counts straight through <see cref="ISharpDatabase"/> rather than <c>GetChannelListQuery</c>, so a
+	/// cached channel list cannot hide a duplicate that is really in storage.
+	/// </summary>
+	private async Task<int> CountNamed(string name)
+		=> await Database.GetAllChannelsAsync().CountAsync(c => c.Name.ToPlainText() == name);
+
+	[Test]
+	public async Task SecondCreateOfTheSameNameIsRefusedAndLeavesOneChannel()
+	{
+		var name = UniqueChannel("UniqSeq");
+
+		var first = await Create(name, "Player");
+		var second = await Create(name, "Player");
+
+		await Assert.That(first.IsSuccess).IsTrue();
+		await Assert.That(second.IsNameTaken).IsTrue();
+		await Assert.That(await CountNamed(name)).IsEqualTo(1);
+	}
+
+	[Test]
+	public async Task RefusedCreateDoesNotResetPrivilegesOrLocks()
+	{
+		var name = UniqueChannel("UniqClobber");
+
+		await Assert.That((await Create(name, "Player", "Wizard")).IsSuccess).IsTrue();
+
+		var channel = (await Mediator.Send(new GetChannelQuery(name)))!;
+		await Mediator.Send(new UpdateChannelCommand(channel, null, null, null,
+			JoinLock: "#1", SpeakLock: "#1", SeeLock: null, HideLock: null, ModLock: null,
+			Mogrifier: null, Buffer: null));
+
+		// The privileges the second caller asks for are deliberately weaker. Under the old UPSERT this
+		// call took the channel over: privs became ["Player"] and every lock went back to "".
+		var loser = await Create(name, "Player");
+
+		await Assert.That(loser.IsNameTaken).IsTrue();
+
+		var survivor = (await Mediator.Send(new GetChannelQuery(name)))!;
+		await Assert.That(survivor.Privs).Contains("Wizard");
+		await Assert.That(survivor.JoinLock).IsEqualTo("#1");
+		await Assert.That(survivor.SpeakLock).IsEqualTo("#1");
+		await Assert.That(await CountNamed(name)).IsEqualTo(1);
+	}
+
+	[Test]
+	public async Task ConcurrentCreatesOfTheSameNameProduceExactlyOneChannel()
+	{
+		const int racers = 8;
+		var name = UniqueChannel("UniqRace");
+
+		var results = await Task.WhenAll(
+			Enumerable.Range(0, racers).Select(_ => Task.Run(async () => await Create(name, "Player"))));
+
+		var winners = results.Count(r => r.IsSuccess);
+		var refused = results.Count(r => r.IsNameTaken);
+		var failed = results.Where(r => r.IsError).Select(r => r.AsError).ToArray();
+
+		await Assert.That(failed).IsEmpty();
+		await Assert.That(winners).IsEqualTo(1);
+		await Assert.That(refused).IsEqualTo(racers - 1);
+		await Assert.That(await CountNamed(name)).IsEqualTo(1);
+	}
+}


### PR DESCRIPTION
> ## ⚠️ Read this first: any non-guest can `/wipe`, `/chown`, `/rename` or `/privs` any channel, on `main`, today
>
> `ChannelCanModifyAsync` evaluates `channel.ModLock`, and `LockService.Evaluate` returns **true** for a null or empty lock string. `CreateChannelAsync` writes only `Name`, `MarkedUpName` and `Privs` — **no channel has ever had a ModLock**. So for every channel in existence the check reduces to `!guest && ChannelCanAccess`, and any non-guest who can access a channel can `@channel/wipe`, `/chown`, `/rename`, `/privs`, `/delete`, `/describe`, `/buffer`, `/mogrifier` and `/decompile` it. `@CLOCK` carried the same defect written out by hand, so the same players could set its join, speak, see, hide and mod locks.
>
> This is live on `main` and has been reachable since #759 made channels creatable at all. It is the most serious thing this effort turned up, and it is the reason this PR is urgent.
>
> **PennMUSH avoids it by construction:** `do_chan_admin` stamps `=#<creator>` onto every channel as it is created (`src/extchat.c:1755-1763`), so Penn's mod lock is never unset and evaluating it unconditionally is safe. SharpMUSH writes no lock, so the fix skips an unset lock instead of evaluating it — the same fix, and the same reasoning, already applied to the control lock in `PermissionService.Controls`. Owner and wizard still pass, so the effective behaviour matches PennMUSH for every channel PennMUSH would have created.

---

**PR 13, the top of a linear stack.** It was written on top of PR 12 (`fix/audit2-12-channel-docs-and-myopic`) and meant to target it. #765 squash-merged that branch into `main` while this was being verified, and its head branch was deleted, so the base is `main` — with these three commits cherry-picked onto `875ab70c` so the diff is only PR 13's own 30 files. Nothing was force-pushed: the pre-rebase branch `fix/audit2-13-channel-enforcement` is still on the remote, untouched and with no PR attached; it can be deleted at leisure.

## The reproduction

Over a real telnet socket (ConnectionServer :4201, Server :8080, shared NATS, fresh ArangoDB, `ASPNETCORE_ENVIRONMENT=Production`). IAC and ANSI stripped.

### Before

```
God> @channel/add WizOnlyBEFOR=wizard player
    Channel has been created.
God> @channel/add DeadedBEFOR=player
    Channel has been created.
God> @channel/privs DeadedBEFOR=disabled
    CHAT: Channel privileges have been updated.
God> @channel/add LockedBEFOR=player
    Channel has been created.
God> @clock/join LockedBEFOR=#1
    JOIN lock set on channel LockedBEFOR.
God> @channel/what WizOnlyBEFOR
    Flags: wizard player
God> @channel/on LockedBEFOR=LoudBEFOR
    CHAT: LoudBEFOR has been added to LockedBEFOR.
God> @clock/speak LockedBEFOR=#1
    SPEAK lock set on channel LockedBEFOR.

MortimerBEFOR> @channel/on WizOnlyBEFOR
    CHAT: MortimerBEFOR has been added to WizOnlyBEFOR.
MortimerBEFOR> @chat WizOnlyBEFOR=Mortimer speaks on WizOnlyBEFOR.
    <WizOnlyBEFOR> MortimerBEFOR says, "Mortimer speaks on WizOnlyBEFOR."
MortimerBEFOR> @channel/on DeadedBEFOR
    CHAT: MortimerBEFOR has been added to DeadedBEFOR.
MortimerBEFOR> @chat DeadedBEFOR=Mortimer speaks on DeadedBEFOR.
    <DeadedBEFOR> MortimerBEFOR says, "Mortimer speaks on DeadedBEFOR."
MortimerBEFOR> @channel/on LockedBEFOR
    CHAT: MortimerBEFOR has been added to LockedBEFOR.
MortimerBEFOR> @chat LockedBEFOR=Mortimer speaks on LockedBEFOR.
    <LockedBEFOR> MortimerBEFOR says, "Mortimer speaks on LockedBEFOR."

God> @channel/who WizOnlyBEFOR
    MortimerBEFOR, God
God> @channel/who DeadedBEFOR
    MortimerBEFOR, God
God> @channel/who LockedBEFOR
    MortimerBEFOR, LoudBEFOR, God
```

A mortal joined a wizard-only channel, a DISABLED channel, and a channel whose join lock they do not pass — and spoke on all three.

### After

```
God> @channel/add WizOnlyAFTR2=wizard player
    Channel has been created.
God> @channel/add DeadedAFTR2=player
    Channel has been created.
God> @channel/privs DeadedAFTR2=disabled
    Warning: channel will be disabled.
    CHAT: Channel privileges have been updated.
God> @channel/add LockedAFTR2=player
    Channel has been created.
God> @clock/join LockedAFTR2=#1
    JOIN lock set on channel LockedAFTR2.
God> @channel/what WizOnlyAFTR2
    Flags: Wizard Player
God> @channel/on LockedAFTR2=LoudAFTR2
    CHAT: Warning: Target does not meet channel join permissions! (joining anyway)
    CHAT: LoudAFTR2 has been added to LockedAFTR2.
God> @clock/speak LockedAFTR2=#1
    SPEAK lock set on channel LockedAFTR2.

MortimerAFTR2> @channel/on WizOnlyAFTR2
    CHAT: I don't recognize that channel.
MortimerAFTR2> @chat WizOnlyAFTR2=Mortimer speaks on WizOnlyAFTR2.
    CHAT: I don't recognize that channel.
MortimerAFTR2> @channel/on DeadedAFTR2
    CHAT: I don't recognize that channel.
MortimerAFTR2> @chat DeadedAFTR2=Mortimer speaks on DeadedAFTR2.
    CHAT: I don't recognize that channel.
MortimerAFTR2> @channel/on LockedAFTR2
    Permission to join denied.
MortimerAFTR2> @chat LockedAFTR2=Mortimer speaks on LockedAFTR2.
    Sorry, you're not allowed to speak on channel <LockedAFTR2>.

LoudAFTR2> @chat LockedAFTR2=LOUD bypasses the speak lock.
    <LockedAFTR2> LoudAFTR2 says, "LOUD bypasses the speak lock."

God> @channel/who WizOnlyAFTR2
    God
God> @channel/who DeadedAFTR2
    God
God> @channel/who LockedAFTR2
    LoudAFTR2, God
```

Note `Flags: wizard player` → `Flags: Wizard Player`: privileges are now stored in the canonical casing of PennMUSH's `chan_privs` table. That casing is the reason none of this worked (below).

## This is pre-existing, and not a regression from this stack

`git log --all -S "PermissionService.ChannelCanJoin"` returns nothing: the join gate has never had a caller anywhere in this repository's history. #759's only edit to `ChannelOn.cs` was adding a duplicate-membership check. It was unreachable before #759 because channels were not creatable at all. Nobody needs to bisect for it.

## Root cause

Seven of the nine channel permission methods on `IPermissionService` had no caller outside `PermissionService` itself — `ChannelOkType`, `ChannelStandardCan`, `ChannelCanPrivate`, `ChannelCanJoin`, `ChannelCanSpeak`, `ChannelCanCemit`, `ChannelCanHide`. Only `ChannelCanSeeAsync` and `ChannelCanModifyAsync` were wired, which is why the channel ADMIN commands were gated and joining and speaking were not. `ChannelOn.Handle` ran from `GetChannelOrError` to "already on?" to `AddUserToChannelCommand` with nothing in between.

`ChannelHelper.GetChannelOrError` took an `IPermissionService` and never touched it, which made all twenty-odd of its call sites read as though a permission check had already happened. That parameter is gone; callers that want a gate now ask for one by name (`GetVisibleChannelOrError`, `JoinRefusal`, `SpeechRefusal`, `CemitRefusal`).

## Audit of the seven unwired methods

None of their string literals had ever been evaluated. Three were wrong:

1. **`ChannelCanHide` read `Privs.Contains("CanHide")`.** The privilege is `Hide_Ok` in `chan_privs`, which is what `@channel/add` writes. The branch could never be true.
2. **`ChannelCanPrivate` was `Chan_Can_Priv` inverted.** PennMUSH is `Wizard(p) || Chan_Can(p, t)` (`hdrs/extchat.h:203`); this was `!Wizard(p) || Chan_Can(p, t)`, so everyone *except* a wizard passed unconditionally. Its argument was the channel rather than the type being set, which is what the macro takes. Renamed `ChannelCanPriv` and given `string[] channelType`.
3. **Every check compared with an ordinal `Contains`.** Privileges reach the database from raw user input: `@channel/add Foo=wizard` persisted the literal `"wizard"`, so `Privs.Contains("Wizard")` answered "no wizard privilege" for a channel whose `@channel/what` plainly said `Flags: wizard`. This defeated the two methods that *were* wired as well as the five that were not — `@clist` was showing mortals wizard-only channels. Names are now normalised on write and compared case-insensitively through `SharpChannelExtensions.HasPriv`.

`ChannelOkType`, `ChannelStandardCan`, `ChannelCanJoin`, `ChannelCanSpeak` and `ChannelCanCemit` were otherwise faithful.

## Semantics implemented

From `pennmush/hdrs/extchat.h:196-222`, verbatim:

| Macro | Header line | Wired at |
|---|---|---|
| `Chan_Ok_Type` | 196 | `@channel/on`, `@chat`, `@cemit`, `@nscemit`, `cemit()`, `nscemit()` |
| `Chan_Can` (DISABLED / WIZARD / ADMIN) | 198 | inside `ChannelStandardCan`, so it gates join, speak, see, hide and modify from one place |
| `Chan_Can_Priv` | 203 | `@channel/privs` |
| `Chan_Can_Join` | 204 | `@channel/on`, `addcom` |
| `Chan_Can_Speak` | 206 | `@chat` |
| `Chan_Can_Cemit` | 208 | `@cemit`, `@nscemit`, `cemit()`, `nscemit()` |
| `Chan_Can_See` | 212 | every command and function that reads channel state |
| `Chan_Can_Hide` | 216 | `@channel/hide` |
| `Chan_Can_Decomp` | 221 | `clock()` |

Refusal strings are PennMUSH's, taken from `src/extchat.c` (`:1241`, `:1263`, `:1267`, `:1355`, `:1533`, `:1541`, `:1545`, `:1636`, `:1737`, `:1833`, `:2002`) rather than invented.

`@channel/on` and `@channel/off` now also require control of a named target (`extchat.c:1250`, `:1289`). Either could previously be pointed at any player: a mortal could remove anyone from any channel.

The channel **function** surface was bypassing the command-level gates the same way `scenelist()` did in #763. Every function that resolves a channel by name now requires `Chan_Can_See` — `cflags`, `clflags`, `cdesc`, `cbuffer`, `cusers`, `cmsgs`, `cinfo`, `ctitle`, `cstatus`, `crecall`, `cbufferadd`, `cwho`, `cowner`, `cmogrifier` — because that is where Penn puts it: `find_channel` itself returns `CMATCH_NONE` unless `Chan_Can_See(chan, player) || onchannel(player, chan)` (`src/extchat.c:959`). `clock()` requires `Chan_Can_Decomp` (`extchat.c:3437`) — it was handing every channel's join/speak/see/hide/mod lock key to any mortal who asked. `channels()` was rewritten to follow `fun_channels` (`extchat.c:3313-3375`).

> **Correction.** An earlier version of this description claimed `cowner`, `cmogrifier` and `cwho` "stay ungated, as they are in Penn". That was wrong, and review caught it — see the round-two section below.

## LOUD

Seeded as a flag in all three provider migrations and consulted nowhere. `hlp/pennflag.hlp:256`: "LOUD objects bypass all speech, channel speech, and interaction @locks." Penn tests it at the call site, not inside the macro (`src/extchat.c:1539`: `if (!Loud(player) && !Chan_Can_Speak(chan, player))`), so `ChannelHelper.SpeechRefusal` does the same. It deliberately does **not** bypass `@cemit`, because `do_cemit` does not consult it.

## `@channel/privs`

Fixed, both halves. It now applies its argument *to* the channel's existing privileges and honours `!priv`, as `string_to_privs(table, str, origprivs)` does (`src/privtab.c:36`). It used to replace the set outright, so `@channel/privs Pub=quiet` silently dropped the `Player` bit and left a channel nobody was the right type for.

One deviation, stated rather than hidden: PennMUSH's `string_to_privs` does **prefix** matching on names; this does exact case-insensitive matching, as the existing parser did. Single-character aliases stay case-sensitive, since `O` is Object and `o` is Open.

## Two deliberate behaviour changes worth review

- **`@channel/add <name>=disabled` is now refused for everybody, wizards included.** That is `Chan_Can`, which is false for the DISABLED bit for every player (`extchat.c:1736`), so Penn refuses it too and its "channel will be created disabled" warning at `:1741` is unreachable. A wizard reaches the same state through `@channel/privs`, where `Chan_Can_Priv`'s `Wizard(p) ||` escape applies. The reproduction above uses that path.
- **A wizard who fails only a join lock is warned and joined anyway**, per `extchat.c:1261-1268` and `:1353-1362`. The brief asked for "disabled channel: everyone refused, including a wizard"; that holds exactly for *speaking* (`do_chat` has no override, and `DisabledChannel_RefusesWizardSpeech` asserts it), but Penn's join path does have one and this follows Penn. Visible in the After transcript as `CHAT: Warning: Target does not meet channel join permissions! (joining anyway)`.

## Also fixed, found while wiring the gates

- `@channel/gag` read and wrote `SharpChannelStatus.Hide`, so gagging a channel hid you from its who-list and left you hearing every word, and `/gag` and `/hide` fought over one field.
- `@channel/mute` wrote the status against the executor rather than the player it had just located, so muting somebody muted yourself.
- `@channel/hide` had its branch inverted — naming a channel hid you on *every* channel, and naming none passed a null name to a lookup that cannot take one — and its "already in that state" test read `status?.Hide ?? false == hideOn`, which binds as `status?.Hide ?? (false == hideOn)`.
- `ChannelCommandTests` built its fixture channel with `Open` alone. A channel with no `Player` privilege admits no players; harmless only while the type gate went unenforced.

## Verification

New `SharpMUSH.Tests/Commands/ChannelPermissionTests.cs`, 15 cases, one per required behaviour plus the end-to-end reproduction.

**Confirmed failing before the fix** — same tests, source reverted, tests kept:

```
failed ChannelPrivsAddsToExistingPrivilegesAndNegates       Expected to contain Player
failed ChannelAddStoresPrivilegesInCanonicalCasing          Expected to contain Wizard
failed NoCemitChannel_RefusesCemitFromSomeoneWhoMaySpeak    Expected to be 0
failed WizardChannel_RefusesMortalSpeech                    Expected to be 0
failed HideOkChannel_PermitsHidingAndPlainChannelDoesNot    Expected to be true
failed AdminChannel_RefusesMortalAndAdmitsRoyalty           Expected to be false
failed DisabledChannel_RefusesMortalJoin                    Expected to be false
failed DisabledChannel_RefusesWizardSpeech                  Expected to be 0
failed MortalCannotJoinOrSpeakOnAnyGatedChannel             Expected to be false
failed SpeakLock_RefusesFailingPlayerAndAdmitsPassingPlayer Expected to be 0
failed WizardChannel_RefusesMortalAndAdmitsWizard           Expected to be false
failed JoinLock_RefusesFailingPlayerAndAdmitsPassingPlayer  Expected to be false
  total: 15  failed: 12  succeeded: 3
```

The three that passed pre-fix are the permit-halves (`AdminChannel_AdmitsChatPrivsPower`, `LoudPlayer_BypassesSpeakLock`, `PlayerOnlyChannel_RefusesAThing`), which pass trivially when nothing is gated.

**Provider matrix, all six legs green:**

| Leg | Result |
|---|---|
| `SharpMUSH.Tests` arangodb | 5280 passed, 0 failed, 192 skipped |
| `SharpMUSH.Tests` memgraph | 5280 passed, 0 failed, 192 skipped |
| `SharpMUSH.Tests` surrealdb | 5280 passed, 0 failed, 192 skipped |
| `SharpMUSH.Tests.Integration` arangodb | 323 passed, 0 failed |
| `SharpMUSH.Tests.Integration` memgraph | 323 passed, 0 failed |
| `SharpMUSH.Tests.Integration` surrealdb | 323 passed, 0 failed |

The known surrealdb `wiki_translation` write-conflict flake did not fire on this run.

One unrelated flake seen on an arangodb unit run: `CreateAndLocate(create({0}), locate(%#,{0},*))`, `Expected "#-1" but received "#1534"`. It passes in isolation twice out of two and fails only under full-suite ordering; it is a `create()`/`locate()` isolation problem with nothing to do with channels. Recorded, not mine.

`dotnet build` (format verification on): 0 errors. Code warnings identical to base — `14 × CS0067` on both `b4b385d1` and this branch. `TreatWarningsAsErrors` untouched, no suppressions added.

---

## Round two: six review findings, all valid, fixed in 8f4f5fe6

Four CodeRabbit (Major / Security & Privacy) and two Copilot. None was a false positive, and one of them was a hole I opened.

### 1. The visibility gate was itself an enumeration oracle

`GetVisibleChannelOrError` passed `notify` straight through to the raw lookup, so a **missing** channel answered `"Channel not found."` and an **invisible** one answered `"CHAT: I don't recognize that channel."` — and the return values differed too, `#-1 CHANNEL NOT FOUND` against a doc comment promising `#-1 NO SUCH CHANNEL`. Either difference lets a caller walk the channel list; the return value is the worse half because softcode reads it.

Both paths now emit one notification and one return code. PennMUSH agrees, so there was no Penn behaviour to weigh against the safe one: `test_channel_fun` (`hdrs/extchat.h:161`) answers a missing channel with exactly the pair every `Chan_Can_See` refusal in `extchat.c` uses for an invisible one. This repository decided the same thing for scenes in PR #750, recorded at `SceneHub.cs:52-57` and `SceneLive.razor:120-124`; the new XML doc cites it.

The gate now also passes for a **member**, per `find_channel` (`extchat.c:959`) — `Chan_Can_See` requires a member to also pass `Chan_Can_Speak`, so without it a gagged or speak-locked member was told their own channel did not exist.

### 2. `@channel/mute` — a hole this PR opened

The "Gag the channel, and mute the player who was named" commit corrected `/mute` to write against the named player. It used to write against the executor, which made it a harmless self-mute; correcting the target without adding authorization turned a no-op bug into **any non-guest silencing any member of any channel**. Now gated on `ChannelCanModifyAsync`.

The other status-writing switches were audited independently, since the question is per-switch:

| Switch | Writes whose status | Modify right |
|---|---|---|
| `/mute` | a **named** player | **required** — added |
| `/gag` | the executor's own | not required |
| `/hide` | the executor's own | not required (has its own `Chan_Can_Hide` gate) |
| `/combine` | the executor's own | not required |
| `/title` | the executor's own | not required |

### 3. …and that gate did nothing until a second hole was fixed

`ChannelCanModifyAsync` evaluates `channel.ModLock`, and an empty lock string evaluates **true**. PennMUSH survives the same shape because it never leaves the lock unset — `do_chan_admin` stamps `=#<creator>` on every channel at creation (`extchat.c:1755-1763`). `CreateChannelCommand` writes no lock, so **every non-guest already had modify rights on every channel in the game**: `@channel/privs`, `/rename`, `/wipe`, `/decompile`, and now `/mute`. An unset mod lock is now skipped rather than evaluated — the same fix, and the same reasoning, as the control lock in `PermissionService.Controls`.

Found by the `/mute` test, which passed for the wrong reason until this was fixed.

### 4. Bulk switches enumerated hidden channels

`@channel/hide` with no channel named walks every channel and names each one back to the executor, routing around the gate. The sweep found `/gag` and `/combine` doing the same. All three now filter through `ChannelHelper.VisibleChannels`.

**Reachability, checked not assumed:** `@CHANNEL`'s dispatcher matches `["HIDE"] when arg0 is not null` (`GeneralCommands.cs:5036-5043`), so the argument-less form falls through to the usage line and **no player can trigger this today**. The handlers implement it anyway and Penn has the argument-less form, so the tests call the handlers directly — through the dispatcher they would assert nothing.

`@channel/list` and `@channel/what` were confirmed (not assumed) already filtering on `ChannelCanSeeAsync`.

### 5. `@channel/who`, `cwho()` — and two more the re-audit found

Both returned member names and dbrefs with no visibility check, `cwho` discarding the executor entirely. `cwho` is reachable from mortal softcode, so it was the `scenelist()` hole from #763 again.

Re-auditing the whole function surface found **`cowner()` and `cmogrifier()` ungated as well**, and disproved a claim in this description: Penn does not leave them ungated, it gates every channel function inside `find_channel`. Corrected above.

**`channels()` was worse than either**, and is a finding beyond the reported sites:

1. Its `on`/`off` arms applied **no visibility rule at all** — `channels(me,off)` listed every channel in the game by name.
2. Its default arm judged visibility against the **object asked about**, not the caller, so naming a wizard read back that wizard's wizard-only channels.

Rewritten to follow `fun_channels` (`extchat.c:3313-3375`): judged against the executor, `Can_Examine` short-circuit, and members flagged hidden withheld from callers without `Priv_Who`.

### 6. Test-helper collision

`UniqueChannel` used a bare six-digit random suffix against a session-shared database; now `TestIsolationHelpers.GenerateUniqueName`, which adds a millisecond timestamp.

### Also fixed while doing the above

`VisibleChannels` and `channels()` materialise the channel list before testing each entry. The per-channel test reads `channel.Members`, and Core.Arango 3.12.x **faults on a thread pool thread and takes the process down** when one `ExecuteStreamAsync` is enumerated inside another — the full suite crashed with an unhandled `NullReferenceException` until this was changed. The same driver race is already worked around in `HelperFunctions.HasPower`.

Two existing tests asserted the old `"Channel not found."` wording and now assert the unified refusal.

### Verification, round two

7 new tests (23 in the class). **Confirmed failing before the fixes**, source reverted and tests kept:

```
failed ChannelReadingFunctionsAreGatedOnVisibility
failed MissingAndInvisibleChannelsAreIndistinguishable
failed BulkSwitchesDoNotNameChannelsTheExecutorCannotSee(hide)
failed CwhoOnInvisibleChannelReturnsNothingUseful
failed ChannelsFunctionJudgesVisibilityAgainstTheCaller
failed MuteRequiresModifyRightsOnTheChannel
  total: 23  failed: 6  succeeded: 17
```

The `gag` and `combine` cases of the bulk test are order-dependent — those two handlers `return` on the first non-member channel instead of continuing, so they expose one name per call rather than all of them. The `hide` case is the deterministic one and it fails without the fix.

**Provider matrix re-run, all six legs green:**

| Leg | Result |
|---|---|
| `SharpMUSH.Tests` arangodb | 5288 passed, 0 failed, 192 skipped |
| `SharpMUSH.Tests` memgraph | 5288 passed, 0 failed, 192 skipped |
| `SharpMUSH.Tests` surrealdb | 5288 passed, 0 failed, 192 skipped |
| `SharpMUSH.Tests.Integration` arangodb | 323 passed, 0 failed |
| `SharpMUSH.Tests.Integration` memgraph | 323 passed, 0 failed |
| `SharpMUSH.Tests.Integration` surrealdb | 323 passed, 0 failed |

The known surrealdb `wiki_translation` flake did not fire. `dotnet build` with the format gate on: 0 errors, no new warnings, no suppressions.

---

## Round three: the ungated-lookup sweep

Review flagged `clock()` and `@CLOCK`. Those were two of **sixteen** call sites still on the ungated `GetChannelOrError`, so all sixteen were swept and decided individually. The pattern that made this hard to see: on nine of them the **authorization was already correct** and the oracle was open anyway — `"Channel not found."` came from the lookup, `"You cannot modify this channel."` came from the gate.

| # | Site | Decision | Reason |
|---|---|---|---|
| 1 | `ChannelDecompile` | → visible | not-found vs `ChannelCanModifyAsync` refusal are worded differently |
| 2 | `ChannelChown` | → visible | as above |
| 3 | `ChannelMogrifier` | → visible | as above |
| 4 | `ChannelBuffer` | → visible | as above |
| 5 | `ChannelWipe` | → visible | as above |
| 6 | `ChannelDelete` | → visible | as above |
| 7 | `ChannelDescribe` | → visible | as above |
| 8 | `ChannelPrivs` | → visible | as above |
| 9 | `ChannelRename` | → visible | as above |
| 10 | `ChannelRecall` | → visible | not-found vs `"Player is not a member of the channel."` |
| 11 | `ChannelTitle` | → visible | not-found vs the not-on-channel refusal |
| 12 | `ChannelOff` | → visible | not-found vs the control/modify refusal |
| 13 | `ChannelFunctions` `clock()` | → visible | **flagged by Copilot.** `#-1 NO SUCH CHANNEL` vs `#-1 PERMISSION DENIED`, readable from mortal softcode |
| 14 | `MoreCommands` `@CLOCK` | → visible **+ authorization fix** | same oracle, **and** it rewrote `Chan_Can_Modify` by hand and carried the ModLock defect — see below |
| 15 | `ChannelAdd` | **keep raw** | must test name uniqueness against *all* channels; a visible lookup would report "no such channel" for a hidden one and create a duplicate. PennMUSH's `ok_channel_name` does the same and leaks the same residual "that name is taken". Documented in the code. |
| 16 | `ChannelCommands` `delcom` | **keep raw** | resolves a channel only to remove the executor from it; lookup is silent, result decides nothing observable, `delcom` answers "Alias deleted." either way. A visible lookup would strand a membership the player can no longer reach. Documented in the code. |

### Beyond the two that were flagged

**`@CLOCK` carried the ModLock hole a second time.** Its check was `Chan_Can_Modify` written out by hand — `isOwner || string.IsNullOrEmpty(channel.ModLock) || Evaluate(...) || IsWizard` — so the middle term was true for every channel and any non-guest could set any lock on any channel they could see. Fixing `ChannelCanModifyAsync` did not reach it, because `@CLOCK` never called it. It does now.

### Factory refactor (CodeRabbit, Trivial)

Taken — I added the fourth copy myself in the previous commit. The four `MUSHCodeParser` constructions collapse to one `BuildParser`, **−121/+27**. It also settled a real inconsistency: `FunctionParser` alone built `FunctionRecursionDepths` case-sensitively, and MUSH function names are not case-sensitive.

### Verification, round three

12 new tests (35 in the class). **All 12 confirmed failing before the sweep**, source reverted and tests kept:

```
failed ClockFunctionDoesNotDistinguishHiddenFromMissing
failed ClockCommandDoesNotDistinguishHiddenFromMissing
failed ClockRequiresModifyRightsOnTheChannel
failed AdminSwitchesDoNotDistinguishHiddenFromMissing(decompile|wipe|delete|recall|describe|buffer|privs|title|off)
  total: 35  failed: 12  succeeded: 23
```

**Provider matrix, all six legs green:**

| Leg | Result |
|---|---|
| `SharpMUSH.Tests` arangodb / memgraph / surrealdb | 5300 passed, 0 failed, 192 skipped (each) |
| `SharpMUSH.Tests.Integration` arangodb / memgraph / surrealdb | 323 passed, 0 failed (each) |

One regression of my own, caught and fixed before pushing: the round-two tests called `NotifyService.ClearReceivedCalls()` on a mock shared for the whole session, which deleted calls other tests were about to assert on and made `MailCommand`, `Flag_Delete_RemovesNonSystemFlag` and `Test_Respond_StatusLine_TooLong` fail at random. They were changed to snapshot a call index instead — which was also wrong, and is fixed properly in round four below.

`dotnet build` with the format gate on: 0 errors, no new warnings, no suppressions.

---

## Round four: channel name uniqueness, and a create that reported success when it failed

The last three review threads. All three were valid. The first was filed as "Heavy lift" and I deferred it; that was wrong, and the correction was that the machinery it needed already existed.

### 1. `ChannelAdd` read before it created, and nothing made the two atomic

`ChannelAdd` looks the name up, finds nothing, and creates — several `await`s later, outside any transaction. Losing that race was a different failure on each provider, so each got the cheapest mechanism that is actually correct for it rather than one mechanism copied three times.

| Provider | Was | Mechanism now | New index/constraint? |
|---|---|---|---|
| ArangoDB | duplicate channel | the exclusive transaction **that was already there** | **no** — see below |
| Memgraph | duplicate channel | `CREATE CONSTRAINT ON (c:Channel) ASSERT c.name IS UNIQUE` | yes, and it is the only mechanism available |
| SurrealDB | **overwrite** | `CREATE` instead of `UPSERT`, + an in-process gate | no — the unique index it already had is irrelevant here |

**ArangoDB needed no new machinery at all.** `CreateChannelAsync` already opened a transaction holding an `Exclusive` lock on `Channels`, `OwnerOfChannel` and `OnChannel` for its whole lifetime. The existence check simply was not inside it. It is now — one AQL `FILTER c.Name == @name LIMIT 1` on the transaction handle — and that is sufficient: a second creator either waits on the lock or reads the committed winner.

**No unique index was added on ArangoDB, deliberately.** It would be redundant with an exclusive lock held on the only path that writes channels, and it cannot be created at all on a database that already holds duplicates — which is exactly the state this bug produces. Memgraph's constraint carries the same limitation, so a database that cannot take it logs a warning and carries on instead of failing start-up; the alternatives are deleting somebody's channel or renaming it behind their back, and neither belongs in a boot-time migration.

**Memgraph is the one that genuinely needs a constraint.** It runs `IN_MEMORY_TRANSACTIONAL` at snapshot isolation, so a `MATCH`-then-`CREATE` in a single query still lets two concurrent writers both observe "absent" and both create. Only the constraint rejects the loser at commit. The comment in `MemgraphDatabase.Migration.cs` claiming the containers run `IN_MEMORY_ANALYTICAL` was stale — `MemgraphTestServer.cs:26` and `MemgraphBaseBenchmark.cs:36` both say `IN_MEMORY_TRANSACTIONAL`, and analytical mode enforces no constraints, so the comment described a configuration in which this fix could not work. Corrected.

**SurrealDB was the worst case, and its unique index could never have caught it.** `channel_name ON channel FIELDS name UNIQUE` has existed the whole time and is irrelevant: the record ID *is* the channel name, so `UPSERT channel:⟨$name⟩ SET …` did not duplicate on a collision, it **overwrote** — unconditionally, every field. `privs` became whatever the second caller asked for and all five locks reset to `''`. A wizard-only, join-locked channel silently became an unrestricted one and **both** callers were told the create succeeded. Overwriting one record violates no uniqueness index.

`CREATE` fails on an existing record ID, which closes the deterministic case. Two more things surfaced only under the full suite:

- SurrealDB does not queue concurrent writers to one record, it fails their commit — *"Failed to commit transaction due to a read or write conflict. This transaction can be retried."* So the eight-way race answered `Error` for the seven losers rather than `ChannelNameTaken`: true, and useless to a player. That one signal is now retried, bounded at eight attempts with the same exponential backoff and jitter Memgraph's `ExecuteWithRetryAsync` uses; the retry finds the winner's record and the `CREATE` reports "already exists". Every other error is still surfaced unretried.
- Retrying was still not enough. Under contention **two `CREATE`s on the same record ID were observed both committing** (`Expected to be 1 but found 2`) — the same overwrite, reached through optimism instead of through `UPSERT`. SurrealDB is **embedded** here, `SurrealDb.Embedded.InMemory` or the RocksDB engine inside the server's own process (`Startup.cs:167-190`), so one process owns the entire store and a `SemaphoreSlim` around the create is a complete guarantee rather than an approximation of one. The same reasoning already produced the in-memory object-key counter at `SurrealDatabase.cs:214-220`. ArangoDB and Memgraph deliberately get no equivalent: they are real servers with other possible clients, so an in-process lock would guarantee nothing there.

**And the create reported success when it failed.** ArangoDB's `catch { await AbortAsync(...); }` had no rethrow and no result, so a schema violation, a missing owner or a dropped connection all returned to the caller looking exactly like a created channel. `CreateChannelAsync` now returns `ChannelCreationResult` — `OneOf<Success, ChannelNameTaken, Error<string>>`, per the repo's DU convention — on all three providers, and `ChannelAdd` says which of the three happened (`CHAT: Channel already exists.` / `CHAT: The channel could not be created.` / `Channel has been created.`). The abort is now unconditional too: skipping it when `CommitAsync` itself threw left a transaction holding the exclusive lock on `Channels` until it expired, which blocks every other channel create.

**The raw lookup in `ChannelAdd` is unchanged**, as the previous round required. It is now documented as what it actually is: a fast path for the friendly message, not the guarantee. Uniqueness must be tested against *every* channel including ones the caller cannot see, exactly as PennMUSH's `ok_channel_name` (`src/extchat.c:1855-1870`) does, and a visibility-gated lookup there would let a hidden channel be created over.

### 2. `@CLOCK` failed in silence, and its own test could not fail

`notify: false` on the lookup, and no later branch spoke on the not-found path, so a mistyped channel name produced **no output at all** while every other channel command in this stack answers `CHAT: I don't recognize that channel.` The reasoning that produced `notify: false` was wrong on its own terms: the gate emits **one** refusal for both the missing and the invisible case, so suppressing it never made the two cases more alike — it made both of them silent.

The paired test was the worse half. `ClockCommandDoesNotDistinguishHiddenFromMissing` compared two notification lists that were **both empty**. Two empty lists are equal for any implementation, including one that has stopped working. It now pins the shared refusal text, the way `AdminSwitchesDoNotDistinguishHiddenFromMissing` already did. Confirmed failing with `notify: false` restored:

```
AssertionException: Expected to contain CHAT: I don't recognize that channel.
but the item was not found in the collection
at Assert.That(afterHidden).Contains(ErrorMessages.Notifications.DontRecognizeThatChannel)
```

**Every other test this PR added was audited for the same defect** — an assertion of absence with nothing asserting presence. Nine were found, and each got a positive anchor:

| Test | Was | Anchor added |
|---|---|---|
| `ClockCommandDoesNotDistinguishHiddenFromMissing` | two empty lists compared | the shared refusal text must be present in both |
| `ChannelsFunctionJudgesVisibilityAgainstTheCaller` | three `DoesNotContain` and nothing else — it passed equally against a `channels()` that returned `""` | a shared channel must be PRESENT in the same answer; `channels(me,on)` checked too |
| `BulkSwitchesDoNotNameChannelsTheExecutorCannotSee` | asserted absence by iterating a collection that may be empty, which asserts nothing | the bulk path must have said something; for `/hide`, the deterministic case, it must have named a channel the executor CAN see, proving the walk happened |
| `ChannelReadingFunctionsAreGatedOnVisibility` | pinned only the refusal | a viewer who passes the gate must get a real answer from the same call |
| `ClockFunctionDoesNotDistinguishHiddenFromMissing` | pinned only the refusal | the owner must get the lock back from the same call |
| `WizardChannel_RefusesMortalSpeech` | a counter did not move | the counter must move for someone the gate admits |
| `DisabledChannel_RefusesWizardSpeech` | a counter did not move | as above |
| `DisabledChannel_RefusesMortalJoin` | a membership was absent | a live channel must admit the same player |
| `MortalCannotJoinOrSpeakOnAnyGatedChannel` | **all six** of its assertions were absences — it read exactly the same way against a `@channel/on` and a `@chat` that had stopped working for everybody | an ungated channel, created by the same command in the same test, must admit the same player and carry his speech |

### 3. `ReceivedCalls()` is not safe to enumerate concurrently — and moving the race is not fixing it

Two earlier shapes were both wrong, and both were mine. First: `ClearReceivedCalls()` on a substitute shared for the whole session, which under TUnit's parallel execution deleted calls other tests were about to assert on — it made `MailCommand`, `Flag_Delete_RemovesNonSystemFlag` and `Test_Respond_StatusLine_TooLong` fail at random. Second: snapshot a call index instead. But `ReceivedCalls().Count()` and `.Skip(n)` **still enumerate the shared substitute while every other test records into it**. That narrowed the window from "the whole suite" to "the length of one enumeration"; it stopped reproducing, which is not the same as being fixed. NSubstitute's threading contract is that verification and production activity must not overlap, and 5.3.0 offers no guarantee for enumeration under concurrent recording.

**Why it is now actually safe, and not merely less likely to fire: no NSubstitute state is read at all.** `TestHelpers.CreateNotifyServiceSubstitute` already had a `When`/`Do` delivery callback — it mirrors `IHttpOutputCapture` so HTTP integration tests do not see empty bodies. That callback now also writes into a `TestHelpers.NotificationRecorder`, on the calling thread, at delivery time. The recorder is a `ConcurrentDictionary<int, ConcurrentQueue<string>>` keyed by recipient:

- `ReceivedCalls()` is never touched, so there is no NSubstitute call log being enumerated and nothing for a concurrent recording to invalidate.
- `ConcurrentQueue.ToArray()` is a point-in-time snapshot that cannot throw while another thread enqueues — that is the type's documented contract, not an empirical observation.
- Recipient bucketing gives isolation on top of that: every test in this class creates a uniquely named player, so no other test writes into the bucket being read.
- `When`/`Do` does not change call recording, so the `Received()`-style assertions elsewhere in the suite are unaffected.

### Verification, round four

New `SharpMUSH.Tests/Database/ChannelUniquenessTests.cs`, 3 cases: a sequential second create, a create that must not reset the winner's privileges or locks, and an eight-way concurrent create. Each asserts that exactly one channel with the name exists afterwards, counted straight through `ISharpDatabase` so a cached channel list cannot hide a duplicate.

**All three confirmed failing on every provider**, with that provider's fix alone reverted and the tests kept.

ArangoDB, in-transaction existence check removed:

```
failed SecondCreateOfTheSameNameIsRefusedAndLeavesOneChannel
  Expected to be true   at Assert.That(second.IsNameTaken).IsTrue()
failed ConcurrentCreatesOfTheSameNameProduceExactlyOneChannel
  Expected to be 1      at Assert.That(winners).IsEqualTo(1)
failed RefusedCreateDoesNotResetPrivilegesOrLocks
  Expected to be true   at Assert.That(loser.IsNameTaken).IsTrue()
  total: 3  failed: 3  succeeded: 0
```

Memgraph, constraint replaced by the plain non-unique index it had before:

```
failed SecondCreateOfTheSameNameIsRefusedAndLeavesOneChannel
  Expected to be true   at Assert.That(second.IsNameTaken).IsTrue()
failed ConcurrentCreatesOfTheSameNameProduceExactlyOneChannel
  Expected to be 1      at Assert.That(winners).IsEqualTo(1)
failed RefusedCreateDoesNotResetPrivilegesOrLocks
  Expected to be true   at Assert.That(loser.IsNameTaken).IsTrue()
  total: 3  failed: 3  succeeded: 0
```

SurrealDB, `UPSERT` restored:

```
failed SecondCreateOfTheSameNameIsRefusedAndLeavesOneChannel
  Expected to be true   at Assert.That(second.IsNameTaken).IsTrue()
failed RefusedCreateDoesNotResetPrivilegesOrLocks
  Expected to be true   at Assert.That(loser.IsNameTaken).IsTrue()
failed ConcurrentCreatesOfTheSameNameProduceExactlyOneChannel
  Expected to be 1      at Assert.That(winners).IsEqualTo(1)
  total: 3  failed: 3  succeeded: 0
```

`RefusedCreateDoesNotResetPrivilegesOrLocks` is the SurrealDB-specific one: it creates the channel `Player Wizard`, sets a join and a speak lock, then creates over it with `Player` alone and asserts the survivor still carries `Wizard` and both locks. That is the overwrite, reproduced and closed.

**Provider matrix, all six legs green:**

| Leg | Result |
|---|---|
| `SharpMUSH.Tests` arangodb | 5303 passed, 0 failed, 192 skipped |
| `SharpMUSH.Tests` memgraph | 5303 passed, 0 failed, 192 skipped |
| `SharpMUSH.Tests` surrealdb | 5303 passed, 0 failed, 192 skipped |
| `SharpMUSH.Tests.Integration` arangodb | 323 passed, 0 failed |
| `SharpMUSH.Tests.Integration` memgraph | 323 passed, 0 failed |
| `SharpMUSH.Tests.Integration` surrealdb | 323 passed, 0 failed |

Recorded rather than hidden: one memgraph full-suite run failed `AdminChannel_RefusesMortalAndAdmitsRoyalty` once. It passed on the immediately preceding and immediately following full runs of the same Memgraph code, and nothing in this round touches that path — it is a round-one test about the ADMIN privilege, not about creation. Not reproduced, not diagnosed, recorded.

`dotnet build` with the format gate on: 0 errors, no new code warnings, no suppressions, `TreatWarningsAsErrors` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MPRzndB5egy4F2A3q5852


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stronger channel access controls for joining, speaking, emitting, hiding, and managing members.
  * Channel visibility is now respected across lookups, listings, messaging, member views, and bulk operations.
  * Channel privileges support additions, removals, and consistent case handling.
  * Added clearer notifications for denied actions, unsupported channel types, guest restrictions, and channel disable warnings.

* **Bug Fixes**
  * Corrected channel muting so it applies to the selected player.
  * Improved hiding behavior for individual and bulk channel actions.
  * Prevented invisible channels from being revealed through lookup, lock inspection, or bulk operations.
  * Enforced appropriate permissions when changing channel locks and member status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


