### PR TITLE
chore(deps): collate Dependabot NuGet bumps (#769–#774)

### DIFF
--- a/SharpMUSH.Database/SharpMUSH.Database.csproj
+++ b/SharpMUSH.Database/SharpMUSH.Database.csproj
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Core.Arango" Version="3.12.2" />
+    <PackageReference Include="Core.Arango" Version="3.12.3" />
     <PackageReference Include="Core.Arango.Migration" Version="3.12.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageReference Include="OneOf" Version="3.0.271" />

--- a/SharpMUSH.Library/SharpMUSH.Library.csproj
+++ b/SharpMUSH.Library/SharpMUSH.Library.csproj
@@ -63,9 +63,9 @@
 	</Target>
 
   <ItemGroup>
-    <PackageReference Include="DotNext" Version="6.5.0" />
+    <PackageReference Include="DotNext" Version="6.6.0" />
     <PackageReference Include="Markdig" Version="1.3.2" />
-    <PackageReference Include="DotNext.Threading" Version="6.5.0" />
+    <PackageReference Include="DotNext.Threading" Version="6.6.0" />
     <PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
@@ -101,7 +101,7 @@
          plugin authors never pull them), and they do not flow transitively to Library consumers. The client
          assemblies are shared from the host ALC at load time (PluginLoaderService SharedAssemblies), so an
          accessor-returned client casts/uses cleanly inside the plugin. -->
-    <PackageReference Include="Core.Arango" Version="3.12.2" PrivateAssets="all" />
+    <PackageReference Include="Core.Arango" Version="3.12.3" PrivateAssets="all" />
     <PackageReference Include="Neo4j.Driver" Version="6.0.0" PrivateAssets="all" />
     <!-- The core SurrealDb.Net client only (NOT the embedded provider). -->
     <PackageReference Include="SurrealDb.Net" Version="0.9.0" PrivateAssets="all" />

--- a/SharpMUSH.Parser.Generated/SharpMUSH.Parser.Generated.csproj
+++ b/SharpMUSH.Parser.Generated/SharpMUSH.Parser.Generated.csproj
@@ -21,7 +21,7 @@
 		<Antlr4 Include="SharpMUSHBoolExpLexer.g4" />
 		<Antlr4 Include="SharpMUSHParser.g4" />
 		<Antlr4 Include="SharpMUSHBoolExpParser.g4" />
-		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.4.0" PrivateAssets="all" IncludeAssets="build" />
+		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.8.2" PrivateAssets="all" IncludeAssets="build" />
   </ItemGroup>
 	
 	<ItemGroup>

--- a/SharpMUSH.Plugins.Scene/SharpMUSH.Plugins.Scene.csproj
+++ b/SharpMUSH.Plugins.Scene/SharpMUSH.Plugins.Scene.csproj
@@ -28,7 +28,7 @@
 	     System.Linq.Async transitive is dropped at compile time to avoid colliding with .NET 10's built-in
 	     System.Linq.AsyncEnumerable. -->
 	<ItemGroup>
-		<PackageReference Include="Core.Arango" Version="3.12.2" ExcludeAssets="runtime" />
+		<PackageReference Include="Core.Arango" Version="3.12.3" ExcludeAssets="runtime" />
 		<PackageReference Include="Neo4j.Driver" Version="6.0.0" ExcludeAssets="runtime" />
 		<PackageReference Include="SurrealDb.Net" Version="0.9.0" ExcludeAssets="runtime" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" ExcludeAssets="compile;runtime" />

--- a/SharpMUSH.Server/Controllers/SeoController.cs
+++ b/SharpMUSH.Server/Controllers/SeoController.cs
@@ -14,6 +14,13 @@ namespace SharpMUSH.Server.Controllers;
 ///   GET /sitemap.xml — XML sitemap covering the site root, /wiki, and every published wiki page
 ///   GET /robots.txt  — crawler directives pointing at the sitemap
 /// </summary>
