### PR TITLE
Guard the Softcode Editor's async responses, and give the API service typed outcomes

### DIFF
--- a/SharpMUSH.Client/Pages/SoftcodeEditor.razor
+++ b/SharpMUSH.Client/Pages/SoftcodeEditor.razor
@@ -559,33 +559,54 @@
         _showCreateAttr = false;
         StateHasChanged();
 
-        var result = await ObjectApi.GetObjectAsync(dbref);
+        try
+        {
+            var result = await ObjectApi.GetObjectAsync(dbref);
 
-        // Someone selected something else while this was in flight; that request owns the state now.
-        if (generation != _objectLoadGeneration) return;
+            // Someone selected something else while this was in flight; that request owns the
+            // state now, including the loading flag it set on its own way in.
+            if (generation != _objectLoadGeneration) return;
 
-        result.Switch(
-            obj =>
+            result.Switch(
+                obj =>
+                {
+                    _selectedObject = obj;
+                    // Mobile drill-down: picking an object advances to its attributes.
+                    if (advanceMobilePane)
+                        _mobilePane = MobilePane.Attrs;
+                },
+                failure =>
+                {
+                    // The selection is deliberately left alone. This runs on the reload after a
+                    // successful save too, and blanking the panes because a re-read failed would
+                    // throw away work the user can still see and re-save.
+                    _saveMessage = Loc["TermErrorLoadingObject", failure.Message];
+                    _saveSeverity = Severity.Error;
+                });
+        }
+        finally
+        {
+            // Only the newest request owns the flag; an older one clearing it would unstick the
+            // spinner while the current load is still running.
+            if (generation == _objectLoadGeneration)
             {
-                _selectedObject = obj;
-                // Mobile drill-down: picking an object advances to its attributes.
-                if (advanceMobilePane)
-                    _mobilePane = MobilePane.Attrs;
-            },
-            failure =>
-            {
-                _selectedObject = null;
-                _saveMessage = Loc["TermErrorLoadingObject", failure.Message];
-                _saveSeverity = Severity.Error;
-            });
-
-        _loadingAttrs = false;
-        StateHasChanged();
+                _loadingAttrs = false;
+                StateHasChanged();
+            }
+        }
     }
 
-    private async Task RefreshAttributesAsync()
+    /// <summary>
+    /// Re-reads the selected object and re-syncs its open tabs.
+    /// </summary>
+    /// <returns>
+    /// Whether the reload actually landed. A caller that is about to report its own success needs
+    /// to know: overwriting a "could not re-read the object" message with "saved" hides the fact
+    /// that what is on screen is now stale.
+    /// </returns>
+    private async Task<bool> RefreshAttributesAsync()
     {
-        if (_selectedObject is null) return;
+        if (_selectedObject is null) return false;
 
         // Captured before the await: the user may select a different object while the reload runs,
         // and this refresh must only ever touch tabs belonging to the object it started on.
@@ -615,6 +636,8 @@
         }
         if (ActiveTab is not null)
             await SetEditorValueAsync(ActiveTab.WorkingContent);
+
+        return _selectedObject is not null && _selectedObject.Dbref == dbref;
     }
 
     private async Task SaveAsync()
@@ -628,6 +651,12 @@
         // overwrote it.
         var tab = ActiveTab;
         var value = await _monacoEditor.GetValue();
+
+        // GetValue is interop and yields. A tab switch during it loads the other tab's text into
+        // Monaco, so `value` may be that tab's content — writing it to `tab` would PUT one
+        // attribute's text over another's.
+        if (!ReferenceEquals(ActiveTab, tab)) return;
+
         tab.WorkingContent = value;
 
         // Sent verbatim — newlines included. The API carries the value in a JSON body, so there is
@@ -644,9 +673,16 @@
         // The buffer is now what the database holds, so that tab is clean by definition.
         tab.SavedContent = value;
         tab.IsDirty = false;
-        await RefreshAttributesAsync();
-        _saveMessage = Loc["TermSavedAttribute", tab.Attr.Name, tab.Obj.Dbref];
-        _saveSeverity = Severity.Success;
+
+        // Only claim success once the re-read confirms it. If the reload failed it has already put
+        // its own error on screen, and overwriting that with "saved" would leave the user looking
+        // at stale panes believing everything is current.
+        if (await RefreshAttributesAsync())
+        {
+            _saveMessage = Loc["TermSavedAttribute", tab.Attr.Name, tab.Obj.Dbref];
+            _saveSeverity = Severity.Success;
+        }
+
         StateHasChanged();
     }
 
@@ -667,11 +703,17 @@
             return;
         }
 
-        _saveMessage = Loc["TermDeletedAttribute", tab.Attr.Name];
-        _saveSeverity = Severity.Info;
         var tabIdx = _openTabs.IndexOf(tab);
         if (tabIdx >= 0) await CloseTabAsync(tabIdx);
-        await RefreshAttributesAsync();
+
+        // After the refresh, not before: RefreshAttributesAsync goes through OnObjectSelected,
+        // which clears _saveMessage on its way in, so a confirmation set earlier never renders.
+        if (await RefreshAttributesAsync())
+        {
+            _saveMessage = Loc["TermDeletedAttribute", tab.Attr.Name];
+            _saveSeverity = Severity.Info;
+        }
+
         StateHasChanged();
     }
 
@@ -760,7 +802,11 @@
             return;
         }
 
