### PR TITLE
Bump Testcontainers to 4.14.0 to clear the SSH.NET advisory

### DIFF
--- a/SharpMUSH.Benchmarks/SharpMUSH.Benchmarks.csproj
+++ b/SharpMUSH.Benchmarks/SharpMUSH.Benchmarks.csproj
@@ -16,8 +16,8 @@
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-		<PackageReference Include="Testcontainers.ArangoDb" Version="4.11.0" />
-		<PackageReference Include="Testcontainers.Nats" Version="4.11.0" />
+		<PackageReference Include="Testcontainers.ArangoDb" Version="4.14.0" />
+		<PackageReference Include="Testcontainers.Nats" Version="4.14.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/SharpMUSH.Messaging/SharpMUSH.Messaging.csproj
+++ b/SharpMUSH.Messaging/SharpMUSH.Messaging.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="Testcontainers.Nats" Version="4.11.0" />
+    <PackageReference Include="Testcontainers.Nats" Version="4.14.0" />
   </ItemGroup>
 
 

--- a/SharpMUSH.Server/SharpMUSH.Server.csproj
+++ b/SharpMUSH.Server/SharpMUSH.Server.csproj
@@ -43,7 +43,7 @@
 		     so FSharp.Core must be present beside the host binary for plugin loading to succeed. -->
 		<PackageReference Include="FSharp.Core" Version="10.1.302" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.7" />
-		<PackageReference Include="Testcontainers.ArangoDb" Version="4.11.0" />
+		<PackageReference Include="Testcontainers.ArangoDb" Version="4.14.0" />
 
 	</ItemGroup>
 	

--- a/SharpMUSH.Tests.Infrastructure/SharpMUSH.Tests.Infrastructure.csproj
+++ b/SharpMUSH.Tests.Infrastructure/SharpMUSH.Tests.Infrastructure.csproj
@@ -18,10 +18,10 @@
 		<!-- Mocking and assertions -->
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<!-- Test containers -->
-		<PackageReference Include="Testcontainers.ArangoDb" Version="4.11.0" />
-		<PackageReference Include="Testcontainers.MySql" Version="4.11.0" />
-		<PackageReference Include="Testcontainers.Nats" Version="4.11.0" />
-		<PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
+		<PackageReference Include="Testcontainers.ArangoDb" Version="4.14.0" />
+		<PackageReference Include="Testcontainers.MySql" Version="4.14.0" />
+		<PackageReference Include="Testcontainers.Nats" Version="4.14.0" />
+		<PackageReference Include="Testcontainers.PostgreSql" Version="4.14.0" />
 		<PackageReference Include="MySqlConnector" Version="2.5.0" />
 		<!-- Logging (Microsoft.Extensions.Logging.Abstractions flows in transitively via
 		     Microsoft.AspNetCore.Mvc.Testing and TUnit.AspNetCore, so no direct pin needed). -->


### PR DESCRIPTION
`main` currently fails `dotnet restore` for **every** project in the solution.

NuGet's vulnerability feed picked up [GHSA-q939-rpr3-3284](https://github.com/advisories/GHSA-q939-rpr3-3284) (high severity, SSH.NET) at 2026-08-14 23:31 UTC. The advisory range is `(, 2025.1.0]` — inclusive. Testcontainers 4.11.0 pins SSH.NET 2025.1.0, `NuGetAudit` warnings are errors here, so NU1903 kills restore before anything builds — including projects with no test dependency at all (ConnectionServer, CodeAnalysis, LanguageServer).

## The fix

4.14.0 is the first Testcontainers release to pin SSH.NET **2026.0.0**, which is outside the advisory range:

| Testcontainers | SSH.NET |
|---|---|
| 4.11.0 (current) | 2025.1.0 ❌ |
| 4.12.0 | 2025.1.0 ❌ |
| 4.13.0 | 2025.1.0 ❌ |
| **4.14.0** | **2026.0.0** ✅ |

So 4.14.0 is the minimum viable bump, not just the newest. All four module packages we use publish it.

8 references across 4 csprojs:

- `SharpMUSH.Benchmarks` — `Testcontainers.ArangoDb`, `Testcontainers.Nats`
- `SharpMUSH.Server` — `Testcontainers.ArangoDb`
- `SharpMUSH.Messaging` — `Testcontainers.Nats`
- `SharpMUSH.Tests.Infrastructure` — `Testcontainers.ArangoDb`, `.MySql`, `.Nats`, `.PostgreSql`

## Verification

**Before** — `dotnet restore` on `main`:

```
error NU1903: Warning As Error: Package 'SSH.NET' 2025.1.0 has a known high severity
vulnerability [SharpMUSH.ConnectionServer, SharpMUSH.Messaging, SharpMUSH.CodeAnalysis,
SharpMUSH.LanguageServer, SharpMUSH.Tests, ...]
```

**After** — restore clean, 0 NU1903. `SSH.NET/2026.0.0` in `project.assets.json`. `dotnet build`: **0 errors**, 33 pre-existing warnings.

The full `SharpMUSH.Tests` suite is running locally against Podman-backed Testcontainers as of opening this; 4.11 → 4.14 is three minor versions of container lifecycle code, so CI's run is the thing to gate on rather than the restore fix alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container-based testing components to version 4.14.0.
  * Improved compatibility and reliability for automated test environments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->