### PR TITLE
Make @power actually work: grant/revoke, God-only definition switches, and /letter

### DIFF
--- a/SharpMUSH.Database.ArangoDB/ArangoDatabase.FlagsAndPowers.cs
+++ b/SharpMUSH.Database.ArangoDB/ArangoDatabase.FlagsAndPowers.cs
@@ -56,7 +56,9 @@ public partial class ArangoDatabase
 		new()
 		{
 			Id = arg.Id,
-			Alias = arg.Alias,
+			// The seeded system powers omit Alias and Symbol entirely, so both arrive as null.
+			Alias = arg.Alias ?? string.Empty,
+			Symbol = arg.Symbol ?? string.Empty,
 			Name = arg.Name,
 			System = arg.System,
 			Disabled = arg.Disabled,
@@ -168,10 +170,6 @@ public partial class ArangoDatabase
 			Aliases = x.Aliases,
 			TypeRestrictions = x.TypeRestrictions
 		};
-	public IAsyncEnumerable<SharpPower> GetObjectPowersAsync(string id, CancellationToken ct = default)
-		=> arangoDb.Query.ExecuteStreamAsync<SharpPower>(handle,
-			$"FOR v IN 1 OUTBOUND {id} GRAPH {DatabaseConstants.GraphPowers} RETURN v", cache: true,
-			cancellationToken: ct);
 	public async ValueTask<SharpObjectFlag?> CreateObjectFlagAsync(string name, string[]? aliases, string symbol,
 		bool system, string[] setPermissions, string[] unsetPermissions, string[] typeRestrictions,
 		CancellationToken ct = default)
@@ -235,13 +233,14 @@ public partial class ArangoDatabase
 		return true;
 	}
 