+// [ApiController] is required by the Asp.Versioning AV0014 analyzer, which every controller the
+// versioning system sees must satisfy. It is behaviourally inert here: both actions already use
+// attribute routing, bind no parameters (so the automatic 400/ProblemDetails paths are unreachable),
+// and only ever return 200 ContentResult. Version resolution is unaffected because
+// AssumeDefaultVersionWhenUnspecified is on, so these root-served documents keep answering
+// unversioned crawler requests.
+[ApiController]
 public class SeoController(
 	IWikiService wikiService,
 	IWikiLocalizationService localization,

--- a/SharpMUSH.Server/SharpMUSH.Server.csproj
+++ b/SharpMUSH.Server/SharpMUSH.Server.csproj
@@ -14,7 +14,7 @@
 	</ItemGroup>
 	
   <ItemGroup>
-		<PackageReference Include="Core.Arango" Version="3.12.2" />
+		<PackageReference Include="Core.Arango" Version="3.12.3" />
 		<PackageReference Include="Core.Arango.Serilog" Version="3.12.3" />
     <PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
     <PackageReference Include="Scriban" Version="7.2.5" />
@@ -109,7 +109,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Asp.Versioning.Mvc" Version="10.0.0" />
+    <PackageReference Include="Asp.Versioning.Mvc" Version="10.2.1" />
     <PackageReference Include="LibGit2Sharp" Version="0.32.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
     <None Include="..\SharpMUSH.Documentation\Helpfiles\SharpMUSH\*.md">

--- a/SharpMUSH.Tests.BUnit/SharpMUSH.Tests.BUnit.csproj
+++ b/SharpMUSH.Tests.BUnit/SharpMUSH.Tests.BUnit.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="bunit" Version="2.8.6" />
-    <PackageReference Include="AngleSharp" Version="1.5.2" />
+    <PackageReference Include="bunit" Version="2.9.0" />
+    <PackageReference Include="AngleSharp" Version="1.7.0" />
     <PackageReference Include="TUnit" Version="1.19.16" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="MudBlazor" Version="9.4.0" />

--- a/SharpMUSH.Tests.ScenePlugin/SharpMUSH.Tests.ScenePlugin.csproj
+++ b/SharpMUSH.Tests.ScenePlugin/SharpMUSH.Tests.ScenePlugin.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
     <!-- The fake IArangoStorageAccessor references Core.Arango types at runtime. -->
-    <PackageReference Include="Core.Arango" Version="3.12.2" />
+    <PackageReference Include="Core.Arango" Version="3.12.3" />
   </ItemGroup>
 
   <!-- Focused unit test for the Scene plugin's AddSceneSystem registration seam (Phase 8). References the

--- a/SharpMUSH.Tests/SharpMUSH.Tests.csproj
+++ b/SharpMUSH.Tests/SharpMUSH.Tests.csproj
@@ -23,8 +23,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="bunit" Version="2.8.6" />
-    <PackageReference Include="AngleSharp" Version="1.5.2" />
+    <PackageReference Include="bunit" Version="2.9.0" />
+    <PackageReference Include="AngleSharp" Version="1.7.0" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Collates the five open Dependabot NuGet PRs into one change so CI runs once instead of five times. Unlike the previous collations this batch spans five unrelated package families rather than a single ASP.NET Core patch family, so the branch is named for the month (`chore/collate-dependabot-2026-08`) rather than a version.

## Bumps from the Dependabot PRs
| Package | From | To | Project(s) | PR |
|---|---|---|---|---|
| Asp.Versioning.Mvc | 10.0.0 | 10.2.1 | Server | #769 |
| bunit | 2.8.6 | 2.9.0 | Tests, Tests.BUnit | #770 |
| AngleSharp | 1.5.2 | 1.7.0 | Tests, Tests.BUnit | #770 |
| Core.Arango | 3.12.2 | 3.12.3 | Database, Library, Server, Plugins.Scene | #771 |
| DotNext | 6.5.0 | 6.6.0 | Library | #773 |
| DotNext.Threading | 6.5.0 | 6.6.0 | Library | #773 |
| Microsoft.Build.Utilities.Core | 18.4.0 | 18.8.2 | Parser.Generated | #774 |

(#770 and #771 are multi-project PRs — Dependabot bumped `bunit`/`AngleSharp` in both test projects and `Core.Arango` in four projects itself.)

## Lockstep bump Dependabot can't see
- **`Core.Arango` 3.12.2 → 3.12.3 in `SharpMUSH.Tests.ScenePlugin`** — #771 bumped the four projects it could see but left this fifth pin at 3.12.2, which would have left the solution straddling two Core.Arango versions. The reference is deliberate and carries an explanatory csproj comment (the fake `IArangoStorageAccessor` references `Core.Arango` types at runtime), so per the precedent in #699 it is bumped rather than deleted.

This also brings `Core.Arango` back in line with `Core.Arango.Migration` and `Core.Arango.Serilog`, both of which were already at 3.12.3.

## Source change the bump forced: `[ApiController]` on `SeoController`
`Asp.Versioning.Mvc` 10.2.1 ships the **AV0014** analyzer, which requires `[ApiController]` on every controller the versioning system sees. `SeoController` was the only controller in the solution without it, so with `TreatWarningsAsErrors` the first CI build failed with:

```
SharpMUSH.Server/Controllers/SeoController.cs(17,14): error AV0014:
Add [ApiController] to the controller or assembly
```

This is a genuine behavior change in the package, not a missed lockstep bump, so it is fixed rather than suppressed — no warning was disabled and `TreatWarningsAsErrors` is untouched.

Adding the attribute is behaviourally inert for these two endpoints:
- both actions already use attribute routing (`[HttpGet("/sitemap.xml")]`, `[HttpGet("/robots.txt")]`), which is `[ApiController]`'s one hard requirement;
- neither action binds any parameter, so the automatic model-validation 400 and `ProblemDetails` paths are unreachable;
- both only ever return a 200 `ContentResult`;
- version resolution is unaffected because `AssumeDefaultVersionWhenUnspecified = true` (`Startup.cs:506`), so `/sitemap.xml` and `/robots.txt` keep answering unversioned crawler requests as before.

The reasoning is recorded in a comment above the attribute so the next person does not have to re-derive it.

## Deleted or omitted
Nothing. None of the five PRs tried to *add* a package reference, so the recurring spurious `Microsoft.AspNetCore.Components.WebAssembly` addition to `SharpMUSH.Server` (dropped in #669, #699 and #707) did not appear this round, and no reference in the batch was redundant enough to drop.

## Floors checked but not requiring action
`bunit` 2.9.0 raises its dependency floors to `AngleSharp >= 1.7.0` and the ASP.NET Core 10.0.10 component packages (`Microsoft.AspNetCore.Components*`, `Microsoft.Extensions.Caching.Memory`, `Microsoft.Extensions.Logging*`, `Microsoft.Extensions.Localization.Abstractions`). Both test projects now pin `AngleSharp` at exactly 1.7.0, and `SharpMUSH.Client` already pins the Components packages at 10.0.10 (from #707), so those floors are met without further bumps. `Microsoft.Extensions.Caching.Memory` stays at 10.0.9 in `SharpMUSH.Library`: no project holds a *direct* reference that bunit's floor could downgrade, so it resolves upward transitively rather than tripping `NU1605`.

## Verification
Restore and build could not be run locally — this session's network policy denies the .NET SDK download hosts (`builds.dotnet.microsoft.com`, `aka.ms` — CONNECT rejected with 403) and no SDK is present in the container. Before the first push, the bumps were instead checked offline against the NuGet v3 API: all seven target versions exist, the published dependency ranges of every bumped package were cross-checked against every `PackageReference` in the solution for downgrade risk, and a grep confirmed no stale copy of any bumped version string remained in a `.csproj`.

CI has since supplied the real verification:
- `build-and-test / build` — **green** (no `NU1605`; the only error was the AV0014 one fixed above)
- `build-and-test / format` — **green**
- `submit-nuget` — **green**
- `claude-review`, `copilot-pull-request-reviewer` — **green**
- CodeQL `Analyze` jobs — **green**
- `test` and `test-integration` (arangodb/memgraph/surrealdb) and `test-bunit` — running at the time of writing; see the checks list for the current result.

The pre-existing MSB3277 conflicts in the plugin fixtures and the CS0067 unused test events are unchanged and unrelated.

Closes #769, closes #770, closes #771, closes #773, closes #774.
