### PR TITLE
Locate: six PennMUSH parity follow-ups from the #785 review

### DIFF
--- a/SharpMUSH.Implementation/Commands/SingleTokenCommands.cs
+++ b/SharpMUSH.Implementation/Commands/SingleTokenCommands.cs
@@ -95,7 +95,7 @@ public partial class Commands
 		return await LocateService!.LocateAndNotifyIfInvalidWithCallStateFunction(parser,
 			enactor,
 			executor,
-			args["1"].Message!.ToString(), LocateFlags.All | LocateFlags.NoVisibilityCheck, async realLocated =>
+			args["1"].Message!.ToString(), LocateFlags.All, async realLocated =>
 			{
 				if (!args.TryGetValue("2", out var tmpContents)
 					|| (!Configuration!.CurrentValue.Attribute.EmptyAttributes

--- a/SharpMUSH.Implementation/Functions/AttributeFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/AttributeFunctions.cs
@@ -531,7 +531,7 @@ public partial class Functions
 		var (db, attr) = details;
 
 		return await LocateService!.LocateAndNotifyIfInvalidWithCallStateFunction(
-			parser, executor, executor, db, LocateFlags.All | LocateFlags.NoVisibilityCheck, async realLocated =>
+			parser, executor, executor, db, LocateFlags.All, async realLocated =>
 			{
 				return split.AsT0 switch
 				{

--- a/SharpMUSH.Implementation/Functions/DbrefFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/DbrefFunctions.cs
@@ -617,10 +617,22 @@ public partial class Functions
 			return "#-1";
 		}
 
+		// fun_locate's relative-scope gate, and it has to live here: it asks whether *executor* may
+		// evaluate against *looker* (fundb.c), while the match below runs with looker as its own
+		// permission subject. Folding both into one Locate call makes the gate ask Nearby(looker, looker),
+		// which is always true — so a non-privileged executor could search a remote looker's neighbours.
+		if ((locateFlags & Library.Services.LocateService.LookerRelativeScopes) != 0
+				&& !await executor.IsSee_All()
+				&& !await Library.Services.LocateService.Nearby(executor, looker)
+				&& !await PermissionService!.Controls(executor, looker))
+		{
+			return "#-1";
+		}
+
 		// fun_locate passes `looker` as match_result's `who` as well as its `where`, so every
 		// can_interact / controls / Long_Fingers / nearby question inside the match is asked about the
-		// looker. The executor is the subject only of the two gates that bracket the call — the 's'
-		// check above, and the visibility check below.
+		// looker. The executor is the subject only of the gates that bracket the call — the 's' check
+		// above, this one, and the visibility check below.
 		var maybeFound = await LocateService.Locate(parser, looker, looker, nameArg, locateFlags);
 
 		// fun_locate writes the dbref itself on every failure path: safe_str("#-1") for the looker gate,

--- a/SharpMUSH.Implementation/Functions/DbrefFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/DbrefFunctions.cs
@@ -617,6 +617,12 @@ public partial class Functions
 			return "#-1";
 		}
 
+		// fun_locate injects the default scope set *before* it gates, and the order is load-bearing: a
+		// flags string naming no scope ('N' is one) picks up MAT_NEIGHBOR and friends here, and must
+		// then clear the gate like any other relative-scope search. Gating on the flags as typed sees no
+		// relative-scope bit and lets the call through.
+		locateFlags = Library.Services.LocateService.ApplyDefaultScopes(locateFlags);
+
 		// fun_locate's relative-scope gate, and it has to live here: it asks whether *executor* may
 		// evaluate against *looker* (fundb.c), while the match below runs with looker as its own
 		// permission subject. Folding both into one Locate call makes the gate ask Nearby(looker, looker),

--- a/SharpMUSH.Implementation/Functions/DbrefFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/DbrefFunctions.cs
@@ -617,11 +617,19 @@ public partial class Functions
 			return "#-1";
 		}
 
-		var maybeFound = await LocateService.Locate(parser, looker, executor, nameArg, locateFlags);
+		// fun_locate passes `looker` as match_result's `who` as well as its `where`, so every
+		// can_interact / controls / Long_Fingers / nearby question inside the match is asked about the
+		// looker. The executor is the subject only of the two gates that bracket the call — the 's'
+		// check above, and the visibility check below.
+		var maybeFound = await LocateService.Locate(parser, looker, looker, nameArg, locateFlags);
 
+		// fun_locate writes the dbref itself on every failure path: safe_str("#-1") for the looker gate,
+		// safe_dbref(item) for NOTHING/AMBIGUOUS, safe_dbref(NOTHING) for a failed visibility check. It
+		// never emits a "#-1 SOMETHING" string, and softcode compares against these — a decorated one
+		// will not `=` a bare #-1.
 		if (maybeFound.IsError)
 		{
-			return maybeFound.AsError.Value;
+			return maybeFound.AsError.Value == ErrorMessages.Returns.AmbiguousMatch ? "#-2" : "#-1";
 		}
 
 		if (maybeFound.IsNone)
@@ -629,10 +637,37 @@ public partial class Functions
 			return "#-1";
 		}
 
-		// No post-hoc type filter: 'F' is MAT_TYPE, which the search itself honours now. Filtering the
-		// winner afterwards could only ever turn a legitimate match into #-1 while the wrong-type
-		// candidate had already displaced the right-type one during matching.
-		return $"#{maybeFound.WithoutError().WithoutNone().Object().DBRef.Number}";
+		var found = maybeFound.WithoutError().WithoutNone();
+
+		// fun_locate's own visibility check, which match_result does not do and no other caller gets:
+		//   loc = Location(item);
+		//   if (GoodObject(loc)) Can_Examine(executor, loc)
+		//                        || ((!DarkLegal(item) || Light(loc) || Light(item)) && can_interact(...))
+		//   else                 (See_All(executor) || !DarkLegal(item) || Light(item)) && can_interact(...)
+		// A room has no location to examine, which is the `else` — it was missing entirely, and asking
+		// Can_Examine about the room itself is a different question with a different answer.
+		var canSee = await PermissionService!.CanInteract(executor, found, IPermissionService.InteractType.See);
+
+		if (found.IsRoom)
+		{
+			return (await executor.IsSee_All() || !await found.IsDarkLegal() || await found.IsLight()) && canSee
+				? $"#{found.Object().DBRef.Number}"
+				: "#-1";
+		}
+
+		// Location(item), the immediate container — not Room(), which walks the chain to the enclosing room.
+		var loc = (await Library.Services.LocateService.FriendlyWhereIs(found)).WithExitOption();
+
+		if (await PermissionService.CanExamine(executor, loc)
+				|| ((!await found.IsDarkLegal() || await loc.IsLight() || await found.IsLight()) && canSee))
+		{
+			// No post-hoc type filter: 'F' is MAT_TYPE, which the search itself honours now. Filtering the
+			// winner afterwards could only ever turn a legitimate match into #-1 while the wrong-type
+			// candidate had already displaced the right-type one during matching.
+			return $"#{found.Object().DBRef.Number}";
+		}
+
+		return "#-1";
 	}
 
 	/// <summary>

--- a/SharpMUSH.Implementation/Functions/DbrefFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/DbrefFunctions.cs
@@ -651,11 +651,11 @@ public partial class Functions
 		// enclosing room, and a room's own dbref is not its location. For an exit db[x].location is
 		// Destination(); for a room it is the drop-to, which is usually unset — and "unset" is exactly
 		// what selects fun_locate's second arm, so this cannot be approximated by `found.IsRoom`.
-		var loc = found.IsRoom
-			? await found.AsRoom.Location.WithCancellation(CancellationToken.None)
-			: found.IsExit
-				? await found.AsExit.Home.WithCancellation(CancellationToken.None)
-				: (await Library.Services.LocateService.FriendlyWhereIs(found)).WithNoneOption();
+		var loc = await found.Match<ValueTask<AnyOptionalSharpContainer>>(
+			async player => (await player.Location.WithCancellation(CancellationToken.None)).WithNoneOption(),
+			room => new(room.Location.WithCancellation(CancellationToken.None)),
+			exit => new(exit.Home.WithCancellation(CancellationToken.None)),
+			async thing => (await thing.Location.WithCancellation(CancellationToken.None)).WithNoneOption());
 
 		// can_interact is the last term of both arms, so it is only asked once Can_Examine has declined
 		// and the dark test has passed — as the else-if ordering has it. It can run softcode through an

--- a/SharpMUSH.Implementation/Functions/DbrefFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/DbrefFunctions.cs
@@ -646,28 +646,38 @@ public partial class Functions
 		//   else                 (See_All(executor) || !DarkLegal(item) || Light(item)) && can_interact(...)
 		// A room has no location to examine, which is the `else` — it was missing entirely, and asking
 		// Can_Examine about the room itself is a different question with a different answer.
-		var canSee = await PermissionService!.CanInteract(executor, found, IPermissionService.InteractType.See);
+		// PennMUSH's Location(x) is db[x].location, which is none of the three helpers that look like it:
+		// FriendlyWhereIs is match.c's `loc` and takes an exit's Source, Room() walks the chain to the
+		// enclosing room, and a room's own dbref is not its location. For an exit db[x].location is
+		// Destination(); for a room it is the drop-to, which is usually unset — and "unset" is exactly
+		// what selects fun_locate's second arm, so this cannot be approximated by `found.IsRoom`.
+		var loc = found.IsRoom
+			? await found.AsRoom.Location.WithCancellation(CancellationToken.None)
+			: found.IsExit
+				? await found.AsExit.Home.WithCancellation(CancellationToken.None)
+				: (await Library.Services.LocateService.FriendlyWhereIs(found)).WithNoneOption();
 
-		if (found.IsRoom)
+		// can_interact is the last term of both arms, so it is only asked once Can_Examine has declined
+		// and the dark test has passed — as the else-if ordering has it. It can run softcode through an
+		// @interact lock, so hoisting it out is neither free nor side-effect-free.
+		bool visible;
+		if (loc.IsNone)
 		{
-			return (await executor.IsSee_All() || !await found.IsDarkLegal() || await found.IsLight()) && canSee
-				? $"#{found.Object().DBRef.Number}"
-				: "#-1";
+			visible = (await executor.IsSee_All() || !await found.IsDarkLegal() || await found.IsLight())
+								&& await PermissionService!.CanInteract(executor, found, IPermissionService.InteractType.See);
+		}
+		else
+		{
+			var container = loc.WithoutNone().WithExitOption();
+			visible = await PermissionService!.CanExamine(executor, container)
+								|| ((!await found.IsDarkLegal() || await container.IsLight() || await found.IsLight())
+										&& await PermissionService.CanInteract(executor, found, IPermissionService.InteractType.See));
 		}
 
-		// Location(item), the immediate container — not Room(), which walks the chain to the enclosing room.
-		var loc = (await Library.Services.LocateService.FriendlyWhereIs(found)).WithExitOption();
-
-		if (await PermissionService.CanExamine(executor, loc)
-				|| ((!await found.IsDarkLegal() || await loc.IsLight() || await found.IsLight()) && canSee))
-		{
-			// No post-hoc type filter: 'F' is MAT_TYPE, which the search itself honours now. Filtering the
-			// winner afterwards could only ever turn a legitimate match into #-1 while the wrong-type
-			// candidate had already displaced the right-type one during matching.
-			return $"#{found.Object().DBRef.Number}";
-		}
-
-		return "#-1";
+		// No post-hoc type filter: 'F' is MAT_TYPE, which the search itself honours now. Filtering the
+		// winner afterwards could only ever turn a legitimate match into #-1 while the wrong-type
+		// candidate had already displaced the right-type one during matching.
+		return visible ? $"#{found.Object().DBRef.Number}" : "#-1";
 	}
 
 	/// <summary>

--- a/SharpMUSH.Implementation/Functions/InformationFunctions.cs
+++ b/SharpMUSH.Implementation/Functions/InformationFunctions.cs
@@ -409,7 +409,7 @@ public partial class Functions
 		var toLocate = parser.CurrentState.Arguments["0"].Message!.ToPlainText();
 
 		return await LocateService!.LocateAndNotifyIfInvalidWithCallStateFunction(
-			parser, executor, executor, toLocate, LocateFlags.All | LocateFlags.NoVisibilityCheck,
+			parser, executor, executor, toLocate, LocateFlags.All,
 			async found => new CallState(await found.IsApproved()));
 	}
 

