### PR TITLE
Typed object/attribute API so the Softcode Editor can store newlines

### DIFF
--- a/SharpMUSH.Client/Pages/SoftcodeEditor.razor
+++ b/SharpMUSH.Client/Pages/SoftcodeEditor.razor
@@ -326,6 +326,10 @@
         // two indistinguishable — an intentional %r looked like formatting and a real newline
         // came back as %r on the next save.
         public string WorkingContent { get; set; } = attr.Value;
+
+        /// <summary>What the database holds. Dirty is derived from this, never tracked by hand.</summary>
+        public string SavedContent { get; set; } = attr.Value;
+
         public bool IsDirty { get; set; }
     }
 
@@ -444,30 +448,38 @@
     private async Task OnEditorInitAsync()
         => await JsRuntime.InvokeVoidAsync("SharpMUSH.Monaco.initEditor", "mush-editor");
 
-    // Monaco raises OnDidChangeModelContent for SetValue too, so loading an attribute, switching
-    // tabs or refreshing would each mark the tab unsaved without the user touching anything —
-    // which also made RefreshAttributesAsync skip those tabs forever, since it only refreshes
-    // clean ones. Every programmatic write goes through SetEditorValueAsync, which consumes the
-    // one change event it causes.
-    private bool _programmaticEditorWrite;
-
     private async Task SetEditorValueAsync(string value)
     {
         if (_monacoEditor is null) return;
-        _programmaticEditorWrite = true;
         await _monacoEditor.SetValue(value);
     }
 
-    private void OnEditorChanged(ModelContentChangedEvent e)
+    /// <summary>
+    /// Dirty means "the buffer differs from what the database holds" — compared, not tracked.
+    /// </summary>
+    /// <remarks>
+    /// Monaco raises OnDidChangeModelContent for SetValue as well as for typing, so loading an
+    /// attribute, switching tabs or refreshing used to mark the tab unsaved with no user input,
+    /// which in turn made RefreshAttributesAsync skip those tabs forever (it only refreshes clean
+    /// ones). A "this write was mine" flag fixes that but is fragile in both directions: it stays
+    /// armed if SetValue throws, and again if Monaco raises no event because the text was already
+    /// identical — and an armed flag swallows the user's next real edit while the tab reads clean,
+    /// so the next refresh silently overwrites their work. Comparing sidesteps the whole question:
+    /// it needs no assumption about when the event fires, and it also clears the flag when an edit
+    /// is undone back to the stored text.
+    /// </remarks>
+    private async Task OnEditorChanged(ModelContentChangedEvent e)
     {
-        if (_programmaticEditorWrite)
-        {
-            _programmaticEditorWrite = false;
-            return;
-        }
+        if (_monacoEditor is null || ActiveTab is null) return;
 
-        if (ActiveTab is not null)
-            ActiveTab.IsDirty = true;
+        var current = await _monacoEditor.GetValue();
+        ActiveTab.WorkingContent = current;
+
+        var dirty = !string.Equals(current, ActiveTab.SavedContent, StringComparison.Ordinal);
+        if (dirty == ActiveTab.IsDirty) return;
+
+        ActiveTab.IsDirty = dirty;
+        StateHasChanged();
     }
 
     private async Task OnAttributeSelected(MushAttribute? attr)
@@ -574,7 +586,12 @@
             {
                 var refreshed = _selectedObject.Attributes.FirstOrDefault(a =>
                     string.Equals(a.Name, tab.Attr.Name, StringComparison.OrdinalIgnoreCase));
-                if (refreshed is not null && !tab.IsDirty)
+                if (refreshed is null) continue;
+
+                // The freshly-read value is authoritative for what the database holds, whether or
+                // not the tab has unsaved edits sitting on top of it.
+                tab.SavedContent = refreshed.Value;
+                if (!tab.IsDirty)
                     tab.WorkingContent = refreshed.Value;
             }
         }
@@ -601,6 +618,8 @@
             return;
         }
 
+        // The buffer is now what the database holds, so the tab is clean by definition.
+        ActiveTab.SavedContent = value;
         ActiveTab.IsDirty = false;
         await RefreshAttributesAsync();
         _saveMessage = Loc["TermSavedAttribute", savedAttrName, savedDbref];

--- a/SharpMUSH.Client/Pages/SoftcodeEditor.razor
+++ b/SharpMUSH.Client/Pages/SoftcodeEditor.razor
@@ -593,6 +593,11 @@
                 tab.SavedContent = refreshed.Value;
                 if (!tab.IsDirty)
                     tab.WorkingContent = refreshed.Value;
+
+                // Derived, never carried over: a tab whose buffer now matches what was just read is
+                // clean by definition, even if it was dirty a moment ago (someone else saving the
+                // same text, or our own save round-tripping).
+                tab.IsDirty = !string.Equals(tab.WorkingContent, tab.SavedContent, StringComparison.Ordinal);
             }
         }
         if (ActiveTab is not null)

--- a/SharpMUSH.Client/Pages/SoftcodeEditor.razor
+++ b/SharpMUSH.Client/Pages/SoftcodeEditor.razor
@@ -7,6 +7,7 @@
 @using SharpMUSH.Client.Services
 @inject ITerminalService Terminal
 @inject MushQueryService QueryService
+@inject ObjectApiService ObjectApi
 @inject IJSRuntime JsRuntime
 @inject IStringLocalizer<SharedResource> Loc
 @implements IAsyncDisposable
@@ -317,7 +318,11 @@
     {
         public MushObject Obj { get; } = obj;
         public MushAttribute Attr { get; } = attr;
-        public string WorkingContent { get; set; } = attr.Value.Replace("%r", "\n").Replace("%R", "\n");
+        // Verbatim: the stored value IS what the author typed. This used to translate every
+        // stored %r into a newline, which was the mirror of the save-side rewrite and made the
+        // two indistinguishable — an intentional %r looked like formatting and a real newline
+        // came back as %r on the next save.
+        public string WorkingContent { get; set; } = attr.Value;
         public bool IsDirty { get; set; }
     }
 
@@ -513,12 +518,12 @@
         StateHasChanged();
         try
         {
-            _selectedObject = await QueryService.GetObjectAsync($"#{dbref}");
+            _selectedObject = await ObjectApi.GetObjectAsync(dbref);
             _selectedObject ??= new MushObject
             {
                 Dbref = dbref,
                 Name = $"#{dbref}",
-                Attributes = await QueryService.GetAttributesAsync($"#{dbref}"),
+                Attributes = await ObjectApi.GetAttributesAsync(dbref),
             };
             // Mobile drill-down: picking an object advances to its attributes.
             if (advanceMobilePane)
@@ -548,7 +553,7 @@
                 var refreshed = _selectedObject.Attributes.FirstOrDefault(a =>
                     string.Equals(a.Name, tab.Attr.Name, StringComparison.OrdinalIgnoreCase));
                 if (refreshed is not null && !tab.IsDirty)
-                    tab.WorkingContent = refreshed.Value.Replace("%r", "\n").Replace("%R", "\n");
+                    tab.WorkingContent = refreshed.Value;
             }
         }
         if (_monacoEditor is not null && ActiveTab is not null)
@@ -562,7 +567,18 @@
         ActiveTab.WorkingContent = value;
         var savedAttrName = ActiveTab.Attr.Name;
         var savedDbref = ActiveTab.Obj.Dbref;
-        await QueryService.SetAttributeAsync($"#{savedDbref}", savedAttrName, value);
+
+        // Sent verbatim — newlines included. The API carries the value in a JSON body, so there is
+        // nothing to escape and nothing for the server to decode.
+        var error = await ObjectApi.SetAttributeAsync(savedDbref, savedAttrName, value);
+        if (error is not null)
+        {
+            _saveMessage = error;
+            _saveSeverity = Severity.Error;
+            StateHasChanged();
+            return;
+        }
+
         ActiveTab.IsDirty = false;
         await RefreshAttributesAsync();
         _saveMessage = Loc["TermSavedAttribute", savedAttrName, savedDbref];
@@ -575,7 +591,16 @@
         if (ActiveTab is null) return;
         var deletedName = ActiveTab.Attr.Name;
         var deletedDbref = ActiveTab.Obj.Dbref;
-        await QueryService.DeleteAttributeAsync($"#{deletedDbref}", deletedName);
+
+        var error = await ObjectApi.DeleteAttributeAsync(deletedDbref, deletedName);
+        if (error is not null)
+        {
+            _saveMessage = error;
+            _saveSeverity = Severity.Error;
+            StateHasChanged();
+            return;
+        }
+
         _saveMessage = Loc["TermDeletedAttribute", deletedName];
         _saveSeverity = Severity.Info;
         var tabIdx = _openTabs.IndexOf(ActiveTab);
@@ -623,7 +648,15 @@
         var name = _createObjectName.Trim();
         _createObjectType = null;
         _createObjectName = string.Empty;
-        var newDbref = await QueryService.CreateObjectAsync(name, type);
+        var (newDbref, error) = await ObjectApi.CreateObjectAsync(name, type);
+        if (error is not null)
+        {
+            _saveMessage = error;
+            _saveSeverity = Severity.Error;
+            StateHasChanged();
+            return;
+        }
+
         if (_objectBrowser is not null)
         {
             await _objectBrowser.RefreshAsync();
@@ -647,7 +680,17 @@
         var attrName = _newAttrName.Trim().ToUpperInvariant();
         _showCreateAttr = false;
         _newAttrName = string.Empty;
-        await QueryService.SetAttributeAsync($"#{_selectedObject.Dbref}", attrName, "null()");
+        // 'null()' rather than an empty value: with empty_attrs off the engine treats an empty set
+        // as a clear, so a genuinely empty attribute could not be created to open a tab on.
+        var error = await ObjectApi.SetAttributeAsync(_selectedObject.Dbref, attrName, "null()");
+        if (error is not null)
+        {
+            _saveMessage = error;
+            _saveSeverity = Severity.Error;
+            StateHasChanged();
+            return;
+        }
+
         await RefreshAttributesAsync();
         var created = _selectedObject?.Attributes.FirstOrDefault(a =>
             string.Equals(a.Name, attrName, StringComparison.OrdinalIgnoreCase));

--- a/SharpMUSH.Client/Pages/SoftcodeEditor.razor
+++ b/SharpMUSH.Client/Pages/SoftcodeEditor.razor
@@ -45,6 +45,9 @@
                 <MudTooltip Text="@Loc["TermCreateRoom"]">
                     <MudIconButton Icon="@Icons.Material.Filled.MeetingRoom" Size="Size.Small" OnClick="@(() => ShowCreateObjectDialog(MushObjectType.Room))" />
                 </MudTooltip>
+                <MudTooltip Text="@Loc["TermCreateExit"]">
+                    <MudIconButton Icon="@Icons.Material.Filled.CallMade" Size="Size.Small" OnClick="@(() => ShowCreateObjectDialog(MushObjectType.Exit))" />
+                </MudTooltip>
             }
             <MudIconButton Icon="@(_objCollapsed ? Icons.Material.Filled.ChevronRight : Icons.Material.Filled.ChevronLeft)"
                            Size="Size.Small" OnClick="@(() => _objCollapsed = !_objCollapsed)"
@@ -441,8 +444,28 @@
     private async Task OnEditorInitAsync()
         => await JsRuntime.InvokeVoidAsync("SharpMUSH.Monaco.initEditor", "mush-editor");
 
+    // Monaco raises OnDidChangeModelContent for SetValue too, so loading an attribute, switching
+    // tabs or refreshing would each mark the tab unsaved without the user touching anything —
+    // which also made RefreshAttributesAsync skip those tabs forever, since it only refreshes
+    // clean ones. Every programmatic write goes through SetEditorValueAsync, which consumes the
+    // one change event it causes.
+    private bool _programmaticEditorWrite;
+
+    private async Task SetEditorValueAsync(string value)
+    {
+        if (_monacoEditor is null) return;
+        _programmaticEditorWrite = true;
+        await _monacoEditor.SetValue(value);
+    }
+
     private void OnEditorChanged(ModelContentChangedEvent e)
     {
+        if (_programmaticEditorWrite)
+        {
+            _programmaticEditorWrite = false;
+            return;
+        }
+
         if (ActiveTab is not null)
             ActiveTab.IsDirty = true;
     }
@@ -467,8 +490,7 @@
             _activeTabIndex = _openTabs.Count - 1;
         }
 
-        if (_monacoEditor is not null)
-            await _monacoEditor.SetValue(ActiveTab!.WorkingContent);
+        await SetEditorValueAsync(ActiveTab!.WorkingContent);
 
         // Mobile drill-down: picking an attribute advances to the editor.
         _mobilePane = MobilePane.Editor;
@@ -482,8 +504,8 @@
         if (_monacoEditor is not null && ActiveTab is not null)
             ActiveTab.WorkingContent = await _monacoEditor.GetValue();
         _activeTabIndex = idx;
-        if (_monacoEditor is not null && ActiveTab is not null)
-            await _monacoEditor.SetValue(ActiveTab.WorkingContent);
+        if (ActiveTab is not null)
+            await SetEditorValueAsync(ActiveTab.WorkingContent);
         StateHasChanged();
     }
 
@@ -496,13 +518,13 @@
         {
             _activeTabIndex = -1;
             if (_monacoEditor is not null)
-                await _monacoEditor.SetValue(string.Empty);
+                await SetEditorValueAsync(string.Empty);
         }
         else
         {
             _activeTabIndex = Math.Clamp(_activeTabIndex, 0, _openTabs.Count - 1);
             if (_monacoEditor is not null)
-                await _monacoEditor.SetValue(ActiveTab!.WorkingContent);
+                await SetEditorValueAsync(ActiveTab!.WorkingContent);
         }
         StateHasChanged();
     }
@@ -556,8 +578,8 @@
                     tab.WorkingContent = refreshed.Value;
             }
         }
-        if (_monacoEditor is not null && ActiveTab is not null)
-            await _monacoEditor.SetValue(ActiveTab.WorkingContent);
+        if (ActiveTab is not null)
+            await SetEditorValueAsync(ActiveTab.WorkingContent);
     }
 
     private async Task SaveAsync()

--- a/SharpMUSH.Client/Program.cs
+++ b/SharpMUSH.Client/Program.cs
@@ -48,6 +48,7 @@ builder.Services.AddSingleton<AdminAccountsService>();
 // Registers the terminal facades — see AddTerminalServices for the rationale.
 builder.Services.AddTerminalServices();
 builder.Services.AddSingleton<MushQueryService>();
