### PR TITLE
perf: reuse the NoParse pass's parse tree for command-argument evaluation

### DIFF
--- a/SharpMUSH.Benchmarks/CommandParseBenchmarks.cs
+++ b/SharpMUSH.Benchmarks/CommandParseBenchmarks.cs
@@ -14,6 +14,7 @@ public class CommandParseBenchmarks : BaseBenchmark
 	private static readonly MString ThinkNameSubstInput = MModule.single("think %N");
 	private static readonly MString PemitSelfInput = MModule.single("@pemit me=Hello World");
 	private static readonly MString SetAttrInput = MModule.single("@set me=SAFE");
+	private static readonly MString PemitWithFunctionInput = MModule.single("@pemit me=[add(1,2)]");
 
 	public override async ValueTask Setup()
 	{
@@ -36,6 +37,10 @@ public class CommandParseBenchmarks : BaseBenchmark
 	[Benchmark(Description = "@pemit me=Hello World")]
 	public async Task PemitSelf() =>
 		await _parser!.CommandParse(PemitSelfInput);
+
+	[Benchmark(Description = "@pemit me=[add(1,2)] (function call in command argument)")]
+	public async Task PemitWithFunctionInArgument() =>
+		await _parser!.CommandParse(PemitWithFunctionInput);
 
 	[Benchmark(Description = "@set me=SAFE (flag toggle)")]
 	public async Task SetFlag() =>

--- a/SharpMUSH.Implementation/MUSHCodeParser.cs
+++ b/SharpMUSH.Implementation/MUSHCodeParser.cs
@@ -391,6 +391,118 @@ public record MUSHCodeParser(ILogger<MUSHCodeParser> Logger,
 		return (result, visitor.DidEmitFunctionDebug);
 	}
 
+	/// <summary>
+	/// Returns a parser bound to a state guaranteed to carry invocation/recursion tracking
+	/// (<see cref="ParserState.TotalInvocations"/>, <see cref="ParserState.CallDepth"/>, etc.),
+	/// pushing a fresh <see cref="ParserState"/> only when the current state stack has none yet
+	/// (i.e. a genuinely top-level entry point — <see cref="State"/> is empty, or the top frame
+	/// predates any tracking counters). Extracted from <see cref="FunctionParse(MString)"/> /
+	/// <see cref="FunctionParse(MString, bool)"/> so other callers that want to evaluate a
+	/// function-position subtree without re-lexing/re-parsing (see
+	/// <c>SharpMUSHParserVisitor.EvaluateArgumentSubtree</c>) can reuse the exact same
+	/// "needsTracking" decision.
+	/// </summary>
+	/// <param name="preserveActors">
+	/// When true, Executor/Enactor/Caller are copied from <see cref="CurrentState"/> into the
+	/// fresh <see cref="ParserState"/> (matches <c>FunctionParse(text, emitSubstDebug: true)</c>).
+	/// When false, they are left null (matches the no-debug <see cref="FunctionParse(MString)"/>
+	/// overload) — this asymmetry already existed between the two overloads before extraction.
+	/// </param>
+	internal IMUSHCodeParser ResolveTrackingParser(bool preserveActors)
+	{
+		var needsTracking = State.IsEmpty || CurrentState.TotalInvocations == null;
+		if (!needsTracking)
+		{
+			return this;
+		}
+
+		return Push(new ParserState(
+			Registers: new([[]]),
+			IterationRegisters: [],
+			RegexRegisters: [],
+			SwitchStack: [],
+			EnvironmentRegisters: [],
+			CurrentEvaluation: null,
+			ExecutionStack: [],
+			ParserFunctionDepth: 0,
+			Function: null,
+			Command: null,
+			CommandInvoker: _ => ValueTask.FromResult(new Option<CallState>(new None())),
+			Switches: [],
+			Arguments: [],
+			Executor: preserveActors ? CurrentState.Executor : null,
+			Enactor: preserveActors ? CurrentState.Enactor : null,
+			Caller: preserveActors ? CurrentState.Caller : null,
+			Handle: null,
+			ParseMode: ParseMode.Default,
+			HttpResponse: null,
+			CallDepth: new InvocationCounter(),
+			FunctionRecursionDepths: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase),
+			TotalInvocations: new InvocationCounter(),
+			LimitExceeded: new LimitExceededFlag()));
+	}
+
+	/// <summary>
+	/// PennMUSH substitution-only debug: when a function-position argument contains only
+	/// substitutions (no function calls), emit a single-line debug trace: "#dbref! raw => evaluated".
+	/// Only fires when function-level debug did NOT already emit for this same parse (<paramref
+	/// name="didEmitFunctionDebug"/>), and when the raw and evaluated text actually differ.
+	/// <para>
+	/// Extracted from <see cref="FunctionParse(MString, bool)"/> so
+	/// <c>SharpMUSHParserVisitor.EvaluateArgumentSubtree</c> can reuse the identical trace logic
+	/// when it evaluates a retained argument subtree directly instead of going through
+	/// <see cref="FunctionParse(MString, bool)"/>'s own lex+parse pass.
+	/// </para>
+	/// </summary>
+	/// <param name="callerState">
+	/// The state to check DEBUG/NODEBUG flags and resolve the executor against — always the
+	/// state of the parser that WOULD have called <see cref="FunctionParse(MString, bool)"/>
+	/// (i.e. <see cref="CurrentState"/> at the call site), not any fresh tracking state pushed by
+	/// <see cref="ResolveTrackingParser"/> for the evaluation itself.
+	/// </param>
+	internal static async ValueTask EmitSubstitutionOnlyDebugTraceAsync(
+		IMediator mediator,
+		INotifyService notifyService,
+		ParserState callerState,
+		string rawText,
+		MString? resultMessage,
+		bool didEmitFunctionDebug)
+	{
+		if (didEmitFunctionDebug || resultMessage is null)
+		{
+			return;
+		}
+
+		var evaluatedText = resultMessage.ToPlainText();
+		if (rawText == evaluatedText)
+		{
+			return;
+		}
+
+		var shouldDebug = false;
+		AnySharpObject? executorObj = null;
+
+		var executor = await callerState.ExecutorObject(mediator);
+		if (!executor.IsNone)
+		{
+			executorObj = executor.Known;
+			var stateFlags = callerState.Flags;
+			if (stateFlags.HasFlag(ParserStateFlags.NoDebug))
+				shouldDebug = false;
+			else if (stateFlags.HasFlag(ParserStateFlags.Debug))
+				shouldDebug = true;
+			else
+				shouldDebug = await executorObj.HasFlag("DEBUG");
+		}
+
+		if (shouldDebug && executorObj is not null)
+		{
+			var dbrefNumber = executorObj.Object().DBRef.Number;
+			var owner = await executorObj.Object().Owner.WithCancellation(CancellationToken.None);
+			await notifyService.Notify(owner, MModule.single($"#{dbrefNumber}! {rawText} => {evaluatedText}"));
+		}
+	}
+
 	public async ValueTask<CallState?> FunctionParse(MString text)
 	{
 		// Short-circuit: empty input (e.g. trailing comma in allof(1,2,3,)) → empty result.
@@ -398,34 +510,7 @@ public record MUSHCodeParser(ILogger<MUSHCodeParser> Logger,
 		if (string.IsNullOrEmpty(MModule.plainText(text)))
 			return CallState.Empty;
 
-		var needsTracking = State.IsEmpty || CurrentState.TotalInvocations == null;
-
-		var parser = needsTracking
-			? Push(new ParserState(
-				Registers: new([[]]),
-				IterationRegisters: [],
-				RegexRegisters: [],
-				SwitchStack: [],
-				EnvironmentRegisters: [],
-				CurrentEvaluation: null,
-				ExecutionStack: [],
-				ParserFunctionDepth: 0,
-				Function: null,
-				Command: null,
-				CommandInvoker: _ => ValueTask.FromResult(new Option<CallState>(new None())),
-				Switches: [],
-				Arguments: [],
-				Executor: null,
-				Enactor: null,
-				Caller: null,
-				Handle: null,
-				ParseMode: ParseMode.Default,
-				HttpResponse: null,
-				CallDepth: new InvocationCounter(),
-				FunctionRecursionDepths: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase),
-				TotalInvocations: new InvocationCounter(),
-				LimitExceeded: new LimitExceededFlag()))
-			: this;
+		var parser = ResolveTrackingParser(preserveActors: false);
 
 		var (result, _) = await ParseInternalCore(text, p => p.startPlainString(), nameof(FunctionParse), parser);
 
@@ -440,70 +525,14 @@ public record MUSHCodeParser(ILogger<MUSHCodeParser> Logger,
 		if (string.IsNullOrEmpty(MModule.plainText(text).ToString()))
 			return CallState.Empty;
 
-		var needsTracking = State.IsEmpty || CurrentState.TotalInvocations == null;
-		var parser = needsTracking
-			? Push(new ParserState(
-				Registers: new([[]]),
-				IterationRegisters: [],
-				RegexRegisters: [],
-				SwitchStack: [],
-				EnvironmentRegisters: [],
-				CurrentEvaluation: null,
-				ExecutionStack: [],
-				ParserFunctionDepth: 0,
-				Function: null,
-				Command: null,
-				CommandInvoker: _ => ValueTask.FromResult(new Option<CallState>(new None())),
-				Switches: [],
-				Arguments: [],
-				Executor: CurrentState.Executor,
-				Enactor: CurrentState.Enactor,
-				Caller: CurrentState.Caller,
-				Handle: null,
-				ParseMode: ParseMode.Default,
-				HttpResponse: null,
-				CallDepth: new InvocationCounter(),
-				FunctionRecursionDepths: new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase),
-				TotalInvocations: new InvocationCounter(),
-				LimitExceeded: new LimitExceededFlag()))
-			: this;
+		var parser = ResolveTrackingParser(preserveActors: true);
 
 		// Capture raw text BEFORE evaluation for substitution-only debug
 		var rawText = MModule.plainText(text).ToString();
 		var (result, didEmitFunctionDebug) = await ParseInternalCore(text, p => p.startPlainString(), nameof(FunctionParse), parser);
 
-		// PennMUSH substitution-only debug: when the argument contains only substitutions
-		// (no function calls), emit a single-line debug trace: "#dbref! raw => evaluated"
-		// Only fires when function-level debug did NOT already emit for this parse.
-		if (!didEmitFunctionDebug && result?.Message is not null)
-		{
-			var evaluatedText = result.Message.ToPlainText();
-			if (rawText != evaluatedText)
-			{
-				var shouldDebug = false;
-				AnySharpObject? executorObj = null;
-
-				var executor = await CurrentState.ExecutorObject(_mediator);
-				if (!executor.IsNone)
-				{
-					executorObj = executor.Known;
-					var stateFlags = CurrentState.Flags;
-					if (stateFlags.HasFlag(ParserStateFlags.NoDebug))
-						shouldDebug = false;
-					else if (stateFlags.HasFlag(ParserStateFlags.Debug))
-						shouldDebug = true;
-					else
-						shouldDebug = await executorObj.HasFlag("DEBUG");
-				}
-
-				if (shouldDebug && executorObj is not null)
-				{
-					var dbrefNumber = executorObj.Object().DBRef.Number;
-					var owner = await executorObj.Object().Owner.WithCancellation(CancellationToken.None);
-					await _notifyService.Notify(owner, MModule.single($"#{dbrefNumber}! {rawText} => {evaluatedText}"));
-				}
-			}
-		}
+		await EmitSubstitutionOnlyDebugTraceAsync(_mediator, _notifyService, CurrentState, rawText, result?.Message,
+			didEmitFunctionDebug);
 
 		return result;
 	}