-        if (_selectedObject?.Dbref != targetDbref) return;
+        // Only the dbref is compared, not the instance: a refresh legitimately replaces
+        // _selectedObject with a fresh read of the same object. The null arm is spelled out rather
+        // than folded into `?.` so a future path that clears the selection cannot turn this into a
+        // NullReferenceException in an event handler.
+        if (_selectedObject is null || _selectedObject.Dbref != targetDbref) return;
 
         await RefreshAttributesAsync();
         var created = _selectedObject?.Attributes.FirstOrDefault(a =>

--- a/SharpMUSH.Client/Pages/SoftcodeEditor.razor
+++ b/SharpMUSH.Client/Pages/SoftcodeEditor.razor
@@ -544,43 +544,56 @@
     // advanceMobilePane: only true for a direct object pick. Internal refreshes
     // (Save, Refresh attributes) reuse this method and must NOT yank the mobile user
     // out of the editor back to the attributes pane.
+    /// <summary>
+    /// Monotonic ticket for object loads. Clicking a second object before the first responds must
+    /// not let the older, slower answer land on top of the newer selection.
+    /// </summary>
+    private int _objectLoadGeneration;
+
     private async Task OnObjectSelected(int dbref, bool advanceMobilePane = true)
     {
+        var generation = ++_objectLoadGeneration;
+
         _loadingAttrs = true;
         _saveMessage = null;
         _showCreateAttr = false;
         StateHasChanged();
-        try
-        {
-            _selectedObject = await ObjectApi.GetObjectAsync(dbref);
-            _selectedObject ??= new MushObject
+
+        var result = await ObjectApi.GetObjectAsync(dbref);
+
+        // Someone selected something else while this was in flight; that request owns the state now.
+        if (generation != _objectLoadGeneration) return;
+
+        result.Switch(
+            obj =>
             {
-                Dbref = dbref,
-                Name = $"#{dbref}",
-                Attributes = await ObjectApi.GetAttributesAsync(dbref),
-            };
-            // Mobile drill-down: picking an object advances to its attributes.
-            if (advanceMobilePane)
-                _mobilePane = MobilePane.Attrs;
-        }
-        catch (Exception ex)
-        {
-            _saveMessage = Loc["TermErrorLoadingObject", ex.Message];
-            _saveSeverity = Severity.Error;
-        }
-        finally
-        {
-            _loadingAttrs = false;
-            StateHasChanged();
-        }
+                _selectedObject = obj;
+                // Mobile drill-down: picking an object advances to its attributes.
+                if (advanceMobilePane)
+                    _mobilePane = MobilePane.Attrs;
+            },
+            failure =>
+            {
+                _selectedObject = null;
+                _saveMessage = Loc["TermErrorLoadingObject", failure.Message];
+                _saveSeverity = Severity.Error;
+            });
+
+        _loadingAttrs = false;
+        StateHasChanged();
     }
 
     private async Task RefreshAttributesAsync()
     {
         if (_selectedObject is null) return;
+
+        // Captured before the await: the user may select a different object while the reload runs,
+        // and this refresh must only ever touch tabs belonging to the object it started on.
         var dbref = _selectedObject.Dbref;
+
         await OnObjectSelected(dbref, advanceMobilePane: false);
-        if (_selectedObject is not null)
+
+        if (_selectedObject is not null && _selectedObject.Dbref == dbref)
         {
             foreach (var tab in _openTabs.Where(t => t.Obj.Dbref == dbref))
             {
@@ -607,27 +620,32 @@
     private async Task SaveAsync()
     {
         if (ActiveTab is null || _monacoEditor is null) return;
+
+        // The tab itself is captured, not just its name and dbref: the user can switch tabs while
+        // the PUT is in flight, and the result belongs to the tab that initiated it. Writing back
+        // through ActiveTab marked whichever tab happened to be active as clean, handing it another
+        // tab's saved baseline — so it read as saved when it was not, and the next refresh
+        // overwrote it.
+        var tab = ActiveTab;
         var value = await _monacoEditor.GetValue();
-        ActiveTab.WorkingContent = value;
-        var savedAttrName = ActiveTab.Attr.Name;
-        var savedDbref = ActiveTab.Obj.Dbref;
+        tab.WorkingContent = value;
 
         // Sent verbatim — newlines included. The API carries the value in a JSON body, so there is
         // nothing to escape and nothing for the server to decode.
-        var error = await ObjectApi.SetAttributeAsync(savedDbref, savedAttrName, value);
-        if (error is not null)
+        var result = await ObjectApi.SetAttributeAsync(tab.Obj.Dbref, tab.Attr.Name, value);
+        if (result.TryPickT1(out var failure, out _))
         {
-            _saveMessage = error;
+            _saveMessage = failure.Message;
             _saveSeverity = Severity.Error;
             StateHasChanged();
             return;
         }
 
-        // The buffer is now what the database holds, so the tab is clean by definition.
-        ActiveTab.SavedContent = value;
-        ActiveTab.IsDirty = false;
+        // The buffer is now what the database holds, so that tab is clean by definition.
+        tab.SavedContent = value;
+        tab.IsDirty = false;
         await RefreshAttributesAsync();
-        _saveMessage = Loc["TermSavedAttribute", savedAttrName, savedDbref];
+        _saveMessage = Loc["TermSavedAttribute", tab.Attr.Name, tab.Obj.Dbref];
         _saveSeverity = Severity.Success;
         StateHasChanged();
     }
@@ -635,21 +653,23 @@
     private async Task DeleteAsync()
     {
         if (ActiveTab is null) return;
-        var deletedName = ActiveTab.Attr.Name;
-        var deletedDbref = ActiveTab.Obj.Dbref;
 
-        var error = await ObjectApi.DeleteAttributeAsync(deletedDbref, deletedName);
-        if (error is not null)
+        // Captured for the same reason as SaveAsync: on return we must close the tab we deleted
+        // from, not whichever one the user switched to meanwhile.
+        var tab = ActiveTab;
+
+        var result = await ObjectApi.DeleteAttributeAsync(tab.Obj.Dbref, tab.Attr.Name);
+        if (result.TryPickT1(out var failure, out _))
         {
-            _saveMessage = error;
+            _saveMessage = failure.Message;
             _saveSeverity = Severity.Error;
             StateHasChanged();
             return;
         }
 
-        _saveMessage = Loc["TermDeletedAttribute", deletedName];
+        _saveMessage = Loc["TermDeletedAttribute", tab.Attr.Name];
         _saveSeverity = Severity.Info;
-        var tabIdx = _openTabs.IndexOf(ActiveTab);
+        var tabIdx = _openTabs.IndexOf(tab);
         if (tabIdx >= 0) await CloseTabAsync(tabIdx);
         await RefreshAttributesAsync();
         StateHasChanged();
@@ -694,10 +714,10 @@
         var name = _createObjectName.Trim();
         _createObjectType = null;
         _createObjectName = string.Empty;
-        var (newDbref, error) = await ObjectApi.CreateObjectAsync(name, type);
-        if (error is not null)
+        var result = await ObjectApi.CreateObjectAsync(name, type);
+        if (result.TryPickT1(out var failure, out var newDbref))
         {
-            _saveMessage = error;
+            _saveMessage = failure.Message;
             _saveSeverity = Severity.Error;
             StateHasChanged();
             return;
@@ -706,8 +726,7 @@
         if (_objectBrowser is not null)
         {
             await _objectBrowser.RefreshAsync();
-            if (newDbref.HasValue)
-                await _objectBrowser.SelectDbrefAsync(newDbref.Value);
+            await _objectBrowser.SelectDbrefAsync(newDbref);
         }
     }
 
@@ -728,14 +747,20 @@
         _newAttrName = string.Empty;
         // 'null()' rather than an empty value: with empty_attrs off the engine treats an empty set
         // as a clear, so a genuinely empty attribute could not be created to open a tab on.
-        var error = await ObjectApi.SetAttributeAsync(_selectedObject.Dbref, attrName, "null()");
-        if (error is not null)
+        // Captured before the await: a refresh must target the object the attribute was created
+        // on, not whichever one is selected by the time the request comes back.
+        var targetDbref = _selectedObject.Dbref;
+
+        var result = await ObjectApi.SetAttributeAsync(targetDbref, attrName, "null()");
+        if (result.TryPickT1(out var failure, out _))
         {
-            _saveMessage = error;
+            _saveMessage = failure.Message;
             _saveSeverity = Severity.Error;
             StateHasChanged();
             return;
         }
+
+        if (_selectedObject?.Dbref != targetDbref) return;
 
         await RefreshAttributesAsync();
         var created = _selectedObject?.Attributes.FirstOrDefault(a =>

--- a/SharpMUSH.Client/Pages/SoftcodeEditor.razor
+++ b/SharpMUSH.Client/Pages/SoftcodeEditor.razor
@@ -802,14 +802,19 @@
             return;
         }
 
-        // Only the dbref is compared, not the instance: a refresh legitimately replaces
-        // _selectedObject with a fresh read of the same object. The null arm is spelled out rather
-        // than folded into `?.` so a future path that clears the selection cannot turn this into a
-        // NullReferenceException in an event handler.
-        if (_selectedObject is null || _selectedObject.Dbref != targetDbref) return;
+        // Read into a local after each await and work from that. Comparing the dbref rather than
+        // the instance is deliberate — a refresh legitimately replaces _selectedObject with a fresh
+        // read of the same object — and the local keeps the null check honestly nullable instead of
+        // a condition the compiler can fold away.
+        var selectedAfterCreate = _selectedObject;
+        if (selectedAfterCreate is null || selectedAfterCreate.Dbref != targetDbref) return;
 
         await RefreshAttributesAsync();
-        var created = _selectedObject?.Attributes.FirstOrDefault(a =>
+
+        var selectedAfterRefresh = _selectedObject;
+        if (selectedAfterRefresh is null || selectedAfterRefresh.Dbref != targetDbref) return;
+
+        var created = selectedAfterRefresh.Attributes.FirstOrDefault(a =>
             string.Equals(a.Name, attrName, StringComparison.OrdinalIgnoreCase));
         if (created is not null)
             await OnAttributeSelected(created);

--- a/SharpMUSH.Client/Services/ApiFailure.cs
+++ b/SharpMUSH.Client/Services/ApiFailure.cs
@@ -8,6 +8,12 @@ public enum ApiFailureKind
 	/// <summary>The server answered 404. The object or attribute is not there.</summary>
 	NotFound,
 
+	/// <summary>
+	/// Nobody is signed in — the session is missing or expired. Distinct from
+	/// <see cref="Forbidden"/> because the remedy is to authenticate again, not to give up.
+	/// </summary>
+	Unauthenticated,
+
 	/// <summary>The engine refused: the acting character lacks the permission.</summary>
 	Forbidden,
 
@@ -22,10 +28,12 @@ public enum ApiFailureKind
 /// The failed arm of a client API call.
 /// </summary>
 /// <remarks>
-/// Kept distinct from a bare <see cref="OneOf.Types.Error"/> because the caller has to tell these
-/// apart: "no such attribute" is an ordinary outcome the editor renders as an empty buffer, while
-/// "you may not read that" and "the server is down" are both errors but say different things to the
-/// user. Collapsing them into <see langword="null"/> is what this type replaced.
+/// Kept distinct from a bare <see cref="OneOf.Types.Error"/> so a caller CAN tell these apart:
+/// "no such attribute", "you may not read that", "you are not signed in" and "the server is down"
+/// are four different facts, and collapsing them into <see langword="null"/> is what this type
+/// replaced. <see cref="Message"/> is what the editor currently renders; <see cref="Kind"/> is
+/// there for callers that need to act differently — re-authenticating on
+/// <see cref="ApiFailureKind.Unauthenticated"/>, for instance — rather than only report.
 /// </remarks>
 /// <param name="Kind">Which category of failure this was.</param>
 /// <param name="Message">Human-readable detail — the engine's own refusal text where it sent one.</param>
@@ -35,10 +43,16 @@ public sealed record ApiFailure(ApiFailureKind Kind, string Message, HttpStatusC
 	public static ApiFailure Transport(Exception ex) =>
 		new(ApiFailureKind.Transport, $"Could not reach the server: {ex.Message}");
 
+	/// <summary>A response arrived but could not be used — an unreadable or malformed body.</summary>
+	public static ApiFailure Malformed(Exception ex, HttpStatusCode? status = null) =>
+		new(ApiFailureKind.Unexpected, $"The server's response could not be read: {ex.Message}", status);
+
 	public static ApiFailure FromStatus(HttpStatusCode status, string? serverMessage) => status switch
 	{
 		HttpStatusCode.NotFound => new ApiFailure(ApiFailureKind.NotFound, serverMessage ?? "Not found.", status),
-		HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized =>
+		HttpStatusCode.Unauthorized =>
+			new ApiFailure(ApiFailureKind.Unauthenticated, serverMessage ?? "Your session has expired.", status),
+		HttpStatusCode.Forbidden =>
 			new ApiFailure(ApiFailureKind.Forbidden, serverMessage ?? "Permission denied.", status),
 		_ => new ApiFailure(ApiFailureKind.Unexpected, serverMessage ?? $"Request failed ({(int)status}).", status)
 	};

--- a/SharpMUSH.Client/Services/ApiFailure.cs
+++ b/SharpMUSH.Client/Services/ApiFailure.cs
@@ -1,0 +1,45 @@
+using System.Net;
+
+namespace SharpMUSH.Client.Services;
+
+/// <summary>Why a call to the game's REST API did not produce a value.</summary>
+public enum ApiFailureKind
+{
+	/// <summary>The server answered 404. The object or attribute is not there.</summary>
+	NotFound,
+
+	/// <summary>The engine refused: the acting character lacks the permission.</summary>
+	Forbidden,
+
+	/// <summary>The request never got an answer — unreachable server, dropped connection, timeout.</summary>
+	Transport,
+
+	/// <summary>An answer arrived but was not one we can use: 5xx, or a body we could not read.</summary>
+	Unexpected
+}
+
+/// <summary>
+/// The failed arm of a client API call.
+/// </summary>
+/// <remarks>
+/// Kept distinct from a bare <see cref="OneOf.Types.Error"/> because the caller has to tell these
+/// apart: "no such attribute" is an ordinary outcome the editor renders as an empty buffer, while
+/// "you may not read that" and "the server is down" are both errors but say different things to the
+/// user. Collapsing them into <see langword="null"/> is what this type replaced.
+/// </remarks>
+/// <param name="Kind">Which category of failure this was.</param>
+/// <param name="Message">Human-readable detail — the engine's own refusal text where it sent one.</param>
+/// <param name="Status">The HTTP status, when there was a response at all.</param>
+public sealed record ApiFailure(ApiFailureKind Kind, string Message, HttpStatusCode? Status = null)
+{
+	public static ApiFailure Transport(Exception ex) =>
+		new(ApiFailureKind.Transport, $"Could not reach the server: {ex.Message}");
+
+	public static ApiFailure FromStatus(HttpStatusCode status, string? serverMessage) => status switch
+	{
+		HttpStatusCode.NotFound => new ApiFailure(ApiFailureKind.NotFound, serverMessage ?? "Not found.", status),
+		HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized =>
+			new ApiFailure(ApiFailureKind.Forbidden, serverMessage ?? "Permission denied.", status),
+		_ => new ApiFailure(ApiFailureKind.Unexpected, serverMessage ?? $"Request failed ({(int)status}).", status)
+	};
+}

--- a/SharpMUSH.Client/Services/ObjectApiService.cs
+++ b/SharpMUSH.Client/Services/ObjectApiService.cs
@@ -210,12 +210,17 @@ public class ObjectApiService(IHttpClientFactory httpClientFactory)
 		ex is HttpRequestException or OperationCanceledException;
 
 	/// <summary>
-	/// A response arrived but its body could not be turned into the expected shape. Deliberately
-	/// narrower than <see cref="IsTransportFailure"/>: anything outside these is a bug here and
-	/// should keep throwing rather than be reported to the user as a server problem.
+	/// A response arrived but its body could not be turned into the expected shape.
 	/// </summary>
+	/// <remarks>
+	/// <see cref="InvalidOperationException"/> belongs here but NOT around request dispatch:
+	/// <c>ReadFromJsonAsync</c> resolves the response charset and throws it for one it cannot
+	/// parse, which is an unreadable body — whereas the same exception escaping
+	/// <see cref="SendCoreAsync"/> means this service misused HttpClient and should keep throwing.
+	/// That is why the two try blocks are separate rather than one predicate over the whole call.
+	/// </remarks>
 	private static bool IsBodyFailure(Exception ex) =>
-		ex is JsonException or NotSupportedException;
+		ex is JsonException or NotSupportedException or InvalidOperationException;
 
 	private static MushObjectType ParseType(string type) => type.ToUpperInvariant() switch
 	{

--- a/SharpMUSH.Client/Services/ObjectApiService.cs
+++ b/SharpMUSH.Client/Services/ObjectApiService.cs
@@ -119,41 +119,58 @@ public class ObjectApiService(IHttpClientFactory httpClientFactory)
 	/// <summary>Sends a request whose success carries no body.</summary>
 	private async Task<OneOf<Success, ApiFailure>> SendAsync(HttpMethod method, string url, object? body = null)
 	{
+		HttpResponseMessage response;
 		try
 		{
-			using var response = await SendCoreAsync(method, url, body);
+			response = await SendCoreAsync(method, url, body);
+		}
+		catch (Exception ex) when (IsTransportFailure(ex))
+		{
+			return ApiFailure.Transport(ex);
+		}
 
+		using (response)
+		{
 			return response.IsSuccessStatusCode
 				? new Success()
 				: ApiFailure.FromStatus(response.StatusCode, await ServerMessageAsync(response));
-		}
-		catch (Exception ex) when (IsRequestFailure(ex))
-		{
-			return ApiFailure.Transport(ex);
 		}
 	}
 
 	/// <summary>Sends a request and deserializes its body.</summary>
 	private async Task<OneOf<T, ApiFailure>> SendAsync<T>(HttpMethod method, string url, object? body = null)
 	{
+		HttpResponseMessage response;
 		try
 		{
-			using var response = await SendCoreAsync(method, url, body);
+			response = await SendCoreAsync(method, url, body);
+		}
+		catch (Exception ex) when (IsTransportFailure(ex))
+		{
+			return ApiFailure.Transport(ex);
+		}
 
+		using (response)
+		{
 			if (!response.IsSuccessStatusCode)
 			{
 				return ApiFailure.FromStatus(response.StatusCode, await ServerMessageAsync(response));
 			}
 
-			var value = await response.Content.ReadFromJsonAsync<T>();
+			// Reading the body is a separate failure mode from reaching the server: a malformed
+			// response reported as "could not reach the server" sends the reader to the wrong place.
+			try
+			{
+				var value = await response.Content.ReadFromJsonAsync<T>();
 
-			return value is null
-				? new ApiFailure(ApiFailureKind.Unexpected, "The server returned an empty body.", response.StatusCode)
-				: OneOf<T, ApiFailure>.FromT0(value);
-		}
-		catch (Exception ex) when (IsRequestFailure(ex))
-		{
-			return ApiFailure.Transport(ex);
+				return value is null
+					? new ApiFailure(ApiFailureKind.Unexpected, "The server returned an empty body.", response.StatusCode)
+					: OneOf<T, ApiFailure>.FromT0(value);
+			}
+			catch (Exception ex) when (IsBodyFailure(ex))
+			{
+				return ApiFailure.Malformed(ex, response.StatusCode);
+			}
 		}
 	}
 
@@ -175,7 +192,7 @@ public class ObjectApiService(IHttpClientFactory httpClientFactory)
 		{
 			return (await response.Content.ReadFromJsonAsync<ApiErrorDto>())?.Error;
 		}
-		catch (Exception ex) when (IsRequestFailure(ex))
+		catch (Exception ex) when (IsBodyFailure(ex) || IsTransportFailure(ex))
 		{
 			// A refusal without a readable body is still a refusal; the status carries the meaning.
 			return null;
@@ -183,15 +200,22 @@ public class ObjectApiService(IHttpClientFactory httpClientFactory)
 	}
 
 	/// <summary>
-	/// Failures worth turning into a value rather than letting escape. Anything else is a bug here
-	/// and should keep throwing.
+	/// The request never produced a response: unreachable server, dropped connection, timeout.
 	/// </summary>
-	private static bool IsRequestFailure(Exception ex) => ex switch
-	{
-		HttpRequestException or JsonException or NotSupportedException or TaskCanceledException
-			or OperationCanceledException or InvalidOperationException => true,
-		_ => false
-	};
+	/// <remarks>
+	/// <see cref="TaskCanceledException"/> needs no separate arm — it derives from
+	/// <see cref="OperationCanceledException"/>, which is how HttpClient surfaces a timeout.
+	/// </remarks>
+	private static bool IsTransportFailure(Exception ex) =>
+		ex is HttpRequestException or OperationCanceledException;
+
+	/// <summary>
+	/// A response arrived but its body could not be turned into the expected shape. Deliberately
+	/// narrower than <see cref="IsTransportFailure"/>: anything outside these is a bug here and
+	/// should keep throwing rather than be reported to the user as a server problem.
+	/// </summary>
+	private static bool IsBodyFailure(Exception ex) =>
+		ex is JsonException or NotSupportedException;
 
 	private static MushObjectType ParseType(string type) => type.ToUpperInvariant() switch
 	{

--- a/SharpMUSH.Client/Services/ObjectApiService.cs
+++ b/SharpMUSH.Client/Services/ObjectApiService.cs
@@ -1,7 +1,9 @@
+using OneOf;
+using OneOf.Types;
 using SharpMUSH.Client.Models;
 using SharpMUSH.Library.API;
-using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 
 namespace SharpMUSH.Client.Services;
 
@@ -9,15 +11,24 @@ namespace SharpMUSH.Client.Services;
 /// Typed client for <c>api/objects</c> — object info, attribute CRUD and object creation.
 /// </summary>
 /// <remarks>
+/// <para>
 /// This replaces the softcode round-trip <see cref="MushQueryService"/> used to run for the same
 /// operations. That route went down the terminal WebSocket, which is line-delimited, so an
 /// attribute value had to have its newlines rewritten as <c>%r</c> to survive as one message —
 /// and since <c>&amp;</c> does not evaluate direct input, the literal <c>%r</c> was what got
 /// stored. Over HTTP a value is just a JSON string, so nothing has to be encoded and nothing has
 /// to be decoded on the way back.
-///
+/// </para>
+/// <para>
+/// Every method returns <see cref="OneOf{T0,T1}"/> with <see cref="ApiFailure"/> on the failed arm,
+/// matching <see cref="CharacterDirectoryService"/>. Nothing here throws for an unreachable server
+/// or a refused request: these are called straight from Blazor event handlers, where an escaping
+/// exception bypasses the page's error banner entirely.
+/// </para>
+/// <para>
 /// <see cref="MushQueryService"/> keeps the operations that genuinely are softcode evaluation:
 /// free-form <c>lsearch</c> expressions and <c>u()</c>.
+/// </para>
 /// </remarks>
 public class ObjectApiService(IHttpClientFactory httpClientFactory)
 {
@@ -33,63 +44,57 @@ public class ObjectApiService(IHttpClientFactory httpClientFactory)
 	private static string AttrPath(int dbref, string attribute)
 		=> $"api/objects/{dbref}/attributes/{Uri.EscapeDataString(attribute)}";
 
-	public async Task<MushObject?> GetObjectAsync(int dbref)
+	public async Task<OneOf<MushObject, ApiFailure>> GetObjectAsync(int dbref)
 	{
-		var response = await Client.GetAsync($"api/objects/{dbref}");
-		if (!response.IsSuccessStatusCode) return null;
+		var summary = await SendAsync<ObjectSummaryDto>(HttpMethod.Get, $"api/objects/{dbref}");
+		if (summary.TryPickT1(out var failure, out var dto)) return failure;
 
-		var summary = await response.Content.ReadFromJsonAsync<ObjectSummaryDto>();
-		if (summary is null) return null;
+		var attributes = await GetAttributesAsync(dbref);
 
 		return new MushObject
 		{
 			Dbref = dbref,
-			Name = summary.Name,
-			Type = ParseType(summary.Type),
-			Owner = summary.Owner,
-			Flags = string.Join(' ', summary.Flags),
-			Attributes = await GetAttributesAsync(dbref),
+			Name = dto.Name,
+			Type = ParseType(dto.Type),
+			Owner = dto.Owner,
+			Flags = string.Join(' ', dto.Flags),
+			// A readable object with unreadable attributes is still worth showing; the attribute
+			// pane renders empty rather than the whole selection failing.
+			Attributes = attributes.Match(list => list, _ => []),
 		};
 	}
 
-	public async Task<List<MushAttribute>> GetAttributesAsync(int dbref)
+	public async Task<OneOf<List<MushAttribute>, ApiFailure>> GetAttributesAsync(int dbref)
 	{
-		var attributes = await Client.GetFromJsonAsync<List<AttributeDto>>(
-			$"api/objects/{dbref}/attributes?depth={ListDepth}");
+		var result = await SendAsync<List<AttributeDto>>(
+			HttpMethod.Get, $"api/objects/{dbref}/attributes?depth={ListDepth}");
 
-		return attributes?.Select(a => new MushAttribute
-		{
-			Name = a.Name,
-			Value = a.Value,
-			AttributeFlags = [.. a.Flags],
-		}).ToList() ?? [];
+		return result.Match<OneOf<List<MushAttribute>, ApiFailure>>(
+			attributes => attributes.Select(a => new MushAttribute
+			{
+				Name = a.Name,
+				Value = a.Value,
+				AttributeFlags = [.. a.Flags],
+			}).ToList(),
+			failure => failure);
 	}
 
-	public async Task<string?> GetAttributeAsync(int dbref, string attribute)
+	public async Task<OneOf<string, ApiFailure>> GetAttributeAsync(int dbref, string attribute)
 	{
-		var response = await Client.GetAsync(AttrPath(dbref, attribute));
-		if (!response.IsSuccessStatusCode) return null;
+		var result = await SendAsync<AttributeDto>(HttpMethod.Get, AttrPath(dbref, attribute));
 
-		return (await response.Content.ReadFromJsonAsync<AttributeDto>())?.Value;
+		return result.Match<OneOf<string, ApiFailure>>(dto => dto.Value, failure => failure);
 	}
 
-	/// <summary>
-	/// Stores <paramref name="value"/> verbatim — newlines included. Returns the server's refusal
-	/// message when the acting character may not write there, or <see langword="null"/> on success.
-	/// </summary>
-	public async Task<string?> SetAttributeAsync(int dbref, string attribute, string value)
-	{
-		var response = await Client.PutAsJsonAsync(
-			AttrPath(dbref, attribute), new SetAttributeRequest(value));
+	/// <summary>Stores <paramref name="value"/> verbatim — newlines included.</summary>
+	public async Task<OneOf<Success, ApiFailure>> SetAttributeAsync(int dbref, string attribute, string value)
+		=> await SendAsync(HttpMethod.Put, AttrPath(dbref, attribute), new SetAttributeRequest(value));
 
-		return await ErrorOrNullAsync(response);
-	}
+	public async Task<OneOf<Success, ApiFailure>> DeleteAttributeAsync(int dbref, string attribute)
+		=> await SendAsync(HttpMethod.Delete, AttrPath(dbref, attribute));
 
-	public async Task<string?> DeleteAttributeAsync(int dbref, string attribute)
-		=> await ErrorOrNullAsync(await Client.DeleteAsync(AttrPath(dbref, attribute)));
-
-	/// <summary>Creates an object, returning its dbref number, or null with the refusal message.</summary>
-	public async Task<(int? Dbref, string? Error)> CreateObjectAsync(string name, MushObjectType type)
+	/// <summary>Creates an object, returning its dbref number.</summary>
+	public async Task<OneOf<int, ApiFailure>> CreateObjectAsync(string name, MushObjectType type)
 	{
 		var typeName = type switch
 		{
@@ -98,30 +103,95 @@ public class ObjectApiService(IHttpClientFactory httpClientFactory)
 			_ => "THING",
 		};
 
-		var response = await Client.PostAsJsonAsync("api/objects", new CreateObjectRequest(name, typeName));
-		if (!response.IsSuccessStatusCode)
+		var result = await SendAsync<CreatedObjectDto>(
+			HttpMethod.Post, "api/objects", new CreateObjectRequest(name, typeName));
+
+		if (result.TryPickT1(out var failure, out var created)) return failure;
+
+		// '#N' or '#N:creationTime' — the browser addresses objects by number.
+		var number = created.Dbref.TrimStart('#').Split(':')[0];
+
+		return int.TryParse(number, out var parsed)
+			? parsed
+			: new ApiFailure(ApiFailureKind.Unexpected, $"Malformed dbref in response: '{created.Dbref}'.");
+	}
+
+	/// <summary>Sends a request whose success carries no body.</summary>
+	private async Task<OneOf<Success, ApiFailure>> SendAsync(HttpMethod method, string url, object? body = null)
+	{
+		try
 		{
-			return (null, await ErrorOrNullAsync(response));
+			using var response = await SendCoreAsync(method, url, body);
+
+			return response.IsSuccessStatusCode
+				? new Success()
+				: ApiFailure.FromStatus(response.StatusCode, await ServerMessageAsync(response));
+		}
+		catch (Exception ex) when (IsRequestFailure(ex))
+		{
+			return ApiFailure.Transport(ex);
+		}
+	}
+
+	/// <summary>Sends a request and deserializes its body.</summary>
+	private async Task<OneOf<T, ApiFailure>> SendAsync<T>(HttpMethod method, string url, object? body = null)
+	{
+		try
+		{
+			using var response = await SendCoreAsync(method, url, body);
+
+			if (!response.IsSuccessStatusCode)
+			{
+				return ApiFailure.FromStatus(response.StatusCode, await ServerMessageAsync(response));
+			}
+
+			var value = await response.Content.ReadFromJsonAsync<T>();
+
+			return value is null
+				? new ApiFailure(ApiFailureKind.Unexpected, "The server returned an empty body.", response.StatusCode)
+				: OneOf<T, ApiFailure>.FromT0(value);
+		}
+		catch (Exception ex) when (IsRequestFailure(ex))
+		{
+			return ApiFailure.Transport(ex);
+		}
+	}
+
+	private async Task<HttpResponseMessage> SendCoreAsync(HttpMethod method, string url, object? body)
+	{
+		using var request = new HttpRequestMessage(method, url);
+		if (body is not null)
+		{
+			request.Content = JsonContent.Create(body, body.GetType());
 		}
 
-		var created = await response.Content.ReadFromJsonAsync<CreatedObjectDto>();
-		// '#N' or '#N:creationTime' — the browser addresses objects by number.
-		var number = created?.Dbref.TrimStart('#').Split(':')[0];
-
-		return int.TryParse(number, out var parsed) ? (parsed, null) : (null, "Malformed dbref in response.");
+		return await Client.SendAsync(request);
 	}
 
-	/// <summary>The server's message for a failed call, or <see langword="null"/> when it succeeded.</summary>
-	private static async Task<string?> ErrorOrNullAsync(HttpResponseMessage response)
+	/// <summary>The engine's own refusal text, when the response carried one.</summary>
+	private static async Task<string?> ServerMessageAsync(HttpResponseMessage response)
 	{
-		if (response.IsSuccessStatusCode) return null;
-
-		var error = response.StatusCode == HttpStatusCode.NotFound
-			? null
-			: (await response.Content.ReadFromJsonAsync<ApiErrorDto>().ConfigureAwait(false))?.Error;
-
-		return error ?? $"Request failed ({(int)response.StatusCode}).";
+		try
+		{
+			return (await response.Content.ReadFromJsonAsync<ApiErrorDto>())?.Error;
+		}
+		catch (Exception ex) when (IsRequestFailure(ex))
+		{
+			// A refusal without a readable body is still a refusal; the status carries the meaning.
+			return null;
+		}
 	}
+
+	/// <summary>
+	/// Failures worth turning into a value rather than letting escape. Anything else is a bug here
+	/// and should keep throwing.
+	/// </summary>
+	private static bool IsRequestFailure(Exception ex) => ex switch
+	{
+		HttpRequestException or JsonException or NotSupportedException or TaskCanceledException
+			or OperationCanceledException or InvalidOperationException => true,
+		_ => false
+	};
 
 	private static MushObjectType ParseType(string type) => type.ToUpperInvariant() switch
 	{

--- a/SharpMUSH.Tests.BUnit/Services/ObjectApiServiceTests.cs
+++ b/SharpMUSH.Tests.BUnit/Services/ObjectApiServiceTests.cs
@@ -149,6 +149,38 @@ public class ObjectApiServiceTests
 	}
 
 	/// <summary>
+	/// A body we cannot read is not an unreachable server. Reporting "could not reach the server"
+	/// for a malformed response sends the user looking at their network instead of the response.
+	/// </summary>
+	[Test]
+	public async Task GetObject_WhenTheBodyIsMalformed_IsUnexpectedRatherThanTransport()
+	{
+		var (service, _) = Build(HttpStatusCode.OK, "{ this is not json");
+
+		var result = await service.GetObjectAsync(7);
+
+		await Assert.That(result.IsT1).IsTrue();
+		await Assert.That(result.AsT1.Kind).IsEqualTo(ApiFailureKind.Unexpected);
+	}
+
+	/// <summary>
+	/// 401 is "you are not signed in" and 403 is "you are, but you may not do that". Collapsing them
+	/// leaves an expired session reading as a permission problem, with no way to re-authenticate.
+	/// </summary>
+	[Test]
+	public async Task Unauthorized_IsDistinctFromForbidden()
+	{
+		var (unauthenticated, _) = Build(HttpStatusCode.Unauthorized);
+		var expired = await unauthenticated.GetObjectAsync(7);
+
+		var (refused, _) = Build(HttpStatusCode.Forbidden, """{"error":"#-1 PERMISSION DENIED"}""");
+		var denied = await refused.GetObjectAsync(7);
+
+		await Assert.That(expired.AsT1.Kind).IsEqualTo(ApiFailureKind.Unauthenticated);
+		await Assert.That(denied.AsT1.Kind).IsEqualTo(ApiFailureKind.Forbidden);
+	}
+
+	/// <summary>
 	/// Not-found and forbidden are different facts and must not collapse into one "it failed".
 	/// </summary>
 	[Test]

--- a/SharpMUSH.Tests.BUnit/Services/ObjectApiServiceTests.cs
+++ b/SharpMUSH.Tests.BUnit/Services/ObjectApiServiceTests.cs
@@ -50,6 +50,16 @@ public class ObjectApiServiceTests
 		return (new ObjectApiService(new SingleClientFactory(handler)), handler);
 	}
 
+	/// <summary>A handler that fails the way an unreachable server does.</summary>
+	private sealed class ThrowingHandler(Exception failure) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(
+			HttpRequestMessage request, CancellationToken cancellationToken) => throw failure;
+	}
+
+	private static ObjectApiService Failing(Exception failure) =>
+		new(new SingleClientFactory(new ThrowingHandler(failure)));
+
 	[Test]
 	public async Task SetAttribute_SendsTheValueVerbatim_NewlinesIntact()
 	{
@@ -100,15 +110,71 @@ public class ObjectApiServiceTests
 			.IsEqualTo("/api/objects/42/attributes/BRANCH%60LEAF");
 	}
 
+	/// <summary>
+	/// A server that cannot be reached must come back as a value, not an exception. These calls are
+	/// made straight from Blazor event handlers, so a thrown HttpRequestException escapes the
+	/// handler instead of reaching the editor's error banner.
+	/// </summary>
+	[Test]
+	public async Task SetAttribute_WhenTheServerIsUnreachable_ReturnsATransportFailure()
+	{
+		var service = Failing(new HttpRequestException("connection refused"));
+
+		var result = await service.SetAttributeAsync(7, "DESC", "x");
+
+		await Assert.That(result.IsT1).IsTrue().Because("a transport failure must be in the return type");
+		await Assert.That(result.AsT1.Kind).IsEqualTo(ApiFailureKind.Transport);
+	}
+
+	[Test]
+	public async Task GetObject_WhenTheServerIsUnreachable_ReturnsATransportFailure()
+	{
+		var service = Failing(new HttpRequestException("connection refused"));
+
+		var result = await service.GetObjectAsync(7);
+
+		await Assert.That(result.IsT1).IsTrue();
+		await Assert.That(result.AsT1.Kind).IsEqualTo(ApiFailureKind.Transport);
+	}
+
+	[Test]
+	public async Task CreateObject_WhenTheServerIsUnreachable_ReturnsATransportFailure()
+	{
+		var service = Failing(new HttpRequestException("connection refused"));
+
+		var result = await service.CreateObjectAsync("Widget", MushObjectType.Thing);
+
+		await Assert.That(result.IsT1).IsTrue();
+		await Assert.That(result.AsT1.Kind).IsEqualTo(ApiFailureKind.Transport);
+	}
+
+	/// <summary>
+	/// Not-found and forbidden are different facts and must not collapse into one "it failed".
+	/// </summary>
+	[Test]
+	public async Task GetAttribute_DistinguishesNotFoundFromForbidden()
+	{
+		var (missing, _) = Build(HttpStatusCode.NotFound);
+		var notFound = await missing.GetAttributeAsync(7, "NOPE");
+
+		var (refused, _) = Build(HttpStatusCode.Forbidden, """{"error":"#-1 PERMISSION DENIED"}""");
+		var forbidden = await refused.GetAttributeAsync(7, "SECRET");
+
+		await Assert.That(notFound.AsT1.Kind).IsEqualTo(ApiFailureKind.NotFound);
+		await Assert.That(forbidden.AsT1.Kind).IsEqualTo(ApiFailureKind.Forbidden);
+		await Assert.That(forbidden.AsT1.Message).IsEqualTo("#-1 PERMISSION DENIED");
+	}
+
 	[Test]
 	public async Task SetAttribute_OnRefusal_ReturnsTheServersMessage()
 	{
 		var (service, _) = Build(
 			HttpStatusCode.Forbidden, """{"error":"You do not have permission to do that."}""");
 
-		var error = await service.SetAttributeAsync(7, "PWNED", "nope");
+		var result = await service.SetAttributeAsync(7, "PWNED", "nope");
 
-		await Assert.That(error).IsEqualTo("You do not have permission to do that.");
+		await Assert.That(result.IsT1).IsTrue();
+		await Assert.That(result.AsT1.Message).IsEqualTo("You do not have permission to do that.");
 	}
 
 	[Test]
@@ -116,7 +182,9 @@ public class ObjectApiServiceTests
 	{
 		var (service, _) = Build();
 
-		await Assert.That(await service.SetAttributeAsync(7, "DESC", "fine")).IsNull();
+		var result = await service.SetAttributeAsync(7, "DESC", "fine");
+
+		await Assert.That(result.IsT0).IsTrue();
 	}
 
 	[Test]
@@ -127,7 +195,7 @@ public class ObjectApiServiceTests
 
 		var attributes = await service.GetAttributesAsync(7);
 
-		await Assert.That(attributes[0].Value).IsEqualTo("line one\nline two")
+		await Assert.That(attributes.AsT0[0].Value).IsEqualTo("line one\nline two")
 			.Because("the load path must not translate either way round");
 	}
 
@@ -136,10 +204,10 @@ public class ObjectApiServiceTests
 	{
 		var (service, _) = Build(HttpStatusCode.OK, """{"dbref":"#123:1700000000"}""");
 
-		var (dbref, error) = await service.CreateObjectAsync("Widget", MushObjectType.Thing);
+		var result = await service.CreateObjectAsync("Widget", MushObjectType.Thing);
 
-		await Assert.That(dbref).IsEqualTo(123);
-		await Assert.That(error).IsNull();
+		await Assert.That(result.IsT0).IsTrue();
+		await Assert.That(result.AsT0).IsEqualTo(123);
 	}
 
 	[Test]
@@ -147,9 +215,10 @@ public class ObjectApiServiceTests
 	{
 		var (service, _) = Build(HttpStatusCode.Forbidden, """{"error":"#-1 THAT IS A BAD NAME."}""");
 
-		var (dbref, error) = await service.CreateObjectAsync("!!", MushObjectType.Thing);
+		var result = await service.CreateObjectAsync("!!", MushObjectType.Thing);
 
-		await Assert.That(dbref).IsNull();
-		await Assert.That(error).IsEqualTo("#-1 THAT IS A BAD NAME.");
+		await Assert.That(result.IsT1).IsTrue();
+		await Assert.That(result.AsT1.Kind).IsEqualTo(ApiFailureKind.Forbidden);
+		await Assert.That(result.AsT1.Message).IsEqualTo("#-1 THAT IS A BAD NAME.");
 	}
 }

--- a/SharpMUSH.Tests.BUnit/Services/ObjectApiServiceTests.cs
+++ b/SharpMUSH.Tests.BUnit/Services/ObjectApiServiceTests.cs
@@ -163,6 +163,35 @@ public class ObjectApiServiceTests
 		await Assert.That(result.AsT1.Kind).IsEqualTo(ApiFailureKind.Unexpected);
 	}
 
+	/// <summary>A response whose Content-Type names a charset .NET cannot resolve.</summary>
+	private sealed class BadCharsetHandler : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(
+			HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			var content = new StringContent("{}", Encoding.UTF8);
+			content.Headers.ContentType!.CharSet = "not-a-real-charset";
+
+			return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+		}
+	}
+
+	/// <summary>
+	/// ReadFromJsonAsync resolves the response charset and throws InvalidOperationException when it
+	/// cannot. That is a body we could not read, not a bug in this service, so it must come back as
+	/// a value rather than escape into the Blazor event handler.
+	/// </summary>
+	[Test]
+	public async Task GetObject_WhenTheResponseCharsetIsInvalid_IsUnexpectedRatherThanThrowing()
+	{
+		var service = new ObjectApiService(new SingleClientFactory(new BadCharsetHandler()));
+
+		var result = await service.GetObjectAsync(7);
+
+		await Assert.That(result.IsT1).IsTrue();
+		await Assert.That(result.AsT1.Kind).IsEqualTo(ApiFailureKind.Unexpected);
+	}
+
 	/// <summary>
 	/// 401 is "you are not signed in" and 403 is "you are, but you may not do that". Collapsing them
 	/// leaves an expired session reading as a permission problem, with no way to re-authenticate.


### PR DESCRIPTION
Fixes #776.

## 1. Stale responses could overwrite newer state

Every handler that awaited an `ObjectApiService` call read `_selectedObject` / `ActiveTab` *after* the await.

`SaveAsync` was the damaging one. It captured the identifiers for the request but wrote the result back through `ActiveTab`:

```csharp
var savedAttrName = ActiveTab.Attr.Name;
var savedDbref = ActiveTab.Obj.Dbref;

var error = await ObjectApi.SetAttributeAsync(savedDbref, savedAttrName, value);
...
ActiveTab.SavedContent = value;   // whichever tab is active NOW
ActiveTab.IsDirty = false;
```

Switch tabs while the PUT is in flight and the tab you switched *to* is marked clean and handed the other tab's saved baseline — so it reads as saved while holding unsaved edits, and the next `RefreshAttributesAsync` overwrites them, because refresh only rewrites clean tabs.

Each handler now captures the `AttrTab` or dbref it started on and applies results only to that target: `SaveAsync`, `DeleteAsync`, `ExecuteCreateAttrAsync`, `RefreshAttributesAsync`.

`OnObjectSelected` needed more than a capture — two loads can overlap, so it carries a monotonic generation ticket and discards any answer that is no longer the newest request.

## 2. API failures escaped as unhandled exceptions

`ObjectApiService` signalled failure with `null` / a nullable tuple slot and threw on transport errors. It is called straight from Blazor event handlers, so `HttpRequestException` escaped the handler instead of reaching the editor's error banner: with the server unreachable, a save left the **previous** save's success message on screen.

Now `OneOf<T, ApiFailure>`, with `ApiFailureKind` keeping `NotFound` / `Forbidden` / `Transport` / `Unexpected` apart — distinctions a single `null` could not carry, so the editor can say which happened.

### On scope: only `ObjectApiService`

On #775 I argued this should convert `ObjectApiService` and `PackagesAdminService` together, on the grounds that `PackagesAdminService` was the only sibling and leaving one converted would make the client layer inconsistent.

That premise was wrong. `CharacterDirectoryService` already returns `OneOf<T, Error>`, so the layer is *already* mixed, and this change moves `ObjectApiService` toward the newer of the two patterns rather than creating a split. `PackagesAdminService` is 16 methods across 5 admin pages with no bug being fixed and no way for me to verify it live (the package flows need remotes configured), so bundling it would be unverifiable churn attached to a real fix. It stays as-is; #776 can keep tracking it.

## Verification

Live A/B against `main`, driving the real portal (Server + ConnectionServer + Client + NATS) with Playwright: two attributes open, a deliberately slowed PUT on the first, tab switched mid-flight, then a save with the API routed to `connectionrefused`.

| check | `main` | this branch |
|---|---|---|
| other tab still marked dirty after the slow save landed | ❌ false | ✅ true |
| banner reports the failure | ❌ false | ✅ true |
| banner still claims success | ❌ true (stale) | ✅ false |

The `main` column is what makes these checks meaningful rather than merely green.

Unit coverage added for the failure modes, all red-by-construction against the old code (which threw rather than returning): transport failure on set/get/create, and `NotFound` vs `Forbidden` staying distinct.

bUnit 487/487 · clean build with the format gate. Engine and integration suites unaffected — this is client-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MPRzndB5egy4F2A3q5852


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor reliability when switching objects or tabs during loading, saving, deleting, and refreshing.
  * Prevented outdated responses from overwriting newer selections.
  * Preserved mobile pane state during refreshes.
  * Added clearer handling for unavailable, restricted, network, and unexpected errors.
  * Improved resilience when attribute requests fail.
  * Ensured object and attribute changes apply to the intended selection.

* **Tests**
  * Added coverage for network failures, successful operations, refusal responses, malformed responses, and preserved attribute values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->