--- a/SharpMUSH.Library/Definitions/ErrorMessages.cs
+++ b/SharpMUSH.Library/Definitions/ErrorMessages.cs
@@ -353,7 +353,8 @@ public static class ErrorMessages
 		public const string CouldNotFind = "Could not find that.";
 		public const string CouldNotFindPlayer = "Could not find that player.";
 		public const string CantFindThatPlayer = "I can't find that player";
-		public const string AmbiguousMatch = "I don't know which one you mean.";
+		// match.c:481 — with the exclamation mark. The neighbouring two are already exact.
+		public const string AmbiguousMatch = "I don't know which one you mean!";
 		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]
 		public const string LocateUnknownSwitchFormat = "I don't understand switch '{0}'.";
 		[StringSyntax(StringSyntaxAttribute.CompositeFormat)]

--- a/SharpMUSH.Library/Services/Interfaces/ILocateService.cs
+++ b/SharpMUSH.Library/Services/Interfaces/ILocateService.cs
@@ -54,19 +54,13 @@ public enum LocateFlags
 	EnglishStyleMatching = MatchOptionalWildCardForPlayerName << 1,
 	NoPartialMatches = EnglishStyleMatching << 1,
 	OnlyMatchLookerControlledObjects = NoPartialMatches << 1,
-	/// <summary>
-	/// Skips the visibility check after locating the object. Used by functions like
-	/// hasflag() that should work on any object the executor can reference by dbref,
-	/// matching PennMUSH behavior.
-	/// </summary>
-	NoVisibilityCheck = OnlyMatchLookerControlledObjects << 1,
 
 	/// <summary>
 	/// <c>MAT_GLOBAL</c> — search the Master Room's exits. Its own flag, and deliberately not part of
 	/// <see cref="All"/>: <c>MAT_EVERYTHING</c> does not include it either, and the master-room scope
 	/// used to be gated on <c>HasFlag(All)</c>, which is a different question.
 	/// </summary>
-	MatchGlobalExits = NoVisibilityCheck << 1,
+	MatchGlobalExits = OnlyMatchLookerControlledObjects << 1,
 
 	/// <summary>
 	/// <c>MAT_EVERYTHING</c>, member for member. <c>MAT_CONTAINER</c>

--- a/SharpMUSH.Library/Services/Interfaces/ILocateService.cs
+++ b/SharpMUSH.Library/Services/Interfaces/ILocateService.cs
@@ -21,6 +21,17 @@ public enum SharpObjectTypes
 	Any = Player | Room | Exit | Thing
 }
 