-	public async ValueTask<SharpPower?> CreatePowerAsync(string name, string alias, bool system,
+	public async ValueTask<SharpPower?> CreatePowerAsync(string name, string alias, string symbol, bool system,
 		string[] setPermissions, string[] unsetPermissions, string[] typeRestrictions,
 		CancellationToken ct = default)
 	{
 		var request = new SharpPowerCreateRequest(
 			name,
 			alias,
+			symbol,
 			system,
 			false,
 			setPermissions,
@@ -263,6 +262,7 @@ public partial class ArangoDatabase
 				Id = result.Id,
 				Name = name,
 				Alias = alias,
+				Symbol = symbol,
 				System = system,
 				SetPermissions = setPermissions,
 				UnsetPermissions = unsetPermissions,
@@ -344,7 +344,7 @@ public partial class ArangoDatabase
 		return true;
 	}
 
-	public async ValueTask<bool> UpdatePowerAsync(string name, string alias,
+	public async ValueTask<bool> UpdatePowerAsync(string name, string alias, string symbol,
 		string[] setPermissions, string[] unsetPermissions, string[] typeRestrictions,
 		CancellationToken ct = default)
 	{
@@ -367,6 +367,7 @@ public partial class ArangoDatabase
 			{
 				Key = key,
 				Alias = alias,
+				Symbol = symbol,
 				SetPermissions = setPermissions,
 				UnsetPermissions = unsetPermissions,
 				TypeRestrictions = typeRestrictions

--- a/SharpMUSH.Database.ArangoDB/Migrations/Migration_AddPowerSymbol.cs
+++ b/SharpMUSH.Database.ArangoDB/Migrations/Migration_AddPowerSymbol.cs
@@ -1,0 +1,36 @@
+using Core.Arango;
+using Core.Arango.Migration;
+
+namespace SharpMUSH.Database.ArangoDB.Migrations;
+
+/// <summary>
+/// Gives every power document a <c>Symbol</c>, the one-character abbreviation <c>@power/letter</c>
+/// writes. <see cref="Migration_CreateDatabase"/> declares <c>Symbol</c> in the <c>ObjectPowers</c>
+/// schema rule but its seeds omit the property, matching PennMUSH, where every entry in
+/// <c>hdrs/flag_tab.h</c> <c>power_table</c> has <c>letter</c> <c>'\0'</c>.
+///
+/// <para>Absent and empty are not the same to AQL — <c>FILTER p.Symbol == ""</c> does not match a
+/// document with no <c>Symbol</c> — so <c>@power/letter</c>'s collision scan would read seeded and
+/// user-created powers differently. Writing the empty string makes them indistinguishable.</para>
+///
+/// <para>Idempotent: only documents whose <c>Symbol</c> is null or missing are touched, so an
+/// assigned letter survives a re-run.</para>
+/// </summary>
+public class Migration_AddPowerSymbol : IArangoMigration
+{
+	public long Id => 20260815_001;
+
+	public string Name => "add_power_symbol";
+
+	public async Task Up(IArangoMigrator migrator, ArangoHandle handle) =>
+		await migrator.Context.Query.ExecuteAsync<object>(
+			handle,
+			"""
+			FOR power IN @@c
+				FILTER power.Symbol == null
+				UPDATE power WITH { Symbol: "" } IN @@c
+			""",
+			bindVars: new Dictionary<string, object> { { "@c", DatabaseConstants.ObjectPowers } });
+
+	public Task Down(IArangoMigrator migrator, ArangoHandle handle) => Task.CompletedTask;
+}

--- a/SharpMUSH.Database.Memgraph/MemgraphDatabase.FlagsAndPowers.cs
+++ b/SharpMUSH.Database.Memgraph/MemgraphDatabase.FlagsAndPowers.cs
@@ -125,17 +125,18 @@ RETURN count(r) AS cnt
 		return result.Result.Count > 0 && result.Result[0]["cnt"].As<long>() > 0;
 	}
 
-	public async ValueTask<SharpPower?> CreatePowerAsync(string name, string alias, bool system,
+	public async ValueTask<SharpPower?> CreatePowerAsync(string name, string alias, string symbol, bool system,
 	string[] setPermissions, string[] unsetPermissions, string[] typeRestrictions,
 	CancellationToken cancellationToken = default)
 	{
 		await ExecuteWithRetryAsync("""
-CREATE (p:Power {name: $name, alias: $alias, system: $system, disabled: false,
+CREATE (p:Power {name: $name, alias: $alias, symbol: $symbol, system: $system, disabled: false,
 setPermissions: $setPerms, unsetPermissions: $unsetPerms, typeRestrictions: $typeRestrictions})
 """, new
 		{
 			name,
 			alias,
+			symbol,
 			system,
 			setPerms = setPermissions,
 			unsetPerms = unsetPermissions,
@@ -144,7 +145,7 @@ setPermissions: $setPerms, unsetPermissions: $unsetPerms, typeRestrictions: $typ
 
 		return new SharpPower
 		{
-			Id = PowerId(name), Name = name, Alias = alias, System = system,
+			Id = PowerId(name), Name = name, Alias = alias, Symbol = symbol, System = system,
 			SetPermissions = setPermissions, UnsetPermissions = unsetPermissions, TypeRestrictions = typeRestrictions
 		};
 	}
@@ -195,7 +196,7 @@ f.typeRestrictions = $typeRestrictions
 		return true;
 	}
 
-	public async ValueTask<bool> UpdatePowerAsync(string name, string alias,
+	public async ValueTask<bool> UpdatePowerAsync(string name, string alias, string symbol,
 	string[] setPermissions, string[] unsetPermissions, string[] typeRestrictions,
 	CancellationToken cancellationToken = default)
 	{
@@ -204,10 +205,10 @@ f.typeRestrictions = $typeRestrictions
 
 		await ExecuteWithRetryAsync("""
 MATCH (p:Power {name: $name})
-SET p.alias = $alias,
+SET p.alias = $alias, p.symbol = $symbol,
 p.setPermissions = $setPerms, p.unsetPermissions = $unsetPerms,
 p.typeRestrictions = $typeRestrictions
-""", new { name, alias, setPerms = setPermissions, unsetPerms = unsetPermissions, typeRestrictions }, cancellationToken);
+""", new { name, alias, symbol, setPerms = setPermissions, unsetPerms = unsetPermissions, typeRestrictions }, cancellationToken);
 		return true;
 	}
 

--- a/SharpMUSH.Database.Memgraph/MemgraphDatabase.Migration.cs
+++ b/SharpMUSH.Database.Memgraph/MemgraphDatabase.Migration.cs
@@ -634,9 +634,10 @@ ON CREATE SET f.symbol = $symbol, f.system = true, f.inheritable = $inheritable
 
 		foreach (var p in powers)
 		{
+			// symbol = '': every entry in PennMUSH hdrs/flag_tab.h power_table has letter '\0'.
 			await ExecuteWithRetryAsync("""
 MERGE (p:Power {name: $name})
-ON CREATE SET p.alias = $alias, p.system = true, p.disabled = false,
+ON CREATE SET p.alias = $alias, p.symbol = '', p.system = true, p.disabled = false,
 p.setPermissions = $setPerms, p.unsetPermissions = $unsetPerms,
 p.typeRestrictions = $typeRestrictions
 """, new
@@ -648,6 +649,10 @@ p.typeRestrictions = $typeRestrictions
 				typeRestrictions = new[] { "ROOM", "PLAYER", "EXIT", "THING" }
 			}, ct);
 		}
+
+		// ON CREATE SET skips powers that already exist, and @power/letter's collision scan must read
+		// the same shape from every power node.
+		await ExecuteWithRetryAsync("MATCH (p:Power) WHERE p.symbol IS NULL SET p.symbol = ''", ct: ct);
 	}
 
 	private async Task CreateInitialAttributeEntries(CancellationToken ct)

--- a/SharpMUSH.Database.Memgraph/MemgraphDatabase.cs
+++ b/SharpMUSH.Database.Memgraph/MemgraphDatabase.cs
@@ -509,6 +509,7 @@ RETURN ownerObj, ownerTyped
 			Id = $"Power/{name}",
 			Name = name,
 			Alias = node.Properties.ContainsKey("alias") ? node["alias"].As<string>() : "",
+			Symbol = node.Properties.ContainsKey("symbol") ? node["symbol"].As<string>() : "",
 			System = node.Properties.ContainsKey("system") && node["system"].As<bool>(),
 			Disabled = node.Properties.ContainsKey("disabled") && node["disabled"].As<bool>(),
 			SetPermissions = node.Properties.ContainsKey("setPermissions")

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.FlagsAndPowers.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.FlagsAndPowers.cs
@@ -190,7 +190,7 @@ public partial class SurrealDatabase
 			yield return MapRecordToPower(element);
 	}
 
-	public async ValueTask<SharpPower?> CreatePowerAsync(string name, string alias, bool system,
+	public async ValueTask<SharpPower?> CreatePowerAsync(string name, string alias, string symbol, bool system,
 		string[] setPermissions, string[] unsetPermissions, string[] typeRestrictions,
 		CancellationToken cancellationToken = default)
 	{
@@ -198,6 +198,7 @@ public partial class SurrealDatabase
 		{
 			["name"] = name,
 			["alias"] = alias,
+			["symbol"] = symbol,
 			["system"] = system,
 			["setPerms"] = setPermissions,
 			["unsetPerms"] = unsetPermissions,
@@ -205,7 +206,7 @@ public partial class SurrealDatabase
 		};
 
 		await ExecuteAsync(
-			"UPSERT power:⟨$name⟩ SET name = $name, alias = $alias, system = $system, disabled = false, setPermissions = $setPerms, unsetPermissions = $unsetPerms, typeRestrictions = $typeRestrictions",
+			"UPSERT power:⟨$name⟩ SET name = $name, alias = $alias, symbol = $symbol, system = $system, disabled = false, setPermissions = $setPerms, unsetPermissions = $unsetPerms, typeRestrictions = $typeRestrictions",
 			parameters, cancellationToken);
 
 		return new SharpPower
@@ -213,6 +214,7 @@ public partial class SurrealDatabase
 			Id = PowerId(name),
 			Name = name,
 			Alias = alias,
+			Symbol = symbol,
 			System = system,
 			SetPermissions = setPermissions,
 			UnsetPermissions = unsetPermissions,
@@ -279,7 +281,7 @@ public partial class SurrealDatabase
 		return existed;
 	}
 
-	public async ValueTask<bool> UpdatePowerAsync(string name, string alias,
+	public async ValueTask<bool> UpdatePowerAsync(string name, string alias, string symbol,
 		string[] setPermissions, string[] unsetPermissions, string[] typeRestrictions,
 		CancellationToken cancellationToken = default)
 	{
@@ -290,13 +292,14 @@ public partial class SurrealDatabase
 		{
 			["name"] = name,
 			["alias"] = alias,
+			["symbol"] = symbol,
 			["setPerms"] = setPermissions,
 			["unsetPerms"] = unsetPermissions,
 			["typeRestrictions"] = typeRestrictions
 		};
 
 		await ExecuteAsync(
-			"UPDATE power SET alias = $alias, setPermissions = $setPerms, unsetPermissions = $unsetPerms, typeRestrictions = $typeRestrictions WHERE name = $name",
+			"UPDATE power SET alias = $alias, symbol = $symbol, setPermissions = $setPerms, unsetPermissions = $unsetPerms, typeRestrictions = $typeRestrictions WHERE name = $name",
 			parameters, cancellationToken);
 		return true;
 	}

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.Migration.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.Migration.cs
@@ -81,6 +81,9 @@ public partial class SurrealDatabase
 				"DEFINE INDEX IF NOT EXISTS attribute_key ON attribute FIELDS key",
 				"DEFINE INDEX IF NOT EXISTS object_flag_name ON object_flag FIELDS name UNIQUE",
 				"DEFINE INDEX IF NOT EXISTS power_name ON power FIELDS name UNIQUE",
+				// "No letter" is the empty string, not an absent field: @power/letter's collision scan
+				// must read the same shape from every power row.
+				"UPDATE power SET symbol = '' WHERE symbol = NONE",
 				"DEFINE INDEX IF NOT EXISTS attribute_flag_name ON attribute_flag FIELDS name UNIQUE",
 				"DEFINE INDEX IF NOT EXISTS attribute_entry_name ON attribute_entry FIELDS name UNIQUE",
 				"DEFINE INDEX IF NOT EXISTS channel_name ON channel FIELDS name UNIQUE",
@@ -641,8 +644,9 @@ public partial class SurrealDatabase
 				["typeRestrictions"] = new[] { "ROOM", "PLAYER", "EXIT", "THING" }
 			};
 
+			// symbol = '': every entry in PennMUSH hdrs/flag_tab.h power_table has letter '\0'.
 			await ExecuteAsync(
-				$"UPSERT power:{SanitizeRecordId(p.Name)} SET name = $name, alias = $alias, system = true, disabled = false, setPermissions = $setPerms, unsetPermissions = $unsetPerms, typeRestrictions = $typeRestrictions",
+				$"UPSERT power:{SanitizeRecordId(p.Name)} SET name = $name, alias = $alias, symbol = '', system = true, disabled = false, setPermissions = $setPerms, unsetPermissions = $unsetPerms, typeRestrictions = $typeRestrictions",
 				parameters, ct);
 		}
 	}

--- a/SharpMUSH.Database.SurrealDB/SurrealDatabase.cs
+++ b/SharpMUSH.Database.SurrealDB/SurrealDatabase.cs
@@ -618,6 +618,7 @@ public partial class SurrealDatabase(
 			Id = $"Power/{record.name}",
 			Name = record.name,
 			Alias = record.alias,
+			Symbol = record.symbol,
 			System = record.system,
 			Disabled = record.disabled,
 			SetPermissions = record.setPermissions,
@@ -911,6 +912,7 @@ public partial class SurrealDatabase(
 	{
 		public string name { get; set; } = "";
 		public string alias { get; set; } = "";
+		public string symbol { get; set; } = "";
 		public bool system { get; set; }
 		public bool disabled { get; set; }
 		public string[] setPermissions { get; set; } = [];

--- a/SharpMUSH.Database/Models/SharpPower.cs
+++ b/SharpMUSH.Database/Models/SharpPower.cs
@@ -1,5 +1,10 @@
-﻿namespace SharpMUSH.Database.Models;
+namespace SharpMUSH.Database.Models;
 
-public record SharpPowerQueryResult(string Id, string Key, bool System, bool Disabled, string Name, string Alias, string[] SetPermissions, string[] UnsetPermissions, string[] TypeRestrictions);
+/// <summary>
+/// A power document as it comes back from the store. <c>Alias</c> and <c>Symbol</c> are nullable
+/// because the seeded system powers omit both properties, and an absent JSON property deserializes
+/// to null rather than to the empty string the model wants.
+/// </summary>
+public record SharpPowerQueryResult(string Id, string Key, bool System, bool Disabled, string Name, string? Alias, string? Symbol, string[] SetPermissions, string[] UnsetPermissions, string[] TypeRestrictions);
 
-public record SharpPowerCreateRequest(string Name, string Alias, bool System, bool Disabled, string[] SetPermissions, string[] UnsetPermissions, string[] TypeRestrictions);
+public record SharpPowerCreateRequest(string Name, string Alias, string Symbol, bool System, bool Disabled, string[] SetPermissions, string[] UnsetPermissions, string[] TypeRestrictions);

--- a/SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpcmd.md
+++ b/SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpcmd.md
@@ -3224,7 +3224,7 @@ This command sets the pennies of every player on the MUSH to `<value>`. It can o
 `@power <power>`<br>
 `@power <object>=[!]<power> [[!]<power>...]`
 
-`@power/list` lists the defined powers (see [powers]), optionally restricted to those whose names match `<power name pattern>`, a wildcard pattern. A list of standard powers with explanations is given in [powers list]. When given a power name as an argument, @power displays information about that power — its name, aliases, the object types it applies to, and the permissions needed to set and reset it. It does *not* list the powers held by an object; use powers() for that.
+`@power/list` lists the defined powers (see [powers]), optionally restricted to those whose names match `<power name pattern>`, a wildcard pattern; each is shown with its one-character abbreviation, if it has one. A list of standard powers with explanations is given in [powers list]. When given a power name as an argument, @power displays information about that power — its name, its character, its aliases, the object types it applies to, and the permissions needed to set and reset it. It does *not* list the powers held by an object; use powers() for that.
 
 The third form manipulates powers on objects, and is limited to Wizards. `@power <object>=<power>` grants the given power; `@power <object>=!<power>` revokes it. Several powers may be given at once, separated by spaces, and each may independently carry the `!` prefix. Powers cannot be granted to players set UNREGISTERED, and only God may alter God's powers.
 
@@ -3238,6 +3238,7 @@ God can add, delete, and otherwise manipulate power definitions. See help @power
 `@power/add <power>=<alias>`<br>
 `@power/delete <power>`<br>
 `@power/alias <power>=<alias>`<br>
+`@power/letter <power>[=<letter>]`<br>
 `@power/restrict <power>=<permissions>`<br>
 `@power/type <power>=<type(s)>`<br>
 `@power/enable <power>`<br>
@@ -3248,21 +3249,23 @@ These commands manipulate power definitions. Only God may use them, with the exc
 - /disable disables a power, making it invisible and unusable
 - /enable re-enables a disabled power
 - /alias replaces the alias of an existing power
+- /letter changes or removes the single-letter abbreviation of an existing power (see below)
 - /restrict changes power permissions (see help @power3)
 - /type changes power type(s) (see help @power3)
 - /delete deletes a power completely, removing it from all objects in the database and the removing it permanently from the power table. It requires the exact power name or alias to be used. Be very very careful with this.
 - /decompile shows a power's full definition
 
-System powers cannot be deleted, disabled, or redefined.
+`@power/letter <power>=<letter>` gives `<power>` a one-character abbreviation, which is shown beside its name in `@power/list` and on the `Character:` line of `@power <power>`. `@power/letter <power>`, with no `=`, clears it again. The letter must be a single character, and it is case sensitive: `W` and `w` are different letters. Two powers that could apply to the same type of object may not share a letter — `@power/letter` will name the power that already holds it and change nothing. Two powers with no type in common may share one.
 
-SharpMUSH has no `/letter` switch: powers here carry an alias rather than a single-letter abbreviation.
+System powers cannot be deleted, disabled, or redefined, and that includes their letters: all of the built-in powers start out with no letter and keep it that way. `/letter` applies to powers you added yourself with `@power/add`.
 
 See help @power3 for information on `@power/add`
 # @power3
 `@power/add <power>=<alias>` adds a new power with the given name and alias. Both are required.
 
-A new power starts out applying to players only, settable and resettable by Wizards. Adjust it afterwards with:
+A new power starts out applying to players only, with no single-letter abbreviation, settable and resettable by Wizards. Adjust it afterwards with:
 
+`@power/letter <power>=<letter>` — the power's one-character abbreviation, which must not collide with that of another power applying to the same object type(s). A power with no letter does not appear in a list of power characters, but can still be tested for by name.<br>
 `@power/type <power>=<type(s)>` — the comma- or space-separated list of types the power applies to: one or more of 'room', 'thing', 'player', 'exit'.<br>
 `@power/restrict <power>=<permissions>` — the list of permissions governing who can set, see and reset the power. See [flag permissions] for details.
 

--- a/SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpcmd.md
+++ b/SharpMUSH.Documentation/Helpfiles/SharpMUSH/sharpcmd.md
@@ -3222,12 +3222,11 @@ This command sets the pennies of every player on the MUSH to `<value>`. It can o
 # @power
 `@power/list [<power name pattern>]`<br>
 `@power <power>`<br>
-`@power <object>=[!]<power>`
+`@power <object>=[!]<power> [[!]<power>...]`
 
-`@power/list` lists the defined powers (see [powers]). A list of standard powers with explanations is given in [powers list]. When given a power name as an argument, @power displays information<br>
-about a power.
+`@power/list` lists the defined powers (see [powers]), optionally restricted to those whose names match `<power name pattern>`, a wildcard pattern. A list of standard powers with explanations is given in [powers list]. When given a power name as an argument, @power displays information about that power — its name, aliases, the object types it applies to, and the permissions needed to set and reset it. It does *not* list the powers held by an object; use powers() for that.
 
-The third form manipulates powers on objects, and is limited to Wizards. `@power <object>=[!]<power>` sets (or clears) the given power on an object.
+The third form manipulates powers on objects, and is limited to Wizards. `@power <object>=<power>` grants the given power; `@power <object>=!<power>` revokes it. Several powers may be given at once, separated by spaces, and each may independently carry the `!` prefix. Powers cannot be granted to players set UNREGISTERED, and only God may alter God's powers.
 
 God can add, delete, and otherwise manipulate power definitions. See help @power2 for these commands.
 
@@ -3236,34 +3235,38 @@ God can add, delete, and otherwise manipulate power definitions. See help @power
 - [powers()]
 - [@flag]
 # @power2
-`@power/add <power>=[<letter>], [<type(s)>], [<setperms>], [<unsetperms>]`<br>
+`@power/add <power>=<alias>`<br>
 `@power/delete <power>`<br>
 `@power/alias <power>=<alias>`<br>
-`@power/letter <power>[=<letter>]`<br>
-`@power/restrict <power>=[<setperms>], [<unsetperms>]`<br>
+`@power/restrict <power>=<permissions>`<br>
 `@power/type <power>=<type(s)>`<br>
 `@power/enable <power>`<br>
-`@power/disable <power>`
+`@power/disable <power>`<br>
+`@power/decompile <power>`
 
-These commands manipulate power definitions. Only God may use them.
+These commands manipulate power definitions. Only God may use them, with the exception of `/decompile`, which only reads.
 - /disable disables a power, making it invisible and unusable
 - /enable re-enables a disabled power
-- /alias adds a new alias for an existing power
-- /letter changes or removes a single-letter alias for an existing power.
+- /alias replaces the alias of an existing power
 - /restrict changes power permissions (see help @power3)
 - /type changes power type(s) (see help @power3)
 - /delete deletes a power completely, removing it from all objects in the database and the removing it permanently from the power table. It requires the exact power name or alias to be used. Be very very careful with this.
+- /decompile shows a power's full definition
+
+System powers cannot be deleted, disabled, or redefined.
+
+SharpMUSH has no `/letter` switch: powers here carry an alias rather than a single-letter abbreviation.
 
 See help @power3 for information on `@power/add`
 # @power3
-`@power/add` is used to add a new power with the given name. Arguments other than the power name are optional:
+`@power/add <power>=<alias>` adds a new power with the given name and alias. Both are required.
 
-`<letter>` gives the power's one-letter abbreviation, which must not conflict with the one-letter abbreviation of another power that could be applied to the same object type(s). It defaults to none, which means it won't appear in a list of power characters but can still be tested for with haspower(), andlpowers(), and orlpowers().<br>
-`<type>` specifies the space-separated list of types to which the power applies, and may be 'any' or one or more of 'room', 'thing', 'player', or 'exit'. It defaults to 'any'.<br>
-`<setperms>` specifies the space-separated list of permissions for who can set and/or see the power. See [flag permissions] for details. It defaults to 'any'<br>
-`<unsetperms>` specifies the space-separated list of permissions for who can clear the power on an object they control. It defaults to whatever `<setperms>` is given, or 'any'.
+A new power starts out applying to players only, settable and resettable by Wizards. Adjust it afterwards with:
 
-Powers added with `@power/add` are saved with the database when it is dumped, and do not need to be re-added at startup. They are treated exactly as any other power in the server.
+`@power/type <power>=<type(s)>` — the comma- or space-separated list of types the power applies to: one or more of 'room', 'thing', 'player', 'exit'.<br>
+`@power/restrict <power>=<permissions>` — the list of permissions governing who can set, see and reset the power. See [flag permissions] for details.
+
+Powers added with `@power/add` are stored in the database, and do not need to be re-added at startup. They are treated exactly as any other power in the server, except that they are never system powers and so remain deletable and disableable.
 # @prefix
 `@prefix <object>[=<message>]`
 

--- a/SharpMUSH.Implementation/Commands/MoreCommands.cs
+++ b/SharpMUSH.Implementation/Commands/MoreCommands.cs
@@ -255,18 +255,19 @@ public partial class Commands
 			output.AppendLine(header);
 
 			var headerLine = useLowercase
-				? "name                 alias              type restrictions"
-				: "NAME                 ALIAS              TYPE RESTRICTIONS";
+				? "name                 symbol alias              type restrictions"
+				: "NAME                 SYMBOL ALIAS              TYPE RESTRICTIONS";
 			output.AppendLine(headerLine);
-			output.AppendLine("-------------------- ------------------ -------------------");
+			output.AppendLine("-------------------- ------ ------------------ -------------------");
 
 			var powers = Mediator!.CreateStream(new GetPowersQuery());
 			await foreach (var power in powers)
 			{
 				var powerName = useLowercase ? power.Name.ToLower() : power.Name;
 				var alias = useLowercase ? power.Alias.ToLower() : power.Alias;
+				// A power's letter is case-sensitive, so /lowercase never folds it.
 				var types = string.Join(",", power.TypeRestrictions.Select(t => useLowercase ? t.ToLower() : t));
-				output.AppendLine($"{powerName,-20} {alias,-18} {types}");
+				output.AppendLine($"{powerName,-20} {power.Symbol,-6} {alias,-18} {types}");
 			}
 
 			await NotifyService!.Notify(executor, output.ToString().TrimEnd(), executor);

--- a/SharpMUSH.Implementation/Commands/WizardCommands.cs
+++ b/SharpMUSH.Implementation/Commands/WizardCommands.cs
@@ -902,7 +902,7 @@ public partial class Commands
 	}
 
 	[SharpCommand(Name = "@POWER",
-		Switches = ["ADD", "TYPE", "LIST", "RESTRICT", "DELETE", "ALIAS", "DISABLE", "ENABLE", "DECOMPILE"],
+		Switches = ["ADD", "TYPE", "LETTER", "LIST", "RESTRICT", "DELETE", "ALIAS", "DISABLE", "ENABLE", "DECOMPILE"],
 		Behavior = CB.Default | CB.EqSplit | CB.RSArgs, MinArgs = 0, MaxArgs = 2, ParameterNames = ["object", "power"])]
 	public static async ValueTask<Option<CallState>> Power(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
@@ -922,8 +922,8 @@ public partial class Commands
 
 			var output = new System.Text.StringBuilder();
 			output.AppendLine("Object Powers:");
-			output.AppendLine("Name                 Alias              Type Restrictions");
-			output.AppendLine("-------------------- ------------------ -------------------");
+			output.AppendLine("Name                 Symbol Alias              Type Restrictions");
+			output.AppendLine("-------------------- ------ ------------------ -------------------");
 
 			var powers = Mediator!.CreateStream(new GetPowersQuery());
 			await foreach (var power in powers)
@@ -939,7 +939,7 @@ public partial class Commands
 				}
 
 				var types = string.Join(",", power.TypeRestrictions);
-				output.AppendLine($"{power.Name,-20} {power.Alias,-18} {types}");
+				output.AppendLine($"{power.Name,-20} {power.Symbol,-6} {power.Alias,-18} {types}");
 			}
 
 			await NotifyService!.Notify(executor, output.ToString().TrimEnd(), executor);
@@ -974,6 +974,7 @@ public partial class Commands
 			var result = await Mediator!.Send(new CreatePowerCommand(
 				powerName.ToUpper(),
 				alias.ToUpper(),
+				string.Empty, // PennMUSH @power/add defaults <letter> to none
 				false, // system - user-created powers are NEVER system powers
 				["FLAG^WIZARD"], // default set permissions
 				["FLAG^WIZARD"], // default unset permissions
@@ -1068,6 +1069,7 @@ public partial class Commands
 			var result = await Mediator!.Send(new UpdatePowerCommand(
 				powerName.ToUpper(),
 				newAlias.ToUpper(),
+				power.Symbol,
 				power.SetPermissions,
 				power.UnsetPermissions,
 				power.TypeRestrictions
@@ -1083,6 +1085,108 @@ public partial class Commands
 				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.FailedToUpdatePowerFormat), executor, powerName);
 				return CallState.Empty;
 			}
+		}
+
+		if (switches.Contains("LETTER"))
+		{
+			// PennMUSH src/flags.c do_flag_letter, via src/cmds.c cmd_power with ns "POWER".
+			if (parser.CurrentState.Arguments.Count < 1)
+			{
+				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.PowerLetterRequiresName), executor);
+				return CallState.Empty;
+			}
+
+			var powerName = parser.CurrentState.Arguments["0"].Message!.ToPlainText().Trim();
+
+			if (string.IsNullOrWhiteSpace(powerName))
+			{
+				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.PowerNameCannotBeEmpty), executor);
+				return CallState.Empty;
+			}
+
+			// do_flag_letter treats an absent and an empty letter alike: both clear it.
+			var newLetter = parser.CurrentState.Arguments.Count > 1
+				? parser.CurrentState.Arguments["1"].Message!.ToPlainText().Trim()
+				: string.Empty;
+
+			var power = await Mediator!.Send(new GetPowerQuery(powerName.ToUpper()));
+			if (power == null)
+			{
+				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.PowerNotFoundFormat), executor, powerName);
+				return CallState.Empty;
+			}
+
+			if (power.System)
+			{
+				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.CannotModifySystemPowerFormat), executor, powerName);
+				return CallState.Empty;
+			}
+
+			if (newLetter.Length > 1)
+			{
+				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.PowerCharactersMustBeSingleCharacters), executor);
+				return CallState.Empty;
+			}
+
+			if (newLetter.Length == 1)
+			{
+				// PennMUSH src/flags.c:955 letter_to_flagptr scopes the search to definitions whose types
+				// overlap, and compares case-sensitively. Its `n->tab == &ptab_flag` guard (:961) makes it
+				// unreachable for powers; this implements the check as written, not as reached.
+				SharpPower? conflict = null;
+				await foreach (var other in Mediator!.CreateStream(new GetPowersQuery()))
+				{
+					if (other.Name.Equals(power.Name, StringComparison.OrdinalIgnoreCase))
+					{
+						continue;
+					}
+
+					if (!string.Equals(other.Symbol, newLetter, StringComparison.Ordinal))
+					{
+						continue;
+					}
+
+					if (!other.TypeRestrictions.Intersect(power.TypeRestrictions, StringComparer.OrdinalIgnoreCase).Any())
+					{
+						continue;
+					}
+
+					conflict = other;
+					break;
+				}
+
+				if (conflict is not null)
+				{
+					await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.PowerLetterConflictFormat), executor, conflict.Name);
+					return CallState.Empty;
+				}
+			}
+
+			var lettered = await Mediator!.Send(new UpdatePowerCommand(
+				power.Name,
+				power.Alias,
+				newLetter,
+				power.SetPermissions,
+				power.UnsetPermissions,
+				power.TypeRestrictions
+			));
+
+			if (!lettered)
+			{
+				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.FailedToUpdatePowerFormat), executor, powerName);
+				return CallState.Empty;
+			}
+
+			if (newLetter.Length == 1)
+			{
+				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.PowerLetterSetFormat), executor, power.Name, newLetter);
+			}
+			else
+			{
+				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.PowerLetterClearedFormat), executor, power.Name);
+			}
+
+			return new CallState(MModule.single(power.Name));
 		}
 
 		if (switches.Contains("TYPE"))
@@ -1122,6 +1226,7 @@ public partial class Commands
 			var result = await Mediator!.Send(new UpdatePowerCommand(
 				powerName.ToUpper(),
 				power.Alias,
+				power.Symbol,
 				power.SetPermissions,
 				power.UnsetPermissions,
 				types
@@ -1174,6 +1279,7 @@ public partial class Commands
 			var result = await Mediator!.Send(new UpdatePowerCommand(
 				powerName.ToUpper(),
 				power.Alias,
+				power.Symbol,
 				perms,
 				perms,
 				power.TypeRestrictions
@@ -1210,6 +1316,7 @@ public partial class Commands
 
 			var output = new System.Text.StringBuilder();
 			output.AppendLine($"Power: {power.Name}");
+			output.AppendLine($"Symbol: {power.Symbol}");
 			output.AppendLine($"Alias: {power.Alias}");
 			output.AppendLine($"System: {(power.System ? "Yes" : "No")}");
 			output.AppendLine($"Disabled: {(power.Disabled ? "Yes" : "No")}");
@@ -1294,6 +1401,7 @@ public partial class Commands
 
 			var info = new System.Text.StringBuilder();
 			info.AppendLine($"{"Name",9}: {namedPower.Name}");
+			info.AppendLine($"{"Character",9}: {namedPower.Symbol}");
 			info.AppendLine($"{"Aliases",9}: {namedPower.Alias}");
 			info.AppendLine($"{"Type(s)",9}: {string.Join(" ", namedPower.TypeRestrictions)}");
 			info.AppendLine($"{"Perms",9}: {string.Join(" ", namedPower.SetPermissions)}");

--- a/SharpMUSH.Implementation/Commands/WizardCommands.cs
+++ b/SharpMUSH.Implementation/Commands/WizardCommands.cs
@@ -901,8 +901,6 @@ public partial class Commands
 		return CallState.Empty;
 	}
 
-	// PennMUSH's /letter switch is deliberately absent: SharpPower has no single-letter abbreviation to
-	// change, so offering the switch would only ever be a no-op.
 	[SharpCommand(Name = "@POWER",
 		Switches = ["ADD", "TYPE", "LIST", "RESTRICT", "DELETE", "ALIAS", "DISABLE", "ENABLE", "DECOMPILE"],
 		Behavior = CB.Default | CB.EqSplit | CB.RSArgs, MinArgs = 0, MaxArgs = 2, ParameterNames = ["object", "power"])]
@@ -913,8 +911,7 @@ public partial class Commands
 
 		if (switches.Contains("LIST"))
 		{
-			// PennMUSH src/flags.c list_all_flags filters by a glob pattern and hides disabled
-			// definitions from everyone but God.
+			// list_all_flags hides disabled definitions from everyone but God.
 			var pattern = parser.CurrentState.Arguments.Count > 0
 				? parser.CurrentState.Arguments["0"].Message!.ToPlainText().Trim()
 				: string.Empty;
@@ -949,8 +946,7 @@ public partial class Commands
 			return CallState.Empty;
 		}
 
-		// Everything below manipulates power *definitions*, which PennMUSH src/flags.c reserves for God.
-		// /decompile only reads, so it stays open like /list.
+		// Editing power definitions is God-only in flags.c; /decompile only reads, so it stays open like /list.
 		if (!switches.Contains("DECOMPILE") && switches.Any() && !executor.IsGod())
 		{
 			await NotifyService!.NotifyLocalized(executor,
@@ -1269,23 +1265,20 @@ public partial class Commands
 			}
 		}
 
-		// Any switch that reached here is one we declare but do not handle; never let it fall through
-		// into the object-manipulating form below.
+		// A declared-but-unhandled switch must not fall through into the grant form below.
 		if (switches.Any())
 		{
 			await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.PowerUsage), executor);
 			return CallState.Empty;
 		}
 
-		// No switch: PennMUSH src/cmds.c cmd_power falls through to src/wiz.c do_power.
 		var powerArgs = parser.CurrentState.Arguments;
 		var objectArg = powerArgs.Count > 0 ? powerArgs["0"].Message!.ToPlainText().Trim() : string.Empty;
 		var powerArg = powerArgs.Count > 1 ? powerArgs["1"].Message!.ToPlainText() : string.Empty;
 
 		if (string.IsNullOrWhiteSpace(powerArg))
 		{
-			// "@power <power>" reports on the power itself — do_power delegates to do_flag_info("POWER", ...).
-			// It does NOT list the powers held by an object.
+			// "@power <power>" describes the power itself. It does NOT list an object's powers.
 			if (string.IsNullOrWhiteSpace(objectArg))
 			{
 				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.PowerUsage), executor);
@@ -1310,9 +1303,8 @@ public partial class Commands
 			return new CallState(MModule.single(namedPower.Name));
 		}
 
-		// "@power <object>=[!]<power> [[!]<power>...]" grants or revokes powers, and is wizard-only.
-		// do_power refuses non-wizards before it even tries to resolve <object>, so a non-wizard is told
-		// they may not grant powers rather than that the object could not be found.
+		// do_power refuses non-wizards before resolving <object>, so a non-wizard is told they may not
+		// grant powers rather than that the object could not be found.
 		if (!await executor.IsWizard())
 		{
 			await NotifyService!.Notify(executor, ErrorMessages.Notifications.OnlyWizardsMayGrantPowers);

--- a/SharpMUSH.Implementation/Commands/WizardCommands.cs
+++ b/SharpMUSH.Implementation/Commands/WizardCommands.cs
@@ -18,6 +18,7 @@ using SharpMUSH.Library.Services;
 using SharpMUSH.Library.Services.Interfaces;
 using SharpMUSH.Messaging.Messages;
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 using CB = SharpMUSH.Library.Definitions.CommandBehavior;
 using ConfigGenerated = SharpMUSH.Configuration.Generated;
 
@@ -900,8 +901,10 @@ public partial class Commands
 		return CallState.Empty;
 	}
 
+	// PennMUSH's /letter switch is deliberately absent: SharpPower has no single-letter abbreviation to
+	// change, so offering the switch would only ever be a no-op.
 	[SharpCommand(Name = "@POWER",
-		Switches = ["ADD", "TYPE", "LETTER", "LIST", "RESTRICT", "DELETE", "ALIAS", "DISABLE", "ENABLE", "DECOMPILE"],
+		Switches = ["ADD", "TYPE", "LIST", "RESTRICT", "DELETE", "ALIAS", "DISABLE", "ENABLE", "DECOMPILE"],
 		Behavior = CB.Default | CB.EqSplit | CB.RSArgs, MinArgs = 0, MaxArgs = 2, ParameterNames = ["object", "power"])]
 	public static async ValueTask<Option<CallState>> Power(IMUSHCodeParser parser, SharpCommandAttribute _2)
 	{
@@ -910,6 +913,16 @@ public partial class Commands
 
 		if (switches.Contains("LIST"))
 		{
+			// PennMUSH src/flags.c list_all_flags filters by a glob pattern and hides disabled
+			// definitions from everyone but God.
+			var pattern = parser.CurrentState.Arguments.Count > 0
+				? parser.CurrentState.Arguments["0"].Message!.ToPlainText().Trim()
+				: string.Empty;
+			var patternRegex = string.IsNullOrEmpty(pattern)
+				? null
+				: new Regex(MModule.getWildcardMatchAsRegex2(pattern), RegexOptions.IgnoreCase);
+			var showDisabled = executor.IsGod();
+
 			var output = new System.Text.StringBuilder();
 			output.AppendLine("Object Powers:");
 			output.AppendLine("Name                 Alias              Type Restrictions");
@@ -918,11 +931,30 @@ public partial class Commands
 			var powers = Mediator!.CreateStream(new GetPowersQuery());
 			await foreach (var power in powers)
 			{
+				if (power.Disabled && !showDisabled)
+				{
+					continue;
+				}
+
+				if (patternRegex is not null && !patternRegex.IsMatch(power.Name))
+				{
+					continue;
+				}
+
 				var types = string.Join(",", power.TypeRestrictions);
 				output.AppendLine($"{power.Name,-20} {power.Alias,-18} {types}");
 			}
 
 			await NotifyService!.Notify(executor, output.ToString().TrimEnd(), executor);
+			return CallState.Empty;
+		}
+
+		// Everything below manipulates power *definitions*, which PennMUSH src/flags.c reserves for God.
+		// /decompile only reads, so it stays open like /list.
+		if (!switches.Contains("DECOMPILE") && switches.Any() && !executor.IsGod())
+		{
+			await NotifyService!.NotifyLocalized(executor,
+				nameof(ErrorMessages.Notifications.NotEnoughMagic), executor);
 			return CallState.Empty;
 		}
 
@@ -1237,7 +1269,63 @@ public partial class Commands
 			}
 		}
 
-		await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.PowerUsage), executor);
+		// Any switch that reached here is one we declare but do not handle; never let it fall through
+		// into the object-manipulating form below.
+		if (switches.Any())
+		{
+			await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.PowerUsage), executor);
+			return CallState.Empty;
+		}
+
+		// No switch: PennMUSH src/cmds.c cmd_power falls through to src/wiz.c do_power.
+		var powerArgs = parser.CurrentState.Arguments;
+		var objectArg = powerArgs.Count > 0 ? powerArgs["0"].Message!.ToPlainText().Trim() : string.Empty;
+		var powerArg = powerArgs.Count > 1 ? powerArgs["1"].Message!.ToPlainText() : string.Empty;
+
+		if (string.IsNullOrWhiteSpace(powerArg))
+		{
+			// "@power <power>" reports on the power itself — do_power delegates to do_flag_info("POWER", ...).
+			// It does NOT list the powers held by an object.
+			if (string.IsNullOrWhiteSpace(objectArg))
+			{
+				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.PowerUsage), executor);
+				return CallState.Empty;
+			}
+
+			var namedPower = await ManipulateSharpObjectService!.FindPower(objectArg);
+			if (namedPower is null)
+			{
+				await NotifyService!.NotifyLocalized(executor, nameof(ErrorMessages.Notifications.NoSuchPowerInfo), executor);
+				return CallState.Empty;
+			}
+
+			var info = new System.Text.StringBuilder();
+			info.AppendLine($"{"Name",9}: {namedPower.Name}");
+			info.AppendLine($"{"Aliases",9}: {namedPower.Alias}");
+			info.AppendLine($"{"Type(s)",9}: {string.Join(" ", namedPower.TypeRestrictions)}");
+			info.AppendLine($"{"Perms",9}: {string.Join(" ", namedPower.SetPermissions)}");
+			info.Append($"{"ResetPrms",9}: {string.Join(" ", namedPower.UnsetPermissions)}");
+
+			await NotifyService!.Notify(executor, info.ToString(), executor);
+			return new CallState(MModule.single(namedPower.Name));
+		}
+
+		// "@power <object>=[!]<power> [[!]<power>...]" grants or revokes powers, and is wizard-only.
+		// do_power refuses non-wizards before it even tries to resolve <object>, so a non-wizard is told
+		// they may not grant powers rather than that the object could not be found.
+		if (!await executor.IsWizard())
+		{
+			await NotifyService!.Notify(executor, ErrorMessages.Notifications.OnlyWizardsMayGrantPowers);
+			return CallState.Empty;
+		}
+
+		var maybeTarget = await LocateService!.LocateAndNotifyIfInvalid(parser, executor, executor, objectArg, LocateFlags.All);
+		if (!maybeTarget.IsValid())
+		{
+			return CallState.Empty;
+		}
+
+		await ManipulateSharpObjectService!.SetOrUnsetPowers(executor, maybeTarget.WithoutError().Known(), powerArg, true);
 		return CallState.Empty;
 	}
 

--- a/SharpMUSH.Implementation/Functions/InformationFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/InformationFunctions.cs
@@ -364,10 +364,13 @@ public partial class Functions
 						return ErrorMessages.Returns.NoSideFx;
 					}
 
+					// PennMUSH src/fundb.c fun_powers hands the side-effect form straight to do_power, so it
+					// gets the same wizard-only check and the same "!" revoke handling as @power.
 					return await LocateService!.LocateAndNotifyIfInvalidWithCallStateFunction(
 						parser, executor, executor, obj!.Message!.ToPlainText(), LocateFlags.All,
 						async found =>
-							await ManipulateSharpObjectService!.SetPower(executor, found, power!.Message!.ToPlainText(), true));
+							await ManipulateSharpObjectService!.SetOrUnsetPowers(executor, found,
+								power!.Message!.ToPlainText(), true));
 				}
 		}
 	}

--- a/SharpMUSH.Implementation/Handlers/Database/PowerManagementCommandHandler.cs
+++ b/SharpMUSH.Implementation/Handlers/Database/PowerManagementCommandHandler.cs
@@ -13,6 +13,7 @@ public class CreatePowerCommandHandler(ISharpDatabase database)
 		return await database.CreatePowerAsync(
 			request.Name,
 			request.Alias,
+			request.Symbol,
 			request.System,
 			request.SetPermissions,
 			request.UnsetPermissions,

--- a/SharpMUSH.Implementation/Handlers/Database/UpdatePowerCommandHandler.cs
+++ b/SharpMUSH.Implementation/Handlers/Database/UpdatePowerCommandHandler.cs
@@ -11,6 +11,7 @@ public class UpdatePowerCommandHandler(ISharpDatabase database) : ICommandHandle
 		return await database.UpdatePowerAsync(
 			command.Name,
 			command.Alias,
+			command.Symbol,
 			command.SetPermissions,
 			command.UnsetPermissions,
 			command.TypeRestrictions,

--- a/SharpMUSH.Library/Commands/Database/CreatePowerCommand.cs
+++ b/SharpMUSH.Library/Commands/Database/CreatePowerCommand.cs
@@ -7,6 +7,7 @@ namespace SharpMUSH.Library.Commands.Database;
 public record CreatePowerCommand(
 	string Name,
 	string Alias,
+	string Symbol,
 	bool System,
 	string[] SetPermissions,
 	string[] UnsetPermissions,

--- a/SharpMUSH.Library/Commands/Database/UpdatePowerCommand.cs
+++ b/SharpMUSH.Library/Commands/Database/UpdatePowerCommand.cs
@@ -5,6 +5,7 @@ namespace SharpMUSH.Library.Commands.Database;
 public record UpdatePowerCommand(
 	string Name,
 	string Alias,
+	string Symbol,
 	string[] SetPermissions,
 	string[] UnsetPermissions,
 	string[] TypeRestrictions

--- a/SharpMUSH.Library/Definitions/ErrorMessages.cs
+++ b/SharpMUSH.Library/Definitions/ErrorMessages.cs
@@ -1435,7 +1435,16 @@ public static class ErrorMessages
 		public const string FailedToDisablePowerFormat = "Failed to disable power '{0}'.";
 		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
 		public const string FailedToEnablePowerFormat = "Failed to enable power '{0}'.";
-		public const string PowerUsage = "Usage: @power <power>, @power <object>=[!]<power>, @power/list, @power/add <name>=<alias>, @power/delete <name>, @power/alias <name>=<alias>, @power/type <name>=<types>, @power/restrict <name>=<permissions>, @power/decompile <name>";
+		// PennMUSH src/flags.c do_flag_letter.
+		public const string PowerLetterRequiresName = "@POWER/LETTER requires a power name.";
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string PowerLetterSetFormat = "Letter for power {0} set to '{1}'.";
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string PowerLetterClearedFormat = "Letter for power {0} cleared.";
+		public const string PowerCharactersMustBeSingleCharacters = "Power characters must be single characters.";
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string PowerLetterConflictFormat = "Letter conflicts with the {0} power.";
+		public const string PowerUsage = "Usage: @power <power>, @power <object>=[!]<power>, @power/list, @power/add <name>=<alias>, @power/delete <name>, @power/alias <name>=<alias>, @power/letter <name>[=<letter>], @power/type <name>=<types>, @power/restrict <name>=<permissions>, @power/decompile <name>";
 
 		public const string FullMotdCleared = "Full MOTD cleared.";
 		public const string RejectMotdUsage = "Usage: @rejectmotd <message>";

--- a/SharpMUSH.Library/Definitions/ErrorMessages.cs
+++ b/SharpMUSH.Library/Definitions/ErrorMessages.cs
@@ -439,6 +439,7 @@ public static class ErrorMessages
 		public const string CantBuyThingsByTakingMoney = "You can't buy things by taking money.";
 
 		public const string DontLookLikeGod = "You don't look like God.";
+		public const string NotEnoughMagic = "You don't have enough magic for that.";
 		public const string NotAnAdmin = "You don't look like an admin to me.";
 		public const string CantAliasCommandToThat = "I can't alias a command to that!";
 		public const string CantMakeMultipleRequests = "You can't make multiple requests at the same time!";
@@ -603,10 +604,22 @@ public static class ErrorMessages
 		public const string DontRecognizeFlag = "{0} - I don't recognize that flag.";
 		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
 		public const string DontRecognizePower = "{0} - I don't recognize that power.";
+		// PennMUSH set_power reports powers as granted/removed, not set/reset.
 		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
-		public const string PowerSet = "{0} - {1} set.";
+		public const string PowerGranted = "{0} - {1} granted.";
 		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
-		public const string PowerAlreadySet = "{0} - {1} (already) set.";
+		public const string PowerAlreadyGranted = "{0} - {1} (already) granted.";
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string PowerRemoved = "{0} - {1} removed.";
+		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
+		public const string PowerAlreadyRemoved = "{0} - {1} (already) removed.";
+
+		// PennMUSH src/wiz.c do_power.
+		public const string OnlyWizardsMayGrantPowers = "Only wizards may grant powers.";
+		public const string GodIsAlreadyAllPowerful = "God is already all-powerful.";
+		public const string MustSpecifyPowerToSet = "You must specify a power to set.";
+		// PennMUSH src/flags.c do_flag_info, with the flagspace name lowercased.
+		public const string NoSuchPowerInfo = "No such power.";
 
 		// --- Attribute set messages aligned with PennMUSH src/set.c ---
 		// PennMUSH format: "ObjectName/ATTRNAME - Set."
@@ -1422,7 +1435,7 @@ public static class ErrorMessages
 		public const string FailedToDisablePowerFormat = "Failed to disable power '{0}'.";
 		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
 		public const string FailedToEnablePowerFormat = "Failed to enable power '{0}'.";
-		public const string PowerUsage = "Usage: @power/list, @power/add <name>=<alias>, @power/delete <name>, @power/alias <name>=<alias>, @power/type <name>=<types>, @power/restrict <name>=<permissions>, @power/decompile <name>";
+		public const string PowerUsage = "Usage: @power <power>, @power <object>=[!]<power>, @power/list, @power/add <name>=<alias>, @power/delete <name>, @power/alias <name>=<alias>, @power/type <name>=<types>, @power/restrict <name>=<permissions>, @power/decompile <name>";
 
 		public const string FullMotdCleared = "Full MOTD cleared.";
 		public const string RejectMotdUsage = "Usage: @rejectmotd <message>";

--- a/SharpMUSH.Library/Definitions/ErrorMessages.cs
+++ b/SharpMUSH.Library/Definitions/ErrorMessages.cs
@@ -1444,7 +1444,7 @@ public static class ErrorMessages
 		public const string PowerCharactersMustBeSingleCharacters = "Power characters must be single characters.";
 		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
 		public const string PowerLetterConflictFormat = "Letter conflicts with the {0} power.";
-		public const string PowerUsage = "Usage: @power <power>, @power <object>=[!]<power>, @power/list, @power/add <name>=<alias>, @power/delete <name>, @power/alias <name>=<alias>, @power/letter <name>[=<letter>], @power/type <name>=<types>, @power/restrict <name>=<permissions>, @power/decompile <name>";
+		public const string PowerUsage = "Usage: @power <power>, @power <object>=[!]<power> [[!]<power>...], @power/list, @power/add <name>=<alias>, @power/delete <name>, @power/alias <name>=<alias>, @power/letter <name>[=<letter>], @power/type <name>=<types>, @power/restrict <name>=<permissions>, @power/decompile <name>";
 
 		public const string FullMotdCleared = "Full MOTD cleared.";
 		public const string RejectMotdUsage = "Usage: @rejectmotd <message>";

--- a/SharpMUSH.Library/ISharpDatabase.cs
+++ b/SharpMUSH.Library/ISharpDatabase.cs
@@ -306,13 +306,14 @@ public interface ISharpDatabase
 	/// </summary>
 	/// <param name="name">Power name</param>
 	/// <param name="alias">Power alias</param>
+	/// <param name="symbol">The power's one-character abbreviation, or the empty string for none</param>
 	/// <param name="system">Whether this is a system power</param>
 	/// <param name="setPermissions">Permissions required to set this power</param>
 	/// <param name="unsetPermissions">Permissions required to unset this power</param>
 	/// <param name="typeRestrictions">Object types this power can be set on</param>
 	/// <param name="cancellationToken">Cancellation Token</param>
 	/// <returns>The created power, or null if creation failed</returns>
-	ValueTask<SharpPower?> CreatePowerAsync(string name, string alias, bool system, string[] setPermissions, string[] unsetPermissions, string[] typeRestrictions, CancellationToken cancellationToken = default);
+	ValueTask<SharpPower?> CreatePowerAsync(string name, string alias, string symbol, bool system, string[] setPermissions, string[] unsetPermissions, string[] typeRestrictions, CancellationToken cancellationToken = default);
 
 	/// <summary>
 	/// Delete a Power by name.
@@ -327,12 +328,13 @@ public interface ISharpDatabase
 	/// </summary>
 	/// <param name="name">Power name</param>
 	/// <param name="alias">Power alias</param>
+	/// <param name="symbol">The power's one-character abbreviation, or the empty string for none</param>
 	/// <param name="setPermissions">Permissions required to set this power</param>
 	/// <param name="unsetPermissions">Permissions required to unset this power</param>
 	/// <param name="typeRestrictions">Object types this power can be set on</param>
 	/// <param name="cancellationToken">Cancellation Token</param>
 	/// <returns>Success or Failure</returns>
-	ValueTask<bool> UpdatePowerAsync(string name, string alias, string[] setPermissions, string[] unsetPermissions, string[] typeRestrictions, CancellationToken cancellationToken = default);
+	ValueTask<bool> UpdatePowerAsync(string name, string alias, string symbol, string[] setPermissions, string[] unsetPermissions, string[] typeRestrictions, CancellationToken cancellationToken = default);
 
 	/// <summary>
 	/// Update an existing object flag.

--- a/SharpMUSH.Library/Models/SharpPower.cs
+++ b/SharpMUSH.Library/Models/SharpPower.cs
@@ -19,6 +19,13 @@ public class SharpPower
 
 	public required string Alias { get; set; }
 
+	/// <summary>
+	/// The power's one-character abbreviation, or the empty string for none — PennMUSH's
+	/// <c>FLAG.letter</c>, set with <c>@power/letter</c>. Two powers that can apply to the same
+	/// object type may not share one; see PennMUSH src/flags.c letter_to_flagptr.
+	/// </summary>
+	public string Symbol { get; set; } = string.Empty;
+
 	public required string[] SetPermissions { get; set; }
 
 	public required string[] UnsetPermissions { get; set; }

--- a/SharpMUSH.Library/Resources/Notifications.resx
+++ b/SharpMUSH.Library/Resources/Notifications.resx
@@ -2124,7 +2124,7 @@
     <value>Letter conflicts with the {0} power.</value>
   </data>
   <data name="PowerUsage" xml:space="preserve">
-    <value>Usage: @power &lt;power&gt;, @power &lt;object&gt;=[!]&lt;power&gt;, @power/list, @power/add &lt;name&gt;=&lt;alias&gt;, @power/delete &lt;name&gt;, @power/alias &lt;name&gt;=&lt;alias&gt;, @power/letter &lt;name&gt;[=&lt;letter&gt;], @power/type &lt;name&gt;=&lt;types&gt;, @power/restrict &lt;name&gt;=&lt;permissions&gt;, @power/decompile &lt;name&gt;</value>
+    <value>Usage: @power &lt;power&gt;, @power &lt;object&gt;=[!]&lt;power&gt; [[!]&lt;power&gt;...], @power/list, @power/add &lt;name&gt;=&lt;alias&gt;, @power/delete &lt;name&gt;, @power/alias &lt;name&gt;=&lt;alias&gt;, @power/letter &lt;name&gt;[=&lt;letter&gt;], @power/type &lt;name&gt;=&lt;types&gt;, @power/restrict &lt;name&gt;=&lt;permissions&gt;, @power/decompile &lt;name&gt;</value>
   </data>
 
   <!-- @rejectmotd / @wizmotd -->

--- a/SharpMUSH.Library/Resources/Notifications.resx
+++ b/SharpMUSH.Library/Resources/Notifications.resx
@@ -252,6 +252,9 @@
   <data name="DontLookLikeGod" xml:space="preserve">
     <value>You don't look like God.</value>
   </data>
+  <data name="NotEnoughMagic" xml:space="preserve">
+    <value>You don't have enough magic for that.</value>
+  </data>
   <data name="NotAnAdmin" xml:space="preserve">
     <value>You don't look like an admin to me.</value>
   </data>
@@ -505,11 +508,29 @@
   <data name="DontRecognizePower" xml:space="preserve">
     <value>{0} - I don't recognize that power.</value>
   </data>
-  <data name="PowerSet" xml:space="preserve">
-    <value>{0} - {1} set.</value>
+  <data name="PowerGranted" xml:space="preserve">
+    <value>{0} - {1} granted.</value>
   </data>
-  <data name="PowerAlreadySet" xml:space="preserve">
-    <value>{0} - {1} (already) set.</value>
+  <data name="PowerAlreadyGranted" xml:space="preserve">
+    <value>{0} - {1} (already) granted.</value>
+  </data>
+  <data name="PowerRemoved" xml:space="preserve">
+    <value>{0} - {1} removed.</value>
+  </data>
+  <data name="PowerAlreadyRemoved" xml:space="preserve">
+    <value>{0} - {1} (already) removed.</value>
+  </data>
+  <data name="OnlyWizardsMayGrantPowers" xml:space="preserve">
+    <value>Only wizards may grant powers.</value>
+  </data>
+  <data name="GodIsAlreadyAllPowerful" xml:space="preserve">
+    <value>God is already all-powerful.</value>
+  </data>
+  <data name="MustSpecifyPowerToSet" xml:space="preserve">
+    <value>You must specify a power to set.</value>
+  </data>
+  <data name="NoSuchPowerInfo" xml:space="preserve">
+    <value>No such power.</value>
   </data>
 
   <!-- Attribute set messages -->
@@ -2088,7 +2109,7 @@
     <value>Failed to enable power '{0}'.</value>
   </data>
   <data name="PowerUsage" xml:space="preserve">
-    <value>Usage: @power/list, @power/add &lt;name&gt;=&lt;alias&gt;, @power/delete &lt;name&gt;, @power/alias &lt;name&gt;=&lt;alias&gt;, @power/type &lt;name&gt;=&lt;types&gt;, @power/restrict &lt;name&gt;=&lt;permissions&gt;, @power/decompile &lt;name&gt;</value>
+    <value>Usage: @power &lt;power&gt;, @power &lt;object&gt;=[!]&lt;power&gt;, @power/list, @power/add &lt;name&gt;=&lt;alias&gt;, @power/delete &lt;name&gt;, @power/alias &lt;name&gt;=&lt;alias&gt;, @power/type &lt;name&gt;=&lt;types&gt;, @power/restrict &lt;name&gt;=&lt;permissions&gt;, @power/decompile &lt;name&gt;</value>
   </data>
 
   <!-- @rejectmotd / @wizmotd -->

--- a/SharpMUSH.Library/Resources/Notifications.resx
+++ b/SharpMUSH.Library/Resources/Notifications.resx
@@ -2108,8 +2108,23 @@
   <data name="FailedToEnablePowerFormat" xml:space="preserve">
     <value>Failed to enable power '{0}'.</value>
   </data>
+  <data name="PowerLetterRequiresName" xml:space="preserve">
+    <value>@POWER/LETTER requires a power name.</value>
+  </data>
+  <data name="PowerLetterSetFormat" xml:space="preserve">
+    <value>Letter for power {0} set to '{1}'.</value>
+  </data>
+  <data name="PowerLetterClearedFormat" xml:space="preserve">
+    <value>Letter for power {0} cleared.</value>
+  </data>
+  <data name="PowerCharactersMustBeSingleCharacters" xml:space="preserve">
+    <value>Power characters must be single characters.</value>
+  </data>
+  <data name="PowerLetterConflictFormat" xml:space="preserve">
+    <value>Letter conflicts with the {0} power.</value>
+  </data>
   <data name="PowerUsage" xml:space="preserve">
-    <value>Usage: @power &lt;power&gt;, @power &lt;object&gt;=[!]&lt;power&gt;, @power/list, @power/add &lt;name&gt;=&lt;alias&gt;, @power/delete &lt;name&gt;, @power/alias &lt;name&gt;=&lt;alias&gt;, @power/type &lt;name&gt;=&lt;types&gt;, @power/restrict &lt;name&gt;=&lt;permissions&gt;, @power/decompile &lt;name&gt;</value>
+    <value>Usage: @power &lt;power&gt;, @power &lt;object&gt;=[!]&lt;power&gt;, @power/list, @power/add &lt;name&gt;=&lt;alias&gt;, @power/delete &lt;name&gt;, @power/alias &lt;name&gt;=&lt;alias&gt;, @power/letter &lt;name&gt;[=&lt;letter&gt;], @power/type &lt;name&gt;=&lt;types&gt;, @power/restrict &lt;name&gt;=&lt;permissions&gt;, @power/decompile &lt;name&gt;</value>
   </data>
 
   <!-- @rejectmotd / @wizmotd -->

--- a/SharpMUSH.Library/Services/Interfaces/IManipulateSharpObjectService.cs
+++ b/SharpMUSH.Library/Services/Interfaces/IManipulateSharpObjectService.cs
@@ -12,6 +12,16 @@ public interface IManipulateSharpObjectService
 
 	ValueTask<CallState> SetOrUnsetFlag(AnySharpObject executor, AnySharpObject obj, string flagOrFlagAlias, bool notify);
 
+	/// <summary>Resolves a power by its name or one of its aliases, or null when no such power exists.</summary>
+	ValueTask<SharpPower?> FindPower(string powerOrPowerAlias);
+
+	/// <summary>
+	/// Applies a whole <c>@power</c> right-hand side: wizard-only, one or more space-separated power names,
+	/// each optionally prefixed with <c>!</c> to revoke rather than grant.
+	/// </summary>
+	ValueTask<CallState> SetOrUnsetPowers(AnySharpObject executor, AnySharpObject obj, string powerSpecification,
+		bool notify);
+
 	ValueTask<CallState> SetPower(AnySharpObject executor, AnySharpObject obj, string powerOrPowerAlias, bool notify);
 
 	ValueTask<CallState> UnsetPower(AnySharpObject executor, AnySharpObject obj, string powerOrPowerAlias, bool notify);

--- a/SharpMUSH.Library/Services/ManipulateSharpObjectService.cs
+++ b/SharpMUSH.Library/Services/ManipulateSharpObjectService.cs
@@ -272,9 +272,100 @@ public class ManipulateSharpObjectService(
 		return true;
 	}
 
+	/// <summary>
+	/// Resolves a power by name or alias.
+	/// </summary>
+	/// <remarks>
+	/// <see cref="SharpPower.Alias"/> is declared non-nullable but the seeded powers store null for "no alias", so an
+	/// unguarded <c>x.Alias.Equals</c> throws on the first aliasless power the stream yields — which, since the
+	/// predicate runs over every power until one matches, made setting or clearing ANY power a
+	/// <see cref="NullReferenceException"/>. GetPowerQueryHandler already guards the same comparison this way.
+	/// </remarks>
+	public ValueTask<SharpPower?> FindPower(string powerOrPowerAlias) =>
+		mediator.CreateStream(new GetPowersQuery())
+			.FirstOrDefaultAsync(x =>
+				x.Name.Equals(powerOrPowerAlias, StringComparison.InvariantCultureIgnoreCase)
+				|| (x.Alias is not null && x.Alias.Equals(powerOrPowerAlias, StringComparison.InvariantCultureIgnoreCase)));
+
+	/// <summary>
+	/// PennMUSH src/wiz.c do_power, the shared body of the <c>@power &lt;object&gt;=...</c> command and the
+	/// side-effect form of <c>powers()</c>: wizard-only, refuses unregistered players and God, then applies
+	/// each space-separated token, granting it or — with a leading <c>!</c> — revoking it.
+	/// </summary>
+	public async ValueTask<CallState> SetOrUnsetPowers(AnySharpObject executor, AnySharpObject obj,
+		string powerSpecification, bool notify)
+	{
+		if (!await executor.IsWizard())
+		{
+			if (notify)
+			{
+				await notifyService.Notify(executor, Definitions.ErrorMessages.Notifications.OnlyWizardsMayGrantPowers);
+			}
+			return ErrorMessages.Returns.PermissionDenied;
+		}
+
+		if (await obj.HasFlag("UNREGISTERED"))
+		{
+			if (notify)
+			{
+				await notifyService.Notify(executor,
+					Definitions.ErrorMessages.Notifications.CantGrantPowersUnregistered);
+			}
+			return ErrorMessages.Returns.PermissionDenied;
+		}
+
+		if (obj.IsGod() && !executor.IsGod())
+		{
+			if (notify)
+			{
+				await notifyService.Notify(executor, Definitions.ErrorMessages.Notifications.GodIsAlreadyAllPowerful);
+			}
+			return ErrorMessages.Returns.PermissionDenied;
+		}
+
+		var tokens = powerSpecification.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+		if (tokens.Length == 0)
+		{
+			if (notify)
+			{
+				await notifyService.Notify(executor, Definitions.ErrorMessages.Notifications.MustSpecifyPowerToSet);
+			}
+			return ErrorMessages.Returns.PermissionDenied;
+		}
+
+		CallState last = true;
+		foreach (var token in tokens)
+		{
+			// A bare "!" is not a revoke: do_power only strips the token when something follows it.
+			var revoke = token[0] == '!' && token.Length > 1;
+			var powerName = revoke ? token[1..] : token;
+
+			last = revoke
+				? await UnsetPower(executor, obj, powerName, notify)
+				: await SetPower(executor, obj, powerName, notify);
+		}
+
+		return last;
+	}
+
 	public async ValueTask<CallState> SetPower(AnySharpObject executor, AnySharpObject obj, string powerOrPowerAlias,
 		bool notify)
 	{
+		// PennMUSH src/flags.c set_power resolves the power before any permission check, and names the
+		// *power* — not the object — when it cannot.
+		var found = await FindPower(powerOrPowerAlias);
+
+		if (found is null)
+		{
+			if (notify)
+			{
+				await notifyService.Notify(executor,
+					string.Format(Definitions.ErrorMessages.Notifications.DontRecognizePower, powerOrPowerAlias));
+			}
+			return ErrorMessages.Returns.NoSuchPower;
+		}
+
 		if (!await permissionService.Controls(executor, obj))
 		{
 			if (notify)
@@ -295,7 +386,7 @@ public class ManipulateSharpObjectService(
 		}
 
 		// Can't make admin (Wizard/Royalty) into guests (PennMUSH src/flags.c)
-		if (powerOrPowerAlias.Equals("Guest", StringComparison.OrdinalIgnoreCase)
+		if (found.Name.Equals("Guest", StringComparison.OrdinalIgnoreCase)
 			&& (await obj.IsWizard() || await obj.IsRoyalty()))
 		{
 			if (notify)
@@ -305,44 +396,23 @@ public class ManipulateSharpObjectService(
 			return ErrorMessages.Returns.PermissionDenied;
 		}
 
-		if (await obj.HasPower(powerOrPowerAlias))
+		if (await obj.HasPower(found.Name))
 		{
 			if (notify)
 			{
 				await notifyService.Notify(executor,
-					string.Format(Definitions.ErrorMessages.Notifications.PowerAlreadySet, obj.Object().Name, powerOrPowerAlias));
+					string.Format(Definitions.ErrorMessages.Notifications.PowerAlreadyGranted, obj.Object().Name, found.Name));
 			}
 			return true;
 		}
 
-		var allPowers = mediator.CreateStream(new GetPowersQuery());
-
-		// Alias is declared non-nullable but the seeded powers store null for "no alias", so an unguarded
-		// x.Alias.Equals throws on the first aliasless power the stream yields — which, since the predicate
-		// runs over every power until one matches, made setting or clearing ANY power a NullReferenceException.
-		// GetPowerQueryHandler already guards the same comparison this way.
-		var found = await allPowers
-			.FirstOrDefaultAsync(x =>
-				x.Name.Equals(powerOrPowerAlias, StringComparison.InvariantCultureIgnoreCase)
-				|| (x.Alias is not null && x.Alias.Equals(powerOrPowerAlias, StringComparison.InvariantCultureIgnoreCase)));
-
-		if (found is null)
-		{
-			if (notify)
-			{
-				await notifyService.Notify(executor,
-					string.Format(Definitions.ErrorMessages.Notifications.DontRecognizePower, obj.Object().Name));
-			}
-			return ErrorMessages.Returns.NoSuchPower;
-		}
+		await mediator.Send(new SetObjectPowerCommand(obj, found));
 
 		if (notify)
 		{
 			await notifyService.Notify(executor,
-				string.Format(Definitions.ErrorMessages.Notifications.PowerSet, obj.Object().Name, powerOrPowerAlias));
+				string.Format(Definitions.ErrorMessages.Notifications.PowerGranted, obj.Object().Name, found.Name));
 		}
-
-		await mediator.Send(new SetObjectPowerCommand(obj, found));
 
 		// Powers trigger the same OBJECT`FLAG event as flags.
 		await publisher.Publish(new ObjectFlagChangedNotification(
@@ -358,6 +428,18 @@ public class ManipulateSharpObjectService(
 	public async ValueTask<CallState> UnsetPower(AnySharpObject executor, AnySharpObject obj, string powerOrPowerAlias,
 		bool notify)
 	{
+		var found = await FindPower(powerOrPowerAlias);
+
+		if (found is null)
+		{
+			if (notify)
+			{
+				await notifyService.Notify(executor,
+					string.Format(Definitions.ErrorMessages.Notifications.DontRecognizePower, powerOrPowerAlias));
+			}
+			return ErrorMessages.Returns.NoSuchPower;
+		}
+
 		if (!await permissionService.Controls(executor, obj))
 		{
 			if (notify)
@@ -377,44 +459,23 @@ public class ManipulateSharpObjectService(
 			return ErrorMessages.Returns.PermissionDenied;
 		}
 
-		if (!await obj.HasPower(powerOrPowerAlias))
+		if (!await obj.HasPower(found.Name))
 		{
 			if (notify)
 			{
 				await notifyService.Notify(executor,
-					string.Format(Definitions.ErrorMessages.Notifications.FlagAlreadyReset, obj.Object().Name, powerOrPowerAlias));
+					string.Format(Definitions.ErrorMessages.Notifications.PowerAlreadyRemoved, obj.Object().Name, found.Name));
 			}
 			return true;
 		}
 
-		var allPowers = mediator.CreateStream(new GetPowersQuery());
-
-		// Alias is declared non-nullable but the seeded powers store null for "no alias", so an unguarded
-		// x.Alias.Equals throws on the first aliasless power the stream yields — which, since the predicate
-		// runs over every power until one matches, made setting or clearing ANY power a NullReferenceException.
-		// GetPowerQueryHandler already guards the same comparison this way.
-		var found = await allPowers
-			.FirstOrDefaultAsync(x =>
-				x.Name.Equals(powerOrPowerAlias, StringComparison.InvariantCultureIgnoreCase)
-				|| (x.Alias is not null && x.Alias.Equals(powerOrPowerAlias, StringComparison.InvariantCultureIgnoreCase)));
-
-		if (found is null)
-		{
-			if (notify)
-			{
-				await notifyService.Notify(executor,
-					string.Format(Definitions.ErrorMessages.Notifications.DontRecognizePower, obj.Object().Name));
-			}
-			return ErrorMessages.Returns.NoSuchPower;
-		}
+		await mediator.Send(new UnsetObjectPowerCommand(obj, found));
 
 		if (notify)
 		{
 			await notifyService.Notify(executor,
-				string.Format(Definitions.ErrorMessages.Notifications.FlagReset, obj.Object().Name, powerOrPowerAlias));
+				string.Format(Definitions.ErrorMessages.Notifications.PowerRemoved, obj.Object().Name, found.Name));
 		}
-
-		await mediator.Send(new UnsetObjectPowerCommand(obj, found));
 
 		// Powers trigger the same OBJECT`FLAG event as flags.
 		await publisher.Publish(new ObjectFlagChangedNotification(

--- a/SharpMUSH.Library/Services/ManipulateSharpObjectService.cs
+++ b/SharpMUSH.Library/Services/ManipulateSharpObjectService.cs
@@ -276,10 +276,8 @@ public class ManipulateSharpObjectService(
 	/// Resolves a power by name or alias.
 	/// </summary>
 	/// <remarks>
-	/// <see cref="SharpPower.Alias"/> is declared non-nullable but the seeded powers store null for "no alias", so an
-	/// unguarded <c>x.Alias.Equals</c> throws on the first aliasless power the stream yields — which, since the
-	/// predicate runs over every power until one matches, made setting or clearing ANY power a
-	/// <see cref="NullReferenceException"/>. GetPowerQueryHandler already guards the same comparison this way.
+	/// <see cref="SharpPower.Alias"/> is declared non-nullable but the seeded powers store null for "no alias", so the
+	/// null guard is load-bearing: without it the predicate throws on the first aliasless power the stream yields.
 	/// </remarks>
 	public ValueTask<SharpPower?> FindPower(string powerOrPowerAlias) =>
 		mediator.CreateStream(new GetPowersQuery())
@@ -288,9 +286,8 @@ public class ManipulateSharpObjectService(
 				|| (x.Alias is not null && x.Alias.Equals(powerOrPowerAlias, StringComparison.InvariantCultureIgnoreCase)));
 
 	/// <summary>
-	/// PennMUSH src/wiz.c do_power, the shared body of the <c>@power &lt;object&gt;=...</c> command and the
-	/// side-effect form of <c>powers()</c>: wizard-only, refuses unregistered players and God, then applies
-	/// each space-separated token, granting it or — with a leading <c>!</c> — revoking it.
+	/// PennMUSH src/wiz.c do_power: the shared body of <c>@power &lt;object&gt;=...</c> and the side-effect
+	/// form of <c>powers()</c>.
 	/// </summary>
 	public async ValueTask<CallState> SetOrUnsetPowers(AnySharpObject executor, AnySharpObject obj,
 		string powerSpecification, bool notify)
@@ -352,8 +349,7 @@ public class ManipulateSharpObjectService(
 	public async ValueTask<CallState> SetPower(AnySharpObject executor, AnySharpObject obj, string powerOrPowerAlias,
 		bool notify)
 	{
-		// PennMUSH src/flags.c set_power resolves the power before any permission check, and names the
-		// *power* — not the object — when it cannot.
+		// set_power resolves the power before any permission check, and names the *power* when it cannot.
 		var found = await FindPower(powerOrPowerAlias);
 
 		if (found is null)

--- a/SharpMUSH.Tests/Commands/AtListCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/AtListCommandTests.cs
@@ -148,7 +148,7 @@ public class AtListCommandTests
 		await NotifyService
 			.Received(1)
 			.Notify(TestHelpers.MatchingObject(executor),
-				Arg.Is<OneOf.OneOf<MString, string>>(s => TestHelpers.MessagePlainTextStartsWith(s, "OBJECT POWERS:\nNAME                 ALIAS              TYPE RESTRICTIONS")), TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
+				Arg.Is<OneOf.OneOf<MString, string>>(s => TestHelpers.MessagePlainTextStartsWith(s, "OBJECT POWERS:\nNAME                 SYMBOL ALIAS              TYPE RESTRICTIONS")), TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
 	}
 
 	[Test]

--- a/SharpMUSH.Tests/Commands/BuildingCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/BuildingCommandTests.cs
@@ -676,8 +676,7 @@ public class BuildingCommandTests
 
 		await parser.CommandParse(player.Handle, ConnectionService, MModule.single("look"));
 
-		// The @descformat evaluation is queued, so the notification can land after CommandParse
-		// returns; poll for it rather than asserting into the race.
+		// The @descformat evaluation is queued, so it can land after CommandParse returns.
 		await TestHelpers.WaitForNotification(NotifyService, player.DbRef, $"THINGDESC_{token.ToUpper()}");
 
 		await NotifyService
@@ -708,8 +707,7 @@ public class BuildingCommandTests
 
 		await parser.CommandParse(player.Handle, ConnectionService, MModule.single("look"));
 
-		// The @idescformat evaluation is queued, so the notification can land after CommandParse
-		// returns; poll for it rather than asserting into the race.
+		// The @idescformat evaluation is queued, so it can land after CommandParse returns.
 		await TestHelpers.WaitForNotification(NotifyService, player.DbRef, $"INSIDEDESC_{token.ToUpper()}");
 
 		await NotifyService

--- a/SharpMUSH.Tests/Commands/BuildingCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/BuildingCommandTests.cs
@@ -676,6 +676,10 @@ public class BuildingCommandTests
 
 		await parser.CommandParse(player.Handle, ConnectionService, MModule.single("look"));
 
+		// The @descformat evaluation is queued, so the notification can land after CommandParse
+		// returns; poll for it rather than asserting into the race.
+		await TestHelpers.WaitForNotification(NotifyService, player.DbRef, $"THINGDESC_{token.ToUpper()}");
+
 		await NotifyService
 			.Received()
 			.Notify(TestHelpers.MatchingObject(player.DbRef), Arg.Is<OneOf<MString, string>>(msg =>
@@ -703,6 +707,10 @@ public class BuildingCommandTests
 		await parser.CommandParse(player.Handle, ConnectionService, MModule.single($"@tel me={objDbRef}"));
 
 		await parser.CommandParse(player.Handle, ConnectionService, MModule.single("look"));
+
+		// The @idescformat evaluation is queued, so the notification can land after CommandParse
+		// returns; poll for it rather than asserting into the race.
+		await TestHelpers.WaitForNotification(NotifyService, player.DbRef, $"INSIDEDESC_{token.ToUpper()}");
 
 		await NotifyService
 			.Received()

--- a/SharpMUSH.Tests/Commands/FlagAndPowerCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/FlagAndPowerCommandTests.cs
@@ -185,7 +185,7 @@ public class FlagAndPowerCommandTests
 		var alias = "TPOW";
 
 		var createdPower = await Mediator.Send(new CreatePowerCommand(
-			powerName, alias, false,
+			powerName, alias, string.Empty, false,
 			["FLAG^WIZARD"], ["FLAG^WIZARD"], ["PLAYER"]
 		));
 		await Assert.That(createdPower).IsNotNull();
@@ -552,6 +552,189 @@ public class FlagAndPowerCommandTests
 		await Assert.That(await PowerNamesOf(newDb)).DoesNotContain("Builder");
 
 		await Parser.CommandParse(1, ConnectionService, MModule.single($"@destroy {newDb}"));
+	}
+
+	// Every built-in power carries letter '\0' (PennMUSH hdrs/flag_tab.h power_table) and SharpMUSH
+	// refuses to redefine a system power, so each /letter test needs a power of its own. Each also
+	// picks a letter no other test uses: the collision check is global and these run in parallel.
+	private async ValueTask<string> CreateLetterlessPower(string[]? types = null)
+	{
+		var powerName = $"TEST_POWER_LTR_{Guid.NewGuid().ToString("N")[..8].ToUpper()}";
+		var created = await Mediator.Send(new CreatePowerCommand(
+			powerName, string.Empty, string.Empty, false,
+			["FLAG^WIZARD"], ["FLAG^WIZARD"], types ?? ["PLAYER"]));
+		await Assert.That(created).IsNotNull();
+		await Assert.That(created!.Symbol).IsEqualTo(string.Empty);
+		return powerName;
+	}
+
+	// PennMUSH src/flags.c:2790 do_flag_letter: "Letter for power <name> set to '<c>'."
+	[Test]
+	public async ValueTask Power_Letter_SetsTheLetter()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var powerName = await CreateLetterlessPower();
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@power/letter {powerName}=Q"));
+
+		var updated = await Mediator.Send(new GetPowerQuery(powerName));
+		await Assert.That(updated).IsNotNull();
+		await Assert.That(updated!.Symbol).IsEqualTo("Q");
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(NotifyService,
+			nameof(ErrorMessages.Notifications.PowerLetterSetFormat), executor, executor)).IsTrue();
+
+		await Mediator.Send(new DeletePowerCommand(powerName));
+	}
+
+	// PennMUSH src/flags.c:2793 do_flag_letter: an empty or absent letter clears it.
+	[Test]
+	public async ValueTask Power_Letter_ClearsTheLetterWhenNoneGiven()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var powerName = await CreateLetterlessPower();
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@power/letter {powerName}=V"));
+		await Assert.That((await Mediator.Send(new GetPowerQuery(powerName)))!.Symbol).IsEqualTo("V");
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@power/letter {powerName}"));
+
+		await Assert.That((await Mediator.Send(new GetPowerQuery(powerName)))!.Symbol).IsEqualTo(string.Empty);
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(NotifyService,
+			nameof(ErrorMessages.Notifications.PowerLetterClearedFormat), executor, executor)).IsTrue();
+
+		await Mediator.Send(new DeletePowerCommand(powerName));
+	}
+
+	// PennMUSH src/flags.c:2778 do_flag_letter: "Power characters must be single characters."
+	[Test]
+	public async ValueTask Power_Letter_RejectsMultipleCharacters()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var powerName = await CreateLetterlessPower();
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@power/letter {powerName}=ABC"));
+
+		await Assert.That((await Mediator.Send(new GetPowerQuery(powerName)))!.Symbol).IsEqualTo(string.Empty);
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(NotifyService,
+			nameof(ErrorMessages.Notifications.PowerCharactersMustBeSingleCharacters), executor, executor)).IsTrue();
+
+		await Mediator.Send(new DeletePowerCommand(powerName));
+	}
+
+	// PennMUSH src/flags.c:2784 do_flag_letter: "Letter conflicts with the <other> power."
+	[Test]
+	public async ValueTask Power_Letter_RejectsLetterTakenByAnotherPower()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var holder = await CreateLetterlessPower();
+		var claimant = await CreateLetterlessPower();
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@power/letter {holder}=Z"));
+		await Assert.That((await Mediator.Send(new GetPowerQuery(holder)))!.Symbol).IsEqualTo("Z");
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@power/letter {claimant}=Z"));
+
+		await Assert.That((await Mediator.Send(new GetPowerQuery(claimant)))!.Symbol).IsEqualTo(string.Empty);
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(NotifyService,
+			nameof(ErrorMessages.Notifications.PowerLetterConflictFormat), executor, executor)).IsTrue();
+
+		await Mediator.Send(new DeletePowerCommand(holder));
+		await Mediator.Send(new DeletePowerCommand(claimant));
+	}
+
+	// PennMUSH src/flags.c:961 letter_to_flagptr only conflicts when the two definitions share an
+	// object type; game/txt/hlp/pennv177.hlp:20 records that as a deliberate fix.
+	[Test]
+	public async ValueTask Power_Letter_AllowsSameLetterOnADisjointType()
+	{
+		var playerPower = await CreateLetterlessPower(["PLAYER"]);
+		var roomPower = await CreateLetterlessPower(["ROOM"]);
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@power/letter {playerPower}=Y"));
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@power/letter {roomPower}=Y"));
+
+		await Assert.That((await Mediator.Send(new GetPowerQuery(playerPower)))!.Symbol).IsEqualTo("Y");
+		await Assert.That((await Mediator.Send(new GetPowerQuery(roomPower)))!.Symbol).IsEqualTo("Y");
+
+		await Mediator.Send(new DeletePowerCommand(playerPower));
+		await Mediator.Send(new DeletePowerCommand(roomPower));
+	}
+
+	// PennMUSH src/flags.c:2764 do_flag_letter refuses anyone but God; a wizard is not enough.
+	[Test]
+	public async ValueTask Power_Letter_RequiresGod()
+	{
+		var powerName = await CreateLetterlessPower();
+		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "PowerLetterNonGod");
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@set {testPlayer.DbRef}=WIZARD"));
+
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService,
+			MModule.single($"@power/letter {powerName}=J"));
+
+		await Assert.That((await Mediator.Send(new GetPowerQuery(powerName)))!.Symbol).IsEqualTo(string.Empty);
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(NotifyService,
+			nameof(ErrorMessages.Notifications.NotEnoughMagic), testPlayer.DbRef, testPlayer.DbRef)).IsTrue();
+
+		await Mediator.Send(new DeletePowerCommand(powerName));
+	}
+
+	// A divergence from PennMUSH, which has no notion of a system power and lets God letter anything.
+	[Test]
+	public async ValueTask Power_Letter_RefusesSystemPower()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var builder = await Mediator.Send(new GetPowerQuery("BUILDER"));
+		await Assert.That(builder).IsNotNull();
+		await Assert.That(builder!.System).IsTrue();
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single("@power/letter BUILDER=B"));
+
+		await Assert.That((await Mediator.Send(new GetPowerQuery("BUILDER")))!.Symbol).IsEqualTo(string.Empty);
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(NotifyService,
+			nameof(ErrorMessages.Notifications.CannotModifySystemPowerFormat), executor, executor)).IsTrue();
+	}
+
+	// PennMUSH src/flags.c list_all_flags FLAG_LIST_NAMECHAR renders the letter beside the name.
+	[Test]
+	public async ValueTask Power_List_ShowsTheLetter()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var powerName = await CreateLetterlessPower();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@power/letter {powerName}=K"));
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@power/list {powerName}"));
+
+		await NotifyService
+			.Received()
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf.OneOf<MString, string>>(s =>
+					TestHelpers.MessagePlainTextContains(s, powerName)
+					&& TestHelpers.MessagePlainTextContains(s, "Symbol")
+					&& TestHelpers.MessagePlainTextContains(s, "K")),
+				TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
+
+		await Mediator.Send(new DeletePowerCommand(powerName));
+	}
+
+	// PennMUSH src/flags.c do_flag_info prints a "Character:" line between Name and Aliases.
+	[Test]
+	public async ValueTask Power_NoEquals_ShowsTheCharacter()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		var powerName = await CreateLetterlessPower();
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@power/letter {powerName}=X"));
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@power {powerName}"));
+
+		await NotifyService
+			.Received()
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf.OneOf<MString, string>>(s =>
+					TestHelpers.MessagePlainTextContains(s, "Character: X")),
+				TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
+
+		await Mediator.Send(new DeletePowerCommand(powerName));
 	}
 
 	// PennMUSH src/flags.c list_all_flags filters the listing by a glob pattern.

--- a/SharpMUSH.Tests/Commands/FlagAndPowerCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/FlagAndPowerCommandTests.cs
@@ -135,8 +135,10 @@ public class FlagAndPowerCommandTests
 		var executor = WebAppFactoryArg.ExecutorDBRef;
 		await Parser.CommandParse(1, ConnectionService, MModule.single("@power/list"));
 
+		// The notify substitute is a session-wide singleton, so any other test that lists powers as God
+		// also matches this specification. Assert the call happened, not how many times.
 		await NotifyService
-			.Received(1)
+			.Received()
 			.Notify(TestHelpers.MatchingObject(executor),
 				Arg.Is<OneOf.OneOf<MString, string>>(s => TestHelpers.MessagePlainTextStartsWith(s, "Object Powers:")), TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
 	}
@@ -369,5 +371,229 @@ public class FlagAndPowerCommandTests
 		await Assert.That(flags.Any(f => f.Name.Equals("TRUST", StringComparison.OrdinalIgnoreCase))).IsTrue();
 
 		await Parser.CommandParse(1, ConnectionService, MModule.single($"@destroy {newDb}"));
+	}
+
+	private async ValueTask<string[]> PowerNamesOf(DBRef dbref)
+	{
+		var node = await Mediator.Send(new GetObjectNodeQuery(dbref));
+		var powers = await node.Object()!.Powers.Value.ToArrayAsync();
+		return powers.Select(p => p.Name).ToArray();
+	}
+
+	/// <summary>
+	/// PennMUSH src/wiz.c do_power: with no switch, <c>@power &lt;object&gt;=&lt;power&gt;</c> grants the power.
+	/// </summary>
+	[Test]
+	public async ValueTask Power_Grant_SetsPowerOnObject()
+	{
+		var createResult = await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"@create {TestIsolationHelpers.GenerateUniqueName("PowerGrant")}"));
+		var newDb = DBRef.Parse(createResult.Message!.ToPlainText()!);
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@power {newDb}=Builder"));
+
+		await Assert.That(await PowerNamesOf(newDb)).Contains("Builder");
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@destroy {newDb}"));
+	}
+
+	/// <summary>
+	/// PennMUSH src/flags.c set_power: granting emits "&lt;name&gt; - &lt;power&gt; granted."
+	/// </summary>
+	[Test]
+	public async ValueTask Power_Grant_NotifiesGranted()
+	{
+		var name = TestIsolationHelpers.GenerateUniqueName("PowerGrantMsg");
+		var createResult = await Parser.CommandParse(1, ConnectionService, MModule.single($"@create {name}"));
+		var newDb = DBRef.Parse(createResult.Message!.ToPlainText()!);
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@power {newDb}=Builder"));
+
+		// ManipulateSharpObjectService reports flag and power changes with no explicit sender.
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf.OneOf<MString, string>>(s => TestHelpers.MessagePlainTextEquals(s, $"{name} - Builder granted.")),
+				null, INotifyService.NotificationType.Announce);
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@destroy {newDb}"));
+	}
+
+	/// <summary>
+	/// PennMUSH src/wiz.c do_power: a leading <c>!</c> on the power name revokes it.
+	/// </summary>
+	[Test]
+	public async ValueTask Power_Revoke_ClearsPowerOnObject()
+	{
+		var createResult = await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"@create {TestIsolationHelpers.GenerateUniqueName("PowerRevoke")}"));
+		var newDb = DBRef.Parse(createResult.Message!.ToPlainText()!);
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@power {newDb}=Builder"));
+		await Assert.That(await PowerNamesOf(newDb)).Contains("Builder");
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@power {newDb}=!Builder"));
+		await Assert.That(await PowerNamesOf(newDb)).DoesNotContain("Builder");
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@destroy {newDb}"));
+	}
+
+	/// <summary>
+	/// PennMUSH src/wiz.c do_power splits the right-hand side on spaces and applies each token.
+	/// </summary>
+	[Test]
+	public async ValueTask Power_Grant_AppliesEverySpaceSeparatedToken()
+	{
+		var createResult = await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"@create {TestIsolationHelpers.GenerateUniqueName("PowerMulti")}"));
+		var newDb = DBRef.Parse(createResult.Message!.ToPlainText()!);
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@power {newDb}=Builder Boot"));
+		var granted = await PowerNamesOf(newDb);
+		await Assert.That(granted).Contains("Builder");
+		await Assert.That(granted).Contains("Boot");
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@power {newDb}=!Builder Boot"));
+		var after = await PowerNamesOf(newDb);
+		await Assert.That(after).DoesNotContain("Builder");
+		await Assert.That(after).Contains("Boot");
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@destroy {newDb}"));
+	}
+
+	/// <summary>
+	/// PennMUSH src/flags.c set_power reports the unrecognised <b>power</b> name, not the object's name.
+	/// </summary>
+	[Test]
+	public async ValueTask Power_Grant_UnknownPowerNamesThePower()
+	{
+		var createResult = await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"@create {TestIsolationHelpers.GenerateUniqueName("PowerUnknown")}"));
+		var newDb = DBRef.Parse(createResult.Message!.ToPlainText()!);
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@power {newDb}=NOSUCHPOWERXYZ"));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf.OneOf<MString, string>>(s =>
+					TestHelpers.MessagePlainTextEquals(s, "NOSUCHPOWERXYZ - I don't recognize that power.")),
+				null, INotifyService.NotificationType.Announce);
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@destroy {newDb}"));
+	}
+
+	/// <summary>
+	/// PennMUSH src/wiz.c do_power: "Only wizards may grant powers."
+	/// </summary>
+	[Test]
+	public async ValueTask Power_Grant_RequiresWizard()
+	{
+		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "PowerNonWiz");
+
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService,
+			MModule.single($"@power {testPlayer.DbRef}=Builder"));
+
+		await Assert.That(await PowerNamesOf(testPlayer.DbRef)).DoesNotContain("Builder");
+		await NotifyService
+			.Received()
+			.Notify(TestHelpers.MatchingObject(testPlayer.DbRef),
+				Arg.Is<OneOf.OneOf<MString, string>>(s => TestHelpers.MessagePlainTextEquals(s,
+					ErrorMessages.Notifications.OnlyWizardsMayGrantPowers)),
+				null, INotifyService.NotificationType.Announce);
+	}
+
+	/// <summary>
+	/// PennMUSH src/wiz.c do_power: with no "=", @power shows information about the named power
+	/// (do_flag_info), it does not list the powers on an object.
+	/// </summary>
+	[Test]
+	public async ValueTask Power_NoEquals_ShowsPowerInformation()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single("@power Builder"));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf.OneOf<MString, string>>(s => TestHelpers.MessagePlainTextStartsWith(s, "     Name: Builder")),
+				TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
+	}
+
+	/// <summary>
+	/// PennMUSH src/flags.c do_flag_info: an unknown name reports "No such power."
+	/// </summary>
+	[Test]
+	public async ValueTask Power_NoEquals_UnknownPowerReportsNoSuchPower()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single("@power NOSUCHPOWERABC"));
+
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(NotifyService,
+			nameof(ErrorMessages.Notifications.NoSuchPowerInfo), executor, executor)).IsTrue();
+	}
+
+	/// <summary>
+	/// PennMUSH src/flags.c: every power *definition* switch is God-only. A wizard is not enough,
+	/// and the switches must never fall through to the object-manipulating form.
+	/// </summary>
+	[Test]
+	public async ValueTask Power_Add_RequiresGod()
+	{
+		var testPlayer = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "PowerAddNonGod");
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@set {testPlayer.DbRef}=WIZARD"));
+
+		var powerName = $"TEST_POWER_{Guid.NewGuid().ToString("N")[..8].ToUpper()}";
+		await Parser.CommandParse(testPlayer.Handle, ConnectionService,
+			MModule.single($"@power/add {powerName}=TPOW"));
+
+		await Assert.That(await Mediator.Send(new GetPowerQuery(powerName))).IsNull();
+		await Assert.That(TestHelpers.ReceivedNotifyLocalizedWithKey(NotifyService,
+			nameof(ErrorMessages.Notifications.NotEnoughMagic), testPlayer.DbRef, testPlayer.DbRef)).IsTrue();
+	}
+
+	/// <summary>
+	/// PennMUSH src/fundb.c fun_powers routes the side-effect form through do_power, so powers()
+	/// honours the same "!" revoke prefix as @power.
+	/// </summary>
+	[Test]
+	public async ValueTask PowersFunction_SideEffect_HonoursRevokePrefix()
+	{
+		var createResult = await Parser.CommandParse(1, ConnectionService,
+			MModule.single($"@create {TestIsolationHelpers.GenerateUniqueName("PowerFnRevoke")}"));
+		var newDb = DBRef.Parse(createResult.Message!.ToPlainText()!);
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@power {newDb}=Builder"));
+		await Assert.That(await PowerNamesOf(newDb)).Contains("Builder");
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"think [powers({newDb},!Builder)]"));
+		await Assert.That(await PowerNamesOf(newDb)).DoesNotContain("Builder");
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single($"@destroy {newDb}"));
+	}
+
+	/// <summary>
+	/// PennMUSH src/flags.c list_all_flags filters the listing by a glob pattern.
+	/// </summary>
+	[Test]
+	public async ValueTask Power_List_FiltersByPattern()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+
+		await Parser.CommandParse(1, ConnectionService, MModule.single("@power/list Buil*"));
+
+		await NotifyService
+			.Received()
+			.Notify(TestHelpers.MatchingObject(executor),
+				Arg.Is<OneOf.OneOf<MString, string>>(s =>
+					TestHelpers.MessagePlainTextContains(s, "Builder")
+					&& !TestHelpers.MessagePlainTextContains(s, "Announce")),
+				TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
 	}
 }

--- a/SharpMUSH.Tests/Commands/FlagAndPowerCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/FlagAndPowerCommandTests.cs
@@ -135,8 +135,7 @@ public class FlagAndPowerCommandTests
 		var executor = WebAppFactoryArg.ExecutorDBRef;
 		await Parser.CommandParse(1, ConnectionService, MModule.single("@power/list"));
 
-		// The notify substitute is a session-wide singleton, so any other test that lists powers as God
-		// also matches this specification. Assert the call happened, not how many times.
+		// The notify substitute is a session-wide singleton, so assert the call happened, not how many times.
 		await NotifyService
 			.Received()
 			.Notify(TestHelpers.MatchingObject(executor),
@@ -380,9 +379,7 @@ public class FlagAndPowerCommandTests
 		return powers.Select(p => p.Name).ToArray();
 	}
 
-	/// <summary>
-	/// PennMUSH src/wiz.c do_power: with no switch, <c>@power &lt;object&gt;=&lt;power&gt;</c> grants the power.
-	/// </summary>
+	// PennMUSH src/wiz.c do_power: with no switch, @power <object>=<power> grants the power.
 	[Test]
 	public async ValueTask Power_Grant_SetsPowerOnObject()
 	{
@@ -397,9 +394,7 @@ public class FlagAndPowerCommandTests
 		await Parser.CommandParse(1, ConnectionService, MModule.single($"@destroy {newDb}"));
 	}
 
-	/// <summary>
-	/// PennMUSH src/flags.c set_power: granting emits "&lt;name&gt; - &lt;power&gt; granted."
-	/// </summary>
+	// PennMUSH src/flags.c set_power: granting emits "<name> - <power> granted."
 	[Test]
 	public async ValueTask Power_Grant_NotifiesGranted()
 	{
@@ -420,9 +415,7 @@ public class FlagAndPowerCommandTests
 		await Parser.CommandParse(1, ConnectionService, MModule.single($"@destroy {newDb}"));
 	}
 
-	/// <summary>
-	/// PennMUSH src/wiz.c do_power: a leading <c>!</c> on the power name revokes it.
-	/// </summary>
+	// PennMUSH src/wiz.c do_power: a leading ! on the power name revokes it.
 	[Test]
 	public async ValueTask Power_Revoke_ClearsPowerOnObject()
 	{
@@ -439,9 +432,7 @@ public class FlagAndPowerCommandTests
 		await Parser.CommandParse(1, ConnectionService, MModule.single($"@destroy {newDb}"));
 	}
 
-	/// <summary>
-	/// PennMUSH src/wiz.c do_power splits the right-hand side on spaces and applies each token.
-	/// </summary>
+	// PennMUSH src/wiz.c do_power splits the right-hand side on spaces and applies each token.
 	[Test]
 	public async ValueTask Power_Grant_AppliesEverySpaceSeparatedToken()
 	{
@@ -462,9 +453,7 @@ public class FlagAndPowerCommandTests
 		await Parser.CommandParse(1, ConnectionService, MModule.single($"@destroy {newDb}"));
 	}
 
-	/// <summary>
-	/// PennMUSH src/flags.c set_power reports the unrecognised <b>power</b> name, not the object's name.
-	/// </summary>
+	// PennMUSH src/flags.c set_power reports the unrecognised power name, not the object's name.
 	[Test]
 	public async ValueTask Power_Grant_UnknownPowerNamesThePower()
 	{
@@ -485,9 +474,7 @@ public class FlagAndPowerCommandTests
 		await Parser.CommandParse(1, ConnectionService, MModule.single($"@destroy {newDb}"));
 	}
 
-	/// <summary>
-	/// PennMUSH src/wiz.c do_power: "Only wizards may grant powers."
-	/// </summary>
+	// PennMUSH src/wiz.c do_power: "Only wizards may grant powers."
 	[Test]
 	public async ValueTask Power_Grant_RequiresWizard()
 	{
@@ -506,10 +493,7 @@ public class FlagAndPowerCommandTests
 				null, INotifyService.NotificationType.Announce);
 	}
 
-	/// <summary>
-	/// PennMUSH src/wiz.c do_power: with no "=", @power shows information about the named power
-	/// (do_flag_info), it does not list the powers on an object.
-	/// </summary>
+	// PennMUSH src/wiz.c do_power: with no "=", @power describes the named power; it does not list an object's powers.
 	[Test]
 	public async ValueTask Power_NoEquals_ShowsPowerInformation()
 	{
@@ -524,9 +508,7 @@ public class FlagAndPowerCommandTests
 				TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
 	}
 
-	/// <summary>
-	/// PennMUSH src/flags.c do_flag_info: an unknown name reports "No such power."
-	/// </summary>
+	// PennMUSH src/flags.c do_flag_info: an unknown name reports "No such power."
 	[Test]
 	public async ValueTask Power_NoEquals_UnknownPowerReportsNoSuchPower()
 	{
@@ -538,10 +520,7 @@ public class FlagAndPowerCommandTests
 			nameof(ErrorMessages.Notifications.NoSuchPowerInfo), executor, executor)).IsTrue();
 	}
 
-	/// <summary>
-	/// PennMUSH src/flags.c: every power *definition* switch is God-only. A wizard is not enough,
-	/// and the switches must never fall through to the object-manipulating form.
-	/// </summary>
+	// PennMUSH src/flags.c: every power definition switch is God-only; a wizard is not enough.
 	[Test]
 	public async ValueTask Power_Add_RequiresGod()
 	{
@@ -558,10 +537,7 @@ public class FlagAndPowerCommandTests
 			nameof(ErrorMessages.Notifications.NotEnoughMagic), testPlayer.DbRef, testPlayer.DbRef)).IsTrue();
 	}
 
-	/// <summary>
-	/// PennMUSH src/fundb.c fun_powers routes the side-effect form through do_power, so powers()
-	/// honours the same "!" revoke prefix as @power.
-	/// </summary>
+	// PennMUSH src/fundb.c fun_powers routes powers() through do_power, so it honours the same "!" revoke prefix.
 	[Test]
 	public async ValueTask PowersFunction_SideEffect_HonoursRevokePrefix()
 	{
@@ -578,9 +554,7 @@ public class FlagAndPowerCommandTests
 		await Parser.CommandParse(1, ConnectionService, MModule.single($"@destroy {newDb}"));
 	}
 
-	/// <summary>
-	/// PennMUSH src/flags.c list_all_flags filters the listing by a glob pattern.
-	/// </summary>
+	// PennMUSH src/flags.c list_all_flags filters the listing by a glob pattern.
 	[Test]
 	public async ValueTask Power_List_FiltersByPattern()
 	{


### PR DESCRIPTION
`@power <object>=<powername>` did nothing. It printed usage and changed no state.

`Power()` in `WizardCommands.cs` handled its switches and then fell through to `NotifyLocalized(..., PowerUsage)` — there was no no-switch branch at all. `ManipulateSharpObjectService.SetPower`/`UnsetPower` already existed, with exactly one caller (the `powers()` side-effect).

Fixing that surfaced several more defects in the same command, and the `/letter` switch it needed to be complete.

## Ground truth

PennMUSH 1.8.8p0. `src/cmds.c:1285` `cmd_power` dispatches switches, else `do_power`. `src/wiz.c:1158` `do_power`: empty right side → `do_flag_info("POWER", ...)`, so **`@power <power>` describes the power — it does not list an object's powers**. Otherwise wizard-only, refuses `Unregistered` targets and God-as-target, splits the right side **on spaces**, strips a leading `!` per token to revoke. `src/flags.c:1939` `set_power` resolves the power first and names the *power* in "I don't recognize that power."

## Fixes

| | Before | After |
|---|---|---|
| `@power obj=Builder` | prints usage, does nothing | grants the power |
| `@power obj=!Builder` | — | revokes |
| `@power obj=A B C` | — | applies each token |
| `@power <power>` | — | describes the power, Penn's `%9s:` layout |
| `powers()` side-effect | **no wizard check, no `!` handling** | shares one code path with `@power` |
| `@power/add`, `/delete`, `/disable` | **no permission check whatsoever** | God-only, as `src/flags.c` |
| `DontRecognizePower` | interpolated the *object's* name | names the power |
| unhandled switches | fell through into the grant path | report usage |
| `@power/list` | ignored its pattern, showed disabled to all | honours the glob, hides disabled from non-God |

`@power/add`, `/delete` and `/disable` being open to any player was a privilege escalation, not a cosmetic gap.

## `/letter`

`@power/letter <power>[=<letter>]` — God-only (`do_flag_letter`, `src/flags.c:2764`), single character (`:2778`), collision-checked against powers sharing an object type (`:2784`), cleared by omitting the letter (`:2793`). Case-sensitive: `W` and `w` differ.

**A deliberate divergence, called out because it is one.** `letter_to_flagptr` (`src/flags.c:955`) is guarded by `n->tab == &ptab_flag` inside its own condition (`:961`), and the POWER flagspace uses `ptab_power` — so for powers it always returns NULL and **Penn silently accepts duplicate power letters**. This implements the check as written rather than as reached; a duplicate letter makes the listing ambiguous, which is the only thing the check exists to prevent.

Surfaces in `@power/list`, `@list powers`, the `Character:` line of `@power <power>`, and `@power/decompile`.

### Schema — breaking, no data loss

`SharpPower.Symbol`, empty string = no letter, matching Penn's all-`'\0'` seed in `hdrs/flag_tab.h`.

- **ArangoDB** — `Migration_CreateDatabase` already *declared* `Symbol` on `ObjectPowers`; nothing ever read or wrote it. New `Migration_AddPowerSymbol` backfills `""`. Load-bearing, not cosmetic: absent ≠ empty to AQL, so `FILTER p.Symbol == ""` would skip seeded powers and the collision scan would read seeded and user-created powers differently.
- **SurrealDB** — schemaless; seed UPSERT sets `symbol = ''`, plus a `WHERE symbol = NONE` backfill.
- **Memgraph** — schemaless; `ON CREATE SET` plus a separate `WHERE p.symbol IS NULL` pass, since `ON CREATE SET` skips existing nodes.

`ISharpDatabase.CreatePowerAsync`/`UpdatePowerAsync` and the two command records change arity — source-breaking for out-of-tree providers or plugins.

## Also in here

- ArangoDB's power reader returned `null` through `SharpPower.Alias`, a non-nullable `required string`, because the seeds carry no alias. The same unguarded `Alias.Equals` made setting or clearing **any** power a `NullReferenceException`.
- `ArangoDatabase.GetObjectPowersAsync(string id, …)` deleted — dead, not on `ISharpDatabase`, absent from the other two providers, duplicating a private method every caller already used, and deserializing raw past the mapper.
- `Look_InsideThing_*` asserted `.Received()` immediately after a queued `@descformat` evaluation. Flaked once under parallel load, passed in isolation and on re-run; both now poll via `TestHelpers.WaitForNotification`, which exists for exactly this.

## Verification

```
SharpMUSH.Tests (arangodb, full)   total: 5561  failed: 0  succeeded: 5369  skipped: 192
FlagAndPowerCommandTests surrealdb total:   42  failed: 0
FlagAndPowerCommandTests memgraph  total:   42  failed: 0
SharpMUSH.Tests.Integration        total:  338  failed: 0
```

18 new tests, written before the fixes and confirmed failing for the right reasons first. Restore clean, build 0 errors.

## Known hole this PR does NOT close

**`@FLAG` has no permission check at all** — no `CommandLock`, no `IsGod()` in the body (`WizardCommands.cs:54-430`). Any player can run `@flag/add`, `@flag/delete`, `@flag/disable`, `@flag/letter`. It is the identical hole closed here for `@power`. `@flag/letter` also errors instead of clearing, and enforces neither the single-character nor the collision rule. Three defects in a command outside this change — they belong in one reviewed follow-up rather than half-fixed here.

Deliberately left out: `@power/add` still takes `<alias>` rather than Penn's `<letter>, <types>, <setperms>, <unsetperms>` (its own compatibility decision; new powers get their letter via `/letter`). `/letter` refuses system powers, matching what `/alias`, `/type` and `/restrict` already do — documented and tested. `list("powers")` still returns bare names, as `list("flags")` does today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)