--- a/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
+++ b/SharpMUSH.Implementation/Visitors/SharpMUSHParserVisitor.cs
@@ -2167,7 +2167,7 @@ public class SharpMUSHParserVisitor(
 		);
 	}
 
-	private static async ValueTask<OneOf<List<CallState>, Error<string>>> ArgumentSplit(IMUSHCodeParser prs, MString src,
+	private async ValueTask<OneOf<List<CallState>, Error<string>>> ArgumentSplit(IMUSHCodeParser prs, MString src,
 		CommandContext context,
 		(SharpCommandAttribute Attribute, Func<IMUSHCodeParser, ValueTask<Option<CallState>>> Function)
 			libraryCommandDefinition,
@@ -2198,13 +2198,20 @@ public class SharpMUSHParserVisitor(
 			src);
 		var spaceInContext = MModule.indexOf(realSubtext, " ");
 
+		// The exact text the NoParse pass below parses to produce argCallState. Retained
+		// EvaluationStringContext nodes on argCallState.ArgumentContexts have token offsets
+		// relative to THIS text (not the command's full source line), so re-visiting them later
+		// in EvaluateArgumentSubtree requires a visitor whose `source` field is this same MString.
+		var parsedArgumentText = MModule.empty();
+
 		// command (space) argument(s)
 		if (spaceInContext != -1)
 		{
 			var remainder =
 				MModule.substring(spaceInContext + 1, MModule.getLength(realSubtext) - spaceInContext, realSubtext);
+			parsedArgumentText = remainder;
 
-			// command arg0 = arg1,still arg 1 
+			// command arg0 = arg1,still arg 1
 			if (behavior.HasFlag(CommandBehavior.EqSplit) && behavior.HasFlag(CommandBehavior.RSArgs))
 			{
 				argCallState = await newNoParseParser.CommandEqSplitArgsParse(remainder);
@@ -2258,6 +2265,7 @@ public class SharpMUSHParserVisitor(
 			if (argsStr.Length > 0)
 			{
 				var argsSubtext = MModule.single(argsStr);
+				parsedArgumentText = argsSubtext;
 				if (behavior.HasFlag(CommandBehavior.EqSplit) && behavior.HasFlag(CommandBehavior.RSArgs))
 				{
 					argCallState = await newNoParseParser.CommandEqSplitArgsParse(argsSubtext);
@@ -2299,6 +2307,14 @@ public class SharpMUSHParserVisitor(
 			return new Error<string>(errorText);
 		}
 
+		// Retained parse-tree nodes from the NoParse pass above, index-parallel to
+		// argCallState.Arguments — see CallState.ArgumentContexts. Reused below so evaluated
+		// arguments can be produced by re-visiting the already-lexed/parsed subtree (via
+		// EvaluateArgumentSubtree) instead of running FunctionParse's full lex+parse pipeline
+		// a third time on text the NoParse pass already tokenized and structured.
+		var argContexts = argCallState.ArgumentContexts ?? [];
+		object? ContextAt(int i) => i >= 0 && i < argContexts.Length ? argContexts[i] : null;
+
 		if (eqSplit)
 		{
 			// The LHS of an EqSplit command is evaluated unless the command declares full NoParse.
@@ -2312,7 +2328,7 @@ public class SharpMUSHParserVisitor(
 			arguments.Add(noParse
 				? new CallState(noParseLhs, argCallState.Depth, null,
 					async () => (await prs.FunctionParse(noParseLhs))!.Message!)
-				: (await prs.FunctionParse(argCallState.Arguments.FirstOrDefault() ?? MModule.empty()))!);
+				: (await EvaluateArgumentSubtree(prs, parsedArgumentText, ContextAt(0), noParseLhs, emitSubstDebug: false))!);
 
 			if (nArgs < 2) return arguments;
 
@@ -2332,8 +2348,10 @@ public class SharpMUSHParserVisitor(
 			else
 			{
 				arguments.AddRange(await argCallState.Arguments.Skip(1)
+						.Select((x, idx) => (Argument: x, Context: ContextAt(idx + 1)))
 						.ToAsyncEnumerable()
-						.Select((MString argument, CancellationToken _) => prs.FunctionParse(argument, true))
+						.Select(((MString Argument, object? Context) pair, CancellationToken _) =>
+							EvaluateArgumentSubtree(prs, parsedArgumentText, pair.Context, pair.Argument, emitSubstDebug: true))
 						.Select(cs => cs!)
 						.ToListAsync());
 			}
@@ -2351,8 +2369,10 @@ public class SharpMUSHParserVisitor(
 			else
 			{
 				arguments.AddRange(await (argCallState.Arguments ?? [])
+					.Select((x, idx) => (Argument: x, Context: ContextAt(idx)))
 					.ToAsyncEnumerable()
-					.Select((MString argument, CancellationToken _) => prs.FunctionParse(argument, true))
+					.Select(((MString Argument, object? Context) pair, CancellationToken _) =>
+						EvaluateArgumentSubtree(prs, parsedArgumentText, pair.Context, pair.Argument, emitSubstDebug: true))
 					.Select(cs => cs!)
 					.ToListAsync());
 			}
@@ -2361,6 +2381,103 @@ public class SharpMUSHParserVisitor(
 		return arguments;
 	}
 
+	/// <summary>
+	/// Evaluates a single command argument by re-visiting the parse subtree retained from the
+	/// NoParse argument-splitting pass (<see cref="CallState.ArgumentContexts"/>) instead of
+	/// re-lexing and re-parsing the argument's raw text a third time via
+	/// <see cref="IMUSHCodeParser.FunctionParse(MString, bool)"/>. Falls back to the original
+	/// FunctionParse pipeline when no retained context is available for this slot (e.g. an empty
+	/// comma-separated argument), or when <paramref name="prs"/> is not a <see cref="MUSHCodeParser"/>
+	/// (the only production implementation of <see cref="IMUSHCodeParser"/>).
+	/// </summary>
+	/// <param name="prs">The command's own parser — equal to this visitor's own <c>parser</c> field
+	/// at every current call site (all three ArgumentSplit callers pass it through unchanged).</param>
+	/// <param name="argumentSourceText">
+	/// The exact text the NoParse pass parsed to produce <paramref name="retainedContext"/>
+	/// (ArgumentSplit's local <c>remainder</c>/<c>argsSubtext</c>) — the retained context's token
+	/// offsets are relative to this text, NOT the command's full source line, so a sub-visitor
+	/// evaluating it must be constructed with this exact text as its own `source`.
+	/// </param>
+	/// <param name="retainedContext">The <see cref="CallState.ArgumentContexts"/> slot for this
+	/// argument (an <c>EvaluationStringContext</c> boxed as <see cref="object"/>), or null.</param>
+	/// <param name="argument">The raw argument text — same value FunctionParse's `text` parameter
+	/// would receive on the fallback path.</param>
+	/// <param name="emitSubstDebug">Mirrors <see cref="IMUSHCodeParser.FunctionParse(MString, bool)"/>'s
+	/// substitution-only QUEUE_DEBUG trace flag.</param>
+	private async ValueTask<CallState?> EvaluateArgumentSubtree(
+		IMUSHCodeParser prs,
+		MString argumentSourceText,
+		object? retainedContext,
+		MString argument,
+		bool emitSubstDebug)
+	{
+		// Escaped text (`\x`, grammar rule `escapedText: ESCAPE ANY;`, the ONLY entry point being a
+		// literal backslash — SharpMUSHLexer.g4) is a hard correctness trap for subtree reuse:
+		// VisitEscapedText (below) strips the backslash and returns the escaped character as plain
+		// text UNCONDITIONALLY — it does not check ParseMode. Under the original re-lex pipeline,
+		// this meant an escaped substitution like `\%#` decoded to bare `%#` during the NoParse
+		// boundary-finding pass, and THEN got a second, fresh lex — where the now-bare `%#` is
+		// tokenized as a live substitution and evaluates (e.g. to "#1"). Re-visiting the SAME
+		// retained EscapedTextContext node instead can never reach that second tokenization: the
+		// node's grammar rule was fixed as "escaped text" at the original lex time, so it always
+		// re-decodes to literal text no matter what ParseMode the revisit runs under — confirmed by
+		// IncludeFromDollarCommandTests.MultiLineBody_SemicolonAtLineEnd_RunsEveryCommand, which
+		// stores `\%#` via @set (EqSplit, no NoParse/RSNoParse -> eager RHS evaluation) and asserts
+		// it comes out as "#1", not "%#". Fall back to the original re-lex pipeline whenever the
+		// retained subtree contains an escape anywhere, so this argument gets byte-identical
+		// treatment to pre-optimization behavior.
+		if (retainedContext is not EvaluationStringContext ctx
+				|| prs is not MUSHCodeParser mushParser
+				|| ContainsEscapedText(ctx))
+		{
+			return await prs.FunctionParse(argument, emitSubstDebug);
+		}
+
+		var evalParser = mushParser.ResolveTrackingParser(preserveActors: emitSubstDebug);
+
+		// A fresh visitor per call mirrors ParseInternalCore's "new SharpMUSHParserVisitor(...)
+		// per parse": its DidEmitFunctionDebug flag must start false for THIS argument alone, not
+		// be shared/polluted by the outer command's own visitor (`this`), which is handling the
+		// whole command line and whose flag may already be set from a sibling argument or an
+		// enclosing function call.
+		var subVisitor = new SharpMUSHParserVisitor(logger, evalParser, Configuration, Mediator, NotifyService,
+			ConnectionService, LocateService, CommandDiscoveryService, AttributeService, HookService, argumentSourceText);
+
+		var result = await subVisitor.Visit(ctx);
+
+		if (emitSubstDebug)
+		{
+			var rawText = MModule.plainText(argument).ToString();
+			await MUSHCodeParser.EmitSubstitutionOnlyDebugTraceAsync(
+				Mediator, NotifyService, prs.CurrentState, rawText, result?.Message, subVisitor.DidEmitFunctionDebug);
+		}
+
+		return result;
+	}
+
+	/// <summary>
+	/// Depth-first search for any <see cref="EscapedTextContext"/> node in <paramref name="node"/>'s
+	/// subtree (inclusive). See the comment in <see cref="EvaluateArgumentSubtree"/> for why this
+	/// gates the subtree-reuse fast path.
+	/// </summary>
+	private static bool ContainsEscapedText(IParseTree node)
+	{
+		if (node is EscapedTextContext)
+		{
+			return true;
+		}
+
+		for (var i = 0; i < node.ChildCount; i++)
+		{
+			var child = node.GetChild(i);
+			if (child is not null && ContainsEscapedText(child))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
 
 	public override async ValueTask<CallState?> VisitEvaluationString(
 		[NotNull] EvaluationStringContext context) => await VisitChildren(context) ?? new CallState(
@@ -2677,7 +2794,10 @@ public class SharpMUSHParserVisitor(
 			[
 				visited?.Message ?? GetContextText(evalString)
 			],
-			ParsedMessage: () => ValueTask.FromResult<MString?>(null));
+			ParsedMessage: () => ValueTask.FromResult<MString?>(null))
+		{
+			ArgumentContexts = [evalString]
+		};
 	}
 
 	/// <summary>
@@ -2697,7 +2817,10 @@ public class SharpMUSHParserVisitor(
 		return new CallState(null,
 			context.Depth(),
 			[baseArg?.Message ?? MModule.empty(), .. commaArgs?.Arguments ?? []],
-			() => ValueTask.FromResult<MString?>(null));
+			() => ValueTask.FromResult<MString?>(null))
+		{
+			ArgumentContexts = [evalString, .. commaArgs?.ArgumentContexts ?? []]
+		};
 	}
 
 	/// <summary>
@@ -2718,7 +2841,10 @@ public class SharpMUSHParserVisitor(
 						? (await Visit(evalStrings[0]))?.Message ?? MModule.empty()
 						: MModule.empty()
 				],
-				() => ValueTask.FromResult<MString?>(null));
+				() => ValueTask.FromResult<MString?>(null))
+			{
+				ArgumentContexts = [evalStrings.Length > 0 ? evalStrings[0] : null]
+			};
 		}
 
 		var lhsExists = evalStrings.Length > 0 && evalStrings[0].Start.StartIndex < equalsToken.Symbol.StartIndex;
@@ -2727,7 +2853,14 @@ public class SharpMUSHParserVisitor(
 		var rhsArg = rsIdx < evalStrings.Length ? await Visit(evalStrings[rsIdx]) : null;
 		return new CallState(null, context.Depth(),
 			[lhsArg?.Message ?? MModule.empty(), rhsArg?.Message ?? MModule.empty()],
-			() => ValueTask.FromResult<MString?>(null));
+			() => ValueTask.FromResult<MString?>(null))
+		{
+			ArgumentContexts =
+			[
+				lhsExists ? evalStrings[0] : null,
+				rsIdx < evalStrings.Length ? evalStrings[rsIdx] : null
+			]
+		};
 	}
 
 	/// <summary>
@@ -2744,6 +2877,7 @@ public class SharpMUSHParserVisitor(
 		var commas = context.COMMAWS();
 		var argCount = commas.Length + 1;
 		var arguments = new MString[argCount];
+		var contexts = new object?[argCount];
 		var evalIdx = 0;
 		for (var i = 0; i < argCount; i++)
 		{
@@ -2752,14 +2886,19 @@ public class SharpMUSHParserVisitor(
 			{
 				var result = await Visit(evalStrings[evalIdx++]);
 				arguments[i] = result?.Message ?? GetContextText(evalStrings[evalIdx - 1]);
+				contexts[i] = evalStrings[evalIdx - 1];
 			}
 			else
 			{
 				arguments[i] = MModule.empty();
+				contexts[i] = null;
 			}
 		}
 
-		return new CallState(null, context.Depth(), arguments, () => ValueTask.FromResult<MString?>(null));
+		return new CallState(null, context.Depth(), arguments, () => ValueTask.FromResult<MString?>(null))
+		{
+			ArgumentContexts = contexts
+		};
 	}
 
 	public override async ValueTask<CallState?> VisitComplexSubstitutionSymbol(

--- a/SharpMUSH.Library/ParserInterfaces/CallState.cs
+++ b/SharpMUSH.Library/ParserInterfaces/CallState.cs
@@ -72,4 +72,21 @@ public record CallState(MString? Message, int Depth, MString[]? Arguments, Func<
 
 	public static readonly CallState EmptyArgument = new(_emptyMString, 0, [], _emptyParsedMessage);
 	public static readonly CallState Empty = new(_emptyMString, 0, null, _emptyParsedMessage);
+
+	/// <summary>
+	/// Parallel to <see cref="Arguments"/>: the retained NoParse-pass parse-tree node for each
+	/// command-argument slot (a <c>SharpMUSHParser.EvaluationStringContext</c>, boxed as
+	/// <see cref="object"/> so this shared/plugin-packaged contract type does not have to reference
+	/// the ANTLR-generated parser assembly — see the <c>PrivateAssets="all"</c> note on the
+	/// <c>SharpMUSH.Parser.Generated</c> reference in SharpMUSH.Library.csproj), or <see langword="null"/>
+	/// where a slot has no evaluationString (e.g. an empty comma-separated argument).
+	/// <para>
+	/// Populated only by the command argument-split visitor methods (<c>VisitCommaCommandArgs</c>,
+	/// <c>VisitStartEqSplitCommandArgs</c>, <c>VisitStartEqSplitCommand</c>,
+	/// <c>VisitStartPlainSingleCommandArg</c> in <c>SharpMUSHParserVisitor</c>), so that
+	/// <c>ArgumentSplit</c> can re-visit the already-lexed/parsed subtree directly instead of
+	/// re-parsing each argument's raw text a third time (avoiding a redundant lex+parse pass).
+	/// </para>
+	/// </summary>
+	public object?[]? ArgumentContexts { get; init; }
 }

--- a/SharpMUSH.Tests/Commands/CommunicationCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/CommunicationCommandTests.cs
@@ -74,6 +74,25 @@ public class CommunicationCommandTests
 			.Notify(TestHelpers.MatchingObject(executor), expected, TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
 	}
 
+	/// <summary>
+	/// Regression test for the command-argument subtree-reuse optimization (ArgumentSplit /
+	/// SharpMUSHParserVisitor.EvaluateArgumentSubtree): a function call with nested brackets inside
+	/// an EqSplit command's RHS argument must still evaluate correctly when the argument's parse
+	/// subtree is re-visited directly instead of being re-lexed from scratch a third time.
+	/// </summary>
+	[Test]
+	[Arguments("@pemit #1=[add(1,2)]", "3")]
+	[Arguments("@pemit #1=[add(1,[mul(2,3)])]", "7")]
+	public async ValueTask PemitWithFunctionCallInArgument(string command, string expected)
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+		await Parser.CommandParse(1, ConnectionService, MModule.single(command));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor), expected, TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
+	}
+
 	[Test]
 	[Arguments("@emit Test broadcast", "Test broadcast")]
 	[Arguments("@emit Another broadcast message", "Another broadcast message")]

--- a/SharpMUSH.Tests/Commands/WizardCommandTests.cs
+++ b/SharpMUSH.Tests/Commands/WizardCommandTests.cs
@@ -135,6 +135,27 @@ public class WizardCommandTests
 			.Because("@force should evaluate [add(1,1)] to 2 before the & command stores it");
 	}
 
+	/// <summary>
+	/// Regression test for the command-argument subtree-reuse optimization (ArgumentSplit /
+	/// SharpMUSHParserVisitor.EvaluateArgumentSubtree): @FORCE is EqSplit + RSBrace WITHOUT
+	/// NoParse/RSNoParse, so its RHS is both (a) brace-preserved by the NoParse boundary-finding
+	/// pass (CommandBehavior.RSBrace -> ParserStateFlags.PreserveBraces) and (b) eagerly
+	/// function-evaluated afterwards — exercising the brace-preservation and subtree-reuse paths
+	/// together in the same argument.
+	/// </summary>
+	[Test]
+	public async ValueTask ForceCommand_PreservesBraces_WhileEvaluatingFunctionInside()
+	{
+		var executor = WebAppFactoryArg.ExecutorDBRef;
+
+		await Parser.CommandParse(1, ConnectionService,
+			MModule.single("@force me={@pemit me=[add(1,2)]}"));
+
+		await NotifyService
+			.Received(1)
+			.Notify(TestHelpers.MatchingObject(executor), "3", TestHelpers.MatchingObject(executor), INotifyService.NotificationType.Announce);
+	}
+
 	[Test]
 	public async ValueTask NotifyCommand()
 	{


### PR DESCRIPTION
## Summary

`@command arg1,arg2` dispatch ran three lex+parse passes per command:
1. the initial command parse (`startSingleCommandString`)
2. a `ParseMode.NoParse` pass over the sliced argument text, purely to locate split boundaries (spaces/`=`/`,`)
3. a full re-parse of *each extracted argument's text* via `FunctionParse`, to actually evaluate it

Pass 3 re-lexed and re-parsed text that pass 2 had already tokenized and structured into a parse tree — a `TODO` at the call site even named this as a known optimization gap.

This change carries the retained `EvaluationStringContext` parse-tree node out of the four command-argument split visitor methods (`VisitCommaCommandArgs`, `VisitStartEqSplitCommandArgs`, `VisitStartEqSplitCommand`, `VisitStartPlainSingleCommandArg`) on a new `CallState.ArgumentContexts` field (index-parallel to `Arguments`), and `ArgumentSplit` re-visits that subtree directly (`EvaluateArgumentSubtree`) instead of calling `FunctionParse` on the extracted text — eliminating pass 3 for the common case.

`ArgumentContexts` is typed `object?[]?` rather than the ANTLR-generated `EvaluationStringContext[]?`, because `SharpMUSH.Library` is packaged as the external plugin contract surface and marks its `SharpMUSH.Parser.Generated` reference `PrivateAssets="all"` specifically to keep that assembly out of the published package surface; exposing the ANTLR type directly on the widely-used `CallState` record would undermine that.

## Two correctness traps

- **Trap A (QUEUE_DEBUG substitution-only trace).** `FunctionParse(text, emitSubstDebug: true)` also emits PennMUSH's `"#dbref! raw => evaluated"` debug trace, and the `needsTracking` fresh-`ParserState` push, with an asymmetry between the two `FunctionParse` overloads (LHS-no-debug leaves Executor/Enactor/Caller null on a fresh push; RHS-with-debug preserves them). Both behaviors are extracted out of `FunctionParse` into `MUSHCodeParser.ResolveTrackingParser`/`EmitSubstitutionOnlyDebugTraceAsync`, called identically by both the original `FunctionParse` path and the new subtree-reuse path — verified against `DebugVerboseTests` (26/26 pass, including the exact `@pemit me=[add(123,456)]` DEBUG-flag scenario).
- **Trap B / a third trap found empirically (escaped text).** Testing surfaced a real regression: `VisitEscapedText` (backslash escapes, `escapedText: ESCAPE ANY;` — the only grammar entry point for a literal `\`) unconditionally strips the escape and returns literal text, with no `ParseMode` check. The original design relied on re-lexing the NoParse pass's *decoded* output a second time, so an escaped substitution like `\%#` — decoded to bare `%#` by pass 2 — got tokenized fresh as a live substitution by pass 3 and evaluated (e.g. to `#1`). Revisiting the retained `EscapedTextContext` node can never reach that second tokenization, since the node's grammar rule was fixed at the original lex time. `EvaluateArgumentSubtree` now detects any `EscapedTextContext` in the retained subtree and falls back to the original `FunctionParse` pipeline for that one argument, confirmed against `IncludeFromDollarCommandTests.MultiLineBody_SemicolonAtLineEnd_RunsEveryCommand` (was failing, now passes).

## Test plan

- [x] Baseline (`origin/main`, `dotnet run -c Release --project SharpMUSH.Tests`): 5630 total / 0 failed / 5442 succeeded / 188 skipped
- [x] After (this branch, same command): 5633 total / 0 failed / 5445 succeeded / 188 skipped — the +3 are the new regression tests below, zero regressions
- [x] Podman/Testcontainers-backed Explicit suites (`TelnetIntegrationTests`, `PuebloMxpIntegrationTests`, `StagingDatabaseTests`, `ArangoDBTests`, `MemoryTest`, `ReplayPersistLatencyBenchmark`): 2/2 passed, identical before and after
- [x] New regression tests: `CommunicationCommandTests.PemitWithFunctionCallInArgument` (`@pemit #1=[add(1,2)]` → `3`, nested-bracket case), `WizardCommandTests.ForceCommand_PreservesBraces_WhileEvaluatingFunctionInside` (`@force me={@pemit me=[add(1,2)]}`, exercises `RSBrace` + eager evaluation together)
- [x] `dotnet format whitespace --folder <dir>` clean (converged on first pass, all four touched project dirs)

## Benchmark

Added `CommandParseBenchmarks.PemitWithFunctionInArgument` (`@pemit me=[add(1,2)]`). BenchmarkDotNet, `SHARPMUSH_CI_BENCHMARK=true` (ShortRun job, N=3 — CI-noise caveat applies), isolated single-benchmark runs for a fair before/after:

| | Mean | Allocated |
|---|---|---|
| Before (optimization reverted, benchmark case only) | 759.2 us | 111.03 KB |
| After (this branch) | 686.3 us | 99.12 KB |

~10.7% less allocation (fewer intermediate lexer/parser structures for the eliminated third pass) is the more reliable signal here — the N=3 ShortRun timing has ~200%+ CI margins, so the ~9.6% mean-time delta should be read as directional, not a confirmed percentage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command argument parsing for embedded and nested function expressions.
  * Preserved braces correctly when evaluating functions in forced commands.
  * Ensured evaluated function results are delivered correctly through communication commands.

* **Tests**
  * Added regression coverage for function calls in communication and wizard command arguments.
  * Added parsing benchmark coverage for function expressions in command arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->