+/// <remarks>
+/// <b>Bit positions are explicit and fixed.</b> This enum is public in a package external plugins
+/// reference (see the contract note in SharpMUSH.Library.csproj), so its numeric values are part of
+/// that contract. Written as a <c>&lt;&lt; 1</c> chain, removing any member silently renumbered every
+/// member below it — which is exactly what happened twice: <c>FailIfNotPreferred</c> (bit 7) and
+/// <c>NoVisibilityCheck</c> (bit 25) were each dropped, shifting the tail down and leaving a plugin
+/// built against 1.0.0 passing one flag and this server reading another.
+///
+/// Both slots stay reserved rather than reused, so every surviving member keeps the value it was
+/// published with. Add new members at the first free bit; never renumber an existing one.
+/// </remarks>
 [Flags]
 public enum LocateFlags
 {
@@ -30,37 +41,41 @@ public enum LocateFlags
 	/// returning <see cref="SharpObjectTypes.None"/> is the same statement — but the switch is
 	/// documented, so the letter has to land somewhere.
 	/// </summary>
-	NoTypePreference = 1,
-	OnlyMatchTypePreference = NoTypePreference << 1,
-	ExitsPreference = OnlyMatchTypePreference << 1,
-	PreferLockPass = ExitsPreference << 1,
-	PlayersPreference = PreferLockPass << 1,
-	RoomsPreference = PlayersPreference << 1,
-	ThingsPreference = RoomsPreference << 1,
-	UseLastIfAmbiguous = ThingsPreference << 1,
-	AbsoluteMatch = UseLastIfAmbiguous << 1,
-	ExitsInTheRoomOfLooker = AbsoluteMatch << 1,
-	ExitsInsideOfLooker = ExitsInTheRoomOfLooker << 1,
-	MatchHereForLookerLocation = ExitsInsideOfLooker << 1,
-	MatchObjectsInLookerInventory = MatchHereForLookerLocation << 1,
-	MatchAgainstLookerLocationName = MatchObjectsInLookerInventory << 1,
-	OnlyMatchObjectsInLookerInventory = MatchAgainstLookerLocationName << 1,
-	MatchRemoteContents = OnlyMatchObjectsInLookerInventory << 1,
-	MatchMeForLooker = MatchRemoteContents << 1,
-	OnlyMatchObjectsInLookerLocation = MatchMeForLooker << 1,
-	MatchObjectsInLookerLocation = OnlyMatchObjectsInLookerLocation << 1,
-	MatchWildCardForPlayerName = MatchObjectsInLookerLocation << 1,
-	MatchOptionalWildCardForPlayerName = MatchWildCardForPlayerName << 1,
-	EnglishStyleMatching = MatchOptionalWildCardForPlayerName << 1,
-	NoPartialMatches = EnglishStyleMatching << 1,
-	OnlyMatchLookerControlledObjects = NoPartialMatches << 1,
+	NoTypePreference = 1 << 0,
+	OnlyMatchTypePreference = 1 << 1,
+	ExitsPreference = 1 << 2,
+	PreferLockPass = 1 << 3,
+	PlayersPreference = 1 << 4,
+	RoomsPreference = 1 << 5,
+	ThingsPreference = 1 << 6,
+	// 1 << 7 — reserved, was FailIfNotPreferred: set by 'F' alongside OnlyMatchTypePreference and read
+	// nowhere. Do not reuse.
+	UseLastIfAmbiguous = 1 << 8,
+	AbsoluteMatch = 1 << 9,
+	ExitsInTheRoomOfLooker = 1 << 10,
+	ExitsInsideOfLooker = 1 << 11,
+	MatchHereForLookerLocation = 1 << 12,
+	MatchObjectsInLookerInventory = 1 << 13,
+	MatchAgainstLookerLocationName = 1 << 14,
+	OnlyMatchObjectsInLookerInventory = 1 << 15,
+	MatchRemoteContents = 1 << 16,
+	MatchMeForLooker = 1 << 17,
+	OnlyMatchObjectsInLookerLocation = 1 << 18,
+	MatchObjectsInLookerLocation = 1 << 19,
+	MatchWildCardForPlayerName = 1 << 20,
+	MatchOptionalWildCardForPlayerName = 1 << 21,
+	EnglishStyleMatching = 1 << 22,
+	NoPartialMatches = 1 << 23,
+	OnlyMatchLookerControlledObjects = 1 << 24,
+	// 1 << 25 — reserved, was NoVisibilityCheck: it opted out of fun_locate's dark/can-examine gate,
+	// which no longer runs for any caller but locate() itself. Do not reuse.
 
 	/// <summary>
 	/// <c>MAT_GLOBAL</c> — search the Master Room's exits. Its own flag, and deliberately not part of
 	/// <see cref="All"/>: <c>MAT_EVERYTHING</c> does not include it either, and the master-room scope
 	/// used to be gated on <c>HasFlag(All)</c>, which is a different question.
 	/// </summary>
-	MatchGlobalExits = OnlyMatchLookerControlledObjects << 1,
+	MatchGlobalExits = 1 << 26,
 
 	/// <summary>
 	/// <c>MAT_EVERYTHING</c>, member for member. <c>MAT_CONTAINER</c>

--- a/SharpMUSH.Library/Services/LocateService.cs
+++ b/SharpMUSH.Library/Services/LocateService.cs
@@ -593,7 +593,7 @@ public partial class LocateService(
 		// not even worth fetching otherwise.
 		ReadOnlySpan<string> aliases = cur.IsPlayer || cur.IsExit ? cur.Aliases : [];
 
-		if (AnyAlias(aliases, name, AliasMatch.Whole)
+		if (AnyAliasMatches(aliases, name)
 				|| objectName.Equals(name, StringComparison.OrdinalIgnoreCase))
 		{
 			return MatchKind.Exact;
@@ -601,7 +601,7 @@ public partial class LocateService(
 
 		if (!allowPartial) return MatchKind.None;
 
-		return (cur.IsPlayer && AnyAlias(aliases, name, AliasMatch.Prefix))
+		return (cur.IsPlayer && AnyAliasStartsWith(aliases, name))
 					 || (!cur.IsExit && StringMatch(objectName, name))
 			? MatchKind.Partial
 			: MatchKind.None;
@@ -640,29 +640,37 @@ public partial class LocateService(
 		return false;
 	}
 
-	/// <summary>How <see cref="AnyAlias"/> compares. An enum rather than a <c>bool</c> so the call sites read.</summary>
-	private enum AliasMatch
-	{
-		/// <summary>check_alias's comparison: the whole entry, case-insensitively.</summary>
-		Whole,
-		Prefix
-	}
-
 	/// <summary>
-	/// A span walk rather than <c>aliases.Any(a =&gt; …)</c> or <c>Contains(name, comparer)</c>: this runs
-	/// up to twice per candidate per locate. The predicate overload would capture <paramref name="name"/>
-	/// into a fresh closure each time, and the comparer overload still boxes the array's enumerator.
+	/// match.c's <c>match_aliases</c>, whose <c>check_alias</c> compares each <c>;</c>-separated entry
+	/// for equality.
 	/// </summary>
-	private static bool AnyAlias(ReadOnlySpan<string> aliases, string name, AliasMatch how)
+	/// <remarks>
+	/// A span walk rather than <c>Any(a =&gt; …)</c> or <c>Contains(name, comparer)</c>: this runs once
+	/// per candidate per locate, and the predicate overload captures <paramref name="name"/> into a fresh
+	/// closure each time while the comparer overload still boxes the array's enumerator.
+	/// </remarks>
+	private static bool AnyAliasMatches(ReadOnlySpan<string> aliases, string name)
 	{
 		foreach (var alias in aliases)
 		{
-			if (how is AliasMatch.Prefix
-						? alias.StartsWith(name, StringComparison.OrdinalIgnoreCase)
-						: alias.Equals(name, StringComparison.OrdinalIgnoreCase))
-			{
-				return true;
-			}
+			if (alias.Equals(name, StringComparison.OrdinalIgnoreCase)) return true;
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Prefix-matching against a player's aliases, which PennMUSH does <b>not</b> do — MATCH_LIST's
+	/// partial branch tests <c>string_match(Name(match), name)</c> and no aliases at all. Penn serves the
+	/// same intent through <c>visible_short_page</c> on the player-match path instead. Kept separate from
+	/// <see cref="AnyAliasMatches"/> rather than folded behind a mode flag so that removing it is a
+	/// deletion: see issue #794.
+	/// </summary>
+	private static bool AnyAliasStartsWith(ReadOnlySpan<string> aliases, string name)
+	{
+		foreach (var alias in aliases)
+		{
+			if (alias.StartsWith(name, StringComparison.OrdinalIgnoreCase)) return true;
 		}
 
 		return false;

--- a/SharpMUSH.Library/Services/LocateService.cs
+++ b/SharpMUSH.Library/Services/LocateService.cs
@@ -786,17 +786,38 @@ public partial class LocateService(
 			thing => new(thing.Location.WithCancellation(CancellationToken.None))
 		);
 
+	/// <summary>
+	/// PennMUSH's <c>where_is</c> (predicat.c:1225), which is <em>not</em> <see cref="FriendlyWhereIs"/>:
+	/// <c>NOTHING</c> for a room and <c>Home()</c> — the destination — for an exit. match.c deliberately
+	/// uses the other one for its <c>loc</c>, taking an exit's <c>Source</c>, so the two disagree on
+	/// purpose and <see cref="Nearby"/> needs this one.
+	/// </summary>
+	private static async ValueTask<DBRef?> WhereIs(AnySharpObject thing)
+	{
+		if (thing.IsRoom) return null;
+		if (!thing.IsExit) return (await FriendlyWhereIs(thing)).Object().DBRef;
+
+		var destination = await thing.MinusRoom().Home();
+		return destination.IsNone ? null : destination.WithoutNone().Object().DBRef;
+	}
+
+	/// <summary>
+	/// PennMUSH's <c>nearby</c> (predicat.c:1251), member for member. The nullable is load-bearing:
+	/// <c>where_is</c> answers <c>NOTHING</c> for a room, and <c>NOTHING == NOTHING</c> must not read as
+	/// "same location" — two objects nowhere are not near each other.
+	/// </summary>
 	public static async ValueTask<bool> Nearby(
 		AnySharpObject obj1,
 		AnySharpObject obj2)
 	{
 		if (obj1.IsRoom && obj2.IsRoom) return false;
 
-		var loc1 = (await FriendlyWhereIs(obj1)).Object().DBRef;
+		var loc1 = await WhereIs(obj1);
 
-		if (loc1 == obj2.Object().DBRef) return true;
+		if (loc1 is not null && loc1 == obj2.Object().DBRef) return true;
 
-		var loc2 = (await FriendlyWhereIs(obj2)).Object().DBRef;
+		var loc2 = await WhereIs(obj2);
+		if (loc2 is null) return false;
 
 		return loc2 == obj1.Object().DBRef || loc2 == loc1;
 	}
@@ -881,38 +902,48 @@ public partial class LocateService(
 			return (name, flags, 0);
 		}
 
-		var mName = name.Split(' ').FirstOrDefault();
-		if (string.IsNullOrWhiteSpace(mName))
+		// match.c:560 — `mname = strchr(*name, ' '); if (!mname) return 0;`. A count with no noun after it
+		// is not a count adjective at all, and the name stands as typed. Split(' ').FirstOrDefault()
+		// hands back the *whole string* when there is no space, so a search for "2nd" became an ordinal
+		// search for the empty string instead of a search for an object named "2nd".
+		var space = name.IndexOf(' ');
+		if (space < 0)
 		{
 			return (name, flags, 0);
 		}
 
+		var mName = name[..space];
 		var ordinalMatch = NthRegex.Match(mName);
 
-		if (ordinalMatch.Success)
+		// match.c:590 — an error like '0th' or '12nd' "wasn't really a count adjective. Reset and press
+		// on", restoring the name rather than consuming the token. Falling through to the shared return
+		// stripped it, so a thing named "5 Swords" was searched for as "Swords" and never found.
+		if (!ordinalMatch.Success)
 		{
-			count = int.Parse(ordinalMatch.Groups["Number"].Value);
-			var ordinal = ordinalMatch.Groups["Ordinal"].Value;
+			return (name, flags, 0);
+		}
 
-			// Validate the ordinal suffix, following PennMUSH parse_english() rules:
-			//   11th, 12th, 13th  → always "th"  (teen exception – not st/nd/rd)
-			//   *1  (excl. 11)    → "st"
-			//   *2  (excl. 12)    → "nd"
-			//   *3  (excl. 13)    → "rd"
-			//   everything else   → "th"
-			var mod100 = count % 100;
-			var isTeen = mod100 >= 11 && mod100 <= 13;
-			var mod10 = count % 10;
+		count = int.Parse(ordinalMatch.Groups["Number"].Value);
+		var ordinal = ordinalMatch.Groups["Ordinal"].Value;
 
-			string expectedSuffix = (isTeen || mod10 == 0 || mod10 > 3) ? "th"
-				: mod10 == 1 ? "st"
-				: mod10 == 2 ? "nd"
-				: "rd";
+		// Validate the ordinal suffix, following PennMUSH parse_english() rules:
+		//   11th, 12th, 13th  → always "th"  (teen exception – not st/nd/rd)
+		//   *1  (excl. 11)    → "st"
+		//   *2  (excl. 12)    → "nd"
+		//   *3  (excl. 13)    → "rd"
+		//   everything else   → "th"
+		var mod100 = count % 100;
+		var isTeen = mod100 >= 11 && mod100 <= 13;
+		var mod10 = count % 10;
 
-			if (count < 1 || !ordinal.Equals(expectedSuffix, StringComparison.CurrentCultureIgnoreCase))
-			{
-				return (name, flags, 0);
-			}
+		string expectedSuffix = (isTeen || mod10 == 0 || mod10 > 3) ? "th"
+			: mod10 == 1 ? "st"
+			: mod10 == 2 ? "nd"
+			: "rd";
+
+		if (count < 1 || !ordinal.Equals(expectedSuffix, StringComparison.CurrentCultureIgnoreCase))
+		{
+			return (name, flags, 0);
 		}
 
 		return (name[mName.Length..].TrimStart(), flags, count);

--- a/SharpMUSH.Library/Services/LocateService.cs
+++ b/SharpMUSH.Library/Services/LocateService.cs
@@ -8,6 +8,7 @@ using SharpMUSH.Library.Models;
 using SharpMUSH.Library.ParserInterfaces;
 using SharpMUSH.Library.Queries.Database;
 using SharpMUSH.Library.Services.Interfaces;
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace SharpMUSH.Library.Services;
@@ -917,7 +918,18 @@ public partial class LocateService(
 			return (name, flags, 0);
 		}
 
-		count = int.Parse(ordinalMatch.Groups["Number"].Value);
+		// `\d` matches every Unicode decimal digit and caps no length, so this group can hold "\u0663" or
+		// twenty nines — int.Parse answers those with FormatException and OverflowException, out of a
+		// path any player reaches by typing `get 99999999999999999999th thing`. match.c runs strtoul,
+		// which saturates and then fails the suffix test, so declining to read it as a count is the same
+		// answer: the name stands as typed. NumberStyles.None also refuses a sign, which `\d+` cannot
+		// produce but which int.Parse would otherwise accept.
+		if (!int.TryParse(ordinalMatch.Groups["Number"].ValueSpan, NumberStyles.None,
+					CultureInfo.InvariantCulture, out count))
+		{
+			return (name, flags, 0);
+		}
+
 		var ordinal = ordinalMatch.Groups["Ordinal"].Value;
 
 		// Validate the ordinal suffix, following PennMUSH parse_english() rules:

--- a/SharpMUSH.Library/Services/LocateService.cs
+++ b/SharpMUSH.Library/Services/LocateService.cs
@@ -593,7 +593,7 @@ public partial class LocateService(
 		// not even worth fetching otherwise.
 		ReadOnlySpan<string> aliases = cur.IsPlayer || cur.IsExit ? cur.Aliases : [];
 
-		if (AnyAlias(aliases, name, prefix: false)
+		if (AnyAlias(aliases, name, AliasMatch.Whole)
 				|| objectName.Equals(name, StringComparison.OrdinalIgnoreCase))
 		{
 			return MatchKind.Exact;
@@ -601,7 +601,7 @@ public partial class LocateService(
 
 		if (!allowPartial) return MatchKind.None;
 
-		return (cur.IsPlayer && AnyAlias(aliases, name, prefix: true))
+		return (cur.IsPlayer && AnyAlias(aliases, name, AliasMatch.Prefix))
 					 || (!cur.IsExit && StringMatch(objectName, name))
 			? MatchKind.Partial
 			: MatchKind.None;
@@ -640,15 +640,24 @@ public partial class LocateService(
 		return false;
 	}
 
+	/// <summary>How <see cref="AnyAlias"/> compares. An enum rather than a <c>bool</c> so the call sites read.</summary>
+	private enum AliasMatch
+	{
+		/// <summary>check_alias's comparison: the whole entry, case-insensitively.</summary>
+		Whole,
+		Prefix
+	}
+
 	/// <summary>
-	/// A span walk rather than <c>aliases.Any(a =&gt; …)</c>: this runs up to twice per candidate per
-	/// locate, and the predicate would capture <paramref name="name"/> into a fresh closure every time.
+	/// A span walk rather than <c>aliases.Any(a =&gt; …)</c> or <c>Contains(name, comparer)</c>: this runs
+	/// up to twice per candidate per locate. The predicate overload would capture <paramref name="name"/>
+	/// into a fresh closure each time, and the comparer overload still boxes the array's enumerator.
 	/// </summary>
-	private static bool AnyAlias(ReadOnlySpan<string> aliases, string name, bool prefix)
+	private static bool AnyAlias(ReadOnlySpan<string> aliases, string name, AliasMatch how)
 	{
 		foreach (var alias in aliases)
 		{
-			if (prefix
+			if (how is AliasMatch.Prefix
 						? alias.StartsWith(name, StringComparison.OrdinalIgnoreCase)
 						: alias.Equals(name, StringComparison.OrdinalIgnoreCase))
 			{

--- a/SharpMUSH.Library/Services/LocateService.cs
+++ b/SharpMUSH.Library/Services/LocateService.cs
@@ -174,7 +174,7 @@ public partial class LocateService(
 		LocateFlags.NoTypePreference | LocateFlags.PlayersPreference | LocateFlags.RoomsPreference |
 		LocateFlags.ThingsPreference | LocateFlags.ExitsPreference |
 		// SharpMUSH's own, and MAT_LAST, which fun_locate applies at the call rather than in match_flags.
-		LocateFlags.UseLastIfAmbiguous | LocateFlags.NoVisibilityCheck;
+		LocateFlags.UseLastIfAmbiguous;
 
 	/// <summary>
 	/// The scopes that make a search depend on where the looker stands, and so require the executor to
@@ -218,41 +218,26 @@ public partial class LocateService(
 		// of those was re-running the same GeneratedRegex over the same string.
 		var absolute = HelperFunctions.ParseDbRef(name);
 
-		var (match, noControl) = await LocateMatch(executor, looker, flags, name, absolute);
-		if (match.IsError) return (match.AsError, noControl);
-		if (match.IsNone) return (match.AsNone, noControl);
-
-		var result = match.WithoutError().WithoutNone();
-
-		// PennMUSH: absolute dbref matches (#N) always bypass visibility checks.
-		if (flags.HasFlag(LocateFlags.NoVisibilityCheck) || absolute.IsSome())
-		{
-			return (result.WithNoneOption().WithErrorOption(), noControl);
-		}
-
-		var location = await FriendlyWhereIs(result);
-
-		if (await permissionService.CanExamine(executor, location.WithExitOption()) ||
-				((!await result.IsDarkLegal() || await location.WithExitOption().IsLight() || await result.IsLight()) &&
-				 await permissionService.CanInteract(executor, result, IPermissionService.InteractType.See)))
-		{
-			return (result.WithNoneOption().WithErrorOption(), noControl);
-		}
-
-		return (new Error<string>(ErrorMessages.Returns.CantSeeThat), noControl);
+		// And that is the whole of it. match_result_internal asks exactly one permission question of a
+		// candidate — can_interact(match, who, INTERACT_MATCH), which MatchList does per candidate — and
+		// there is no Can_Examine, DarkLegal or INTERACT_SEE anywhere in match.c. That block belongs to
+		// fun_locate, which applies it to what match_result hands back; it lives in Functions.Locate now.
+		// Having it here put fun_locate's filter on every caller, so commands rejected objects PennMUSH
+		// resolves and reported them as "I can't see that here" rather than as a suppressed match.
+		return await LocateMatch(executor, looker, flags, name, absolute);
 	}
 
 	// A player-name match is GLOBAL in PennMUSH: pmatch()/player lookup resolves any player by name
-	// regardless of where they stand or whether the looker can "see" them. NoVisibilityCheck keeps
-	// Locate()'s post-match dark/can-examine gate from rejecting a perfectly valid player just because
-	// an unprivileged looker (e.g. the profile http_handler #4) is neither near nor a controller —
-	// which 404'd GET /api/profile/<name> for every character.
+	// regardless of where they stand or whether the looker can "see" them. It no longer needs a flag to
+	// say so — the dark/can-examine gate that used to reject a perfectly valid player here (404'ing
+	// GET /api/profile/<name> for every character, since the profile http_handler #4 is neither near nor
+	// a controller) was fun_locate's, and has gone back there.
 	// AbsoluteMatch because lookup_player resolves "#1" as readily as a name, and every caller of this
 	// helper hands it whatever the user typed. It used to arrive by accident: the flag set names a scope,
 	// so nothing was injected, and a dbref reached no scope at all.
 	private const LocateFlags PlayerMatchFlags =
 		LocateFlags.PlayersPreference | LocateFlags.OnlyMatchTypePreference | LocateFlags.EnglishStyleMatching |
-		LocateFlags.MatchOptionalWildCardForPlayerName | LocateFlags.AbsoluteMatch | LocateFlags.NoVisibilityCheck;
+		LocateFlags.MatchOptionalWildCardForPlayerName | LocateFlags.AbsoluteMatch;
 
 	public ValueTask<AnyOptionalSharpObjectOrError> LocatePlayerAndNotifyIfInvalid(IMUSHCodeParser parser,
 		AnySharpObject looker, AnySharpObject executor,

--- a/SharpMUSH.Library/Services/LocateService.cs
+++ b/SharpMUSH.Library/Services/LocateService.cs
@@ -601,9 +601,42 @@ public partial class LocateService(
 		if (!allowPartial) return MatchKind.None;
 
 		return (cur.IsPlayer && AnyAlias(aliases, name, prefix: true))
-					 || (!cur.IsExit && objectName.StartsWith(name, StringComparison.OrdinalIgnoreCase))
+					 || (!cur.IsExit && StringMatch(objectName, name))
 			? MatchKind.Partial
 			: MatchKind.None;
+	}
+
+	/// <summary>
+	/// PennMUSH's <c>string_match</c> (strutil.c): <paramref name="sub"/> is a prefix of <em>any word</em>
+	/// of <paramref name="src"/>, not just of the whole string. `sword` matches `Big Sword`, which is how
+	/// players ordinarily refer to things — most object names are more than one word, and testing only
+	/// the first left every one of them reachable by its leading word or in full and no other way.
+	/// </summary>
+	/// <remarks>
+	/// The word separator is <c>isalnum</c>, not whitespace: `Myrddin's` advances past the apostrophe to
+	/// `s`, so splitting on spaces is not the same function. Runs once per candidate per locate, so it
+	/// walks spans rather than allocating.
+	/// </remarks>
+	private static bool StringMatch(ReadOnlySpan<char> src, ReadOnlySpan<char> sub)
+	{
+		if (sub.IsEmpty) return false;
+
+		while (!src.IsEmpty)
+		{
+			if (src.StartsWith(sub, StringComparison.OrdinalIgnoreCase)) return true;
+
+			// Scan to the beginning of the next word, exactly as string_match does. IsLetterOrDigit stands
+			// in for isalnum, which PennMUSH runs under a UTF-8 ctype locale, so both are Unicode-aware.
+			var i = 0;
+			while (i < src.Length && char.IsLetterOrDigit(src[i])) i++;
+			while (i < src.Length && !char.IsLetterOrDigit(src[i])) i++;
+
+			// One of those two scans always advances, so i >= 1 — but this is a per-candidate loop and a
+			// hang here would be a denial of service, so don't rest the whole thing on that reasoning.
+			src = src[Math.Max(i, 1)..];
+		}
+
+		return false;
 	}
 
 	/// <summary>

--- a/SharpMUSH.Library/Services/LocateService.cs
+++ b/SharpMUSH.Library/Services/LocateService.cs
@@ -181,8 +181,12 @@ public partial class LocateService(
 	/// The scopes that make a search depend on where the looker stands, and so require the executor to
 	/// be able to stand there too. fun_locate gates on exactly this set (fundb.c: <c>MAT_NEIGHBOR |
 	/// MAT_CONTAINER | MAT_POSSESSION | MAT_HERE | MAT_EXIT | MAT_CARRIED_EXIT</c>).
+	///
+	/// Public because <c>fun_locate</c> has to apply this gate itself: it asks it of <c>executor</c>
+	/// against <c>looker</c>, while passing <c>looker</c> as the match subject, so the two cannot be
+	/// folded into one call.
 	/// </summary>
-	private const LocateFlags LookerRelativeScopes =
+	public const LocateFlags LookerRelativeScopes =
 		LocateFlags.MatchObjectsInLookerLocation | LocateFlags.MatchAgainstLookerLocationName |
 		LocateFlags.MatchObjectsInLookerInventory | LocateFlags.MatchHereForLookerLocation |
 		LocateFlags.ExitsInTheRoomOfLooker | LocateFlags.ExitsInsideOfLooker;

--- a/SharpMUSH.Library/Services/LocateService.cs
+++ b/SharpMUSH.Library/Services/LocateService.cs
@@ -178,6 +178,23 @@ public partial class LocateService(
 		LocateFlags.UseLastIfAmbiguous;
 
 	/// <summary>
+	/// fun_locate's default-scope injection: with no scope named there is nowhere to search, so the
+	/// default set is supplied. The old test asked whether four unrelated flags were absent, which is a
+	/// different question and fired even when a scope had been named.
+	/// </summary>
+	/// <remarks>
+	/// Public because ordering matters and fun_locate has it one way round: it injects <em>before</em>
+	/// applying <see cref="LookerRelativeScopes"/> (fundb.c), so a flags string naming no scope — <c>N</c>
+	/// is one — still acquires MAT_NEIGHBOR and friends and still has to clear the gate. Gating on the
+	/// flags as typed reads no relative-scope bit and waves the call through, which is a permission
+	/// bypass rather than a missed search. Callers that gate must resolve first, with this.
+	/// </remarks>
+	public static LocateFlags ApplyDefaultScopes(LocateFlags flags)
+		=> (flags & ~NonScopeFlags) == 0
+			? flags | LocateFlags.All | LocateFlags.MatchAgainstLookerLocationName | LocateFlags.ExitsInsideOfLooker
+			: flags;
+
+	/// <summary>
 	/// The scopes that make a search depend on where the looker stands, and so require the executor to
 	/// be able to stand there too. fun_locate gates on exactly this set (fundb.c: <c>MAT_NEIGHBOR |
 	/// MAT_CONTAINER | MAT_POSSESSION | MAT_HERE | MAT_EXIT | MAT_CARRIED_EXIT</c>).
@@ -202,13 +219,7 @@ public partial class LocateService(
 		string name,
 		LocateFlags flags)
 	{
-		// fun_locate: with no scope named there is nowhere to search, so inject the default set. The old
-		// test asked whether four unrelated flags were absent, which is a different question and fired
-		// even when a scope had been named.
-		if ((flags & ~NonScopeFlags) == 0)
-		{
-			flags |= LocateFlags.All | LocateFlags.MatchAgainstLookerLocationName | LocateFlags.ExitsInsideOfLooker;
-		}
+		flags = ApplyDefaultScopes(flags);
 
 		if ((flags & LookerRelativeScopes) != 0
 				// Cheapest first: See_All is a flag read, Nearby resolves up to two locations.

--- a/SharpMUSH.Library/Services/LocateService.cs
+++ b/SharpMUSH.Library/Services/LocateService.cs
@@ -787,37 +787,31 @@ public partial class LocateService(
 		);
 
 	/// <summary>
-	/// PennMUSH's <c>where_is</c> (predicat.c:1225), which is <em>not</em> <see cref="FriendlyWhereIs"/>:
-	/// <c>NOTHING</c> for a room and <c>Home()</c> — the destination — for an exit. match.c deliberately
-	/// uses the other one for its <c>loc</c>, taking an exit's <c>Source</c>, so the two disagree on
-	/// purpose and <see cref="Nearby"/> needs this one.
+	/// PennMUSH's <c>nearby</c> (predicat.c:1251), which resolves each side with <c>where_is</c>.
 	/// </summary>
-	private static async ValueTask<DBRef?> WhereIs(AnySharpObject thing)
-	{
-		if (thing.IsRoom) return null;
-		if (!thing.IsExit) return (await FriendlyWhereIs(thing)).Object().DBRef;
-
-		var destination = await thing.MinusRoom().Home();
-		return destination.IsNone ? null : destination.WithoutNone().Object().DBRef;
-	}
-
-	/// <summary>
-	/// PennMUSH's <c>nearby</c> (predicat.c:1251), member for member. The nullable is load-bearing:
-	/// <c>where_is</c> answers <c>NOTHING</c> for a room, and <c>NOTHING == NOTHING</c> must not read as
-	/// "same location" — two objects nowhere are not near each other.
-	/// </summary>
+	/// <remarks>
+	/// <c>where_is</c> returns <c>Home(thing)</c> for an exit, and <c>Home(x)</c>, <c>Source(x)</c> and
+	/// <c>Exits(x)</c> are all the same field — <c>db[x].exits</c> (dbdefs.h:35-40). So an exit's
+	/// <c>where_is</c> is the room it <em>sits in</em>, not where it leads; <c>Destination(x)</c> is the
+	/// separate <c>db[x].location</c> field. <see cref="FriendlyWhereIs"/> already answers that, because
+	/// <see cref="SharpExit.Location"/> is documented as <c>Source()</c>.
+	///
+	/// The other divergence, <c>where_is</c> answering <c>NOTHING</c> for a room where this hands back
+	/// the room itself, does not reach an observable difference: the only arms it could change are
+	/// guarded by the both-rooms early return, and a room's own dbref answers the two remaining
+	/// comparisons the same way <c>NOTHING</c> would fail them.
+	/// </remarks>
 	public static async ValueTask<bool> Nearby(
 		AnySharpObject obj1,
 		AnySharpObject obj2)
 	{
 		if (obj1.IsRoom && obj2.IsRoom) return false;
 
-		var loc1 = await WhereIs(obj1);
+		var loc1 = (await FriendlyWhereIs(obj1)).Object().DBRef;
 
-		if (loc1 is not null && loc1 == obj2.Object().DBRef) return true;
+		if (loc1 == obj2.Object().DBRef) return true;
 
-		var loc2 = await WhereIs(obj2);
-		if (loc2 is null) return false;
+		var loc2 = (await FriendlyWhereIs(obj2)).Object().DBRef;
 
 		return loc2 == obj1.Object().DBRef || loc2 == loc1;
 	}

--- a/SharpMUSH.Plugins.Scene/Common/SceneLocate.cs
+++ b/SharpMUSH.Plugins.Scene/Common/SceneLocate.cs
@@ -33,8 +33,7 @@ public static class SceneLocate
 	// so spell out a player-matching set that also covers those two forms the scene softcode relies on.
 	private const LocateFlags PlayerFlags =
 		LocateFlags.PlayersPreference | LocateFlags.MatchMeForLooker | LocateFlags.AbsoluteMatch |
-		LocateFlags.MatchOptionalWildCardForPlayerName | LocateFlags.EnglishStyleMatching |
-		LocateFlags.NoVisibilityCheck;
+		LocateFlags.MatchOptionalWildCardForPlayerName | LocateFlags.EnglishStyleMatching;
 
 	/// <summary>
 	/// Resolves a room/object reference to a concrete dbref string, or returns <paramref name="name"/>

--- a/SharpMUSH.Tests/Functions/LocateFunctionPermissionTests.cs
+++ b/SharpMUSH.Tests/Functions/LocateFunctionPermissionTests.cs
@@ -1,0 +1,62 @@
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using SharpMUSH.Library.Models;
+using SharpMUSH.Library.ParserInterfaces;
+using SharpMUSH.Library.Services.Interfaces;
+
+namespace SharpMUSH.Tests.Functions;
+
+/// <summary>
+/// <c>fun_locate</c>'s relative-scope gate (fundb.c): when the requested scopes depend on where the
+/// looker stands, the <em>executor</em> must be able to evaluate against that looker — near it,
+/// controlling it, or See_All — or the whole call answers <c>#-1</c>.
+///
+/// <para>The gate and the match have different permission subjects. <c>match_result(looker, …)</c>
+/// asks its can_interact/controls questions about the <b>looker</b>, while the gate above it asks
+/// about the <b>executor</b>. Collapsing the two turns the gate into <c>nearby(looker, looker)</c>,
+/// which is always true, and a mortal can then search any object's surroundings by naming it.</para>
+/// </summary>
+public class LocateFunctionPermissionTests
+{
+	[ClassDataSource<ServerWebAppFactory>(Shared = SharedType.PerTestSession)]
+	public required ServerWebAppFactory WebAppFactoryArg { get; init; }
+
+	private IMediator Mediator => WebAppFactoryArg.Services.GetRequiredService<IMediator>();
+	private IConnectionService ConnectionService => WebAppFactoryArg.Services.GetRequiredService<IConnectionService>();
+	private IMUSHCodeParser GodParser => WebAppFactoryArg.CommandParser;
+
+	private async Task<string> EvalAs(DBRef executor, string expr)
+		=> (await WebAppFactoryArg.FunctionParserFor(executor).FunctionParse(MModule.single(expr)))
+			?.Message!.ToPlainText() ?? "<null>";
+
+	private async Task<string> God(string command)
+		=> (await GodParser.CommandParse(1, ConnectionService, MModule.single(command)))?.Message?.ToPlainText() ?? "";
+
+	[Test]
+	[NotInParallel]
+	public async Task AMortalCannotSearchARemoteLookersNeighbours()
+	{
+		// A room the mortal is nowhere near, holding a looker and something for it to find. The looker
+		// is a thing rather than the room itself: MAT_NEIGHBOR searches Contents(loc) and match.c skips
+		// that scope when loc == where, which is always so for a room (match.c:437).
+		var room = DBRef.Parse((await God("@dig LocatePermRoom")).Trim().Split(' ')[^1].Trim());
+		var looker = DBRef.Parse((await God("@create LocatePermLooker")).Trim());
+		var target = DBRef.Parse((await God("@create LocatePermTarget")).Trim());
+		await God($"@tel #{looker.Number}=#{room.Number}");
+		await God($"@tel #{target.Number}=#{room.Number}");
+
+		var mortal = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "LocatePerm");
+
+		// 'n' is MAT_NEIGHBOR — a looker-relative scope, so the gate applies. The mortal is neither
+		// near the looker, nor controls it, nor See_All.
+		var mortalSees = await EvalAs(mortal.DbRef, $"locate(#{looker.Number},LocatePermTarget,n)");
+
+		// God is See_All, so the same call passes the gate and finds it — proving the refusal above is
+		// the gate talking and not simply a search that was never going to match.
+		var godSees = await EvalAs(new DBRef(1), $"locate(#{looker.Number},LocatePermTarget,n)");
+
+		await Assert.That(mortalSees).IsEqualTo("#-1");
+		await Assert.That(godSees).IsEqualTo($"#{target.Number}");
+	}
+}

--- a/SharpMUSH.Tests/Functions/LocateFunctionPermissionTests.cs
+++ b/SharpMUSH.Tests/Functions/LocateFunctionPermissionTests.cs
@@ -59,4 +59,29 @@ public class LocateFunctionPermissionTests
 		await Assert.That(mortalSees).IsEqualTo("#-1");
 		await Assert.That(godSees).IsEqualTo($"#{target.Number}");
 	}
+
+	[Test]
+	[NotInParallel]
+	public async Task TheGateSurvivesDefaultScopeInjection()
+	{
+		// fun_locate injects the default scope set *before* it gates (fundb.c), so a flags string that
+		// names no scope at all still ends up searching the looker's surroundings — and still has to
+		// clear the gate. 'N' is NOTYPE: not a scope, so the injection fires and MAT_NEIGHBOR and
+		// friends arrive implicitly. Gating on the flags as typed reads no relative-scope bit and waves
+		// the call through.
+		var room = DBRef.Parse((await God("@dig LocateInjectRoom")).Trim().Split(' ')[^1].Trim());
+		var looker = DBRef.Parse((await God("@create LocateInjectLooker")).Trim());
+		var target = DBRef.Parse((await God("@create LocateInjectTarget")).Trim());
+		await God($"@tel #{looker.Number}=#{room.Number}");
+		await God($"@tel #{target.Number}=#{room.Number}");
+
+		var mortal = await TestIsolationHelpers.CreateTestPlayerWithHandleAsync(
+			WebAppFactoryArg.Services, Mediator, ConnectionService, "LocateInject");
+
+		var mortalSees = await EvalAs(mortal.DbRef, $"locate(#{looker.Number},LocateInjectTarget,N)");
+		var godSees = await EvalAs(new DBRef(1), $"locate(#{looker.Number},LocateInjectTarget,N)");
+
+		await Assert.That(mortalSees).IsEqualTo("#-1");
+		await Assert.That(godSees).IsEqualTo($"#{target.Number}");
+	}
 }

--- a/SharpMUSH.Tests/Services/LocateSeamCharacterisationTests.cs
+++ b/SharpMUSH.Tests/Services/LocateSeamCharacterisationTests.cs
@@ -509,4 +509,24 @@ public class LocateSeamCharacterisationTests
 		await Assert.That(await LocateService.Nearby(roomA, inA)).IsTrue();
 		await Assert.That(await LocateService.Nearby(inA, roomA)).IsTrue();
 	}
+
+	[Test]
+	[Arguments("99999999999999999999th Sword")]
+	[Arguments("12345678901st Sword")]
+	[Arguments("\u0663rd Sword")]
+	public async Task AnOrdinalTooBigOrNotAsciiIsNotACount(string search)
+	{
+		// NthRegex's \d accepts every Unicode decimal digit and caps no length, so int.Parse used to
+		// answer these with OverflowException/FormatException out of a path any player can type.
+		// match.c's strtoul saturates and then fails the suffix test, so the name stands as typed.
+		var room = _factory.CreateRoom(999, "Shared Room");
+		var looker = _factory.CreatePlayer(1, "TestPlayer", room);
+		Holds(looker);
+		Holds(room, looker, _factory.CreateThing(3, "Sword", room));
+
+		var result = await _locateService.Locate(_parser, looker, looker, search, LocateFlags.All);
+
+		// Not a count, so the whole string is the name — and nothing is called that.
+		await Assert.That(result.IsNone).IsTrue();
+	}
 }

--- a/SharpMUSH.Tests/Services/LocateSeamCharacterisationTests.cs
+++ b/SharpMUSH.Tests/Services/LocateSeamCharacterisationTests.cs
@@ -480,25 +480,27 @@ public class LocateSeamCharacterisationTests
 	}
 
 	[Test]
-	public async Task NearbyUsesAnExitsDestination()
+	public async Task NearbyUsesAnExitsSourceRoom()
 	{
-		// nearby() resolves each side with where_is() (predicat.c:1225), which is Home() for an exit —
-		// its destination — and NOTHING for a room. match.c uses Source for its own `loc`, so the two
-		// disagree deliberately; Nearby needs where_is's answer.
+		// where_is() returns Home(thing) for an exit, and Home/Source/Exits are all db[x].exits
+		// (dbdefs.h:35-40) — so it is the room the exit sits in, not where it leads. Destination() is the
+		// separate db[x].location field. SharpExit.Location is documented as Source(), so FriendlyWhereIs
+		// is already the right answer here.
 		var source = _factory.CreateRoom(999, "Source");
 		var destination = _factory.CreateRoom(998, "Destination");
 		var exit = _factory.CreateExit(8, "North", ["n"], source, destination);
 		var traveller = _factory.CreatePlayer(1, "Traveller", destination);
 		var stayer = _factory.CreatePlayer(2, "Stayer", source);
 
-		await Assert.That(await LocateService.Nearby(exit, traveller)).IsTrue();
-		await Assert.That(await LocateService.Nearby(exit, stayer)).IsFalse();
+		await Assert.That(await LocateService.Nearby(exit, stayer)).IsTrue();
+		await Assert.That(await LocateService.Nearby(exit, traveller)).IsFalse();
 	}
 
 	[Test]
-	public async Task TwoRoomsAreNeverNearbyAndNeitherAreTwoObjectsNowhere()
+	public async Task ARoomIsNearbyWhatItContainsButNotAnotherRoom()
 	{
-		// where_is() is NOTHING for a room, and NOTHING == NOTHING must not read as "same location".
+		// nearby() early-returns for two rooms; the room-vs-content arms are the ones where where_is's
+		// NOTHING and FriendlyWhereIs's own-dbref could have differed, and do not.
 		var roomA = _factory.CreateRoom(999, "A");
 		var roomB = _factory.CreateRoom(998, "B");
 		var inA = _factory.CreatePlayer(1, "InA", roomA);

--- a/SharpMUSH.Tests/Services/LocateSeamCharacterisationTests.cs
+++ b/SharpMUSH.Tests/Services/LocateSeamCharacterisationTests.cs
@@ -436,4 +436,28 @@ public class LocateSeamCharacterisationTests
 		await Assert.That(Found(me)).IsEqualTo(new DBRef(1, 0));
 	}
 
+
+	[Test]
+	[Arguments("Big Sword", "Sword", true)]
+	[Arguments("Big Sword", "Big", true)]
+	[Arguments("Big Sword", "word", false)]
+	[Arguments("BBS - Myrddin's Global BBS", "Myrddin", true)]
+	[Arguments("BBS - Myrddin's Global BBS", "s", true)]
+	[Arguments("mbboard", "bboard", false)]
+	[Arguments("oak door", "do", true)]
+	[Arguments("oak door", "oor", false)]
+	public async Task PartialMatchingFollowsStringMatchWordBoundaries(string objectName, string search, bool found)
+	{
+		// PennMUSH's string_match (strutil.c) tests whether the search term prefixes *any word* of the
+		// name, not just the whole string — it rescans at each isalnum boundary. Testing only the first
+		// word left every multi-word object reachable by its leading word or in full and no other way,
+		// which is not how players refer to things.
+		var room = _factory.CreateRoom(999, "Shared Room");
+		var looker = _factory.CreatePlayer(1, "TestPlayer", room);
+		Holds(room, looker, _factory.CreateThing(3, objectName, room));
+
+		var result = await _locateService.Locate(_parser, looker, looker, search, LocateFlags.All);
+
+		await Assert.That(result.IsValid()).IsEqualTo(found);
+	}
 }

--- a/SharpMUSH.Tests/Services/LocateSeamCharacterisationTests.cs
+++ b/SharpMUSH.Tests/Services/LocateSeamCharacterisationTests.cs
@@ -480,7 +480,7 @@ public class LocateSeamCharacterisationTests
 	}
 
 	[Test]
-	public async Task NearbyUsesAnExitsSourceRoom()
+	public async Task NearbyUsesTheSourceRoomOfAnExit()
 	{
 		// where_is() returns Home(thing) for an exit, and Home/Source/Exits are all db[x].exits
 		// (dbdefs.h:35-40) — so it is the room the exit sits in, not where it leads. Destination() is the

--- a/SharpMUSH.Tests/Services/LocateSeamCharacterisationTests.cs
+++ b/SharpMUSH.Tests/Services/LocateSeamCharacterisationTests.cs
@@ -460,4 +460,51 @@ public class LocateSeamCharacterisationTests
 
 		await Assert.That(result.IsValid()).IsEqualTo(found);
 	}
+
+	[Test]
+	public async Task ParseEnglishRestoresANonOrdinalDigitToken()
+	{
+		// match.c:590 — '0th'/'12nd' "wasn't really a count adjective. Reset and press on." And
+		// match.c:560 quick-exits a count with no noun after it. Both used to consume the token, so a
+		// thing named "5 Swords" was searched for as "Swords" and never found.
+		var room = _factory.CreateRoom(999, "Shared Room");
+		var looker = _factory.CreatePlayer(1, "TestPlayer", room);
+		Holds(looker);
+		Holds(room, looker, _factory.CreateThing(3, "5 Swords", room), _factory.CreateThing(4, "2nd", room));
+
+		var noSuffix = await _locateService.Locate(_parser, looker, looker, "5 Swords", LocateFlags.All);
+		var countNoNoun = await _locateService.Locate(_parser, looker, looker, "2nd", LocateFlags.All);
+
+		await Assert.That(Found(noSuffix)).IsEqualTo(new DBRef(3, 0));
+		await Assert.That(Found(countNoNoun)).IsEqualTo(new DBRef(4, 0));
+	}
+
+	[Test]
+	public async Task NearbyUsesAnExitsDestination()
+	{
+		// nearby() resolves each side with where_is() (predicat.c:1225), which is Home() for an exit —
+		// its destination — and NOTHING for a room. match.c uses Source for its own `loc`, so the two
+		// disagree deliberately; Nearby needs where_is's answer.
+		var source = _factory.CreateRoom(999, "Source");
+		var destination = _factory.CreateRoom(998, "Destination");
+		var exit = _factory.CreateExit(8, "North", ["n"], source, destination);
+		var traveller = _factory.CreatePlayer(1, "Traveller", destination);
+		var stayer = _factory.CreatePlayer(2, "Stayer", source);
+
+		await Assert.That(await LocateService.Nearby(exit, traveller)).IsTrue();
+		await Assert.That(await LocateService.Nearby(exit, stayer)).IsFalse();
+	}
+
+	[Test]
+	public async Task TwoRoomsAreNeverNearbyAndNeitherAreTwoObjectsNowhere()
+	{
+		// where_is() is NOTHING for a room, and NOTHING == NOTHING must not read as "same location".
+		var roomA = _factory.CreateRoom(999, "A");
+		var roomB = _factory.CreateRoom(998, "B");
+		var inA = _factory.CreatePlayer(1, "InA", roomA);
+
+		await Assert.That(await LocateService.Nearby(roomA, roomB)).IsFalse();
+		await Assert.That(await LocateService.Nearby(roomA, inA)).IsTrue();
+		await Assert.That(await LocateService.Nearby(inA, roomA)).IsTrue();
+	}
 }

--- a/SharpMUSH.Tests/Services/LocateSeamCharacterisationTests.cs
+++ b/SharpMUSH.Tests/Services/LocateSeamCharacterisationTests.cs
@@ -518,15 +518,22 @@ public class LocateSeamCharacterisationTests
 	{
 		// NthRegex's \d accepts every Unicode decimal digit and caps no length, so int.Parse used to
 		// answer these with OverflowException/FormatException out of a path any player can type.
-		// match.c's strtoul saturates and then fails the suffix test, so the name stands as typed.
+		// match.c's strtoul saturates and then fails the suffix test, so the token is restored and the
+		// whole string stands as the name.
+		//
+		// The decoy named "Sword" is what makes this discriminating. Asserting "found nothing" would
+		// pass either way — a leading token wrongly consumed leaves an ordinal search for "Sword" that
+		// also finds nothing. With the decoy present, consuming the token finds *it* (or, for a count
+		// that survives, nothing), where restoring the token must find the object actually so named.
 		var room = _factory.CreateRoom(999, "Shared Room");
 		var looker = _factory.CreatePlayer(1, "TestPlayer", room);
 		Holds(looker);
-		Holds(room, looker, _factory.CreateThing(3, "Sword", room));
+		Holds(room, looker,
+			_factory.CreateThing(3, "Sword", room),
+			_factory.CreateThing(4, search, room));
 
 		var result = await _locateService.Locate(_parser, looker, looker, search, LocateFlags.All);
 
-		// Not a count, so the whole string is the name — and nothing is called that.
-		await Assert.That(result.IsNone).IsTrue();
+		await Assert.That(Found(result)).IsEqualTo(new DBRef(4, 0));
 	}
 }

--- a/SharpMUSH.Tests/Services/LocateServiceCompatibilityTests.cs
+++ b/SharpMUSH.Tests/Services/LocateServiceCompatibilityTests.cs
@@ -1230,37 +1230,6 @@ public class LocateServiceCompatibilityTests
 		await Assert.That(result.WithoutError().WithoutNone().Object().DBRef).IsEqualTo(new DBRef(42, 0));
 	}
 
-	[Test]
-	public async Task MatchList_NoVisibilityCheck_Flag_PreservesMatchWhenPostMatchVisibilityFails()
-	{
-		// The NoVisibilityCheck flag bypasses the post-match CanExamine/CanInteract check
-		// in Locate(). This test verifies the flag independently of absolute DBRef behavior
-		// by using Match_List directly (which has no post-match visibility check).
-		// The visibility check that NoVisibilityCheck bypasses is in Locate(), not Match_List.
-		// So this test verifies that a non-visible object in Match_List is found when
-		// CanInteract returns true (Match_List only skips objects where CanInteract is false).
-
-		var sharedRoom = _factory.CreateRoom(999, "Shared Room");
-		var player = _factory.CreatePlayer(1, "TestPlayer", sharedRoom);
-		var thing = _factory.CreateThing(3, "TargetObject", sharedRoom, player);
-
-		_permissionService.CanInteract(Arg.Any<AnySharpObject>(), Arg.Any<AnySharpObject>(),
-				Arg.Any<IPermissionService.InteractType>())
-			.Returns(true);
-
-		var list = new[] { thing }.ToAsyncEnumerable();
-
-		var state = new LocateService.MatchState(LocateFlags.NoTypePreference | LocateFlags.NoVisibilityCheck,
-			HelperFunctions.ParseDbRef("TargetObject"), 0);
-		await _locateService.MatchList(state, list, player, "TargetObject");
-		var bestMatch = state.Best;
-		var curr = state.Count;
-
-		await Assert.That(curr).IsEqualTo(1);
-		await Assert.That(bestMatch.IsValid()).IsTrue();
-		await Assert.That(bestMatch.WithoutError().WithoutNone().Object().DBRef).IsEqualTo(new DBRef(3, 0));
-	}
-
 	/// <summary>
 	/// Verifies that the ordinal validation logic (matching PennMUSH parse_english())
 	/// correctly accepts well-formed ordinals and rejects malformed ones.


### PR DESCRIPTION
Closes #787
Closes #788
Closes #789
Closes #791
Closes #792

The parity follow-ups split out of #785 (#790 turned out to be invalid and is closed — see below), in one PR because two of them rewrite the same method and would conflict apart. One commit per theme, so review can still go issue by issue.

Governing rule for all of these: where SharpMUSH and PennMUSH differ, PennMUSH wins — including where its behaviour looks like a quirk.

## `fun_locate`'s visibility gate goes back to `fun_locate` (#791, #789, #792) — `df944846`

`match_result_internal` asks exactly **one** permission question of a candidate, `can_interact(match, who, INTERACT_MATCH)` inside `MATCH_LIST`. There is no `Can_Examine`, `DarkLegal` or `INTERACT_SEE` anywhere in `match.c`; that block belongs to `fun_locate`, applied to whatever `match_result` returns.

SharpMUSH had it in `LocateWithDiagnosis` — the funnel every `ILocateService` entry point runs through, ~345 non-test call sites. Every command's object lookup carried a filter PennMUSH applies to one softcode function, rejecting objects Penn resolves and reporting them as "I can't see that here" rather than as a suppressed match.

The `else` arm was missing outright: `Location(item)` is not a good object for a room, so Penn asks `See_All || !DarkLegal || Light`, where SharpMUSH always took the other branch and asked `Can_Examine(executor, theRoomItself)` — a different question. Both arms are spelt out now, and the good-object one uses `FriendlyWhereIs` (`Location`) rather than `Room()`, which walks the whole chain.

`LocateFlags.NoVisibilityCheck` is gone — it opted out of a gate that no longer applies to any of its callers, so it now describes the default. Four call sites, `PlayerMatchFlags` and `SceneLocate` drop it, along with a test whose own comment conceded it verified nothing.

Two things ride along because they are the same lines:

- `fun_locate` passes `looker` as `match_result`'s `who` **and** its `where` (fundb.c), so every can_interact / controls / Long_Fingers / nearby question inside the match is asked about the looker. SharpMUSH passed the executor. Visible under the `s` switch, where Penn matches objects the *looker* controls. The general `match_result_relative` seam is untouched and stays right — look.c does pass the executor as `who`.
- `fun_locate` writes the dbref itself on every failure path and never emits a `#-1 SOMETHING` string. `locate()` returned `#-1 NOT PERMITTED TO EVALUATE ON LOOKER`, `#-2 I DON'T KNOW WHICH ONE YOU MEAN` and `#-1 CAN'T SEE THAT HERE` where Penn returns bare `#-1`/`#-2`. Softcode compares against these; a decorated string will not `=` a bare `#-1`. Internal error values are unchanged — the noisy entry points read them to pick a notification. The ambiguous notification also takes match.c:481's exclamation mark.

## Partial matching tries every word (#787) — `3105bd22`

`string_match` (strutil.c) rescans at each `isalnum` boundary, so `sword` matches `Big Sword`. `Classify` used `Name.StartsWith`, so only a name's leading word could be prefix-matched — and most MUSH object names are more than one word, which made every one of them reachable by its first word or in full and no other way. Probably the most player-visible divergence left.

The separator is `isalnum`, not whitespace (`Myrddin's` advances past the apostrophe), so splitting on spaces is not the same function. `Classify` is per-candidate, so the port walks spans and allocates nothing.

## `parse_english` puts back what it declines (#788, #790) — `1a6b8b0b`

Two spots where a leading token was consumed that PennMUSH restores: a count with no noun (match.c:560 quick-exits; `Split(' ').FirstOrDefault()` returned the whole string when there was no space, making `2nd` an ordinal search for `""`), and a regex miss falling through to the stripping return (match.c:590 resets and presses on, so a thing named `5 Swords` was searched for as `Swords`).

## `Nearby` was already correct — #790 was invalid (`671d0b7c`)

`1a6b8b0b` also "fixed" `Nearby`, and was wrong to. #790 read `where_is`'s `Home(thing)` as an exit's destination, but `Home(x)`, `Source(x)` and `Exits(x)` are three names for one field, `db[x].exits` (dbdefs.h:35-40); it is `Destination(x)` that is `db[x].location`. So `where_is(exit)` is the room the exit *sits in* — which is what `FriendlyWhereIs` already gave, since `SharpExit.Location` is documented as `Source()`. `671d0b7c` reverts that half and retargets the tests to the correct direction. #790 is closed as invalid.

The genuine half of #790 — `where_is` answering `NOTHING` for a room where `FriendlyWhereIs` returns the room itself — is proven benign rather than left open, with a test and a comment so it does not get refiled.

## Verification

- `dotnet build` clean with the format gate on
- `SharpMUSH.Tests` — 5625 total, **0 failed**, 188 skipped
- `SharpMUSH.Tests.Integration` — 338 total, **0 failed**, 0 skipped

New tests: 8 table-driven word-boundary cases against `string_match`'s rules, the two `parse_english` restore paths, `Nearby` for an exit in both directions, and the room/nowhere cases.

## Reviewer note

#791 is the one to look hardest at. It **loosens** a permission gate across every command — the change is toward PennMUSH, but "PennMUSH is more permissive here" deserves a deliberate look rather than a silent parity fix. Both suites pass unchanged, which is evidence but not proof: no existing test covered a DARK object matched by a non-`See_All` executor through a command path, because until now the gate made that unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visibility checks when locating objects, setting attributes, checking flags, and verifying approval status.
  * Restricted remote relative-scope searches appropriately while preserving See-All access.
  * Corrected nearby-object and exit-destination matching behavior.
  * Improved partial-name matching across word boundaries.
  * Preserved non-ordinal numeric tokens and strengthened ordinal validation.
  * Standardized lookup errors and updated ambiguous-match wording.

* **Tests**
  * Added coverage for visibility, permissions, matching, nearby locations, room contents, and ordinal parsing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Self-review pass (`671d0b7c`)

Re-read against the bar #785 set, which caught three defects of my own beyond the `Nearby` revert:

- **`Location(item)` is none of the helpers that resemble it.** The gate used `FriendlyWhereIs`, which is match.c's `loc` and takes an exit's *Source*; `db[exit].location` is `Destination()`. It also used `found.IsRoom` to pick the `!GoodObject(loc)` arm, but a room's location is its drop-to — usually unset, which is what actually selects that arm, and a room *with* one belongs in the other.
- **`can_interact` was hoisted above the branch**, so it ran even when `Can_Examine` would have short-circuited. It is the last term of both arms, and it can run softcode through an `@interact` lock, so hoisting is neither free nor side-effect-free.
- Checked for regressions against #785's performance work: no new allocations or LINQ on the per-candidate path (`Split(' ')` is gone in favour of `IndexOf`), `Classify` still allocation-free, `FriendlyWhereIs` still non-async, `MatchState` still carries the invariants.