+builder.Services.AddSingleton<ObjectApiService>();
 builder.Services.AddHttpClient("help", c =>
 {
 	c.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);

--- a/SharpMUSH.Client/Resources/SharedResource.bg.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.bg.resx
@@ -3484,6 +3484,10 @@
     <value>Създай стая</value>
     <comment>MT</comment>
   </data>
+  <data name="TermCreateExit" xml:space="preserve">
+    <value>Създай изход</value>
+    <comment>MT</comment>
+  </data>
   <data name="TermCreateThing" xml:space="preserve">
     <value>Създай нещо</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.da.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.da.resx
@@ -3484,6 +3484,10 @@
     <value>Opret rum</value>
     <comment>MT</comment>
   </data>
+  <data name="TermCreateExit" xml:space="preserve">
+    <value>Opret udgang</value>
+    <comment>MT</comment>
+  </data>
   <data name="TermCreateThing" xml:space="preserve">
     <value>Opret ting</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.de.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.de.resx
@@ -3484,6 +3484,10 @@
     <value>Raum erstellen</value>
     <comment>MT</comment>
   </data>
+  <data name="TermCreateExit" xml:space="preserve">
+    <value>Ausgang erstellen</value>
+    <comment>MT</comment>
+  </data>
   <data name="TermCreateThing" xml:space="preserve">
     <value>Objekt erstellen</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.es.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.es.resx
@@ -3484,6 +3484,10 @@
     <value>Crear habitación</value>
     <comment>MT</comment>
   </data>
+  <data name="TermCreateExit" xml:space="preserve">
+    <value>Crear salida</value>
+    <comment>MT</comment>
+  </data>
   <data name="TermCreateThing" xml:space="preserve">
     <value>Crear cosa</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.fr.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.fr.resx
@@ -985,6 +985,9 @@
   <data name="TermCreateRoom" xml:space="preserve">
     <value>Créer une salle</value>
   </data>
+  <data name="TermCreateExit" xml:space="preserve">
+    <value>Créer une sortie</value>
+  </data>
   <data name="TermExpandObjects" xml:space="preserve">
     <value>Développer les objets</value>
   </data>

--- a/SharpMUSH.Client/Resources/SharedResource.hr.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.hr.resx
@@ -3484,6 +3484,10 @@
     <value>Stvori sobu</value>
     <comment>MT</comment>
   </data>
+  <data name="TermCreateExit" xml:space="preserve">
+    <value>Stvori izlaz</value>
+    <comment>MT</comment>
+  </data>
   <data name="TermCreateThing" xml:space="preserve">
     <value>Stvori predmet</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.hu.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.hu.resx
@@ -3484,6 +3484,10 @@
     <value>Szoba létrehozása</value>
     <comment>MT</comment>
   </data>
+  <data name="TermCreateExit" xml:space="preserve">
+    <value>Kijárat létrehozása</value>
+    <comment>MT</comment>
+  </data>
   <data name="TermCreateThing" xml:space="preserve">
     <value>Tárgy létrehozása</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.nb.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.nb.resx
@@ -3484,6 +3484,10 @@
     <value>Opprett rom</value>
     <comment>MT</comment>
   </data>
+  <data name="TermCreateExit" xml:space="preserve">
+    <value>Opprett utgang</value>
+    <comment>MT</comment>
+  </data>
   <data name="TermCreateThing" xml:space="preserve">
     <value>Opprett ting</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.nl.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.nl.resx
@@ -3484,6 +3484,10 @@
     <value>Kamer aanmaken</value>
     <comment>MT</comment>
   </data>
+  <data name="TermCreateExit" xml:space="preserve">
+    <value>Uitgang aanmaken</value>
+    <comment>MT</comment>
+  </data>
   <data name="TermCreateThing" xml:space="preserve">
     <value>Ding aanmaken</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.pl.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.pl.resx
@@ -3484,6 +3484,10 @@
     <value>Utwórz pokój</value>
     <comment>MT</comment>
   </data>
+  <data name="TermCreateExit" xml:space="preserve">
+    <value>Utwórz wyjście</value>
+    <comment>MT</comment>
+  </data>
   <data name="TermCreateThing" xml:space="preserve">
     <value>Utwórz rzecz</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.pt-BR.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.pt-BR.resx
@@ -3484,6 +3484,10 @@
     <value>Criar sala</value>
     <comment>MT</comment>
   </data>
+  <data name="TermCreateExit" xml:space="preserve">
+    <value>Criar saída</value>
+    <comment>MT</comment>
+  </data>
   <data name="TermCreateThing" xml:space="preserve">
     <value>Criar coisa</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.resx
@@ -1837,6 +1837,9 @@
   <data name="TermCreateRoom" xml:space="preserve">
     <value>Create Room</value>
   </data>
+  <data name="TermCreateExit" xml:space="preserve">
+    <value>Create Exit</value>
+  </data>
   <data name="TermExpandObjects" xml:space="preserve">
     <value>Expand objects</value>
   </data>

--- a/SharpMUSH.Client/Resources/SharedResource.ro.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.ro.resx
@@ -3484,6 +3484,10 @@
     <value>Creare cameră</value>
     <comment>MT</comment>
   </data>
+  <data name="TermCreateExit" xml:space="preserve">
+    <value>Creare ieșire</value>
+    <comment>MT</comment>
+  </data>
   <data name="TermCreateThing" xml:space="preserve">
     <value>Creare obiect</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.ru.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.ru.resx
@@ -3484,6 +3484,10 @@
     <value>Создать комнату</value>
     <comment>MT</comment>
   </data>
+  <data name="TermCreateExit" xml:space="preserve">
+    <value>Создать выход</value>
+    <comment>MT</comment>
+  </data>
   <data name="TermCreateThing" xml:space="preserve">
     <value>Создать предмет</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.sv.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.sv.resx
@@ -3484,6 +3484,10 @@
     <value>Skapa rum</value>
     <comment>MT</comment>
   </data>
+  <data name="TermCreateExit" xml:space="preserve">
+    <value>Skapa utgång</value>
+    <comment>MT</comment>
+  </data>
   <data name="TermCreateThing" xml:space="preserve">
     <value>Skapa sak</value>
     <comment>MT — corpus renders thing as 'sak'.</comment>

--- a/SharpMUSH.Client/Resources/SharedResource.zh-Hans.resx
+++ b/SharpMUSH.Client/Resources/SharedResource.zh-Hans.resx
@@ -3484,6 +3484,10 @@
     <value>创建房间</value>
     <comment>MT</comment>
   </data>
+  <data name="TermCreateExit" xml:space="preserve">
+    <value>创建出口</value>
+    <comment>MT</comment>
+  </data>
   <data name="TermCreateThing" xml:space="preserve">
     <value>创建物品</value>
     <comment>MT</comment>

--- a/SharpMUSH.Client/Services/MushQueryService.cs
+++ b/SharpMUSH.Client/Services/MushQueryService.cs
@@ -9,88 +9,15 @@ namespace SharpMUSH.Client.Services;
 /// so output is unambiguous and permission-safe (the server enforces all MUSH permissions).
 /// <see cref="ITerminalService.SendCommandAsync"/> returns the result over the out-of-band channel,
 /// so structured output never appears in the visible terminal (or on other sessions).
+///
+/// What remains here is what genuinely IS softcode evaluation: free-form <c>lsearch</c>
+/// expressions and <c>u()</c>. Object info, attribute CRUD and object creation moved to
+/// <see cref="ObjectApiService"/>, because this channel is line-delimited and so could not carry
+/// an attribute value containing a newline without encoding it.
 /// </summary>
 public partial class MushQueryService(ITerminalService terminal, ILogger<MushQueryService> logger)
 {
 	private readonly ILogger<MushQueryService> _logger = logger;
-
-	/// <summary>Retrieve basic details (name, type, owner) and the full attribute list for a single object.</summary>
-	public async Task<MushObject?> GetObjectAsync(string dbref)
-	{
-		_logger.LogDebug("GetObjectAsync {Dbref}", dbref);
-		var infoExpr = $"SHARP_INFO:{dbref}:[name({dbref})]:[type({dbref})]:[owner({dbref})]";
-		// edit() collapses actual newlines in values to @@NL@@ so SHARP_ATTR stays single-line.
-		var attrExpr = $"iter(lattr({dbref}/**),SHARP_ATTR:%i0::[edit(get({dbref}/%i0),%r,@@NL@@)],%b,%r)";
-
-		var infoLines = await terminal.SendCommandAsync(infoExpr);
-		var attrLines = await terminal.SendCommandAsync(attrExpr);
-
-		var obj = ParseInfo(infoLines);
-		if (obj is null) return null;
-
-		obj.Attributes = ParseAttributes(attrLines);
-		return obj;
-	}
-
-	/// <summary>Get only the attribute list for an object (faster than full GetObjectAsync).</summary>
-	public async Task<List<MushAttribute>> GetAttributesAsync(string dbref)
-	{
-		// edit() replaces any actual newlines in the attribute value with @@NL@@ so the
-		// SHARP_ATTR marker stays on a single line — safe even when attrs contain %r output.
-		var expr = $"iter(lattr({dbref}/**),SHARP_ATTR:%i0::[edit(get({dbref}/%i0),%r,@@NL@@)],%b,%r)";
-		var lines = await terminal.SendCommandAsync(expr);
-		return ParseAttributes(lines);
-	}
-
-	/// <summary>Get a single attribute value.</summary>
-	public async Task<string?> GetAttributeAsync(string dbref, string attrName)
-	{
-		var lines = await terminal.SendCommandAsync($"get({dbref}/{attrName})");
-		return lines.Length > 0 ? string.Join("\n", lines) : null;
-	}
-
-	/// <summary>Set (or clear) an attribute via the standard &amp;ATTR command.
-	/// Newlines in <paramref name="value"/> are converted to the MUSH <c>%r</c> substitution
-	/// so the command is always a single-line WebSocket message.</summary>
-	public Task SetAttributeAsync(string dbref, string attrName, string value)
-	{
-		// Replace actual newlines with %r (MUSH convention) so the &ATTR command
-		// is a single WebSocket message — a multi-line message would be split by
-		// the server into separate commands, truncating the attribute value.
-		var safeValue = value.Replace("\r\n", "%r").Replace("\r", "%r").Replace("\n", "%r");
-		return terminal.SendAsync($"&{attrName} {dbref}={safeValue}");
-	}
-
-	/// <summary>Delete an attribute by setting it to empty.</summary>
-	public Task DeleteAttributeAsync(string dbref, string attrName)
-		=> terminal.SendAsync($"&{attrName} {dbref}=");
-
-	/// <summary>
-	/// Create a new in-game object using the appropriate building command.
-	/// Returns the new object's dbref if the server confirms creation, otherwise null.
-	/// </summary>
-	/// <summary>
-	/// Create a new in-game object using the appropriate softcode function
-	/// (<c>create()</c>, <c>dig()</c>, or <c>open()</c>) so the new dbref is
-	/// returned directly in one round-trip — no text parsing needed.
-	/// </summary>
-	public async Task<int?> CreateObjectAsync(string name, MushObjectType type)
-	{
-		// Each function returns the new dbref (#N or #N:timestamp).
-		// We wrap with before(…,:) to strip any creation-time suffix from dig()/open().
-		var expr = type switch
-		{
-			MushObjectType.Room => $"before(dig({name}),:)",
-			MushObjectType.Exit => $"before(open({name}),:)",
-			_ => $"create({name})",   // create() already returns #N cleanly
-		};
-
-		var lines = await terminal.SendCommandAsync(expr);
-		if (lines.Length == 0) return null;
-
-		var dbrefStr = lines.FirstOrDefault(l => l.TrimStart().StartsWith('#'))?.Trim();
-		return dbrefStr is not null && int.TryParse(dbrefStr.TrimStart('#'), out var n) ? n : null;
-	}
 
 	/// <summary>
 	/// Returns true if the currently connected player has the WIZARD flag.
@@ -147,58 +74,6 @@ public partial class MushQueryService(ITerminalService terminal, ILogger<MushQue
 	/// </summary>
 	public Task<string[]> EvalAsync(string dbref, string attrName)
 		=> terminal.SendCommandAsync($"u({dbref}/{attrName})");
-
-	private static MushObject? ParseInfo(string[] lines)
-	{
-		foreach (var line in lines)
-		{
-			if (!line.StartsWith("SHARP_INFO:")) continue;
-
-			// SHARP_INFO:<dbref>:<name>:<type>:<owner>
-			var parts = line.Split(':', 5);
-			if (parts.Length < 5) continue;
-
-			if (!int.TryParse(parts[1].TrimStart('#'), out var dbref)) continue;
-
-			return new MushObject
-			{
-				Dbref = dbref,
-				Name = parts[2],
-				Type = ParseType(parts[3]),
-				Owner = parts[4],
-			};
-		}
-
-		return null;
-	}
-
-	private static List<MushAttribute> ParseAttributes(string[] lines)
-	{
-		var attrs = new List<MushAttribute>();
-
-		foreach (var line in lines)
-		{
-			if (!line.StartsWith("SHARP_ATTR:")) continue;
-
-			// SHARP_ATTR:<name>:<flags>:<value…>
-			var parts = line.Split(':', 4);
-			if (parts.Length < 4) continue;
-
-			// Decode @@NL@@ placeholders back to actual newlines (see edit() in iter expr).
-			var value = parts[3].Replace("@@NL@@", "\n");
-
-			attrs.Add(new MushAttribute
-			{
-				Name = parts[1],
-				AttributeFlags = string.IsNullOrEmpty(parts[2])
-					? []
-					: [.. parts[2].Split(' ', StringSplitOptions.RemoveEmptyEntries)],
-				Value = value,
-			});
-		}
-
-		return attrs;
-	}
 
 	private static List<MushSearchResult> ParseSearchResults(string[] lines)
 	{

--- a/SharpMUSH.Client/Services/ObjectApiService.cs
+++ b/SharpMUSH.Client/Services/ObjectApiService.cs
@@ -1,0 +1,134 @@
+using SharpMUSH.Client.Models;
+using SharpMUSH.Library.API;
+using System.Net;
+using System.Net.Http.Json;
+
+namespace SharpMUSH.Client.Services;
+
+/// <summary>
+/// Typed client for <c>api/objects</c> — object info, attribute CRUD and object creation.
+/// </summary>
+/// <remarks>
+/// This replaces the softcode round-trip <see cref="MushQueryService"/> used to run for the same
+/// operations. That route went down the terminal WebSocket, which is line-delimited, so an
+/// attribute value had to have its newlines rewritten as <c>%r</c> to survive as one message —
+/// and since <c>&amp;</c> does not evaluate direct input, the literal <c>%r</c> was what got
+/// stored. Over HTTP a value is just a JSON string, so nothing has to be encoded and nothing has
+/// to be decoded on the way back.
+///
+/// <see cref="MushQueryService"/> keeps the operations that genuinely are softcode evaluation:
+/// free-form <c>lsearch</c> expressions and <c>u()</c>.
+/// </remarks>
+public class ObjectApiService(IHttpClientFactory httpClientFactory)
+{
+	/// <summary>
+	/// Attribute-tree levels requested when listing. The engine's own default is 1 (what
+	/// <c>examine</c> shows); the editor wants leaves too, which the old <c>lattr(#N/**)</c>
+	/// listing also returned.
+	/// </summary>
+	private const int ListDepth = 10;
+
+	private HttpClient Client => httpClientFactory.CreateClient("api");
+
+	private static string AttrPath(int dbref, string attribute)
+		=> $"api/objects/{dbref}/attributes/{Uri.EscapeDataString(attribute)}";
+
+	public async Task<MushObject?> GetObjectAsync(int dbref)
+	{
+		var response = await Client.GetAsync($"api/objects/{dbref}");
+		if (!response.IsSuccessStatusCode) return null;
+
+		var summary = await response.Content.ReadFromJsonAsync<ObjectSummaryDto>();
+		if (summary is null) return null;
+
+		return new MushObject
+		{
+			Dbref = dbref,
+			Name = summary.Name,
+			Type = ParseType(summary.Type),
+			Owner = summary.Owner,
+			Flags = string.Join(' ', summary.Flags),
+			Attributes = await GetAttributesAsync(dbref),
+		};
+	}
+
+	public async Task<List<MushAttribute>> GetAttributesAsync(int dbref)
+	{
+		var attributes = await Client.GetFromJsonAsync<List<AttributeDto>>(
+			$"api/objects/{dbref}/attributes?depth={ListDepth}");
+
+		return attributes?.Select(a => new MushAttribute
+		{
+			Name = a.Name,
+			Value = a.Value,
+			AttributeFlags = [.. a.Flags],
+		}).ToList() ?? [];
+	}
+
+	public async Task<string?> GetAttributeAsync(int dbref, string attribute)
+	{
+		var response = await Client.GetAsync(AttrPath(dbref, attribute));
+		if (!response.IsSuccessStatusCode) return null;
+
+		return (await response.Content.ReadFromJsonAsync<AttributeDto>())?.Value;
+	}
+
+	/// <summary>
+	/// Stores <paramref name="value"/> verbatim — newlines included. Returns the server's refusal
+	/// message when the acting character may not write there, or <see langword="null"/> on success.
+	/// </summary>
+	public async Task<string?> SetAttributeAsync(int dbref, string attribute, string value)
+	{
+		var response = await Client.PutAsJsonAsync(
+			AttrPath(dbref, attribute), new SetAttributeRequest(value));
+
+		return await ErrorOrNullAsync(response);
+	}
+
+	public async Task<string?> DeleteAttributeAsync(int dbref, string attribute)
+		=> await ErrorOrNullAsync(await Client.DeleteAsync(AttrPath(dbref, attribute)));
+
+	/// <summary>Creates an object, returning its dbref number, or null with the refusal message.</summary>
+	public async Task<(int? Dbref, string? Error)> CreateObjectAsync(string name, MushObjectType type)
+	{
+		var typeName = type switch
+		{
+			MushObjectType.Room => "ROOM",
+			MushObjectType.Exit => "EXIT",
+			_ => "THING",
+		};
+
+		var response = await Client.PostAsJsonAsync("api/objects", new CreateObjectRequest(name, typeName));
+		if (!response.IsSuccessStatusCode)
+		{
+			return (null, await ErrorOrNullAsync(response));
+		}
+
+		var created = await response.Content.ReadFromJsonAsync<CreatedObjectDto>();
+		// '#N' or '#N:creationTime' — the browser addresses objects by number.
+		var number = created?.Dbref.TrimStart('#').Split(':')[0];
+
+		return int.TryParse(number, out var parsed) ? (parsed, null) : (null, "Malformed dbref in response.");
+	}
+
+	/// <summary>The server's message for a failed call, or <see langword="null"/> when it succeeded.</summary>
+	private static async Task<string?> ErrorOrNullAsync(HttpResponseMessage response)
+	{
+		if (response.IsSuccessStatusCode) return null;
+
+		var error = response.StatusCode == HttpStatusCode.NotFound
+			? null
+			: (await response.Content.ReadFromJsonAsync<ApiErrorDto>().ConfigureAwait(false))?.Error;
+
+		return error ?? $"Request failed ({(int)response.StatusCode}).";
+	}
+
+	private static MushObjectType ParseType(string type) => type.ToUpperInvariant() switch
+	{
+		"THING" => MushObjectType.Thing,
+		"ROOM" => MushObjectType.Room,
+		"EXIT" => MushObjectType.Exit,
+		"PLAYER" => MushObjectType.Player,
+		_ => MushObjectType.Unknown,
+	};
+}

--- a/SharpMUSH.Contracts/API/ObjectsApiModels.cs
+++ b/SharpMUSH.Contracts/API/ObjectsApiModels.cs
@@ -1,0 +1,50 @@
+namespace SharpMUSH.Library.API;
+
+/// <summary>
+/// Wire models for <c>api/objects</c>, the typed object/attribute API the portal's Softcode Editor
+/// writes through.
+///
+/// The point of these existing at all is the value carrier: an attribute value travels as a JSON
+/// string, which carries newlines natively. The terminal channel it replaces is line-delimited,
+/// which is why the editor previously had to rewrite newlines as <c>%r</c> before sending
+/// <c>&amp;ATTR #dbref=value</c>.
+/// </summary>
+/// <param name="Dbref">The object's dbref, formatted <c>#N</c>.</param>
+/// <param name="Name">The object's name.</param>
+/// <param name="Type">PLAYER, THING, ROOM or EXIT.</param>
+/// <param name="Owner">The owner's name and dbref, formatted <c>Name(#N)</c>.</param>
+/// <param name="Flags">Flag names set on the object.</param>
+public sealed record ObjectSummaryDto(
+	string Dbref,
+	string Name,
+	string Type,
+	string Owner,
+	IReadOnlyList<string> Flags);
+
+/// <param name="Name">The full attribute name, backtick-separated for a tree leaf.</param>
+/// <param name="Value">The stored value, verbatim — newlines included, nothing substituted.</param>
+/// <param name="Flags">Attribute flag names.</param>
+public sealed record AttributeDto(
+	string Name,
+	string Value,
+	IReadOnlyList<string> Flags);
+
+/// <param name="Value">
+/// The value to store, verbatim. An empty value clears the attribute unless
+/// <c>Attribute.EmptyAttributes</c> is enabled, matching what <c>&amp;ATTR obj=</c> does.
+/// </param>
+public sealed record SetAttributeRequest(string Value);
+
+/// <param name="Flag">The attribute flag name to set.</param>
+public sealed record SetAttributeFlagRequest(string Flag);
+
+/// <param name="Name">The new object's name.</param>
+/// <param name="Type">THING, ROOM or EXIT. Players are created through account character creation.</param>
+/// <param name="Destination">For an EXIT, where it leads. Ignored for other types.</param>
+public sealed record CreateObjectRequest(string Name, string Type, string? Destination = null);
+
+/// <param name="Dbref">The created object's dbref, formatted <c>#N</c>.</param>
+public sealed record CreatedObjectDto(string Dbref);
+
+/// <param name="Error">The engine's own refusal message.</param>
+public sealed record ApiErrorDto(string Error);

--- a/SharpMUSH.Implementation/Handlers/Database/CreateExitCommandHandler.cs
+++ b/SharpMUSH.Implementation/Handlers/Database/CreateExitCommandHandler.cs
@@ -1,12 +1,20 @@
 using Mediator;
 using SharpMUSH.Library;
 using SharpMUSH.Library.Commands.Database;
+using SharpMUSH.Library.Definitions;
 using SharpMUSH.Library.Models;
+using ZiggyCreatures.Caching.Fusion;
 
 namespace SharpMUSH.Implementation.Handlers.Database;
 
-public class CreateExitCommandHandler(ISharpDatabase database) : ICommandHandler<CreateExitCommand, DBRef>
+/// <inheritdoc cref="CreateThingCommandHandler"/>
+public class CreateExitCommandHandler(ISharpDatabase database, IFusionCache cache)
+	: ICommandHandler<CreateExitCommand, DBRef>
 {
 	public async ValueTask<DBRef> Handle(CreateExitCommand request, CancellationToken cancellationToken)
-		=> await database.CreateExitAsync(request.Name, request.Aliases, request.Location, request.Creator, cancellationToken);
+	{
+		var created = await database.CreateExitAsync(request.Name, request.Aliases, request.Location, request.Creator, cancellationToken);
+		await cache.RemoveAsync(CacheKeys.Object(created), token: cancellationToken);
+		return created;
+	}
 }

--- a/SharpMUSH.Implementation/Handlers/Database/CreateExitCommandHandler.cs
+++ b/SharpMUSH.Implementation/Handlers/Database/CreateExitCommandHandler.cs
@@ -14,7 +14,11 @@ public class CreateExitCommandHandler(ISharpDatabase database, IFusionCache cach
 	public async ValueTask<DBRef> Handle(CreateExitCommand request, CancellationToken cancellationToken)
 	{
 		var created = await database.CreateExitAsync(request.Name, request.Aliases, request.Location, request.Creator, cancellationToken);
-		await cache.RemoveAsync(CacheKeys.Object(created), token: cancellationToken);
+
+		// CancellationToken.None deliberately: this runs AFTER the insert has committed. A token
+		// cancelled in between would abort the invalidation and leave the cached "no such object"
+		// entry pointing at a dbref that now exists — the exact defect this line exists to prevent.
+		await cache.RemoveAsync(CacheKeys.Object(created), token: CancellationToken.None);
 		return created;
 	}
 }

--- a/SharpMUSH.Implementation/Handlers/Database/CreatePlayerCommandHandler.cs
+++ b/SharpMUSH.Implementation/Handlers/Database/CreatePlayerCommandHandler.cs
@@ -15,7 +15,11 @@ public class CreatePlayerCommandHandler(ISharpDatabase database, IFusionCache ca
 	{
 		var created = await database.CreatePlayerAsync(
 			request.Name, request.Password, request.Location, request.Home, request.Quota, request.Salt, cancellationToken);
-		await cache.RemoveAsync(CacheKeys.Object(created), token: cancellationToken);
+
+		// CancellationToken.None deliberately: this runs AFTER the insert has committed. A token
+		// cancelled in between would abort the invalidation and leave the cached "no such object"
+		// entry pointing at a dbref that now exists — the exact defect this line exists to prevent.
+		await cache.RemoveAsync(CacheKeys.Object(created), token: CancellationToken.None);
 		return created;
 	}
 }

--- a/SharpMUSH.Implementation/Handlers/Database/CreatePlayerCommandHandler.cs
+++ b/SharpMUSH.Implementation/Handlers/Database/CreatePlayerCommandHandler.cs
@@ -1,12 +1,21 @@
 using Mediator;
 using SharpMUSH.Library;
 using SharpMUSH.Library.Commands.Database;
+using SharpMUSH.Library.Definitions;
 using SharpMUSH.Library.Models;
+using ZiggyCreatures.Caching.Fusion;
 
 namespace SharpMUSH.Implementation.Handlers.Database;
 
-public class CreatePlayerCommandHandler(ISharpDatabase database) : ICommandHandler<CreatePlayerCommand, DBRef>
+/// <inheritdoc cref="CreateThingCommandHandler"/>
+public class CreatePlayerCommandHandler(ISharpDatabase database, IFusionCache cache)
+	: ICommandHandler<CreatePlayerCommand, DBRef>
 {
 	public async ValueTask<DBRef> Handle(CreatePlayerCommand request, CancellationToken cancellationToken)
-		=> await database.CreatePlayerAsync(request.Name, request.Password, request.Location, request.Home, request.Quota, request.Salt, cancellationToken);
+	{
+		var created = await database.CreatePlayerAsync(
+			request.Name, request.Password, request.Location, request.Home, request.Quota, request.Salt, cancellationToken);
+		await cache.RemoveAsync(CacheKeys.Object(created), token: cancellationToken);
+		return created;
+	}
 }

--- a/SharpMUSH.Implementation/Handlers/Database/CreateRoomCommandHandler.cs
+++ b/SharpMUSH.Implementation/Handlers/Database/CreateRoomCommandHandler.cs
@@ -14,7 +14,11 @@ public class CreateRoomCommandHandler(ISharpDatabase database, IFusionCache cach
 	public async ValueTask<DBRef> Handle(CreateRoomCommand request, CancellationToken cancellationToken)
 	{
 		var created = await database.CreateRoomAsync(request.Name, request.Creator, cancellationToken);
-		await cache.RemoveAsync(CacheKeys.Object(created), token: cancellationToken);
+
+		// CancellationToken.None deliberately: this runs AFTER the insert has committed. A token
+		// cancelled in between would abort the invalidation and leave the cached "no such object"
+		// entry pointing at a dbref that now exists — the exact defect this line exists to prevent.
+		await cache.RemoveAsync(CacheKeys.Object(created), token: CancellationToken.None);
 		return created;
 	}
 }

--- a/SharpMUSH.Implementation/Handlers/Database/CreateRoomCommandHandler.cs
+++ b/SharpMUSH.Implementation/Handlers/Database/CreateRoomCommandHandler.cs
@@ -1,14 +1,20 @@
 using Mediator;
 using SharpMUSH.Library;
 using SharpMUSH.Library.Commands.Database;
+using SharpMUSH.Library.Definitions;
 using SharpMUSH.Library.Models;
+using ZiggyCreatures.Caching.Fusion;
 
 namespace SharpMUSH.Implementation.Handlers.Database;
 
-public class CreateRoomCommandHandler(ISharpDatabase database) : ICommandHandler<CreateRoomCommand, DBRef>
+/// <inheritdoc cref="CreateThingCommandHandler"/>
+public class CreateRoomCommandHandler(ISharpDatabase database, IFusionCache cache)
+	: ICommandHandler<CreateRoomCommand, DBRef>
 {
 	public async ValueTask<DBRef> Handle(CreateRoomCommand request, CancellationToken cancellationToken)
 	{
-		return await database.CreateRoomAsync(request.Name, request.Creator, cancellationToken);
+		var created = await database.CreateRoomAsync(request.Name, request.Creator, cancellationToken);
+		await cache.RemoveAsync(CacheKeys.Object(created), token: cancellationToken);
+		return created;
 	}
 }

--- a/SharpMUSH.Implementation/Handlers/Database/CreateThingCommandHandler.cs
+++ b/SharpMUSH.Implementation/Handlers/Database/CreateThingCommandHandler.cs
@@ -1,14 +1,28 @@
 using Mediator;
 using SharpMUSH.Library;
 using SharpMUSH.Library.Commands.Database;
+using SharpMUSH.Library.Definitions;
 using SharpMUSH.Library.Models;
+using ZiggyCreatures.Caching.Fusion;
 
 namespace SharpMUSH.Implementation.Handlers.Database;
 
-public class CreateThingCommandHandler(ISharpDatabase database) : ICommandHandler<CreateThingCommand, DBRef>
+/// <summary>
+/// Creating an object clears the cached lookup for the dbref it lands on.
+/// </summary>
+/// <remarks>
+/// <see cref="SharpMUSH.Library.Queries.Database.GetObjectNodeByNumberQuery"/> is cacheable and the
+/// caching behaviour stores misses too, so anything that looked up this dbref before it existed left
+/// a "no such object" entry behind. The command's own <c>CacheKeys</c> cannot cover this: the new
+/// dbref is not known until the insert returns, which is why the invalidation lives here.
+/// </remarks>
+public class CreateThingCommandHandler(ISharpDatabase database, IFusionCache cache)
+	: ICommandHandler<CreateThingCommand, DBRef>
 {
 	public async ValueTask<DBRef> Handle(CreateThingCommand request, CancellationToken cancellationToken)
 	{
-		return await database.CreateThingAsync(request.Name, request.Where, request.Owner, request.Home, cancellationToken);
+		var created = await database.CreateThingAsync(request.Name, request.Where, request.Owner, request.Home, cancellationToken);
+		await cache.RemoveAsync(CacheKeys.Object(created), token: cancellationToken);
+		return created;
 	}
 }

--- a/SharpMUSH.Implementation/Handlers/Database/CreateThingCommandHandler.cs
+++ b/SharpMUSH.Implementation/Handlers/Database/CreateThingCommandHandler.cs
@@ -22,7 +22,11 @@ public class CreateThingCommandHandler(ISharpDatabase database, IFusionCache cac
 	public async ValueTask<DBRef> Handle(CreateThingCommand request, CancellationToken cancellationToken)
 	{
 		var created = await database.CreateThingAsync(request.Name, request.Where, request.Owner, request.Home, cancellationToken);
-		await cache.RemoveAsync(CacheKeys.Object(created), token: cancellationToken);
+
+		// CancellationToken.None deliberately: this runs AFTER the insert has committed. A token
+		// cancelled in between would abort the invalidation and leave the cached "no such object"
+		// entry pointing at a dbref that now exists — the exact defect this line exists to prevent.
+		await cache.RemoveAsync(CacheKeys.Object(created), token: CancellationToken.None);
 		return created;
 	}
 }

--- a/SharpMUSH.Implementation/Services/PackageLifecycleRunner.cs
+++ b/SharpMUSH.Implementation/Services/PackageLifecycleRunner.cs
@@ -98,30 +98,7 @@ public class PackageLifecycleRunner(
 			// AINSTALL/AUPDATE contain commands (@function/@hook/@set/&attr) — they must be
 			// command-parsed, not function-evaluated — and run as the object so `%!`/`me` resolve
 			// to it (e.g. `@function header=%!,HEADER` targets the package object's own attribute).
-			var basedParser = parser.Push(new ParserState(
-				Registers: new([[]]),
-				IterationRegisters: [],
-				RegexRegisters: [],
-				SwitchStack: [],
-				ExecutionStack: [],
-				EnvironmentRegisters: new Dictionary<string, CallState>(),
-				CurrentEvaluation: null,
-				ParserFunctionDepth: 0,
-				Function: null,
-				Command: null,
-				CommandInvoker: _ => ValueTask.FromResult(new Option<CallState>(new None())),
-				Switches: [],
-				Arguments: [],
-				Executor: god.Object().DBRef,
-				Enactor: god.Object().DBRef,
-				Caller: god.Object().DBRef,
-				Handle: null,
-				ParseMode: ParseMode.Default,
-				HttpResponse: null,
-				CallDepth: new InvocationCounter(),
-				FunctionRecursionDepths: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase),
-				TotalInvocations: new InvocationCounter(),
-				LimitExceeded: new LimitExceededFlag()));
+			var basedParser = parser.Push(ParserState.RootFor(god.Object().DBRef));
 
 			var ran = await StartupAttributeRunner.RunObjectAttributeAsync(
 				basedParser, attributeService, target, attribute, god);

--- a/SharpMUSH.Library/ParserInterfaces/ParserState.cs
+++ b/SharpMUSH.Library/ParserInterfaces/ParserState.cs
@@ -314,6 +314,43 @@ public partial record ParserState(
 		new LimitExceededFlag());
 
 	/// <summary>
+	/// A fresh root state for code that runs as <paramref name="actor"/> with no ambient parser:
+	/// the boot @STARTUP pass, package lifecycle attributes, HTTP handler dispatch, and the
+	/// portal's typed object API. The actor is executor, enactor and caller at once, because there
+	/// is no outer frame for those to differ in.
+	/// </summary>
+	/// <remarks>
+	/// Unlike <see cref="Empty"/>, the register stack is seeded with one frame — code invoked from
+	/// a root state must be able to <c>setq()</c> without pushing a frame of its own. Callers
+	/// needing extras (seeded q-registers, %0-%9, an HTTP response context) apply them with a
+	/// <c>with</c> expression rather than growing this signature.
+	/// </remarks>
+	public static ParserState RootFor(DBRef actor) => new(
+		Registers: new([[]]),
+		IterationRegisters: [],
+		RegexRegisters: [],
+		SwitchStack: [],
+		ExecutionStack: [],
+		EnvironmentRegisters: new Dictionary<string, CallState>(),
+		CurrentEvaluation: null,
+		ParserFunctionDepth: 0,
+		Function: null,
+		Command: null,
+		CommandInvoker: _ => ValueTask.FromResult(new Option<CallState>(new None())),
+		Switches: [],
+		Arguments: new Dictionary<string, CallState>(),
+		Executor: actor,
+		Enactor: actor,
+		Caller: actor,
+		Handle: null,
+		ParseMode: ParseMode.Default,
+		HttpResponse: null,
+		CallDepth: new InvocationCounter(),
+		FunctionRecursionDepths: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase),
+		TotalInvocations: new InvocationCounter(),
+		LimitExceeded: new LimitExceededFlag());
+
+	/// <summary>
 	/// The executor of a command is the object actually carrying out the command or running the code: %!
 	/// </summary>
 	/// <param name="mediator">Mediator to get the object node with.</param>

--- a/SharpMUSH.Library/Services/HttpHandlerCommandService.cs
+++ b/SharpMUSH.Library/Services/HttpHandlerCommandService.cs
@@ -65,34 +65,16 @@ public class HttpHandlerCommandService(
 
 		// Build a fresh parser state — there is no ambient parser on the HTTP request path.
 		// 'Invisible login': the handler is executor, enactor, and caller, as in Penn.
-		var evalParser = parser.Push(new ParserState(
-			Registers: new([BuildHeaderRegisters(headers)]),
-			IterationRegisters: [],
-			RegexRegisters: [],
-			SwitchStack: [],
-			ExecutionStack: [],
-			EnvironmentRegisters: new Dictionary<string, CallState>
+		var evalParser = parser.Push(ParserState.RootFor(handlerRef) with
+		{
+			Registers = new([BuildHeaderRegisters(headers)]),
+			EnvironmentRegisters = new Dictionary<string, CallState>
 			{
 				["0"] = new CallState(path),
 				["1"] = new CallState(body)
 			},
-			CurrentEvaluation: null,
-			ParserFunctionDepth: 0,
-			Function: null,
-			Command: null,
-			CommandInvoker: _ => ValueTask.FromResult(new Option<CallState>(new None())),
-			Switches: [],
-			Arguments: [],
-			Executor: handlerRef,
-			Enactor: handlerRef,
-			Caller: handlerRef,
-			Handle: null,
-			ParseMode: ParseMode.Default,
-			HttpResponse: context,
-			CallDepth: new InvocationCounter(),
-			FunctionRecursionDepths: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase),
-			TotalInvocations: new InvocationCounter(),
-			LimitExceeded: new LimitExceededFlag()));
+			HttpResponse = context
+		});
 
 		var attributeValue = attributeResult.AsAttribute.Last().Value;
 

--- a/SharpMUSH.Library/Services/ValidateService.cs
+++ b/SharpMUSH.Library/Services/ValidateService.cs
@@ -280,7 +280,18 @@ public partial class ValidateService(
 			.AnyAsync(x => x.Object.Name.Equals(plainName, StringComparison.InvariantCultureIgnoreCase));
 	}
 
-	[GeneratedRegex(@"[^ \[\]%\\=&\|][\[\]%\\=&\|]*?[^ \[\]%\\=&\|]?$")]
+	/// <summary>
+	/// A legal object name: at least one character, no leading or trailing space, and none of
+	/// <c>[ ] % \ = &amp; |</c> anywhere. Interior spaces are fine ("a red ball"), and so is
+	/// <c>;</c> — <c>@open</c> splits exit aliases on it.
+	/// </summary>
+	/// <remarks>
+	/// Anchored at both ends deliberately. The previous pattern had <c>$</c> but no <c>^</c>, and
+	/// its middle term matched the forbidden set instead of its complement, so
+	/// <see cref="Regex.IsMatch"/> could satisfy the whole expression against the last character or
+	/// two of any input — every forbidden character passed as long as it was not at the very end.
+	/// </remarks>
+	[GeneratedRegex(@"^[^ \[\]%\\=&\|](?:[^\[\]%\\=&\|]*[^ \[\]%\\=&\|])?$")]
 	private partial Regex NameRegex();
 
 	private bool ValidateName(MString value)

--- a/SharpMUSH.Library/Services/ValidateService.cs
+++ b/SharpMUSH.Library/Services/ValidateService.cs
@@ -281,17 +281,23 @@ public partial class ValidateService(
 	}
 
 	/// <summary>
-	/// A legal object name: at least one character, no leading or trailing space, and none of
-	/// <c>[ ] % \ = &amp; |</c> anywhere. Interior spaces are fine ("a red ball"), and so is
-	/// <c>;</c> — <c>@open</c> splits exit aliases on it.
+	/// A legal object name: at least one character, no leading or trailing space, no control
+	/// characters anywhere, and none of <c>[ ] % \ = &amp; |</c>. Interior spaces are fine
+	/// ("a red ball"), and so is <c>;</c> — <c>@open</c> splits exit aliases on it.
 	/// </summary>
 	/// <remarks>
-	/// Anchored at both ends deliberately. The previous pattern had <c>$</c> but no <c>^</c>, and
-	/// its middle term matched the forbidden set instead of its complement, so
-	/// <see cref="Regex.IsMatch"/> could satisfy the whole expression against the last character or
-	/// two of any input — every forbidden character passed as long as it was not at the very end.
+	/// <para>
+	/// Anchored with <c>\A</c>/<c>\z</c> rather than <c>^</c>/<c>$</c>: in .NET <c>$</c> also
+	/// matches immediately before a trailing newline, so <c>$</c> accepts <c>"name\n"</c>.
+	/// </para>
+	/// <para>
+	/// The previous pattern had <c>$</c> but no start anchor at all, and its middle term matched the
+	/// forbidden set instead of its complement, so <see cref="Regex.IsMatch"/> could satisfy the
+	/// whole expression against the last character or two of any input — every forbidden character
+	/// passed as long as it was not at the very end.
+	/// </para>
 	/// </remarks>
-	[GeneratedRegex(@"^[^ \[\]%\\=&\|](?:[^\[\]%\\=&\|]*[^ \[\]%\\=&\|])?$")]
+	[GeneratedRegex(@"\A[^ \p{C}\[\]%\\=&\|](?:[^\p{C}\[\]%\\=&\|]*[^ \p{C}\[\]%\\=&\|])?\z")]
 	private partial Regex NameRegex();
 
 	private bool ValidateName(MString value)

--- a/SharpMUSH.Server/Controllers/ObjectsController.cs
+++ b/SharpMUSH.Server/Controllers/ObjectsController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using SharpMUSH.Configuration.Options;
 using SharpMUSH.Library.API;
+using SharpMUSH.Library.Definitions;
 using SharpMUSH.Library.DiscriminatedUnions;
 using SharpMUSH.Library.Extensions;
 using SharpMUSH.Library.Models;
@@ -46,7 +47,8 @@ public class ObjectsController(
 	IMediator mediator,
 	IAttributeService attributeService,
 	IOptionsWrapper<SharpMUSHOptions> configuration,
-	IEngineCommandInvoker commandInvoker) : ControllerBase
+	IEngineCommandInvoker commandInvoker,
+	IPermissionService permissionService) : ControllerBase
 {
 	/// <summary>
 	/// Attribute-tree levels returned by the listing endpoint when the caller does not ask.
@@ -114,7 +116,16 @@ public class ObjectsController(
 		if (await ResolveExecutorAsync(ct) is not { } executor) return Unauthorized();
 		if (await ResolveTargetAsync(dbref, ct) is not { } target) return NotFound();
 
-		return Ok(await SummariseAsync(target));
+		// The attribute endpoints inherit their visibility check from IAttributeService; this one
+		// returns name, owner and flags directly, so it has to ask. Without it any authenticated
+		// character could enumerate the database by dbref.
+		if (!await permissionService.CanExamine(executor, target))
+		{
+			return StatusCode(StatusCodes.Status403Forbidden,
+				new ApiErrorDto(ErrorMessages.Returns.PermissionDenied));
+		}
+
+		return Ok(await SummariseAsync(target, ct));
 	}
 
 	[HttpGet("{dbref:int}/attributes")]
@@ -246,11 +257,11 @@ public class ObjectsController(
 		attribute.Value.ToPlainText(),
 		attribute.Flags.Select(f => f.Name).ToList());
 
-	private static async Task<ObjectSummaryDto> SummariseAsync(AnySharpObject target)
+	private static async Task<ObjectSummaryDto> SummariseAsync(AnySharpObject target, CancellationToken ct)
 	{
 		var obj = target.Object();
-		var owner = await obj.Owner.WithCancellation(CancellationToken.None);
-		var flags = await obj.Flags.Value.Select(f => f.Name).ToListAsync();
+		var owner = await obj.Owner.WithCancellation(ct);
+		var flags = await obj.Flags.Value.Select(f => f.Name).ToListAsync(ct);
 
 		return new ObjectSummaryDto(
 			$"#{obj.Key}",

--- a/SharpMUSH.Server/Controllers/ObjectsController.cs
+++ b/SharpMUSH.Server/Controllers/ObjectsController.cs
@@ -1,0 +1,262 @@
+using Mediator;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using SharpMUSH.Configuration.Options;
+using SharpMUSH.Library.API;
+using SharpMUSH.Library.DiscriminatedUnions;
+using SharpMUSH.Library.Extensions;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Queries.Database;
+using SharpMUSH.Library.Services.Interfaces;
+using SharpMUSH.Server.Authentication;
+using SharpMUSH.Server.Services;
+
+namespace SharpMUSH.Server.Controllers;
+
+/// <summary>
+/// Typed object and attribute API, acting as the authenticated session's character.
+///
+/// This exists because the portal's Softcode Editor cannot write multi-line attributes through the
+/// terminal: that channel is line-delimited, so the editor rewrote every newline as the two
+/// characters <c>%r</c> and sent <c>&amp;ATTR #dbref=value</c>. <c>&amp;</c> is RSNoParse for direct
+/// input, so the literal <c>%r</c> was what reached the database — the one write path in the server
+/// that mangled its input, where <c>@set</c>, <c>&amp;</c> from a queue and package installs all
+/// store real newlines.
+///
+/// Values here travel in a JSON body and are stored verbatim. Permissions are the engine's: every
+/// operation goes through <see cref="IAttributeService"/>, the same service the <c>&amp;</c> command
+/// calls, which enforces <c>Controls</c> and <c>CanSet</c> itself. There is no portal-role gate
+/// beyond being authenticated with a character.
+///
+/// Routes:
+///   GET    api/objects/{dbref}                              — name, type, owner, flags
+///   GET    api/objects/{dbref}/attributes[?depth=N]         — visible attributes
+///   GET    api/objects/{dbref}/attributes/{name}            — one attribute
+///   PUT    api/objects/{dbref}/attributes/{name}            — set  { value }
+///   DELETE api/objects/{dbref}/attributes/{name}            — clear
+///   POST   api/objects/{dbref}/attributes/{name}/flags      — set flag  { flag }
+///   DELETE api/objects/{dbref}/attributes/{name}/flags/{f}  — unset flag
+/// </summary>
+[ApiController]
+[Route("api/objects")]
+[Authorize]
+public class ObjectsController(
+	IMediator mediator,
+	IAttributeService attributeService,
+	IOptionsWrapper<SharpMUSHOptions> configuration,
+	IEngineCommandInvoker commandInvoker) : ControllerBase
+{
+	/// <summary>
+	/// Attribute-tree levels returned by the listing endpoint when the caller does not ask.
+	/// One level is what <c>examine</c> shows and what every in-engine caller of
+	/// <see cref="IAttributeService.GetVisibleAttributesAsync"/> uses.
+	/// </summary>
+	private const int DefaultListDepth = 1;
+
+	/// <summary>Ceiling on <c>?depth=</c>, so a caller cannot ask the server to walk an unbounded tree.</summary>
+	private const int MaxListDepth = 10;
+
+	/// <summary>
+	/// Creates an object by running the engine's own building command, so quota, zone inheritance,
+	/// the <c>OBJECT`CREATE</c> event and plugin hooks all happen exactly as they do in-game. The
+	/// name is handed over as a pre-split argument and never spliced into a command line.
+	/// </summary>
+	[HttpPost]
+	public async Task<IActionResult> CreateObject([FromBody] CreateObjectRequest request, CancellationToken ct)
+	{
+		if (await ResolveExecutorAsync(ct) is not { } executor) return Unauthorized();
+
+		var arguments = new Dictionary<string, CallState> { ["0"] = new CallState(request.Name) };
+
+		string command;
+		switch (request.Type?.ToUpperInvariant())
+		{
+			case "THING":
+				command = "@CREATE";
+				break;
+			case "ROOM":
+				command = "@DIG";
+				break;
+			case "EXIT":
+				command = "@OPEN";
+				if (!string.IsNullOrWhiteSpace(request.Destination))
+				{
+					arguments["1"] = new CallState(request.Destination);
+				}
+
+				break;
+			default:
+				return BadRequest(new ApiErrorDto(
+					$"'{request.Type}' is not a creatable type. Use THING, ROOM or EXIT; players are " +
+					"created through account character creation."));
+		}
+
+		var result = await commandInvoker.InvokeAsync(command, executor.Object().DBRef, arguments);
+		var message = result?.Message?.ToPlainText();
+
+		if (string.IsNullOrWhiteSpace(message))
+		{
+			return StatusCode(StatusCodes.Status500InternalServerError,
+				new ApiErrorDto($"{command} returned no result."));
+		}
+
+		// Building commands report refusals as a '#-1 …' CallState rather than throwing.
+		return message.StartsWith("#-1", StringComparison.Ordinal)
+			? StatusCode(StatusCodes.Status403Forbidden, new ApiErrorDto(message))
+			: Ok(new CreatedObjectDto(message));
+	}
+
+	[HttpGet("{dbref:int}")]
+	public async Task<IActionResult> GetObject(int dbref, CancellationToken ct)
+	{
+		if (await ResolveExecutorAsync(ct) is not { } executor) return Unauthorized();
+		if (await ResolveTargetAsync(dbref, ct) is not { } target) return NotFound();
+
+		return Ok(await SummariseAsync(target));
+	}
+
+	[HttpGet("{dbref:int}/attributes")]
+	public async Task<IActionResult> ListAttributes(int dbref, [FromQuery] int? depth, CancellationToken ct)
+	{
+		if (await ResolveExecutorAsync(ct) is not { } executor) return Unauthorized();
+		if (await ResolveTargetAsync(dbref, ct) is not { } target) return NotFound();
+
+		var requested = Math.Clamp(depth ?? DefaultListDepth, 1, MaxListDepth);
+		var result = await attributeService.GetVisibleAttributesAsync(executor, target, requested);
+
+		return result.Match<IActionResult>(
+			attributes => Ok(attributes.Select(ToDto).ToList()),
+			error => StatusCode(StatusCodes.Status403Forbidden, new ApiErrorDto(error.Value)));
+	}
+
+	[HttpGet("{dbref:int}/attributes/{name}")]
+	public async Task<IActionResult> GetAttribute(int dbref, string name, CancellationToken ct)
+	{
+		if (await ResolveExecutorAsync(ct) is not { } executor) return Unauthorized();
+		if (await ResolveTargetAsync(dbref, ct) is not { } target) return NotFound();
+
+		// parent: false — an editor must show what is stored on THIS object. Rendering an
+		// inherited value and then saving it would silently copy the parent's code down.
+		var result = await attributeService.GetAttributeAsync(
+			executor, target, name, IAttributeService.AttributeMode.Read, parent: false);
+
+		return result.Match<IActionResult>(
+			attributes => Ok(ToDto(attributes.Last())),
+			_ => NotFound(),
+			error => StatusCode(StatusCodes.Status403Forbidden, new ApiErrorDto(error.Value)));
+	}
+
+	[HttpPut("{dbref:int}/attributes/{name}")]
+	public async Task<IActionResult> SetAttribute(
+		int dbref, string name, [FromBody] SetAttributeRequest request, CancellationToken ct)
+	{
+		if (await ResolveExecutorAsync(ct) is not { } executor) return Unauthorized();
+		if (await ResolveTargetAsync(dbref, ct) is not { } target) return NotFound();
+
+		// '& attr obj=' with an empty value clears unless empty_attrs is on — the same fork the
+		// command takes, so the two paths cannot disagree about what an empty save means.
+		if (string.IsNullOrEmpty(request.Value) && !configuration.CurrentValue.Attribute.EmptyAttributes)
+		{
+			return await ClearAttributeAsync(executor, target, name);
+		}
+
+		var result = await attributeService.SetAttributeAsync(
+			executor, target, name, MModule.single(request.Value));
+
+		return result.Match<IActionResult>(
+			_ => NoContent(),
+			error => StatusCode(StatusCodes.Status403Forbidden, new ApiErrorDto(error.Value)));
+	}
+
+	[HttpDelete("{dbref:int}/attributes/{name}")]
+	public async Task<IActionResult> ClearAttribute(int dbref, string name, CancellationToken ct)
+	{
+		if (await ResolveExecutorAsync(ct) is not { } executor) return Unauthorized();
+		if (await ResolveTargetAsync(dbref, ct) is not { } target) return NotFound();
+
+		return await ClearAttributeAsync(executor, target, name);
+	}
+
+	[HttpPost("{dbref:int}/attributes/{name}/flags")]
+	public async Task<IActionResult> SetAttributeFlag(
+		int dbref, string name, [FromBody] SetAttributeFlagRequest request, CancellationToken ct)
+	{
+		if (await ResolveExecutorAsync(ct) is not { } executor) return Unauthorized();
+		if (await ResolveTargetAsync(dbref, ct) is not { } target) return NotFound();
+
+		var result = await attributeService.SetAttributeFlagAsync(executor, target, name, request.Flag);
+
+		return result.Match<IActionResult>(
+			_ => NoContent(),
+			error => StatusCode(StatusCodes.Status403Forbidden, new ApiErrorDto(error.Value)));
+	}
+
+	[HttpDelete("{dbref:int}/attributes/{name}/flags/{flag}")]
+	public async Task<IActionResult> UnsetAttributeFlag(int dbref, string name, string flag, CancellationToken ct)
+	{
+		if (await ResolveExecutorAsync(ct) is not { } executor) return Unauthorized();
+		if (await ResolveTargetAsync(dbref, ct) is not { } target) return NotFound();
+
+		var result = await attributeService.UnsetAttributeFlagAsync(executor, target, name, flag);
+
+		return result.Match<IActionResult>(
+			_ => NoContent(),
+			error => StatusCode(StatusCodes.Status403Forbidden, new ApiErrorDto(error.Value)));
+	}
+
+	private async Task<IActionResult> ClearAttributeAsync(AnySharpObject executor, AnySharpObject target, string name)
+	{
+		var result = await attributeService.ClearAttributeAsync(
+			executor, target, name,
+			IAttributeService.AttributePatternMode.Exact,
+			IAttributeService.AttributeClearMode.Safe);
+
+		return result.Match<IActionResult>(
+			_ => NoContent(),
+			error => StatusCode(StatusCodes.Status403Forbidden, new ApiErrorDto(error.Value)));
+	}
+
+	/// <summary>
+	/// The character this request acts as. Same rule as <c>MailController</c>: the
+	/// <c>character_dbref</c> claim, which <c>AuthController.SwitchCharacter</c> keeps in step with
+	/// the terminal's own character.
+	/// </summary>
+	private async Task<AnySharpObject?> ResolveExecutorAsync(CancellationToken ct)
+	{
+		if (User.GetActingCharacter() is not { } character) return null;
+
+		var result = await mediator.Send(new GetObjectNodeQuery(character), ct);
+		return result.IsNone ? null : result.Known;
+	}
+
+	/// <summary>
+	/// Addressing is by dbref only. Name resolution needs a parser and notifies on failure, and the
+	/// editor already picks its target out of the object browser as a dbref.
+	/// </summary>
+	private async Task<AnySharpObject?> ResolveTargetAsync(int dbref, CancellationToken ct)
+	{
+		var result = await mediator.Send(new GetObjectNodeQuery(new DBRef(dbref)), ct);
+		return result.IsNone ? null : result.Known;
+	}
+
+	private static AttributeDto ToDto(SharpAttribute attribute) => new(
+		attribute.LongName ?? attribute.Name,
+		attribute.Value.ToPlainText(),
+		attribute.Flags.Select(f => f.Name).ToList());
+
+	private static async Task<ObjectSummaryDto> SummariseAsync(AnySharpObject target)
+	{
+		var obj = target.Object();
+		var owner = await obj.Owner.WithCancellation(CancellationToken.None);
+		var flags = await obj.Flags.Value.Select(f => f.Name).ToListAsync();
+
+		return new ObjectSummaryDto(
+			$"#{obj.Key}",
+			obj.Name,
+			obj.Type.ToUpperInvariant(),
+			$"{owner.Object.Name}(#{owner.Object.Key})",
+			flags);
+	}
+}

--- a/SharpMUSH.Server/Services/EngineCommandInvoker.cs
+++ b/SharpMUSH.Server/Services/EngineCommandInvoker.cs
@@ -1,0 +1,71 @@
+using SharpMUSH.Library.DiscriminatedUnions;
+using SharpMUSH.Library.Definitions;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Services;
+
+namespace SharpMUSH.Server.Services;
+
+/// <summary>
+/// Runs a registered engine command as a given object, with its arguments supplied already split.
+/// </summary>
+/// <remarks>
+/// This exists so web callers can reuse a command instead of reimplementing it. <c>@create</c>, for
+/// instance, resolves the default home, validates the name, inherits the creator's zone with a
+/// cycle check, fires <c>OBJECT`CREATE</c>, and dispatches
+/// <c>IPluginHookDispatcher.ObjectCreatedAsync</c> — a controller that duplicated that would drift
+/// from it within one release.
+///
+/// Arguments are passed structurally, never by building a command line. Object names are not
+/// required to exclude <c>;</c> (see <c>ValidateService.NameRegex</c>), so a synthesized
+/// <c>"@create " + name</c> would be a command-injection sink.
+/// </remarks>
+public interface IEngineCommandInvoker
+{
+	/// <summary>
+	/// Invokes <paramref name="commandName"/> as <paramref name="actor"/>.
+	/// </summary>
+	/// <param name="commandName">Registered command name, e.g. <c>@CREATE</c>. Case-insensitive.</param>
+	/// <param name="actor">The object the command runs as — executor, enactor and caller.</param>
+	/// <param name="arguments">Pre-split arguments, keyed as the command expects ("0", "1", …).</param>
+	/// <param name="switches">Command switches, if any.</param>
+	/// <returns>
+	/// The command's <see cref="CallState"/>, or <see langword="null"/> when the command is not
+	/// registered or returned nothing.
+	/// </returns>
+	ValueTask<CallState?> InvokeAsync(
+		string commandName,
+		DBRef actor,
+		Dictionary<string, CallState> arguments,
+		IEnumerable<string>? switches = null);
+}
+
+/// <inheritdoc />
+public class EngineCommandInvoker(
+	IMUSHCodeParser parser,
+	LibraryService<string, CommandDefinition> commands) : IEngineCommandInvoker
+{
+	/// <inheritdoc />
+	public async ValueTask<CallState?> InvokeAsync(
+		string commandName,
+		DBRef actor,
+		Dictionary<string, CallState> arguments,
+		IEnumerable<string>? switches = null)
+	{
+		if (!commands.TryGetValue(commandName, out var registered))
+		{
+			return null;
+		}
+
+		var state = ParserState.RootFor(actor) with
+		{
+			Command = commandName,
+			Arguments = arguments,
+			Switches = switches ?? []
+		};
+
+		var result = await registered.LibraryInformation.Command(parser.Push(state));
+
+		return result.TryGetValue(out var callState) ? callState : null;
+	}
+}

--- a/SharpMUSH.Server/Services/StartupAttributeBootstrapService.cs
+++ b/SharpMUSH.Server/Services/StartupAttributeBootstrapService.cs
@@ -46,31 +46,8 @@ public class StartupAttributeBootstrapService(
 			var god = godNode.Known;
 
 			// Fresh parser state: God is executor, enactor, and caller — there is no ambient
-			// parser at boot (mirrors the package lifecycle / HTTP handler invocation pattern).
-			var bootParser = parser.Push(new ParserState(
-				Registers: new([[]]),
-				IterationRegisters: [],
-				RegexRegisters: [],
-				SwitchStack: [],
-				ExecutionStack: [],
-				EnvironmentRegisters: new Dictionary<string, CallState>(),
-				CurrentEvaluation: null,
-				ParserFunctionDepth: 0,
-				Function: null,
-				Command: null,
-				CommandInvoker: _ => ValueTask.FromResult(new Option<CallState>(new None())),
-				Switches: [],
-				Arguments: [],
-				Executor: god.Object().DBRef,
-				Enactor: god.Object().DBRef,
-				Caller: god.Object().DBRef,
-				Handle: null,
-				ParseMode: ParseMode.Default,
-				HttpResponse: null,
-				CallDepth: new InvocationCounter(),
-				FunctionRecursionDepths: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase),
-				TotalInvocations: new InvocationCounter(),
-				LimitExceeded: new LimitExceededFlag()));
+			// parser at boot.
+			var bootParser = parser.Push(ParserState.RootFor(god.Object().DBRef));
 
 			logger.LogInformation("Running boot @STARTUP pass on all objects as God (#1).");
 			await StartupAttributeRunner.RunAllAsync(bootParser, mediator, attributeService, god);

--- a/SharpMUSH.Server/Startup.cs
+++ b/SharpMUSH.Server/Startup.cs
@@ -246,6 +246,7 @@ public class Startup(
 		services.AddSingleton<IMoveService, MoveService>();
 		services.AddSingleton<IExpandedObjectDataService, ExpandedObjectDataService>();
 		services.AddSingleton<IAttributeService, AttributeService>();
+		services.AddSingleton<IEngineCommandInvoker, EngineCommandInvoker>();
 		services.AddSingleton<IManipulateSharpObjectService, ManipulateSharpObjectService>();
 		services.AddSingleton<ITaskScheduler, TaskScheduler>();
 		services.AddSingleton<IConnectionService, ConnectionService>();

--- a/SharpMUSH.Tests.BUnit/Services/ObjectApiServiceTests.cs
+++ b/SharpMUSH.Tests.BUnit/Services/ObjectApiServiceTests.cs
@@ -1,0 +1,155 @@
+using SharpMUSH.Client.Models;
+using SharpMUSH.Client.Services;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+namespace SharpMUSH.Tests.BUnit.Services;
+
+/// <summary>
+/// That <see cref="ObjectApiService"/> puts an attribute value on the wire unmodified.
+///
+/// This is the seam that used to mangle: its predecessor,
+/// <c>MushQueryService.SetAttributeAsync</c>, rewrote every newline as the two characters
+/// <c>%r</c> so the value would survive as one line on the terminal WebSocket, and the editor
+/// translated <c>%r</c> back to a newline on load. Together those made a real newline and a typed
+/// <c>%r</c> indistinguishable. A JSON body has no line limit, so neither conversion is needed —
+/// and these tests fail if either is reintroduced.
+/// </summary>
+public class ObjectApiServiceTests
+{
+	/// <summary>Captures the one request the service makes and replies with a canned response.</summary>
+	private sealed class CapturingHandler(HttpStatusCode status, string? responseJson = null) : HttpMessageHandler
+	{
+		public HttpRequestMessage? Request { get; private set; }
+		public string? RequestBody { get; private set; }
+
+		protected override async Task<HttpResponseMessage> SendAsync(
+			HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			Request = request;
+			RequestBody = request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+
+			return new HttpResponseMessage(status)
+			{
+				Content = new StringContent(responseJson ?? string.Empty, Encoding.UTF8, "application/json")
+			};
+		}
+	}
+
+	private sealed class SingleClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+	{
+		public HttpClient CreateClient(string name) =>
+			new(handler, disposeHandler: false) { BaseAddress = new Uri("https://localhost/") };
+	}
+
+	private static (ObjectApiService Service, CapturingHandler Handler) Build(
+		HttpStatusCode status = HttpStatusCode.NoContent, string? responseJson = null)
+	{
+		var handler = new CapturingHandler(status, responseJson);
+		return (new ObjectApiService(new SingleClientFactory(handler)), handler);
+	}
+
+	[Test]
+	public async Task SetAttribute_SendsTheValueVerbatim_NewlinesIntact()
+	{
+		var (service, handler) = Build();
+		const string value = "$greet *:@pemit %#=Hi;\n  @pemit %#=Bye";
+
+		await service.SetAttributeAsync(7, "CMD_GREET", value);
+
+		var sent = JsonDocument.Parse(handler.RequestBody!).RootElement.GetProperty("value").GetString();
+
+		await Assert.That(sent).IsEqualTo(value);
+	}
+
+	[Test]
+	public async Task SetAttribute_DoesNotConvertNewlinesToPercentR()
+	{
+		var (service, handler) = Build();
+
+		await service.SetAttributeAsync(7, "DESC", "line one\nline two");
+
+		await Assert.That(handler.RequestBody).DoesNotContain("%r")
+			.Because("the %r rewrite is exactly the behaviour this service replaced");
+	}
+
+	[Test]
+	public async Task SetAttribute_LeavesATypedPercentRAlone()
+	{
+		var (service, handler) = Build();
+
+		await service.SetAttributeAsync(7, "DESC", "line one%rline two");
+
+		var sent = JsonDocument.Parse(handler.RequestBody!).RootElement.GetProperty("value").GetString();
+
+		await Assert.That(sent).IsEqualTo("line one%rline two");
+		await Assert.That(sent).DoesNotContain("\n")
+			.Because("a %r the author typed is content, not formatting to expand");
+	}
+
+	[Test]
+	public async Task SetAttribute_UsesPutOnTheAttributeRoute()
+	{
+		var (service, handler) = Build();
+
+		await service.SetAttributeAsync(42, "BRANCH`LEAF", "x");
+
+		await Assert.That(handler.Request!.Method).IsEqualTo(HttpMethod.Put);
+		await Assert.That(handler.Request.RequestUri!.AbsolutePath)
+			.IsEqualTo("/api/objects/42/attributes/BRANCH%60LEAF");
+	}
+
+	[Test]
+	public async Task SetAttribute_OnRefusal_ReturnsTheServersMessage()
+	{
+		var (service, _) = Build(
+			HttpStatusCode.Forbidden, """{"error":"You do not have permission to do that."}""");
+
+		var error = await service.SetAttributeAsync(7, "PWNED", "nope");
+
+		await Assert.That(error).IsEqualTo("You do not have permission to do that.");
+	}
+
+	[Test]
+	public async Task SetAttribute_OnSuccess_ReturnsNoError()
+	{
+		var (service, _) = Build();
+
+		await Assert.That(await service.SetAttributeAsync(7, "DESC", "fine")).IsNull();
+	}
+
+	[Test]
+	public async Task GetAttributes_ReadsValuesVerbatim()
+	{
+		var (service, _) = Build(HttpStatusCode.OK,
+			"""[{"name":"DESC","value":"line one\nline two","flags":[]}]""");
+
+		var attributes = await service.GetAttributesAsync(7);
+
+		await Assert.That(attributes[0].Value).IsEqualTo("line one\nline two")
+			.Because("the load path must not translate either way round");
+	}
+
+	[Test]
+	public async Task CreateObject_ReturnsTheDbrefNumber_StrippingAnyCreationTime()
+	{
+		var (service, _) = Build(HttpStatusCode.OK, """{"dbref":"#123:1700000000"}""");
+
+		var (dbref, error) = await service.CreateObjectAsync("Widget", MushObjectType.Thing);
+
+		await Assert.That(dbref).IsEqualTo(123);
+		await Assert.That(error).IsNull();
+	}
+
+	[Test]
+	public async Task CreateObject_OnRefusal_ReturnsTheMessageAndNoDbref()
+	{
+		var (service, _) = Build(HttpStatusCode.Forbidden, """{"error":"#-1 THAT IS A BAD NAME."}""");
+
+		var (dbref, error) = await service.CreateObjectAsync("!!", MushObjectType.Thing);
+
+		await Assert.That(dbref).IsNull();
+		await Assert.That(error).IsEqualTo("#-1 THAT IS A BAD NAME.");
+	}
+}

--- a/SharpMUSH.Tests.Integration/Portal/ObjectsApiTests.cs
+++ b/SharpMUSH.Tests.Integration/Portal/ObjectsApiTests.cs
@@ -98,7 +98,10 @@ public class ObjectsApiTests(ServerWebAppFactory factory)
 		var (http, dbref) = await CharacterAsync("literalpr");
 		const string value = "line one%rline two";
 
-		await http.PutAsJsonAsync(AttrUrl(dbref, "DESC_LITERAL"), new SetAttributeRequest(value));
+		var put = await http.PutAsJsonAsync(AttrUrl(dbref, "DESC_LITERAL"), new SetAttributeRequest(value));
+		await Assert.That(put.StatusCode).IsEqualTo(HttpStatusCode.NoContent)
+			.Because("a refused write would make the read below fail for the wrong reason");
+
 		var read = await http.GetFromJsonAsync<AttributeDto>(AttrUrl(dbref, "DESC_LITERAL"));
 
 		await Assert.That(read!.Value).IsEqualTo(value);
@@ -124,7 +127,8 @@ public class ObjectsApiTests(ServerWebAppFactory factory)
 	{
 		var (http, dbref) = await CharacterAsync("delattr");
 
-		await http.PutAsJsonAsync(AttrUrl(dbref, "TRANSIENT"), new SetAttributeRequest("here"));
+		var seeded = await http.PutAsJsonAsync(AttrUrl(dbref, "TRANSIENT"), new SetAttributeRequest("here"));
+		await Assert.That(seeded.StatusCode).IsEqualTo(HttpStatusCode.NoContent);
 		var deleted = await http.DeleteAsync(AttrUrl(dbref, "TRANSIENT"));
 		await Assert.That(deleted.StatusCode).IsEqualTo(HttpStatusCode.NoContent);
 
@@ -137,7 +141,8 @@ public class ObjectsApiTests(ServerWebAppFactory factory)
 	{
 		var (http, dbref) = await CharacterAsync("listattr");
 
-		await http.PutAsJsonAsync(AttrUrl(dbref, "LISTED_ONE"), new SetAttributeRequest("first"));
+		var seeded = await http.PutAsJsonAsync(AttrUrl(dbref, "LISTED_ONE"), new SetAttributeRequest("first"));
+		await Assert.That(seeded.StatusCode).IsEqualTo(HttpStatusCode.NoContent);
 
 		var all = await http.GetFromJsonAsync<List<AttributeDto>>($"api/objects/{dbref}/attributes");
 

--- a/SharpMUSH.Tests.Integration/Portal/ObjectsApiTests.cs
+++ b/SharpMUSH.Tests.Integration/Portal/ObjectsApiTests.cs
@@ -1,0 +1,205 @@
+using SharpMUSH.Tests.Infrastructure;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+
+namespace SharpMUSH.Tests.Integration.Portal;
+
+/// <summary>
+/// The typed object/attribute API (<c>api/objects</c>) that the portal's Softcode Editor writes
+/// through instead of the terminal.
+///
+/// The terminal channel is line-delimited, so the editor used to rewrite every newline as the two
+/// characters <c>%r</c> before sending <c>&amp;ATTR #dbref=value</c>; because <c>&amp;</c> is
+/// RSNoParse for direct input, that literal <c>%r</c> is what reached the database. Every other
+/// write path in the server — <c>@set</c>, <c>&amp;</c> from a queue, package install — stores real
+/// newlines. These tests pin the API to that majority behaviour: what you send is what is stored,
+/// byte for byte, with the engine's own permission checks in front of it.
+/// </summary>
+[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+public class ObjectsApiTests(ServerWebAppFactory factory)
+{
+	private record CharacterSummary(int DbrefNumber, long CreationTime, string Name, string Flags);
+	private record AccountLoginResponse(string AccountId, string Username, List<CharacterSummary> Characters, string AccountSessionToken, bool MustChangePassword);
+	private record AccountRegisterRequest(string Username, string? Email, string Password);
+	private record CreateCharacterRequest(string Name, string Password);
+	private record CreatedCharacterResponse(int DbrefNumber, long CreationTime);
+
+	private record AttributeDto(string Name, string Value, IReadOnlyList<string> Flags);
+	private record SetAttributeRequest(string Value);
+	private record ObjectSummaryDto(string Dbref, string Name, string Type, string Owner, IReadOnlyList<string> Flags);
+	private record CreateObjectRequest(string Name, string Type, string? Destination = null);
+	private record CreatedObjectDto(string Dbref);
+
+	private const string Password = "Integration-Test-Pw-1!";
+
+	/// <summary>
+	/// Pinned to https: the server uses UseHttpsRedirection, and following the 307 from http→https
+	/// makes HttpClient drop the Authorization header.
+	/// </summary>
+	private HttpClient CreateClient()
+	{
+		var http = factory.CreateHttpClient();
+		http.BaseAddress = new Uri("https://localhost/");
+		return http;
+	}
+
+	private static string UniqueName(string prefix) => $"{prefix}{Guid.NewGuid():N}"[..20];
+
+	/// <summary>An account with exactly one character, and a client bearing its session token.</summary>
+	private async Task<(HttpClient Http, int Dbref)> CharacterAsync(string prefix)
+	{
+		var http = CreateClient();
+
+		var registered = await http.PostAsJsonAsync(
+			"api/auth/account-register", new AccountRegisterRequest(UniqueName(prefix), null, Password));
+		await Assert.That(registered.StatusCode).IsEqualTo(HttpStatusCode.OK);
+		var account = (await registered.Content.ReadFromJsonAsync<AccountLoginResponse>())!;
+
+		http.DefaultRequestHeaders.Authorization =
+			new AuthenticationHeaderValue("Bearer", account.AccountSessionToken);
+
+		var created = await http.PostAsJsonAsync(
+			"api/account/characters", new CreateCharacterRequest(UniqueName($"{prefix}c"), Password));
+		await Assert.That(created.StatusCode).IsEqualTo(HttpStatusCode.OK);
+		var character = (await created.Content.ReadFromJsonAsync<CreatedCharacterResponse>())!;
+
+		return (http, character.DbrefNumber);
+	}
+
+	private static string AttrUrl(int dbref, string attribute)
+		=> $"api/objects/{dbref}/attributes/{Uri.EscapeDataString(attribute)}";
+
+	/// <summary>
+	/// The headline case. A three-line value survives the round trip unchanged — no %r anywhere,
+	/// no lost indentation, no truncation at the first newline.
+	/// </summary>
+	[Test]
+	public async Task SetAttribute_MultiLineValue_RoundTripsByteExact()
+	{
+		var (http, dbref) = await CharacterAsync("multiline");
+		const string value = "$greet *:@pemit %#=Hi;\n  @pemit %#=There;\n  @pemit %#=Bye";
+
+		var put = await http.PutAsJsonAsync(AttrUrl(dbref, "CMD_GREET"), new SetAttributeRequest(value));
+		await Assert.That(put.StatusCode).IsEqualTo(HttpStatusCode.NoContent);
+
+		var read = await http.GetFromJsonAsync<AttributeDto>(AttrUrl(dbref, "CMD_GREET"));
+
+		await Assert.That(read!.Value).IsEqualTo(value);
+	}
+
+	/// <summary>
+	/// The other half of dropping the conversion: a %r the author actually typed is content, not a
+	/// newline, and must come back as the two characters they wrote.
+	/// </summary>
+	[Test]
+	public async Task SetAttribute_LiteralPercentR_IsStoredLiterally()
+	{
+		var (http, dbref) = await CharacterAsync("literalpr");
+		const string value = "line one%rline two";
+
+		await http.PutAsJsonAsync(AttrUrl(dbref, "DESC_LITERAL"), new SetAttributeRequest(value));
+		var read = await http.GetFromJsonAsync<AttributeDto>(AttrUrl(dbref, "DESC_LITERAL"));
+
+		await Assert.That(read!.Value).IsEqualTo(value);
+		await Assert.That(read.Value).DoesNotContain("\n");
+	}
+
+	/// <summary>Attribute trees address by backtick, which has to survive URL routing.</summary>
+	[Test]
+	public async Task SetAttribute_AttributeTreeLeaf_RoundTrips()
+	{
+		var (http, dbref) = await CharacterAsync("attrtree");
+		const string value = "leaf body\nsecond line";
+
+		var put = await http.PutAsJsonAsync(AttrUrl(dbref, "BRANCH`LEAF"), new SetAttributeRequest(value));
+		await Assert.That(put.StatusCode).IsEqualTo(HttpStatusCode.NoContent);
+
+		var read = await http.GetFromJsonAsync<AttributeDto>(AttrUrl(dbref, "BRANCH`LEAF"));
+		await Assert.That(read!.Value).IsEqualTo(value);
+	}
+
+	[Test]
+	public async Task DeleteAttribute_RemovesIt()
+	{
+		var (http, dbref) = await CharacterAsync("delattr");
+
+		await http.PutAsJsonAsync(AttrUrl(dbref, "TRANSIENT"), new SetAttributeRequest("here"));
+		var deleted = await http.DeleteAsync(AttrUrl(dbref, "TRANSIENT"));
+		await Assert.That(deleted.StatusCode).IsEqualTo(HttpStatusCode.NoContent);
+
+		var read = await http.GetAsync(AttrUrl(dbref, "TRANSIENT"));
+		await Assert.That(read.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+	}
+
+	[Test]
+	public async Task ListAttributes_IncludesWhatWasJustWritten()
+	{
+		var (http, dbref) = await CharacterAsync("listattr");
+
+		await http.PutAsJsonAsync(AttrUrl(dbref, "LISTED_ONE"), new SetAttributeRequest("first"));
+
+		var all = await http.GetFromJsonAsync<List<AttributeDto>>($"api/objects/{dbref}/attributes");
+
+		await Assert.That(all!.Any(a => a.Name.Equals("LISTED_ONE", StringComparison.OrdinalIgnoreCase))).IsTrue()
+			.Because($"got: [{string.Join(", ", all!.Select(a => a.Name))}]");
+	}
+
+	/// <summary>
+	/// Creation runs the real <c>@create</c> through the engine rather than reimplementing it, so
+	/// the object it returns is a genuine one: addressable, and immediately writable through the
+	/// rest of this API.
+	/// </summary>
+	[Test]
+	public async Task CreateObject_ReturnsAUsableThing()
+	{
+		var (http, _) = await CharacterAsync("createobj");
+		var name = UniqueName("Widget");
+
+		var created = await http.PostAsJsonAsync("api/objects", new CreateObjectRequest(name, "THING"));
+		await Assert.That(created.StatusCode).IsEqualTo(HttpStatusCode.OK)
+			.Because($"body: [{await created.Content.ReadAsStringAsync()}]");
+
+		var dto = (await created.Content.ReadFromJsonAsync<CreatedObjectDto>())!;
+		var number = int.Parse(dto.Dbref.TrimStart('#').Split(':')[0]);
+
+		var summary = await http.GetFromJsonAsync<ObjectSummaryDto>($"api/objects/{number}");
+		await Assert.That(summary!.Name).IsEqualTo(name);
+		await Assert.That(summary.Type).IsEqualTo("THING");
+	}
+
+	/// <summary>
+	/// The name never becomes part of a command line, so a separator in it is inert data rather
+	/// than a second command. <c>NameRegex</c> does not forbid ';', which is exactly why the
+	/// endpoint passes the name as a pre-split argument instead of building "@create {name}".
+	/// </summary>
+	[Test]
+	public async Task CreateObject_NameContainingASeparator_IsNotTreatedAsASecondCommand()
+	{
+		var (http, _) = await CharacterAsync("createinj");
+		var name = $"{UniqueName("Inj")};@dig Injected";
+
+		var created = await http.PostAsJsonAsync("api/objects", new CreateObjectRequest(name, "THING"));
+		await Assert.That(created.StatusCode).IsEqualTo(HttpStatusCode.OK)
+			.Because($"body: [{await created.Content.ReadAsStringAsync()}]");
+
+		var dto = (await created.Content.ReadFromJsonAsync<CreatedObjectDto>())!;
+		var number = int.Parse(dto.Dbref.TrimStart('#').Split(':')[0]);
+
+		var summary = await http.GetFromJsonAsync<ObjectSummaryDto>($"api/objects/{number}");
+		await Assert.That(summary!.Name).IsEqualTo(name)
+			.Because("the whole string is the name; nothing after the ';' may execute");
+	}
+
+	[Test]
+	public async Task GetObject_ReportsNameAndType()
+	{
+		var (http, dbref) = await CharacterAsync("objinfo");
+
+		var summary = await http.GetFromJsonAsync<ObjectSummaryDto>($"api/objects/{dbref}");
+
+		await Assert.That(summary!.Type).IsEqualTo("PLAYER");
+		await Assert.That(summary.Name).IsNotNull().And.IsNotEmpty();
+	}
+
+}

--- a/SharpMUSH.Tests.Integration/Portal/ObjectsControllerPermissionTests.cs
+++ b/SharpMUSH.Tests.Integration/Portal/ObjectsControllerPermissionTests.cs
@@ -1,0 +1,127 @@
+using Mediator;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using SharpMUSH.Configuration.Options;
+using SharpMUSH.Library.API;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.Services.Interfaces;
+using SharpMUSH.Server.Controllers;
+using SharpMUSH.Server.Hubs;
+using SharpMUSH.Server.Services;
+using SharpMUSH.Tests.Infrastructure;
+using System.Security.Claims;
+
+namespace SharpMUSH.Tests.Integration.Portal;
+
+/// <summary>
+/// That <c>api/objects</c> enforces MUSH permissions rather than merely being authenticated.
+///
+/// These drive <see cref="ObjectsController"/> directly instead of over HTTP, because the shared
+/// test host runs in Development, where <c>DebugAuthenticationHandler</c> is the default scheme and
+/// authenticates every request — including anonymous ones — as an admin. Over HTTP every caller
+/// would be the same privileged identity, so an identity-dependent assertion there would pass no
+/// matter what the controller did. Constructing the controller lets the test choose the acting
+/// character while still exercising the real controller code against the real engine services.
+///
+/// The bypass this guards against is concrete: <c>PackageInstallService</c> legitimately writes
+/// attributes straight to <c>ISharpDatabase</c> as a wizard, skipping permission checks. If someone
+/// ever reaches for that shortcut here, these tests fail.
+/// </summary>
+[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+public class ObjectsControllerPermissionTests(ServerWebAppFactory factory)
+{
+	private IMediator Mediator => factory.Services.GetRequiredService<IMediator>();
+	private IAttributeService AttributeService => factory.Services.GetRequiredService<IAttributeService>();
+
+	/// <summary>A controller acting as <paramref name="actor"/>, wired exactly as DI would build it.</summary>
+	private ObjectsController ControllerAs(DBRef actor)
+		=> ControllerFor(new ClaimsIdentity(
+			[new Claim(GameHub.CharacterDbrefClaim, actor.ToString())], "TestScheme"));
+
+	private ObjectsController ControllerFor(ClaimsIdentity identity) =>
+		new(
+			Mediator,
+			AttributeService,
+			factory.Services.GetRequiredService<IOptionsWrapper<SharpMUSHOptions>>(),
+			factory.Services.GetRequiredService<IEngineCommandInvoker>())
+		{
+			ControllerContext = new ControllerContext
+			{
+				HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+			}
+		};
+
+	private async Task<DBRef> NewPlayerAsync(string prefix)
+		=> await TestIsolationHelpers.CreateTestPlayerAsync(factory.Services, Mediator, prefix);
+
+	[Test]
+	public async Task SetAttribute_OnAnObjectTheActorDoesNotControl_IsRefused()
+	{
+		var intruder = await NewPlayerAsync("ObjApiIntruder");
+		var victim = await NewPlayerAsync("ObjApiVictim");
+
+		var result = await ControllerAs(intruder).SetAttribute(
+			victim.Number, "PWNED", new SetAttributeRequest("intruder was here"), CancellationToken.None);
+
+		await Assert.That(result).IsTypeOf<ObjectResult>();
+		await Assert.That(((ObjectResult)result).StatusCode).IsEqualTo(StatusCodes.Status403Forbidden);
+	}
+
+	[Test]
+	public async Task SetAttribute_RefusedWrite_LeavesNothingBehind()
+	{
+		var intruder = await NewPlayerAsync("ObjApiNoWrite");
+		var victim = await NewPlayerAsync("ObjApiUntouched");
+
+		await ControllerAs(intruder).SetAttribute(
+			victim.Number, "PWNED", new SetAttributeRequest("intruder was here"), CancellationToken.None);
+
+		// Read back as the victim, who would be allowed to see it if it existed.
+		var read = await ControllerAs(victim).GetAttribute(victim.Number, "PWNED", CancellationToken.None);
+
+		await Assert.That(read).IsTypeOf<NotFoundResult>()
+			.Because("a refused write must not reach the database");
+	}
+
+	[Test]
+	public async Task SetAttribute_OnTheActorsOwnObject_Succeeds()
+	{
+		var actor = await NewPlayerAsync("ObjApiSelf");
+
+		var result = await ControllerAs(actor).SetAttribute(
+			actor.Number, "SELF_SET", new SetAttributeRequest("line one\nline two"), CancellationToken.None);
+
+		await Assert.That(result).IsTypeOf<NoContentResult>()
+			.Because("the refusal above must come from permissions, not from the endpoint refusing everything");
+	}
+
+	[Test]
+	public async Task ClearAttribute_OnAnObjectTheActorDoesNotControl_IsRefused()
+	{
+		var owner = await NewPlayerAsync("ObjApiClearOwner");
+		var intruder = await NewPlayerAsync("ObjApiClearIntruder");
+
+		await ControllerAs(owner).SetAttribute(
+			owner.Number, "KEEP_ME", new SetAttributeRequest("still here"), CancellationToken.None);
+
+		var attempt = await ControllerAs(intruder).ClearAttribute(
+			owner.Number, "KEEP_ME", CancellationToken.None);
+
+		await Assert.That(attempt).IsTypeOf<ObjectResult>();
+		await Assert.That(((ObjectResult)attempt).StatusCode).IsEqualTo(StatusCodes.Status403Forbidden);
+
+		var stillThere = await ControllerAs(owner).GetAttribute(owner.Number, "KEEP_ME", CancellationToken.None);
+		await Assert.That(stillThere).IsTypeOf<OkObjectResult>();
+	}
+
+	[Test]
+	public async Task NoCharacterClaim_IsUnauthorized()
+	{
+		var victim = await NewPlayerAsync("ObjApiNoClaim");
+
+		var result = await ControllerFor(new ClaimsIdentity()).GetObject(victim.Number, CancellationToken.None);
+
+		await Assert.That(result).IsTypeOf<UnauthorizedResult>();
+	}
+}

--- a/SharpMUSH.Tests.Integration/Portal/ObjectsControllerPermissionTests.cs
+++ b/SharpMUSH.Tests.Integration/Portal/ObjectsControllerPermissionTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using SharpMUSH.Configuration.Options;
 using SharpMUSH.Library.API;
 using SharpMUSH.Library.Models;
+using SharpMUSH.Library.Queries.Database;
 using SharpMUSH.Library.Services.Interfaces;
 using SharpMUSH.Server.Controllers;
 using SharpMUSH.Server.Hubs;
@@ -44,7 +45,8 @@ public class ObjectsControllerPermissionTests(ServerWebAppFactory factory)
 			Mediator,
 			AttributeService,
 			factory.Services.GetRequiredService<IOptionsWrapper<SharpMUSHOptions>>(),
-			factory.Services.GetRequiredService<IEngineCommandInvoker>())
+			factory.Services.GetRequiredService<IEngineCommandInvoker>(),
+			factory.Services.GetRequiredService<IPermissionService>())
 		{
 			ControllerContext = new ControllerContext
 			{
@@ -113,6 +115,51 @@ public class ObjectsControllerPermissionTests(ServerWebAppFactory factory)
 
 		var stillThere = await ControllerAs(owner).GetAttribute(owner.Number, "KEEP_ME", CancellationToken.None);
 		await Assert.That(stillThere).IsTypeOf<OkObjectResult>();
+	}
+
+	/// <summary>
+	/// Reads are gated too, not just writes. An attribute the actor may not see must not come back
+	/// through the API just because it can be addressed by dbref.
+	/// </summary>
+	[Test]
+	public async Task GetAttribute_OnAnObjectTheActorCannotSee_DoesNotReturnTheValue()
+	{
+		var owner = await NewPlayerAsync("ObjApiReadOwner");
+		var snooper = await NewPlayerAsync("ObjApiSnooper");
+
+		await ControllerAs(owner).SetAttribute(
+			owner.Number, "PRIVATE_NOTE", new SetAttributeRequest("for my eyes only"), CancellationToken.None);
+
+		var result = await ControllerAs(snooper).GetAttribute(owner.Number, "PRIVATE_NOTE", CancellationToken.None);
+
+		var leaked = result is OkObjectResult { Value: AttributeDto dto } && dto.Value.Contains("eyes only");
+		await Assert.That(leaked).IsFalse()
+			.Because("a read the engine refuses must not surface the stored value");
+	}
+
+	/// <summary>
+	/// The object summary carries name, owner and flags, so it needs the same visibility check the
+	/// attribute endpoints get for free from <see cref="IAttributeService"/>.
+	/// </summary>
+	[Test]
+	public async Task GetObject_OnAnObjectTheActorCannotExamine_IsRefused()
+	{
+		var owner = await NewPlayerAsync("ObjApiExamineOwner");
+		var snooper = await NewPlayerAsync("ObjApiExamineSnooper");
+
+		var permissions = factory.Services.GetRequiredService<IPermissionService>();
+		var ownerObject = (await Mediator.Send(new GetObjectNodeQuery(owner))).Known;
+		var snooperObject = (await Mediator.Send(new GetObjectNodeQuery(snooper))).Known;
+
+		// Only meaningful while the engine actually refuses this pairing.
+		var mayExamine = await permissions.CanExamine(snooperObject, ownerObject);
+		await Assert.That(mayExamine).IsFalse()
+			.Because("two unrelated mortals must not be able to examine each other, or this test proves nothing");
+
+		var result = await ControllerAs(snooper).GetObject(owner.Number, CancellationToken.None);
+
+		await Assert.That(result).IsTypeOf<ObjectResult>();
+		await Assert.That(((ObjectResult)result).StatusCode).IsEqualTo(StatusCodes.Status403Forbidden);
 	}
 
 	[Test]

--- a/SharpMUSH.Tests/Commands/IncludeFromDollarCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/IncludeFromDollarCommandTests.cs
@@ -105,6 +105,40 @@ public class IncludeFromDollarCommandTests
 			.Because($"a q-register set before a ';'-separated @include must be readable in the included body; got: [{string.Join(" | ", msgs)}]");
 	}
 
+	/// <summary>
+	/// A body whose ';' separators are followed by a REAL newline runs every command, because
+	/// the lexer's <c>SEMICOLON: ';' WS</c> (WS = <c>[ \r\n\f\t]*</c>) swallows the newline and the
+	/// continuation indent as part of the ';' token.
+	///
+	/// This is the premise the portal's typed attribute API rests on: it stores what the author
+	/// typed byte-for-byte instead of rewriting newlines to '%r', so idiomatic multi-line softcode
+	/// has to already execute correctly. '@set' is used to author it because its RHS is evaluated
+	/// (no RSNoParse, unlike '&' from a player's keyboard), which is what turns %r into a real
+	/// newline on the way in — the same route @force and package installs take.
+	/// </summary>
+	[Test]
+	public async ValueTask MultiLineBody_SemicolonAtLineEnd_RunsEveryCommand()
+	{
+		var tag = Guid.NewGuid().ToString("N")[..8];
+		var obj = await TestIsolationHelpers.CreateTestThingAsync(Parser, ConnectionService, "IncNewline");
+		var token = $"nlcmd{tag}";
+
+		// \%# escapes the substitution so %# survives @set's evaluation and resolves at trigger
+		// time; %r does NOT escape, so it becomes the raw newline this test is about.
+		await Cmd($"@set {obj}=DO_NL_{tag}:${token}:@pemit \\%#=FIRST_{tag};%r@pemit \\%#=SECOND_{tag}");
+
+		var stored = (await Parser.FunctionParse(MModule.single($"[get({obj}/DO_NL_{tag})]")))?.Message?.ToPlainText();
+		await Assert.That(stored).Contains("\n")
+			.Because($"the test is vacuous unless a real newline reached the attribute; stored: [{stored}]");
+
+		var msgs = await TriggerAndCollect(token);
+
+		await Assert.That(msgs.Any(m => m.Trim() == $"FIRST_{tag}")).IsTrue()
+			.Because($"the command before the newline must run; got: [{string.Join(" | ", msgs)}]");
+		await Assert.That(msgs.Any(m => m.Trim() == $"SECOND_{tag}")).IsTrue()
+			.Because($"the command after the newline must run as its own command; got: [{string.Join(" | ", msgs)}]");
+	}
+
 	[Test]
 	public async ValueTask SemicolonSeparatedBody_RunsEveryCommand()
 	{

--- a/SharpMUSH.Tests/Commands/IncludeFromDollarCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/IncludeFromDollarCommandTests.cs
@@ -127,9 +127,14 @@ public class IncludeFromDollarCommandTests
 		// time; %r does NOT escape, so it becomes the raw newline this test is about.
 		await Cmd($"@set {obj}=DO_NL_{tag}:${token}:@pemit \\%#=FIRST_{tag};%r@pemit \\%#=SECOND_{tag}");
 
+		// Assert the whole value, not just that a newline exists somewhere: this is the
+		// byte-for-byte storage contract, so position and surrounding text matter.
+		//
+		// '%#' appears as '#1' because @set evaluates its RHS — the same evaluation that turns the
+		// %r into the real newline this test is about. The enactor is #1 (God) via Cmd's handle.
 		var stored = (await Parser.FunctionParse(MModule.single($"[get({obj}/DO_NL_{tag})]")))?.Message?.ToPlainText();
-		await Assert.That(stored).Contains("\n")
-			.Because($"the test is vacuous unless a real newline reached the attribute; stored: [{stored}]");
+		await Assert.That(stored).IsEqualTo($"${token}:@pemit #1=FIRST_{tag};\n@pemit #1=SECOND_{tag}")
+			.Because($"a real newline must follow the ';' and nothing else may have been rewritten; stored: [{stored}]");
 
 		var msgs = await TriggerAndCollect(token);
 
@@ -137,6 +142,28 @@ public class IncludeFromDollarCommandTests
 			.Because($"the command before the newline must run; got: [{string.Join(" | ", msgs)}]");
 		await Assert.That(msgs.Any(m => m.Trim() == $"SECOND_{tag}")).IsTrue()
 			.Because($"the command after the newline must run as its own command; got: [{string.Join(" | ", msgs)}]");
+	}
+
+	/// <summary>
+	/// The contrast case, and the reason the ';' matters: a newline on its own does NOT separate
+	/// commands. The lexer only swallows whitespace as part of a ';' token, so an unseparated body
+	/// is one command whose argument runs to the end of the value — the first verb takes the rest as
+	/// its own text. Authoring bugs of this shape used to get blamed on @include and %! instead.
+	/// </summary>
+	[Test]
+	public async ValueTask MultiLineBody_WithoutSemicolon_DoesNotRunTheSecondCommand()
+	{
+		var tag = Guid.NewGuid().ToString("N")[..8];
+		var obj = await TestIsolationHelpers.CreateTestThingAsync(Parser, ConnectionService, "IncNoSemi");
+		var token = $"nosemi{tag}";
+
+		// Same shape as the passing case, minus the ';' before the newline.
+		await Cmd($"@set {obj}=DO_NS_{tag}:${token}:@pemit \\%#=ALPHA_{tag}%r@pemit \\%#=BETA_{tag}");
+
+		var msgs = await TriggerAndCollect(token);
+
+		await Assert.That(msgs.Any(m => m.Trim() == $"BETA_{tag}")).IsFalse()
+			.Because($"without a ';' the second verb is swallowed into the first's argument; got: [{string.Join(" | ", msgs)}]");
 	}
 
 	[Test]

--- a/SharpMUSH.Tests/Commands/IncludeFromDollarCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/IncludeFromDollarCommandTests.cs
@@ -162,6 +162,11 @@ public class IncludeFromDollarCommandTests
 
 		var msgs = await TriggerAndCollect(token);
 
+		// Guard first: without this the test would also pass if the $-command never matched at all,
+		// which would prove nothing about separation.
+		await Assert.That(msgs.Any(m => m.Contains($"ALPHA_{tag}"))).IsTrue()
+			.Because($"the body must have run for its shape to be under test; got: [{string.Join(" | ", msgs)}]");
+
 		await Assert.That(msgs.Any(m => m.Trim() == $"BETA_{tag}")).IsFalse()
 			.Because($"without a ';' the second verb is swallowed into the first's argument; got: [{string.Join(" | ", msgs)}]");
 	}

--- a/SharpMUSH.Tests/Database/CreateInvalidatesNegativeCacheTests.cs
+++ b/SharpMUSH.Tests/Database/CreateInvalidatesNegativeCacheTests.cs
@@ -1,0 +1,67 @@
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Queries.Database;
+using SharpMUSH.Library.Services.Interfaces;
+using SharpMUSH.Tests.Infrastructure;
+
+namespace SharpMUSH.Tests.Database;
+
+/// <summary>
+/// Creating an object must invalidate the cached lookup for its dbref.
+///
+/// <see cref="GetObjectNodeByNumberQuery"/> is <c>ICacheable</c>, and
+/// <see cref="SharpMUSH.Library.Behaviors.QueryCachingBehavior{TRequest,TResponse}"/> caches whatever
+/// it returns — including a miss. The create commands declare cache keys for the objects they touch
+/// (owner, home, container), but they cannot declare the NEW object's key, because its dbref does not
+/// exist until the insert returns. So a lookup of a not-yet-existing dbref poisoned that key, and the
+/// object stayed invisible after creation until the entry aged out.
+///
+/// Anything that probes a dbref before it exists hits this. The portal's Softcode Editor does it on
+/// every create: it makes the object, then immediately selects it, and the select 404'd.
+/// </summary>
+[NotInParallel]
+public class CreateInvalidatesNegativeCacheTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactoryArg { get; init; }
+
+	private IMediator Mediator => WebAppFactoryArg.Services.GetRequiredService<IMediator>();
+	private IConnectionService ConnectionService => WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
+	private IMUSHCodeParser Parser => WebAppFactoryArg.CommandParser;
+
+	private async ValueTask<DBRef> CreateThingAsync(string prefix)
+		=> await TestIsolationHelpers.CreateTestThingAsync(Parser, ConnectionService, prefix);
+
+	[Test]
+	public async ValueTask ObjectIsVisible_WhenItsDbrefWasLookedUpBeforeItExisted()
+	{
+		// Establish where the next dbref will land, then poison exactly that key.
+		var first = await CreateThingAsync("NegCacheAnchor");
+		var next = new DBRef(first.Number + 1);
+
+		var beforeCreation = await Mediator.Send(new GetObjectNodeQuery(next));
+		await Assert.That(beforeCreation.IsNone).IsTrue()
+			.Because($"#{next.Number} must not exist yet for this test to mean anything");
+
+		var created = await CreateThingAsync("NegCacheTarget");
+		await Assert.That(created.Number).IsEqualTo(next.Number)
+			.Because("dbrefs are handed out sequentially; if not, the poisoned key is not the one under test");
+
+		var afterCreation = await Mediator.Send(new GetObjectNodeQuery(created));
+
+		await Assert.That(afterCreation.IsNone).IsFalse()
+			.Because("creating the object must clear the cached miss for its dbref");
+	}
+
+	[Test]
+	public async ValueTask CreatedObjectResolvesByBareDbref_ImmediatelyAfterCreation()
+	{
+		var created = await CreateThingAsync("NegCacheBare");
+
+		var resolved = await Mediator.Send(new GetObjectNodeQuery(new DBRef(created.Number)));
+
+		await Assert.That(resolved.IsNone).IsFalse();
+	}
+}

--- a/SharpMUSH.Tests/Database/CreateInvalidatesNegativeCacheTests.cs
+++ b/SharpMUSH.Tests/Database/CreateInvalidatesNegativeCacheTests.cs
@@ -37,22 +37,36 @@ public class CreateInvalidatesNegativeCacheTests
 	[Test]
 	public async ValueTask ObjectIsVisible_WhenItsDbrefWasLookedUpBeforeItExisted()
 	{
-		// Establish where the next dbref will land, then poison exactly that key.
-		var first = await CreateThingAsync("NegCacheAnchor");
-		var next = new DBRef(first.Number + 1);
+		// The test has to poison the key for a dbref that does not exist yet, which means predicting
+		// the next one. The factory is shared per test session, so another class can take that dbref
+		// in between; retry rather than fail, since a lost race says nothing about the behaviour.
+		const int attempts = 5;
+		for (var attempt = 1; ; attempt++)
+		{
+			var anchor = await CreateThingAsync("NegCacheAnchor");
+			var next = new DBRef(anchor.Number + 1);
 
-		var beforeCreation = await Mediator.Send(new GetObjectNodeQuery(next));
-		await Assert.That(beforeCreation.IsNone).IsTrue()
-			.Because($"#{next.Number} must not exist yet for this test to mean anything");
+			var beforeCreation = await Mediator.Send(new GetObjectNodeQuery(next));
+			if (!beforeCreation.IsNone)
+			{
+				if (attempt < attempts) continue;
+				Assert.Fail($"#{next.Number} already existed on every one of {attempts} attempts.");
+			}
 
-		var created = await CreateThingAsync("NegCacheTarget");
-		await Assert.That(created.Number).IsEqualTo(next.Number)
-			.Because("dbrefs are handed out sequentially; if not, the poisoned key is not the one under test");
+			var created = await CreateThingAsync("NegCacheTarget");
+			if (created.Number != next.Number)
+			{
+				// Someone else took the dbref we poisoned; this round proves nothing either way.
+				if (attempt < attempts) continue;
+				Assert.Fail($"lost the dbref race {attempts} times (wanted #{next.Number}, got #{created.Number}).");
+			}
 
-		var afterCreation = await Mediator.Send(new GetObjectNodeQuery(created));
+			var afterCreation = await Mediator.Send(new GetObjectNodeQuery(created));
 
-		await Assert.That(afterCreation.IsNone).IsFalse()
-			.Because("creating the object must clear the cached miss for its dbref");
+			await Assert.That(afterCreation.IsNone).IsFalse()
+				.Because("creating the object must clear the cached miss for its dbref");
+			return;
+		}
 	}
 
 	[Test]

--- a/SharpMUSH.Tests/Internal/ParserStateRootForTests.cs
+++ b/SharpMUSH.Tests/Internal/ParserStateRootForTests.cs
@@ -1,0 +1,80 @@
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+
+namespace SharpMUSH.Tests.Internal;
+
+/// <summary>
+/// Contract tests for <see cref="ParserState.RootFor"/>, the shared "fresh root state acting as
+/// one object" constructor. Three callers used to hand-roll this block — the boot @STARTUP pass,
+/// the package lifecycle runner, and the HTTP handler dispatcher — and a fourth (the portal's
+/// engine command invoker) needs it too.
+///
+/// The distinction that matters is against <see cref="ParserState.Empty"/>, whose register stack
+/// is genuinely empty. A root state must ship one q-register frame, or the first setq() in the
+/// code it runs has nowhere to write.
+/// </summary>
+public class ParserStateRootForTests
+{
+	private static readonly DBRef Actor = new(42, 1700000000);
+
+	[Test]
+	public async Task RootFor_BindsExecutorEnactorAndCaller_ToTheSameObject()
+	{
+		var state = ParserState.RootFor(Actor);
+
+		await Assert.That(state.Executor).IsEqualTo(Actor);
+		await Assert.That(state.Enactor).IsEqualTo(Actor);
+		await Assert.That(state.Caller).IsEqualTo(Actor);
+	}
+
+	[Test]
+	public async Task RootFor_SeedsExactlyOneRegisterFrame()
+	{
+		var state = ParserState.RootFor(Actor);
+
+		await Assert.That(state.Registers.Count).IsEqualTo(1)
+			.Because("code running from a root state must be able to setq() without pushing a frame first");
+	}
+
+	[Test]
+	public async Task RootFor_HasNoConnectionAndNoHttpResponse()
+	{
+		var state = ParserState.RootFor(Actor);
+
+		await Assert.That(state.Handle).IsNull();
+		await Assert.That(state.HttpResponse).IsNull();
+		await Assert.That(state.ParseMode).IsEqualTo(ParseMode.Default);
+	}
+
+	[Test]
+	public async Task RootFor_ProvidesTheLimitCounters()
+	{
+		var state = ParserState.RootFor(Actor);
+
+		await Assert.That(state.CallDepth).IsNotNull();
+		await Assert.That(state.TotalInvocations).IsNotNull();
+		await Assert.That(state.LimitExceeded).IsNotNull();
+		await Assert.That(state.FunctionRecursionDepths).IsNotNull();
+	}
+
+	[Test]
+	public async Task RootFor_StartsWithNoArgumentsOrEnvironmentRegisters()
+	{
+		var state = ParserState.RootFor(Actor);
+
+		await Assert.That(state.Arguments).IsEmpty();
+		await Assert.That(state.EnvironmentRegisters).IsEmpty();
+	}
+
+	[Test]
+	public async Task RootFor_ReturnsAnIndependentStatePerCall()
+	{
+		var first = ParserState.RootFor(Actor);
+		var second = ParserState.RootFor(Actor);
+
+		first.Arguments["0"] = new CallState("mine");
+
+		await Assert.That(second.Arguments).IsEmpty()
+			.Because("two invocations sharing a mutable dictionary would leak arguments between callers");
+	}
+}

--- a/SharpMUSH.Tests/Internal/ValidateNameTests.cs
+++ b/SharpMUSH.Tests/Internal/ValidateNameTests.cs
@@ -1,0 +1,94 @@
+using Mediator;
+using NSubstitute;
+using OneOf.Types;
+using SharpMUSH.Configuration.Options;
+using SharpMUSH.Library.Services;
+using SharpMUSH.Library.Services.Interfaces;
+
+namespace SharpMUSH.Tests.Internal;
+
+/// <summary>
+/// Object-name validation (<see cref="IValidateService.ValidationType.Name"/>).
+///
+/// The rule the character class has always described is: no leading or trailing space, and none of
+/// <c>[ ] % \ = &amp; |</c> anywhere. The pattern did not enforce it — it carried a <c>$</c> but no
+/// <c>^</c>, and its middle term matched the forbidden set rather than its complement, so
+/// <see cref="Regex.IsMatch"/> could satisfy it against the last character or two of any string.
+/// Every forbidden character passed as long as it was not at the very end.
+///
+/// Names reach this only on create/rename and through the <c>valid()</c> function, so tightening it
+/// cannot reject an object that already exists — it stops new ones being made.
+///
+/// <c>;</c> stays legal: <c>@open</c> splits exit aliases on it (<c>@open north;n</c>).
+/// </summary>
+public class ValidateNameTests
+{
+	private static ValidateService Service() => new(
+		Substitute.For<IMediator>(),
+		Substitute.For<IOptionsWrapper<SharpMUSHOptions>>(),
+		Substitute.For<ILockService>());
+
+	private static async ValueTask<bool> IsValid(string name)
+		=> await Service().Valid(IValidateService.ValidationType.Name, MModule.single(name), new None());
+
+	[Test]
+	[Arguments("TestName")]
+	[Arguments("X")]
+	[Arguments("a red ball")]
+	[Arguments("Bob's Hat")]
+	[Arguments("north;n")]
+	[Arguments("A Room (Upstairs)")]
+	[Arguments("widget-42_v2")]
+	public async Task AcceptsOrdinaryNames(string name)
+		=> await Assert.That(await IsValid(name)).IsTrue().Because($"'{name}' is a legal object name");
+
+	[Test]
+	[Arguments("foo[bar")]
+	[Arguments("foo]bar")]
+	[Arguments("foo%bar")]
+	[Arguments("foo\\bar")]
+	[Arguments("foo=bar")]
+	[Arguments("foo&bar")]
+	[Arguments("foo|bar")]
+	public async Task RejectsAForbiddenCharacterInTheMiddle(string name)
+		=> await Assert.That(await IsValid(name)).IsFalse()
+			.Because($"'{name}' contains a forbidden character; the old pattern matched only the tail");
+
+	[Test]
+	[Arguments("[leading")]
+	[Arguments("%leading")]
+	[Arguments("=leading")]
+	public async Task RejectsAForbiddenCharacterAtTheStart(string name)
+		=> await Assert.That(await IsValid(name)).IsFalse().Because($"'{name}' starts with a forbidden character");
+
+	[Test]
+	[Arguments("trailing[")]
+	[Arguments("trailing%")]
+	[Arguments("trailing|")]
+	public async Task RejectsAForbiddenCharacterAtTheEnd(string name)
+		=> await Assert.That(await IsValid(name)).IsFalse().Because($"'{name}' ends with a forbidden character");
+
+	[Test]
+	[Arguments(" leading space")]
+	[Arguments("trailing space ")]
+	[Arguments("  ")]
+	[Arguments(" ")]
+	public async Task RejectsLeadingAndTrailingWhitespace(string name)
+		=> await Assert.That(await IsValid(name)).IsFalse().Because($"'{name}' is space-padded");
+
+	[Test]
+	public async Task RejectsAnEmptyName()
+		=> await Assert.That(await IsValid(string.Empty)).IsFalse();
+
+	[Test]
+	[Arguments("me")]
+	[Arguments("here")]
+	[Arguments("home")]
+	[Arguments("!")]
+	public async Task RejectsMagicCookies(string name)
+		=> await Assert.That(await IsValid(name)).IsFalse().Because($"'{name}' is a lookup token, not a name");
+
+	[Test]
+	public async Task RejectsNonAsciiNames()
+		=> await Assert.That(await IsValid("Café")).IsFalse();
+}

--- a/SharpMUSH.Tests/Internal/ValidateNameTests.cs
+++ b/SharpMUSH.Tests/Internal/ValidateNameTests.cs
@@ -76,6 +76,22 @@ public class ValidateNameTests
 	public async Task RejectsLeadingAndTrailingWhitespace(string name)
 		=> await Assert.That(await IsValid(name)).IsFalse().Because($"'{name}' is space-padded");
 
+	/// <summary>
+	/// Control characters are not names. A tab or an embedded newline would corrupt every
+	/// line-oriented surface the name appears on, and <c>$</c> in .NET matches immediately before a
+	/// trailing <c>\n</c> — so an anchor of <c>$</c> rather than <c>\z</c> accepts <c>"name\n"</c>.
+	/// </summary>
+	[Test]
+	[Arguments("na\tme")]
+	[Arguments("na\nme")]
+	[Arguments("name\n")]
+	[Arguments("name\r\n")]
+	[Arguments("\nname")]
+	[Arguments("\tname")]
+	public async Task RejectsControlCharacters(string name)
+		=> await Assert.That(await IsValid(name)).IsFalse()
+			.Because($"'{name.Replace("\n", "\\n").Replace("\t", "\\t").Replace("\r", "\\r")}' contains a control character");
+
 	[Test]
 	public async Task RejectsAnEmptyName()
 		=> await Assert.That(await IsValid(string.Empty)).IsFalse();

--- a/docs/design/architectural-decisions.md
+++ b/docs/design/architectural-decisions.md
@@ -423,7 +423,7 @@ body has no line limit, so the conversion has no reason to exist.
 consumes a newline and its continuation indent as part of the `;` token, so
 idiomatic multi-line softcode already parses correctly:
 
-```
+```mushcode
 $greet *:@pemit %#=Hi;
   @pemit %#=Bye
 ```

--- a/docs/design/architectural-decisions.md
+++ b/docs/design/architectural-decisions.md
@@ -402,6 +402,45 @@ serves via ASP.NET static files or a file controller.
 **Migration path:** Swap `LocalFileStorage` for `MinioFileStorage` when scaling
 requires it. Client code unchanged (URLs work either way).
 
+### 4.5 Attribute Editing: Typed API, Values Stored Verbatim
+
+**Decision:** The Softcode Editor reads and writes attributes through
+`api/objects` (`ObjectsController`), not through the terminal. Values are stored
+exactly as typed — no encoding on the way out, no decoding on the way back.
+
+**Rationale:** The terminal channel is line-delimited, so the editor had to
+rewrite every newline as the two characters `%r` to keep `&ATTR #dbref=value` a
+single message. `&` is `RSNoParse` for direct input, so that literal `%r` is what
+reached the database, and the editor translated `%r` back to a newline on load.
+The two were indistinguishable in both directions.
+
+Every other write path already stores real newlines — `@set` and `&` from a queue
+both evaluate their RHS (and `%r` expands to `"\n"`), and package installs write
+their YAML block scalars byte-for-byte. The editor was the sole exception. A JSON
+body has no line limit, so the conversion has no reason to exist.
+
+**No grammar change was needed.** `SEMICOLON: ';' WS` with `WS: [ \r\n\f\t]*`
+consumes a newline and its continuation indent as part of the `;` token, so
+idiomatic multi-line softcode already parses correctly:
+
+```
+$greet *:@pemit %#=Hi;
+  @pemit %#=Bye
+```
+
+**Permissions** are the engine's. Every operation goes through `IAttributeService`
+— the same service `&` calls — which enforces `Controls` and `CanSet` itself.
+There is no portal-role gate beyond holding a session with a character.
+
+**Object creation** invokes the registered `@CREATE` / `@DIG` / `@OPEN` through
+`IEngineCommandInvoker` with pre-split arguments, so quota, zone inheritance, the
+`OBJECT`CREATE` event and plugin hooks all still fire. Names are never spliced
+into a command line: `ValidateService.NameRegex` does not forbid `;`.
+
+**No migration.** Attributes written by the old editor hold a literal `%r`, and
+nothing can distinguish one the author meant from one that was a mangled newline.
+They now display as `%r`, which is what is stored.
+
 ---
 
 ## 5. Content Formatting & Rendering Pipeline


### PR DESCRIPTION
## Why

The Softcode Editor was the only attribute-writing path in the server that mangled its input.
`MushQueryService.SetAttributeAsync` rewrote every newline as the two characters `%r` and sent
`&ATTR #dbref=value` down the terminal WebSocket, because that channel is line-delimited and a raw
newline would split into two commands. `&` is `RSNoParse` for direct input, so the literal `%r` is
what reached the database — and the editor translated every stored `%r` back to a newline on load,
making the two indistinguishable in both directions.

Every other write path already stores real newlines:

| Path | Evaluates RHS | `%r` in source becomes |
|---|---|---|
| `&attr obj=…` typed at the keyboard | no | literal `%r` |
| `&attr obj=…` from `@force` / `@trigger` / `@wait` | yes | real `\n` |
| `@set obj=attr:…` | yes | real `\n` |
| package install | n/a — YAML verbatim | real `\n` |

`%r` expands to `"\n"` (`Substitutions.cs`). The concrete bug: open a package-installed two-line
`DESCRIBE` (e.g. `examples/packages/starter-area/package.yaml`), save it, and the real newlines
become literal `%r`. That is content drift against the managed baseline (`ManagedAttributeRecord`
value + SHA), so the next `@package upgrade` reports a conflict on an attribute nobody meaningfully
edited.

**No grammar change was needed.** `SEMICOLON: ';' WS` with `WS: [ \r\n\f\t]*` already consumes a
newline and its continuation indent as part of the `;` token, so idiomatic multi-line softcode
parses correctly today:

```
$greet *:@pemit %#=Hi;
  @pemit %#=Bye
```

A new test in `IncludeFromDollarCommandTests` pins that, with a guard asserting a real newline
actually reached the attribute so it cannot pass vacuously.

## What

**`api/objects`** — a typed path that stores values verbatim.

```
GET    api/objects/{dbref}                              name, type, owner, flags
GET    api/objects/{dbref}/attributes[?depth=N]         visible attributes
GET    api/objects/{dbref}/attributes/{name}            one attribute
PUT    api/objects/{dbref}/attributes/{name}            set  { value }
DELETE api/objects/{dbref}/attributes/{name}            clear
POST   api/objects/{dbref}/attributes/{name}/flags      set flag
DELETE api/objects/{dbref}/attributes/{name}/flags/{f}  unset flag
POST   api/objects                                      create { name, type }
```

- Permissions are the engine's: every operation goes through `IAttributeService`, the same service
  `&` calls, which enforces `Controls` and `CanSet` itself. No portal-role gate beyond holding a
  session with a character.
- Executor is `User.GetActingCharacter()`. It cannot diverge from the connected terminal —
  `AuthController.SwitchCharacter` rebinds the session and mints the terminal's OTT in one response.
- Addressing is by dbref only; name resolution needs a parser and notifies on failure, and the
  editor already picks its target out of the object browser as a dbref.
- Empty value clears or stores empty per `Attribute.EmptyAttributes`, matching `&`.
- Reads use `parent: false` — an editor must show what is stored on *this* object. The old `get()`
  followed parents, so saving an inherited value silently copied the parent's code down.

**Creation runs the real command.** `@CREATE` does default-home resolution, name validation, zone
inheritance with cycle checks, the ``OBJECT`CREATE`` event and `IPluginHookDispatcher` — not
reimplementable in a controller. A new `IEngineCommandInvoker` resolves the `CommandDefinition` and
invokes it with pre-split `Arguments` on a parser bound to the acting character. Names are never
spliced into a command line: `NameRegex` does not forbid `;`.

**Client.** New `ObjectApiService`; `MushQueryService` keeps only what is genuinely softcode
evaluation (free-form `lsearch`, `u()`); both `Replace("%r", "\n")` calls are gone from
`SoftcodeEditor.razor`.

**Boy Scout: `ParserState.RootFor`.** The boot `@STARTUP` pass, the package lifecycle runner and the
HTTP handler dispatcher each hand-rolled the same 20-line "fresh root state acting as one object"
block; the comment in one of them already said it was copying the others.

## Fixes found by driving the editor end to end

Running the real stack and walking the UI surfaced three defects, each with a regression test.

**Creating an object did not invalidate the cached lookup for its dbref.**
`GetObjectNodeByNumberQuery` is `ICacheable` and `QueryCachingBehavior` stores whatever the handler
returns, misses included. The create commands declare cache keys for the objects they *touch*
(owner, home, container) but cannot declare the new object's key, because the dbref does not exist
until the insert returns. Any lookup of a not-yet-existing dbref left a "no such object" entry
behind. Reproduced deterministically:

```
probe #15 before it exists:  404
created: {"dbref":"#15:1786373813183"}
read it back immediately:    404
```

The editor hit this on *every* create — it makes the object, immediately selects it, and the select
404'd. Invalidated in all four create handlers.

**The editor could not create exits.** `_createObjectType` already handled `@open`, but nothing ever
invoked `ShowCreateObjectDialog(MushObjectType.Exit)` — only Thing and Room buttons existed. Added
the third, with `TermCreateExit` across all 16 locales.

**Every attribute opened showed as unsaved.** Monaco raises `OnDidChangeModelContent` for `SetValue`
too, so loading an attribute, switching tabs or refreshing marked the tab dirty with no user input —
which also made `RefreshAttributesAsync` skip those tabs permanently, since it only refreshes clean
ones. Programmatic writes now go through a guarded helper.

**Separately: `NameRegex` was unanchored** (`ValidateService.cs`). It had `$` but no `^`, and its
middle term matched the forbidden set instead of its complement, so `IsMatch` could satisfy the whole
expression against the last character or two of any input — `"foo[bar"` matched on `ar$`. Every
character the class set out to forbid passed unless it sat at the very end. Rewritten as the rule the
class always described: no leading/trailing space, none of `[ ] % \ = & |` anywhere, interior spaces
and `;` still legal. Names are validated only on create/rename and through `valid()`, so this cannot
reject an object that already exists.

## Behaviour change

Attributes written by the old editor hold a literal `%r` and now display as `%r`, because that is
what is stored. There is no migration — nothing can tell an intentional `%r` from a mangled newline.
Recorded in `docs/design/architectural-decisions.md` §4.5.

## Verification

Engine 5304 passed / 0 failed / 192 skipped · Integration 336/336 · bUnit 483/483 · solution builds
clean with the format gate on.

Verified against a live stack (Server + ConnectionServer + Client + NATS), not only in tests: created
a Thing, a Room and an Exit through the UI, wrote a three-line `$`-command, saved it, navigated away
and back, and ran it in `/play`. The body reopens with its formatting intact and all three lines
execute as separate commands.

Notes on the test suites:

- The shared integration host runs in Development, where `DebugAuthenticationHandler` is the default
  scheme and authenticates every request — including anonymous ones — as an admin. Identity-dependent
  assertions over HTTP would pass no matter what the controller did, so those live in
  `ObjectsControllerPermissionTests`, which constructs the controller with a chosen principal against
  the real engine services.
- Tests written against already-existing code were mutation-checked rather than trusted: swallowing
  the 403 fails the permission test, and reintroducing the `%r` rewrite fails two client tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MPRzndB5egy4F2A3q5852


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added portal-based object and attribute management, including creation, editing, retrieval, deletion, and flag updates.
  * Added an “Create Exit” action with localized labels across supported languages.
* **Bug Fixes**
  * Preserved multiline attribute content and literal `%r` tokens exactly.
  * Improved error reporting, permission enforcement, and editor dirty-state tracking.
  * Object creation results are available immediately, including after prior failed lookups.
  * Improved object-name validation and preserved unsaved content during refreshes.
* **Documentation**
  * Documented typed attribute editing and related behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->